### PR TITLE
doc: add link for leptos watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ cd [your project name]
 cargo leptos watch
 ```
 
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 ## FAQs
 
 ### Can I use this for native GUI?

--- a/examples/counter_isomorphic/README.md
+++ b/examples/counter_isomorphic/README.md
@@ -17,6 +17,9 @@ cargo install --locked cargo-leptos
 ```bash
 cargo leptos watch
 ```
+
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 3. When ready to deploy, run
 ```bash
 cargo leptos build --release

--- a/examples/hackernews/README.md
+++ b/examples/hackernews/README.md
@@ -17,6 +17,9 @@ cargo install --locked cargo-leptos
 ```bash
 cargo leptos watch
 ```
+
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 3. When ready to deploy, run
 ```bash
 cargo leptos build --release

--- a/examples/hackernews_axum/README.md
+++ b/examples/hackernews_axum/README.md
@@ -17,6 +17,9 @@ cargo install --locked cargo-leptos
 ```bash
 cargo leptos watch
 ```
+
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 3. When ready to deploy, run
 ```bash
 cargo leptos build --release

--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -16,6 +16,8 @@ and
 
 in this directory.
 
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 You can begin editing your app at `src/app.rs`.
 
 ## Installing Tailwind

--- a/examples/todo_app_sqlite/README.md
+++ b/examples/todo_app_sqlite/README.md
@@ -17,6 +17,9 @@ cargo install --locked cargo-leptos
 ```bash
 cargo leptos watch
 ```
+
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 3. When ready to deploy, run
 ```bash
 cargo leptos build --release

--- a/examples/todo_app_sqlite_axum/README.md
+++ b/examples/todo_app_sqlite_axum/README.md
@@ -17,6 +17,9 @@ cargo install --locked cargo-leptos
 ```bash
 cargo leptos watch
 ```
+
+Open browser on [http://localhost:3000/](http://localhost:3000/)
+
 3. When ready to deploy, run
 ```bash
 cargo leptos build --release


### PR DESCRIPTION
Why:
- didn't know when reading the documentation if I had to serve the app myself or if it was listening on a port

What was done:
- Explain to open browser on localhost:3000 after leptos watch