### PR TITLE
Clippy fixes: redundant clone and .to_string() issues.

### DIFF
--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -132,5 +132,5 @@ where
         _ => unreachable!(),
     };
 
-    leptos_dom::View::Suspense(current_id.clone(), core_component)
+    leptos_dom::View::Suspense(current_id, core_component)
 }

--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -20,7 +20,7 @@ where
           Some(errors) => {
             let id = HydrationCtx::id();
             errors.update({
-              let id = id.clone();
+              let id = id;
               move |errors: &mut Errors| errors.insert(id, error)
             });
 

--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -19,10 +19,7 @@ where
         match use_context::<RwSignal<Errors>>(cx) {
           Some(errors) => {
             let id = HydrationCtx::id();
-            errors.update({
-              let id = id;
-              move |errors: &mut Errors| errors.insert(id, error)
-            });
+            errors.update(move |errors: &mut Errors| errors.insert(id, error));
 
             // remove the error from the list if this drops,
             // i.e., if it's in a DynChild that switches from Err to Ok

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -99,7 +99,7 @@ impl RouteContext {
             inner: Rc::new(RouteContextInner {
                 cx,
                 id,
-                base_path: base.to_string(),
+                base_path: base,
                 child: Box::new(child),
                 path: RefCell::new(path),
                 original_path: route.original_path.to_string(),

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -216,7 +216,6 @@ impl RouterContextInner {
             match resolved_to {
                 None => Err(NavigationError::NotRoutable(to.to_string())),
                 Some(resolved_to) => {
-                    let resolved_to = resolved_to;
                     if self.referrers.borrow().len() > 32 {
                         return Err(NavigationError::MaxRedirects);
                     }

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -216,7 +216,7 @@ impl RouterContextInner {
             match resolved_to {
                 None => Err(NavigationError::NotRoutable(to.to_string())),
                 Some(resolved_to) => {
-                    let resolved_to = resolved_to.to_string();
+                    let resolved_to = resolved_to;
                     if self.referrers.borrow().len() > 32 {
                         return Err(NavigationError::MaxRedirects);
                     }


### PR DESCRIPTION
There have been lots of improvements recently

Clippy is very good at spotting redundant .clone() calls, which I think are always good to removed, without spending the time to see if they are on a hot code path or not.

Might as well fix some reported .to_string() while I see them.

