### PR TITLE
fixed `fallback` type signature

### DIFF
--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -1,10 +1,18 @@
-use std::{borrow::Cow, cell::Cell, rc::Rc};
-
-use leptos::*;
-
 use crate::{
-    matching::{resolve_path, PathMatch, RouteDefinition, RouteMatch},
-    ParamsMap, RouterContext,
+  matching::{
+    resolve_path,
+    PathMatch,
+    RouteDefinition,
+    RouteMatch,
+  },
+  ParamsMap,
+  RouterContext,
+};
+use leptos::*;
+use std::{
+  borrow::Cow,
+  cell::Cell,
+  rc::Rc,
 };
 
 thread_local! {
@@ -15,187 +23,191 @@ thread_local! {
 /// the element it should display, and data that should be loaded alongside the route.
 #[component(transparent)]
 pub fn Route<E, F, P>(
-    cx: Scope,
-    /// The path fragment that this route should match. This can be static (`users`),
-    /// include a parameter (`:id`) or an optional parameter (`:id?`), or match a
-    /// wildcard (`user/*any`).
-    path: P,
-    /// The view that should be shown when this route is matched. This can be any function
-    /// that takes a [Scope] and returns an [Element] (like `|cx| view! { cx, <p>"Show this"</p> })`
-    /// or `|cx| view! { cx, <MyComponent/>` } or even, for a component with no props, `MyComponent`).
-    view: F,
-    /// `children` may be empty or include nested routes.
-    #[prop(optional)]
-    children: Option<Box<dyn FnOnce(Scope) -> Fragment>>,
+  cx: Scope,
+  /// The path fragment that this route should match. This can be static (`users`),
+  /// include a parameter (`:id`) or an optional parameter (`:id?`), or match a
+  /// wildcard (`user/*any`).
+  path: P,
+  /// The view that should be shown when this route is matched. This can be any function
+  /// that takes a [Scope] and returns an [Element] (like `|cx| view! { cx, <p>"Show this"</p> })`
+  /// or `|cx| view! { cx, <MyComponent/>` } or even, for a component with no props, `MyComponent`).
+  view: F,
+  /// `children` may be empty or include nested routes.
+  #[prop(optional)]
+  children: Option<Box<dyn FnOnce(Scope) -> Fragment>>,
 ) -> impl IntoView
 where
-    E: IntoView,
-    F: Fn(Scope) -> E + 'static,
-    P: std::fmt::Display,
+  E: IntoView,
+  F: Fn(Scope) -> E + 'static,
+  P: std::fmt::Display,
 {
-    let children = children
-        .map(|children| {
-            children(cx)
-                .as_children()
-                .iter()
-                .filter_map(|child| {
-                    child
-                        .as_transparent()
-                        .and_then(|t| t.downcast_ref::<RouteDefinition>())
-                })
-                .cloned()
-                .collect::<Vec<_>>()
+  let children = children
+    .map(|children| {
+      children(cx)
+        .as_children()
+        .iter()
+        .filter_map(|child| {
+          child
+            .as_transparent()
+            .and_then(|t| t.downcast_ref::<RouteDefinition>())
         })
-        .unwrap_or_default();
-    let id = ROUTE_ID.with(|id| {
-        let next = id.get() + 1;
-        id.set(next);
-        next
-    });
-    RouteDefinition {
-        id,
-        path: path.to_string(),
-        children,
-        view: Rc::new(move |cx| view(cx).into_view(cx)),
-    }
+        .cloned()
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+  let id = ROUTE_ID.with(|id| {
+    let next = id.get() + 1;
+    id.set(next);
+    next
+  });
+  RouteDefinition {
+    id,
+    path: path.to_string(),
+    children,
+    view: Rc::new(move |cx| view(cx).into_view(cx)),
+  }
 }
 
 impl IntoView for RouteDefinition {
-    fn into_view(self, cx: Scope) -> View {
-        Transparent::new(self).into_view(cx)
-    }
+  fn into_view(self, cx: Scope) -> View {
+    Transparent::new(self).into_view(cx)
+  }
 }
 
 /// Context type that contains information about the current, matched route.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RouteContext {
-    inner: Rc<RouteContextInner>,
+  inner: Rc<RouteContextInner>,
 }
 
 impl RouteContext {
-    pub(crate) fn new(
-        cx: Scope,
-        router: &RouterContext,
-        child: impl Fn() -> Option<RouteContext> + 'static,
-        matcher: impl Fn() -> Option<RouteMatch> + 'static,
-    ) -> Option<Self> {
-        let base = router.base();
-        let base = base.path();
-        let RouteMatch { path_match, route } = matcher()?;
-        let PathMatch { path, .. } = path_match;
-        let RouteDefinition {
-            view: element, id, ..
-        } = route.key;
-        let params = create_memo(cx, move |_| {
-            matcher()
-                .map(|matched| matched.path_match.params)
-                .unwrap_or_default()
-        });
+  pub(crate) fn new(
+    cx: Scope,
+    router: &RouterContext,
+    child: impl Fn() -> Option<RouteContext> + 'static,
+    matcher: impl Fn() -> Option<RouteMatch> + 'static,
+  ) -> Option<Self> {
+    let base = router.base();
+    let base = base.path();
+    let RouteMatch { path_match, route } = matcher()?;
+    let PathMatch { path, .. } = path_match;
+    let RouteDefinition {
+      view: element, id, ..
+    } = route.key;
+    let params = create_memo(cx, move |_| {
+      matcher()
+        .map(|matched| matched.path_match.params)
+        .unwrap_or_default()
+    });
 
-        Some(Self {
-            inner: Rc::new(RouteContextInner {
-                cx,
-                id,
-                base_path: base.to_string(),
-                child: Box::new(child),
-                path,
-                original_path: route.original_path.to_string(),
-                params,
-                outlet: Box::new(move || Some(element(cx))),
-            }),
-        })
-    }
+    Some(Self {
+      inner: Rc::new(RouteContextInner {
+        cx,
+        id,
+        base_path: base.to_string(),
+        child: Box::new(child),
+        path,
+        original_path: route.original_path.to_string(),
+        params,
+        outlet: Box::new(move || Some(element(cx))),
+      }),
+    })
+  }
 
-    /// Returns the reactive scope of the current route.
-    pub fn cx(&self) -> Scope {
-        self.inner.cx
-    }
+  /// Returns the reactive scope of the current route.
+  pub fn cx(&self) -> Scope {
+    self.inner.cx
+  }
 
-    pub(crate) fn id(&self) -> usize {
-        self.inner.id
-    }
+  pub(crate) fn id(&self) -> usize {
+    self.inner.id
+  }
 
-    /// Returns the URL path of the current route,
-    /// including param values in their places.
-    ///
-    /// e.g., this will return `/article/0` rather than `/article/:id`.
-    /// For the opposite behavior, see [RouteContext::original_path].
-    pub fn path(&self) -> &str {
-        &self.inner.path
-    }
+  /// Returns the URL path of the current route,
+  /// including param values in their places.
+  ///
+  /// e.g., this will return `/article/0` rather than `/article/:id`.
+  /// For the opposite behavior, see [RouteContext::original_path].
+  pub fn path(&self) -> &str {
+    &self.inner.path
+  }
 
-    /// Returns the original URL path of the current route,
-    /// with the param name rather than the matched parameter itself.
-    ///
-    /// e.g., this will return `/article/:id` rather than `/article/0`
-    /// For the opposite behavior, see [RouteContext::path].
-    pub fn original_path(&self) -> &str {
-        &self.inner.original_path
-    }
+  /// Returns the original URL path of the current route,
+  /// with the param name rather than the matched parameter itself.
+  ///
+  /// e.g., this will return `/article/:id` rather than `/article/0`
+  /// For the opposite behavior, see [RouteContext::path].
+  pub fn original_path(&self) -> &str {
+    &self.inner.original_path
+  }
 
-    /// A reactive wrapper for the route parameters that are currently matched.
-    pub fn params(&self) -> Memo<ParamsMap> {
-        self.inner.params
-    }
+  /// A reactive wrapper for the route parameters that are currently matched.
+  pub fn params(&self) -> Memo<ParamsMap> {
+    self.inner.params
+  }
 
-    pub(crate) fn base(cx: Scope, path: &str, fallback: Option<fn() -> View>) -> Self {
-        Self {
-            inner: Rc::new(RouteContextInner {
-                cx,
-                id: 0,
-                base_path: path.to_string(),
-                child: Box::new(|| None),
-                path: path.to_string(),
-                original_path: path.to_string(),
-                params: create_memo(cx, |_| ParamsMap::new()),
-                outlet: Box::new(move || fallback.map(|f| f().into_view(cx))),
-            }),
-        }
+  pub(crate) fn base(
+    cx: Scope,
+    path: &str,
+    fallback: Option<fn(Scope) -> View>,
+  ) -> Self {
+    Self {
+      inner: Rc::new(RouteContextInner {
+        cx,
+        id: 0,
+        base_path: path.to_string(),
+        child: Box::new(|| None),
+        path: path.to_string(),
+        original_path: path.to_string(),
+        params: create_memo(cx, |_| ParamsMap::new()),
+        outlet: Box::new(move || fallback.map(|f| f(cx).into_view(cx))),
+      }),
     }
+  }
 
-    /// Resolves a relative route, relative to the current route's path.
-    pub fn resolve_path<'a>(&'a self, to: &'a str) -> Option<Cow<'a, str>> {
-        resolve_path(&self.inner.base_path, to, Some(&self.inner.path))
-    }
+  /// Resolves a relative route, relative to the current route's path.
+  pub fn resolve_path<'a>(&'a self, to: &'a str) -> Option<Cow<'a, str>> {
+    resolve_path(&self.inner.base_path, to, Some(&self.inner.path))
+  }
 
-    /// The nested child route, if any.
-    pub fn child(&self) -> Option<RouteContext> {
-        (self.inner.child)()
-    }
+  /// The nested child route, if any.
+  pub fn child(&self) -> Option<RouteContext> {
+    (self.inner.child)()
+  }
 
-    /// The view associated with the current route.
-    pub fn outlet(&self) -> impl IntoView {
-        (self.inner.outlet)()
-    }
+  /// The view associated with the current route.
+  pub fn outlet(&self) -> impl IntoView {
+    (self.inner.outlet)()
+  }
 }
 
 pub(crate) struct RouteContextInner {
-    cx: Scope,
-    base_path: String,
-    pub(crate) id: usize,
-    pub(crate) child: Box<dyn Fn() -> Option<RouteContext>>,
-    pub(crate) path: String,
-    pub(crate) original_path: String,
-    pub(crate) params: Memo<ParamsMap>,
-    pub(crate) outlet: Box<dyn Fn() -> Option<View>>,
+  cx: Scope,
+  base_path: String,
+  pub(crate) id: usize,
+  pub(crate) child: Box<dyn Fn() -> Option<RouteContext>>,
+  pub(crate) path: String,
+  pub(crate) original_path: String,
+  pub(crate) params: Memo<ParamsMap>,
+  pub(crate) outlet: Box<dyn Fn() -> Option<View>>,
 }
 
 impl PartialEq for RouteContextInner {
-    fn eq(&self, other: &Self) -> bool {
-        self.cx == other.cx
-            && self.base_path == other.base_path
-            && self.path == other.path
-            && self.original_path == other.original_path
-            && self.params == other.params
-    }
+  fn eq(&self, other: &Self) -> bool {
+    self.cx == other.cx
+      && self.base_path == other.base_path
+      && self.path == other.path
+      && self.original_path == other.original_path
+      && self.params == other.params
+  }
 }
 
 impl std::fmt::Debug for RouteContextInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RouteContextInner")
-            .field("path", &self.path)
-            .field("ParamsMap", &self.params)
-            .field("child", &(self.child)())
-            .finish()
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RouteContextInner")
+      .field("path", &self.path)
+      .field("ParamsMap", &self.params)
+      .field("child", &(self.child)())
+      .finish()
+  }
 }

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -1,418 +1,433 @@
-use cfg_if::cfg_if;
-use std::{cell::RefCell, rc::Rc};
-
-use leptos::*;
-use thiserror::Error;
-
+use crate::{
+  create_location,
+  matching::resolve_path,
+  Branch,
+  History,
+  Location,
+  LocationChange,
+  RouteContext,
+  RouterIntegrationContext,
+  State,
+};
 #[cfg(not(feature = "ssr"))]
-use wasm_bindgen::JsCast;
-
+use crate::{
+  unescape,
+  Url,
+};
+use cfg_if::cfg_if;
+use leptos::*;
 #[cfg(feature = "transition")]
 use leptos_reactive::use_transition;
-
-use crate::{
-    create_location, matching::resolve_path, Branch, History, Location, LocationChange,
-    RouteContext, RouterIntegrationContext, State,
+use std::{
+  cell::RefCell,
+  rc::Rc,
 };
-
+use thiserror::Error;
 #[cfg(not(feature = "ssr"))]
-use crate::{unescape, Url};
+use wasm_bindgen::JsCast;
 
 /// Provides for client-side and server-side routing. This should usually be somewhere near
 /// the root of the application.
 #[component]
 pub fn Router(
-    cx: Scope,
-    /// The base URL for the router. Defaults to "".
-    #[prop(optional)]
-    base: Option<&'static str>,
-    /// A fallback that should be shown if no route is matched.
-    #[prop(optional)]
-    fallback: Option<fn() -> View>,
-    /// The `<Router/>` should usually wrap your whole page. It can contain
-    /// any elements, and should include a [Routes](crate::Routes) component somewhere
-    /// to define and display [Route](crate::Route)s.
-    children: Box<dyn FnOnce(Scope) -> Fragment>,
+  cx: Scope,
+  /// The base URL for the router. Defaults to "".
+  #[prop(optional)]
+  base: Option<&'static str>,
+  /// A fallback that should be shown if no route is matched.
+  #[prop(optional)]
+  fallback: Option<fn(Scope) -> View>,
+  /// The `<Router/>` should usually wrap your whole page. It can contain
+  /// any elements, and should include a [Routes](crate::Routes) component somewhere
+  /// to define and display [Route](crate::Route)s.
+  children: Box<dyn FnOnce(Scope) -> Fragment>,
 ) -> impl IntoView {
-    // create a new RouterContext and provide it to every component beneath the router
-    let router = RouterContext::new(cx, base, fallback);
-    provide_context(cx, router);
+  // create a new RouterContext and provide it to every component beneath the router
+  let router = RouterContext::new(cx, base, fallback);
+  provide_context(cx, router);
 
-    children(cx)
+  children(cx)
 }
 
 /// Context type that contains information about the current router state.
 #[derive(Debug, Clone)]
 pub struct RouterContext {
-    pub(crate) inner: Rc<RouterContextInner>,
+  pub(crate) inner: Rc<RouterContextInner>,
 }
 pub(crate) struct RouterContextInner {
-    pub location: Location,
-    pub base: RouteContext,
-    pub possible_routes: RefCell<Option<Vec<Branch>>>,
-    #[allow(unused)] // used in CSR/hydrate
-    base_path: String,
-    history: Box<dyn History>,
-    cx: Scope,
-    reference: ReadSignal<String>,
-    set_reference: WriteSignal<String>,
-    referrers: Rc<RefCell<Vec<LocationChange>>>,
-    state: ReadSignal<State>,
-    set_state: WriteSignal<State>,
+  pub location: Location,
+  pub base: RouteContext,
+  pub possible_routes: RefCell<Option<Vec<Branch>>>,
+  #[allow(unused)] // used in CSR/hydrate
+  base_path: String,
+  history: Box<dyn History>,
+  cx: Scope,
+  reference: ReadSignal<String>,
+  set_reference: WriteSignal<String>,
+  referrers: Rc<RefCell<Vec<LocationChange>>>,
+  state: ReadSignal<State>,
+  set_state: WriteSignal<State>,
 }
 
 impl std::fmt::Debug for RouterContextInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("RouterContextInner")
-            .field("location", &self.location)
-            .field("base", &self.base)
-            .field("cx", &self.cx)
-            .field("reference", &self.reference)
-            .field("set_reference", &self.set_reference)
-            .field("referrers", &self.referrers)
-            .field("state", &self.state)
-            .field("set_state", &self.set_state)
-            .finish()
-    }
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RouterContextInner")
+      .field("location", &self.location)
+      .field("base", &self.base)
+      .field("cx", &self.cx)
+      .field("reference", &self.reference)
+      .field("set_reference", &self.set_reference)
+      .field("referrers", &self.referrers)
+      .field("state", &self.state)
+      .field("set_state", &self.set_state)
+      .finish()
+  }
 }
 
 impl RouterContext {
-    pub(crate) fn new(
-        cx: Scope,
-        base: Option<&'static str>,
-        fallback: Option<fn() -> View>,
-    ) -> Self {
-        cfg_if! {
-            if #[cfg(any(feature = "csr", feature = "hydrate"))] {
-                let history = use_context::<RouterIntegrationContext>(cx)
-                    .unwrap_or_else(|| RouterIntegrationContext(Rc::new(crate::BrowserIntegration {})));
-            } else {
-                let history = use_context::<RouterIntegrationContext>(cx).unwrap_or_else(|| {
-                    let msg = "No router integration found.\n\nIf you are using this in the browser, \
-                        you should enable `feature = [\"csr\"]` or `feature = [\"hydrate\"] in your \
-                        `leptos_router` import.\n\nIf you are using this on the server without a \
-                        Leptos server integration, you must call provide_context::<RouterIntegrationContext>(cx, ...) \
-                        somewhere above the <Router/>.";
-                    leptos::debug_warn!("{}", msg);
-                    panic!("{}", msg);
-                });
-            }
-        };
-
-        // Any `History` type gives a way to get a reactive signal of the current location
-        // in the browser context, this is drawn from the `popstate` event
-        // different server adapters can provide different `History` implementations to allow server routing
-        let source = history.location(cx);
-
-        // if initial route is empty, redirect to base path, if it exists
-        let base = base.unwrap_or_default();
-        let base_path = resolve_path("", base, None);
-
-        if let Some(base_path) = &base_path {
-            if source.with(|s| s.value.is_empty()) {
-                history.navigate(&LocationChange {
-                    value: base_path.to_string(),
-                    replace: true,
-                    scroll: false,
-                    state: State(None),
-                });
-            }
-        }
-
-        // the current URL
-        let (reference, set_reference) = create_signal(cx, source.with(|s| s.value.clone()));
-
-        // the current History.state
-        let (state, set_state) = create_signal(cx, source.with(|s| s.state.clone()));
-
-        // we'll use this transition to wait for async resources to load when navigating to a new route
-        #[cfg(feature = "transition")]
-        let transition = use_transition(cx);
-
-        // Each field of `location` reactively represents a different part of the current location
-        let location = create_location(cx, reference, state);
-        let referrers: Rc<RefCell<Vec<LocationChange>>> = Rc::new(RefCell::new(Vec::new()));
-
-        // Create base route with fallback element
-        let base_path = base_path.unwrap_or_default();
-        let base = RouteContext::base(cx, &base_path, fallback);
-
-        // Every time the History gives us a new location,
-        // 1) start a transition
-        // 2) update the reference (URL)
-        // 3) update the state
-        // this will trigger the new route match below
-        create_render_effect(cx, move |_| {
-            let LocationChange { value, state, .. } = source.get();
-            cx.untrack(move || {
-                if value != reference.get() {
-                    set_reference.update(move |r| *r = value);
-                    set_state.update(move |s| *s = state);
-                }
+  pub(crate) fn new(
+    cx: Scope,
+    base: Option<&'static str>,
+    fallback: Option<fn(Scope) -> View>,
+  ) -> Self {
+    cfg_if! {
+        if #[cfg(any(feature = "csr", feature = "hydrate"))] {
+            let history = use_context::<RouterIntegrationContext>(cx)
+                .unwrap_or_else(|| RouterIntegrationContext(Rc::new(crate::BrowserIntegration {})));
+        } else {
+            let history = use_context::<RouterIntegrationContext>(cx).unwrap_or_else(|| {
+                let msg = "No router integration found.\n\nIf you are using this in the browser, \
+                    you should enable `feature = [\"csr\"]` or `feature = [\"hydrate\"] in your \
+                    `leptos_router` import.\n\nIf you are using this on the server without a \
+                    Leptos server integration, you must call provide_context::<RouterIntegrationContext>(cx, ...) \
+                    somewhere above the <Router/>.";
+                leptos::debug_warn!("{}", msg);
+                panic!("{}", msg);
             });
+        }
+    };
+
+    // Any `History` type gives a way to get a reactive signal of the current location
+    // in the browser context, this is drawn from the `popstate` event
+    // different server adapters can provide different `History` implementations to allow server routing
+    let source = history.location(cx);
+
+    // if initial route is empty, redirect to base path, if it exists
+    let base = base.unwrap_or_default();
+    let base_path = resolve_path("", base, None);
+
+    if let Some(base_path) = &base_path {
+      if source.with(|s| s.value.is_empty()) {
+        history.navigate(&LocationChange {
+          value: base_path.to_string(),
+          replace: true,
+          scroll: false,
+          state: State(None),
         });
-
-        let inner = Rc::new(RouterContextInner {
-            base_path: base_path.into_owned(),
-            location,
-            base,
-            history: Box::new(history),
-            cx,
-            reference,
-            set_reference,
-            referrers,
-            state,
-            set_state,
-            possible_routes: Default::default(),
-        });
-
-        // handle all click events on anchor tags
-        #[cfg(not(feature = "ssr"))]
-        leptos_dom::window_event_listener("click", {
-            let inner = Rc::clone(&inner);
-            move |ev| inner.clone().handle_anchor_click(ev)
-        });
-        // TODO on_cleanup remove event listener
-
-        Self { inner }
+      }
     }
 
-    /// The current [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname).
-    pub fn pathname(&self) -> Memo<String> {
-        self.inner.location.pathname
-    }
+    // the current URL
+    let (reference, set_reference) =
+      create_signal(cx, source.with(|s| s.value.clone()));
 
-    /// The [RouteContext] of the base route.
-    pub fn base(&self) -> RouteContext {
-        self.inner.base.clone()
-    }
+    // the current History.state
+    let (state, set_state) =
+      create_signal(cx, source.with(|s| s.state.clone()));
 
-    /// A list of all possible routes this router can match.
-    pub fn possible_branches(&self) -> Vec<Branch> {
-        self.inner
-            .possible_routes
-            .borrow()
-            .clone()
-            .unwrap_or_default()
-    }
+    // we'll use this transition to wait for async resources to load when navigating to a new route
+    #[cfg(feature = "transition")]
+    let transition = use_transition(cx);
+
+    // Each field of `location` reactively represents a different part of the current location
+    let location = create_location(cx, reference, state);
+    let referrers: Rc<RefCell<Vec<LocationChange>>> =
+      Rc::new(RefCell::new(Vec::new()));
+
+    // Create base route with fallback element
+    let base_path = base_path.unwrap_or_default();
+    let base = RouteContext::base(cx, &base_path, fallback);
+
+    // Every time the History gives us a new location,
+    // 1) start a transition
+    // 2) update the reference (URL)
+    // 3) update the state
+    // this will trigger the new route match below
+    create_render_effect(cx, move |_| {
+      let LocationChange { value, state, .. } = source.get();
+      cx.untrack(move || {
+        if value != reference.get() {
+          set_reference.update(move |r| *r = value);
+          set_state.update(move |s| *s = state);
+        }
+      });
+    });
+
+    let inner = Rc::new(RouterContextInner {
+      base_path: base_path.into_owned(),
+      location,
+      base,
+      history: Box::new(history),
+      cx,
+      reference,
+      set_reference,
+      referrers,
+      state,
+      set_state,
+      possible_routes: Default::default(),
+    });
+
+    // handle all click events on anchor tags
+    #[cfg(not(feature = "ssr"))]
+    leptos_dom::window_event_listener("click", {
+      let inner = Rc::clone(&inner);
+      move |ev| inner.clone().handle_anchor_click(ev)
+    });
+    // TODO on_cleanup remove event listener
+
+    Self { inner }
+  }
+
+  /// The current [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/Location/pathname).
+  pub fn pathname(&self) -> Memo<String> {
+    self.inner.location.pathname
+  }
+
+  /// The [RouteContext] of the base route.
+  pub fn base(&self) -> RouteContext {
+    self.inner.base.clone()
+  }
+
+  /// A list of all possible routes this router can match.
+  pub fn possible_branches(&self) -> Vec<Branch> {
+    self
+      .inner
+      .possible_routes
+      .borrow()
+      .clone()
+      .unwrap_or_default()
+  }
 }
 
 impl RouterContextInner {
-    pub(crate) fn navigate_from_route(
-        self: Rc<Self>,
-        to: &str,
-        options: &NavigateOptions,
-    ) -> Result<(), NavigationError> {
-        let cx = self.cx;
-        let this = Rc::clone(&self);
+  pub(crate) fn navigate_from_route(
+    self: Rc<Self>,
+    to: &str,
+    options: &NavigateOptions,
+  ) -> Result<(), NavigationError> {
+    let cx = self.cx;
+    let this = Rc::clone(&self);
 
-        cx.untrack(move || {
-            let resolved_to = if options.resolve {
-                this.base.resolve_path(to)
+    cx.untrack(move || {
+      let resolved_to = if options.resolve {
+        this.base.resolve_path(to)
+      } else {
+        resolve_path("", to, None)
+      };
+
+      match resolved_to {
+        None => Err(NavigationError::NotRoutable(to.to_string())),
+        Some(resolved_to) => {
+          let resolved_to = resolved_to.to_string();
+          if self.referrers.borrow().len() > 32 {
+            return Err(NavigationError::MaxRedirects);
+          }
+
+          if resolved_to != this.reference.get()
+            || options.state != (this.state).get()
+          {
+            if cfg!(feature = "server") {
+              self.history.navigate(&LocationChange {
+                value: resolved_to,
+                replace: options.replace,
+                scroll: options.scroll,
+                state: options.state.clone(),
+              });
             } else {
-                resolve_path("", to, None)
-            };
-
-            match resolved_to {
-                None => Err(NavigationError::NotRoutable(to.to_string())),
-                Some(resolved_to) => {
-                    let resolved_to = resolved_to.to_string();
-                    if self.referrers.borrow().len() > 32 {
-                        return Err(NavigationError::MaxRedirects);
-                    }
-
-                    if resolved_to != this.reference.get() || options.state != (this.state).get() {
-                        if cfg!(feature = "server") {
-                            self.history.navigate(&LocationChange {
-                                value: resolved_to,
-                                replace: options.replace,
-                                scroll: options.scroll,
-                                state: options.state.clone(),
-                            });
-                        } else {
-                            {
-                                self.referrers.borrow_mut().push(LocationChange {
-                                    value: self.reference.get(),
-                                    replace: options.replace,
-                                    scroll: options.scroll,
-                                    state: self.state.get(),
-                                });
-                            }
-                            let len = self.referrers.borrow().len();
-
-                            #[cfg(feature = "transition")]
-                            let transition = use_transition(self.cx);
-                            //transition.start({
-                            let set_reference = self.set_reference;
-                            let set_state = self.set_state;
-                            let referrers = self.referrers.clone();
-                            let this = Rc::clone(&self);
-                            //move || {
-
-                            let resolved = resolved_to.to_string();
-                            let state = options.state.clone();
-                            queue_microtask(move || {
-                                set_reference.update(move |r| *r = resolved);
-
-                                set_state.update({
-                                    let next_state = state.clone();
-                                    move |state| *state = next_state
-                                });
-                                if referrers.borrow().len() == len {
-                                    this.navigate_end(LocationChange {
-                                        value: resolved_to.to_string(),
-                                        replace: false,
-                                        scroll: true,
-                                        state,
-                                    })
-                                    //}
-                                }
-                            });
-                            //});
-                        }
-                    }
-
-                    Ok(())
-                }
-            }
-        })
-    }
-
-    pub(crate) fn navigate_end(self: Rc<Self>, mut next: LocationChange) {
-        let first = self.referrers.borrow().get(0).cloned();
-        if let Some(first) = first {
-            if next.value != first.value || next.state != first.state {
-                next.replace = first.replace;
-                next.scroll = first.scroll;
-                self.history.navigate(&next);
-            }
-            self.referrers.borrow_mut().clear();
-        }
-    }
-
-    #[cfg(not(feature = "ssr"))]
-    pub(crate) fn handle_anchor_click(self: Rc<Self>, ev: web_sys::Event) {
-        let ev = ev.unchecked_into::<web_sys::MouseEvent>();
-        if ev.default_prevented()
-            || ev.button() != 0
-            || ev.meta_key()
-            || ev.alt_key()
-            || ev.ctrl_key()
-            || ev.shift_key()
-        {
-            return;
-        }
-
-        let composed_path = ev.composed_path();
-        let mut a: Option<web_sys::HtmlAnchorElement> = None;
-        for i in 0..composed_path.length() {
-            if let Ok(el) = composed_path
-                .get(i)
-                .dyn_into::<web_sys::HtmlAnchorElement>()
-            {
-                a = Some(el);
-            }
-        }
-        if let Some(a) = a {
-            let href = a.href();
-            let target = a.target();
-
-            // let browser handle this event if link has target,
-            // or if it doesn't have href or state
-            // TODO "state" is set as a prop, not an attribute
-            if !target.is_empty() || (href.is_empty() && !a.has_attribute("state")) {
-                return;
-            }
-
-            let rel = a.get_attribute("rel").unwrap_or_default();
-            let mut rel = rel.split([' ', '\t']);
-
-            // let browser handle event if it has rel=external or download
-            if a.has_attribute("download") || rel.any(|p| p == "external") {
-                return;
-            }
-
-            let url = Url::try_from(href.as_str()).unwrap();
-            let path_name = unescape(&url.pathname);
-
-            // let browser handle this event if it leaves our domain
-            // or our base path
-            if url.origin != leptos_dom::location().origin().unwrap_or_default()
-                || (!self.base_path.is_empty()
-                    && !path_name.is_empty()
-                    && !path_name
-                        .to_lowercase()
-                        .starts_with(&self.base_path.to_lowercase()))
-            {
-                return;
-            }
-
-            let to = path_name + &unescape(&url.search) + &unescape(&url.hash);
-            let state = get_property(a.unchecked_ref(), "state")
-                .ok()
-                .and_then(|value| {
-                    if value == wasm_bindgen::JsValue::UNDEFINED {
-                        None
-                    } else {
-                        Some(value)
-                    }
+              {
+                self.referrers.borrow_mut().push(LocationChange {
+                  value: self.reference.get(),
+                  replace: options.replace,
+                  scroll: options.scroll,
+                  state: self.state.get(),
                 });
+              }
+              let len = self.referrers.borrow().len();
 
-            ev.prevent_default();
+              #[cfg(feature = "transition")]
+              let transition = use_transition(self.cx);
+              //transition.start({
+              let set_reference = self.set_reference;
+              let set_state = self.set_state;
+              let referrers = self.referrers.clone();
+              let this = Rc::clone(&self);
+              //move || {
 
-            let replace = get_property(a.unchecked_ref(), "replace")
-                .ok()
-                .and_then(|value| value.as_bool())
-                .unwrap_or(false);
-            if let Err(e) = self.navigate_from_route(
-                &to,
-                &NavigateOptions {
-                    resolve: false,
-                    replace,
-                    scroll: !a.has_attribute("noscroll"),
-                    state: State(state),
-                },
-            ) {
-                log::error!("{e:#?}");
+              let resolved = resolved_to.to_string();
+              let state = options.state.clone();
+              queue_microtask(move || {
+                set_reference.update(move |r| *r = resolved);
+
+                set_state.update({
+                  let next_state = state.clone();
+                  move |state| *state = next_state
+                });
+                if referrers.borrow().len() == len {
+                  this.navigate_end(LocationChange {
+                    value: resolved_to.to_string(),
+                    replace: false,
+                    scroll: true,
+                    state,
+                  })
+                  //}
+                }
+              });
+              //});
             }
+          }
+
+          Ok(())
         }
+      }
+    })
+  }
+
+  pub(crate) fn navigate_end(self: Rc<Self>, mut next: LocationChange) {
+    let first = self.referrers.borrow().get(0).cloned();
+    if let Some(first) = first {
+      if next.value != first.value || next.state != first.state {
+        next.replace = first.replace;
+        next.scroll = first.scroll;
+        self.history.navigate(&next);
+      }
+      self.referrers.borrow_mut().clear();
     }
+  }
+
+  #[cfg(not(feature = "ssr"))]
+  pub(crate) fn handle_anchor_click(self: Rc<Self>, ev: web_sys::Event) {
+    let ev = ev.unchecked_into::<web_sys::MouseEvent>();
+    if ev.default_prevented()
+      || ev.button() != 0
+      || ev.meta_key()
+      || ev.alt_key()
+      || ev.ctrl_key()
+      || ev.shift_key()
+    {
+      return;
+    }
+
+    let composed_path = ev.composed_path();
+    let mut a: Option<web_sys::HtmlAnchorElement> = None;
+    for i in 0..composed_path.length() {
+      if let Ok(el) = composed_path
+        .get(i)
+        .dyn_into::<web_sys::HtmlAnchorElement>()
+      {
+        a = Some(el);
+      }
+    }
+    if let Some(a) = a {
+      let href = a.href();
+      let target = a.target();
+
+      // let browser handle this event if link has target,
+      // or if it doesn't have href or state
+      // TODO "state" is set as a prop, not an attribute
+      if !target.is_empty() || (href.is_empty() && !a.has_attribute("state")) {
+        return;
+      }
+
+      let rel = a.get_attribute("rel").unwrap_or_default();
+      let mut rel = rel.split([' ', '\t']);
+
+      // let browser handle event if it has rel=external or download
+      if a.has_attribute("download") || rel.any(|p| p == "external") {
+        return;
+      }
+
+      let url = Url::try_from(href.as_str()).unwrap();
+      let path_name = unescape(&url.pathname);
+
+      // let browser handle this event if it leaves our domain
+      // or our base path
+      if url.origin != leptos_dom::location().origin().unwrap_or_default()
+        || (!self.base_path.is_empty()
+          && !path_name.is_empty()
+          && !path_name
+            .to_lowercase()
+            .starts_with(&self.base_path.to_lowercase()))
+      {
+        return;
+      }
+
+      let to = path_name + &unescape(&url.search) + &unescape(&url.hash);
+      let state =
+        get_property(a.unchecked_ref(), "state")
+          .ok()
+          .and_then(|value| {
+            if value == wasm_bindgen::JsValue::UNDEFINED {
+              None
+            } else {
+              Some(value)
+            }
+          });
+
+      ev.prevent_default();
+
+      let replace = get_property(a.unchecked_ref(), "replace")
+        .ok()
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false);
+      if let Err(e) = self.navigate_from_route(
+        &to,
+        &NavigateOptions {
+          resolve: false,
+          replace,
+          scroll: !a.has_attribute("noscroll"),
+          state: State(state),
+        },
+      ) {
+        log::error!("{e:#?}");
+      }
+    }
+  }
 }
 
 /// An error that occurs during navigation.
 #[derive(Debug, Error)]
 pub enum NavigationError {
-    /// The given path is not routable.
-    #[error("Path {0:?} is not routable")]
-    NotRoutable(String),
-    /// Too many redirects occurred during routing (prevents and infinite loop.)
-    #[error("Too many redirects")]
-    MaxRedirects,
+  /// The given path is not routable.
+  #[error("Path {0:?} is not routable")]
+  NotRoutable(String),
+  /// Too many redirects occurred during routing (prevents and infinite loop.)
+  #[error("Too many redirects")]
+  MaxRedirects,
 }
 
 /// Options that can be used to configure a navigation. Used with [use_navigate](crate::use_navigate).
 #[derive(Clone, Debug)]
 pub struct NavigateOptions {
-    /// Whether the URL being navigated to should be resolved relative to the current route.
-    pub resolve: bool,
-    /// If `true` the new location will replace the current route in the history stack, meaning
-    /// the "back" button will skip over the current route. (Defaults to `false`).
-    pub replace: bool,
-    /// If `true`, the router will scroll to the top of the window at the end of navigation.
-    /// Defaults to `true.
-    pub scroll: bool,
-    /// [State](https://developer.mozilla.org/en-US/docs/Web/API/History/state) that should be pushed
-    /// onto the history stack during navigation.
-    pub state: State,
+  /// Whether the URL being navigated to should be resolved relative to the current route.
+  pub resolve: bool,
+  /// If `true` the new location will replace the current route in the history stack, meaning
+  /// the "back" button will skip over the current route. (Defaults to `false`).
+  pub replace: bool,
+  /// If `true`, the router will scroll to the top of the window at the end of navigation.
+  /// Defaults to `true.
+  pub scroll: bool,
+  /// [State](https://developer.mozilla.org/en-US/docs/Web/API/History/state) that should be pushed
+  /// onto the history stack during navigation.
+  pub state: State,
 }
 
 impl Default for NavigateOptions {
-    fn default() -> Self {
-        Self {
-            resolve: true,
-            replace: false,
-            scroll: true,
-            state: State(None),
-        }
+  fn default() -> Self {
+    Self {
+      resolve: true,
+      replace: false,
+      scroll: true,
+      state: State(None),
     }
+  }
 }


### PR DESCRIPTION
Since `fallback` doesn't provide a `Scope` to the view function, there's no way for the view function to return any view that is not `View::Unit`, or `View::Text`, as the `fallback` must be a function pointer, and not a closure. Therefore `Scope` can't be grandfathered in from it's environment.