### PR TITLE
Use rust-cache in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,16 +39,7 @@ jobs:
       - name: Run Rustfmt
         run: cargo fmt -- --check
 
-      - name: Cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run tests with all features
         run: cargo make ci


### PR DESCRIPTION
[`rust-cache`](https://github.com/Swatinem/rust-cache) can make CI faster. It caches `~/.cargo` and `./target`, disables incremental compilation and does some other things.

ref: https://matklad.github.io/2021/09/04/fast-rust-builds.html