### PR TITLE
Minor: For each sub crate the landing page should be the root README.md.

### DIFF
--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Configuraiton for the Leptos web framework."
+readme = "../README.md"
 
 [dependencies]
 config = "0.13.3"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "view macro for the Leptos web framework."
+readme = "../README.md"
 
 [lib]
 proc-macro = true

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/gbj/leptos"
 description = "RPC for the Leptos web framework."
+readme = "../README.md"
 
 [dependencies]
 leptos_dom = { workspace = true }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"
+README = "../README.md"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Router for the Leptos web framework."
 


### PR DESCRIPTION
This fixes 317

https://crates.io/crates/leptos_router

is bare ...  we are missing a link the the root README.md