### PR TITLE
Pre resolved data

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -284,7 +284,7 @@ pub fn render_data_app_to_stream<Data, Fut, IV>(
 ) -> Route
 where
     Data: 'static,
-    Fut: Future<Output = Data>,
+    Fut: Future<Output = Result<Data, actix_web::Error>>,
     IV: IntoView + 'static,
 {
     web::get().to(move |req: HttpRequest| {
@@ -294,7 +294,10 @@ where
         let res_options = ResponseOptions::default();
 
         async move {
-            let data = data_fn(req.clone()).await;
+            let data = match data_fn(req.clone()).await {
+                Err(e) => return HttpResponse::from_error(e),
+                Ok(d) => d,
+            };
 
             let app = {
                 let app_fn = app_fn.clone();
@@ -505,7 +508,7 @@ pub trait LeptosRoutes {
     ) -> Self
     where
         Data: 'static,
-        Fut: Future<Output = Data>,
+        Fut: Future<Output = Result<Data, actix_web::Error>>,
         IV: IntoView + 'static;
 }
 
@@ -540,7 +543,7 @@ where
     ) -> Self
     where
         Data: 'static,
-        Fut: Future<Output = Data>,
+        Fut: Future<Output = Result<Data, actix_web::Error>>,
         IV: IntoView + 'static,
     {
         let mut router = self;

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -258,19 +258,13 @@ where
         let options = options.clone();
         let app_fn = app_fn.clone();
         let res_options = ResponseOptions::default();
-        let res_options_default = res_options.clone();
-        async move {
-            let path = leptos_corrected_path(&req);
 
+        async move {
             let app = {
                 let app_fn = app_fn.clone();
+                let res_options = res_options.clone();
                 move |cx| {
-                    let integration = ServerIntegration { path: path.clone() };
-                    provide_context(cx, RouterIntegrationContext::new(integration));
-                    provide_context(cx, MetaContext::new());
-                    provide_context(cx, res_options_default.clone());
-                    provide_context(cx, req.clone());
-
+                    provide_contexts(cx, &req, res_options);
                     (app_fn)(cx).into_view(cx)
                 }
             };
@@ -280,6 +274,16 @@ where
             stream_app(app, head, tail, res_options).await
         }
     })
+}
+
+fn provide_contexts(cx: leptos::Scope, req: &HttpRequest, res_options: ResponseOptions) {
+    let path = leptos_corrected_path(&req);
+
+    let integration = ServerIntegration { path };
+    provide_context(cx, RouterIntegrationContext::new(integration));
+    provide_context(cx, MetaContext::new());
+    provide_context(cx, res_options);
+    provide_context(cx, req.clone());
 }
 
 fn leptos_corrected_path(req: &HttpRequest) -> String {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -279,7 +279,7 @@ where
 
 pub fn render_data_app_to_stream<Data, Fut, IV>(
     options: LeptosOptions,
-    data_fn: impl Fn(&HttpRequest) -> Fut + Clone + 'static,
+    data_fn: impl Fn(HttpRequest) -> Fut + Clone + 'static,
     app_fn: impl Fn(leptos::Scope, Data) -> IV + Clone + Send + 'static,
 ) -> Route
 where
@@ -294,7 +294,7 @@ where
         let res_options = ResponseOptions::default();
 
         async move {
-            let data = data_fn(&req).await;
+            let data = data_fn(req.clone()).await;
 
             let app = {
                 let app_fn = app_fn.clone();
@@ -500,7 +500,7 @@ pub trait LeptosRoutes {
         self,
         options: LeptosOptions,
         paths: Vec<String>,
-        data_fn: impl Fn(&HttpRequest) -> Fut + Clone + 'static,
+        data_fn: impl Fn(HttpRequest) -> Fut + Clone + 'static,
         app_fn: impl Fn(leptos::Scope, Data) -> IV + Clone + Send + 'static,
     ) -> Self
     where
@@ -535,7 +535,7 @@ where
         self,
         options: LeptosOptions,
         paths: Vec<String>,
-        data_fn: impl Fn(&HttpRequest) -> Fut + Clone + 'static,
+        data_fn: impl Fn(HttpRequest) -> Fut + Clone + 'static,
         app_fn: impl Fn(leptos::Scope, Data) -> IV + Clone + Send + 'static,
     ) -> Self
     where

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -326,9 +326,9 @@ fn leptos_corrected_path(req: &HttpRequest) -> String {
     let path = req.path();
     let query = req.query_string();
     if query.is_empty() {
-        path.to_string()
+        "http://leptos".to_string() + path
     } else {
-        path.to_string() + "?" + query
+        "http://leptos".to_string() + path + "?" + query
     }
 }
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -260,14 +260,7 @@ where
         let res_options = ResponseOptions::default();
         let res_options_default = res_options.clone();
         async move {
-            let path = req.path();
-
-            let query = req.query_string();
-            let path = if query.is_empty() {
-                "http://leptos".to_string() + path
-            } else {
-                "http://leptos".to_string() + path + "?" + query
-            };
+            let path = leptos_corrected_path(&req);
 
             let app = {
                 let app_fn = app_fn.clone();
@@ -287,6 +280,16 @@ where
             stream_app(app, head, tail, res_options).await
         }
     })
+}
+
+fn leptos_corrected_path(req: &HttpRequest) -> String {
+    let path = req.path();
+    let query = req.query_string();
+    if query.is_empty() {
+        path.to_string()
+    } else {
+        path.to_string() + "?" + query
+    }
 }
 
 async fn stream_app(app: impl FnOnce(leptos::Scope) -> View + 'static, 


### PR DESCRIPTION
So basically I provide a way to resolve data before calling the app. This is how it looks when using it:

```rust
        App::new().leptos_preloaded_data_routes(
                leptos_options.clone(),
                routes.to_owned(),
                data_populate,
                |cx, (data, theme)| view! { cx, <App theme data /> },
            )
    })
    
    async fn data_populate(req: HttpRequest) -> Result<(JsonResponse, Theme), actix_web::Error> {
       ....
    }
```

In the end, I made it as a new LeptosRoutes function, because like this it doesn't break backward compatibility. 

I will also need to refactor the integrations to support custom Actix Guards (my root path has a wildcard which means it needs to use a guard for Accept=text/html in order to not be used for things like favicon requests. 

Once the second refactoring is done, then we could discuss implementing any breaking changes.

Ping @benwis 