### PR TITLE
Make sure Axum returns a relative URI for http and https requests

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -323,7 +323,12 @@ where
                 // Need to get the path and query string of the Request
                 let path = req.uri();
 
-                let full_path = format!("http://leptos.dev{path}");
+                // For reasons that escape me, if the incoming URI protocol is https, it provides the absolute URI
+                // if http, it returns a relative path
+                let full_path = match path.to_string().starts_with("https") {
+                    true => path.to_string(),
+                    false => format!("http://leptos.dev{path}"),
+                };
 
                 let pkg_path = &options.site_pkg_dir;
                 let output_name = &options.output_name;

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -321,14 +321,11 @@ where
 
             async move {
                 // Need to get the path and query string of the Request
-                let path = req.uri();
-
                 // For reasons that escape me, if the incoming URI protocol is https, it provides the absolute URI
-                // if http, it returns a relative path
-                let full_path = match path.to_string().starts_with("https") {
-                    true => path.to_string(),
-                    false => format!("http://leptos.dev{path}"),
-                };
+                // if http, it returns a relative path. Adding .path() seems to make it explicitly return the relative uri
+                let path = req.uri().path();
+
+                let full_path = format!("http://leptos.dev{path}");
 
                 let pkg_path = &options.site_pkg_dir;
                 let output_name = &options.output_name;


### PR DESCRIPTION
For some odd reason, the `.uri()` method returns an absolute URI when given an https address, and a relative one with http. This caused routing errors for https paths, and this change will fix it.