### PR TITLE
typed-builder inconsistent version.

### DIFF
--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -13,4 +13,4 @@ fs = "0.0.5"
 regex = "1.7.0"
 serde = { version = "1.0.151", features = ["derive"] }
 thiserror = "1.0.38"
-typed-builder = "0.11.0"
+typed-builder = "0.11"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -29,7 +29,7 @@ lazy_static = "1.4"
 
 [dev-dependencies]
 log = "0.4"
-typed-builder = "0.10"
+typed-builder = "0.11"
 leptos = { path = "../leptos" }
 
 [features]


### PR DESCRIPTION
This is really minor.

typed-builder is used in 4 sub crates, it looks like there is a small oversight.

3 crates use 

```
typed-builder = "0.11"
```

1 crate 
```
typed-builder = "0.10"
```

"One of these kids is doing his own thing."

