### PR TITLE
Update Generated API URL on Windows Attempt #2

### DIFF
--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -49,7 +49,7 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
             #[cfg(not(target_os = "windows"))]
             let url = format!("{}/{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace('/', "-");
             #[cfg(target_os = "windows")]
-            let url = format!("{}/{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace("\\", "-");
+            let url = format!("{}\\{}", span.source_file().path().to_string_lossy(), fn_name_as_str).replace("\\", "-");
         } else {
             let url = fn_name_as_str;
         }


### PR DESCRIPTION
The PR #144 left in a single extra `'/'` which was from the `format!` macro and was not properly converted to `'-'` because the replace call was changed. 

This PR updates the `format!` macro while on Windows to match everything else emitted from `span.source_file().path().to_string_lossy()` so the `replace()` properly cleans up everything.