### PR TITLE
Allow snake case components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ blob.rs
 Cargo.lock
 **/*.rs.bk
 .DS_Store
+.idea

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -57,6 +57,40 @@ fn ssr_test_with_components() {
 
 #[cfg(not(any(feature = "csr", feature = "hydrate")))]
 #[test]
+fn ssr_test_with_snake_case_components() {
+    use leptos::*;
+
+    #[component]
+    fn snake_case_counter(cx: Scope, initial_value: i32) -> impl IntoView {
+        let (value, set_value) = create_signal(cx, initial_value);
+        view! {
+            cx,
+            <div>
+                <button on:click=move |_| set_value.update(|value| *value -= 1)>"-1"</button>
+                <span>"Value: " {move || value.get().to_string()} "!"</span>
+                <button on:click=move |_| set_value.update(|value| *value += 1)>"+1"</button>
+            </div>
+        }
+    }
+
+    _ = create_scope(create_runtime(), |cx| {
+        let rendered = view! {
+            cx,
+            <div class="counters">
+                <SnakeCaseCounter initial_value=1/>
+                <SnakeCaseCounter initial_value=2/>
+            </div>
+        };
+
+        assert_eq!(
+            rendered.into_view(cx).render_to_string(cx),
+            "<div id=\"_0-1\" class=\"counters\"><!--hk=_0-1-0o|leptos-snake-case-counter-start--><div id=\"_0-1-1\"><button id=\"_0-1-2\">-1</button><span id=\"_0-1-3\">Value: <!--hk=_0-1-4o|leptos-dyn-child-start-->1<!--hk=_0-1-4c|leptos-dyn-child-end-->!</span><button id=\"_0-1-5\">+1</button></div><!--hk=_0-1-0c|leptos-snake-case-counter-end--><!--hk=_0-1-5-0o|leptos-snake-case-counter-start--><div id=\"_0-1-5-1\"><button id=\"_0-1-5-2\">-1</button><span id=\"_0-1-5-3\">Value: <!--hk=_0-1-5-4o|leptos-dyn-child-start-->2<!--hk=_0-1-5-4c|leptos-dyn-child-end-->!</span><button id=\"_0-1-5-5\">+1</button></div><!--hk=_0-1-5-0c|leptos-snake-case-counter-end--></div>"
+        );
+    });
+}
+
+#[cfg(not(any(feature = "csr", feature = "hydrate")))]
+#[test]
 fn test_classes() {
     use leptos::*;
 

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -27,6 +27,7 @@ leptos_dom = { workspace = true }
 leptos_reactive = { workspace = true }
 leptos_server = { workspace = true }
 lazy_static = "1.4"
+convert_case = "0.6.0"
 
 [dev-dependencies]
 log = "0.4"

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1,3 +1,4 @@
+use convert_case::{Case::{Snake, Pascal}, Casing};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, ToTokens, TokenStreamExt};
@@ -75,7 +76,7 @@ impl Parse for Model {
             is_transparent: false,
             docs,
             vis: item.vis.clone(),
-            name: item.sig.ident.clone(),
+            name: convert_from_snake_case(&item.sig.ident),
             scope_name,
             props,
             ret: item.sig.output.clone(),
@@ -94,6 +95,15 @@ fn drain_filter<T>(vec: &mut Vec<T>, mut some_predicate: impl FnMut(&mut T) -> b
         } else {
             i += 1;
         }
+    }
+}
+
+fn convert_from_snake_case(name: &Ident) -> Ident {
+    let name_str = name.to_string();
+    if !name_str.is_case(Snake) {
+        name.clone()
+    } else {
+        Ident::new(&*name_str.to_case(Pascal), name.span().clone())
     }
 }
 

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1,4 +1,7 @@
-use convert_case::{Case::{Snake, Pascal}, Casing};
+use convert_case::{
+    Case::{Pascal, Snake},
+    Casing,
+};
 use itertools::Itertools;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, ToTokens, TokenStreamExt};

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -324,16 +324,18 @@ pub fn view(tokens: TokenStream) -> TokenStream {
 ///    to do relatively expensive work within the component function, as it will only happen once,
 ///    not on every state change.
 ///
-/// 2. The component name should be `CamelCase` instead of `snake_case`. This is how the renderer
-///    recognizes that a particular tag is a component, not an HTML element.
+/// 2. If a `snake_case` name is used, then the generated component's name will still be in
+///    `CamelCase`. This is how the renderer recognizes that a particular tag is a component, not
+///    an HTML element. It's important to be aware of this when using or importing the component.
 ///
 /// ```
 /// # use leptos::*;
-/// // ❌ not snake_case
-/// #[component]
-/// fn my_component(cx: Scope) -> impl IntoView { todo!() }
 ///
-/// // ✅ CamelCase
+/// // snake_case: Generated component will be called MySnakeCaseComponent
+/// #[component]
+/// fn my_snake_case_component(cx: Scope) -> impl IntoView { todo!() }
+///
+/// // CamelCase: Generated component will be called MyComponent
 /// #[component]
 /// fn MyComponent(cx: Scope) -> impl IntoView { todo!() }
 /// ```
@@ -352,6 +354,18 @@ pub fn view(tokens: TokenStream) -> TokenStream {
 ///
 ///   #[component]
 ///   pub fn MyComponent(cx: Scope) -> impl IntoView { todo!() }
+/// }
+/// ```
+/// ```
+/// # use leptos::*;
+///
+/// use snake_case_component::{MySnakeCaseComponent, MySnakeCaseComponentProps};
+///
+/// mod snake_case_component {
+///   use leptos::*;
+///
+///   #[component]
+///   pub fn my_snake_case_component(cx: Scope) -> impl IntoView { todo!() }
 /// }
 /// ```
 ///


### PR DESCRIPTION
Couldn't find any guides for external contributor PRs, so I'm winging this a bit. 

# What?
- Allow `snake_case` functions to be used for components
- Add a unit test
- Update docs for `#[component]` macro (very minor change)

# How?
Added a little function which uses the `convert_case` crate to check whether `item.sig.ident` is `snake_case`, and if so it converts the `ident` to `PascalCase` (referred to as `camelCase` in the docs, but I don't think the distinction matters too much because most people refer to it as that anyway) which is later used to generate the `Component` and `ComponentProps` structs.

```rs
use convert_case::{Case::{Snake, Pascal}, Casing};

// . . .

fn convert_from_snake_case(name: &Ident) -> Ident {
    let name_str = name.to_string();
    if !name_str.is_case(Snake) {
        name.clone()
    } else {
        Ident::new(&*name_str.to_case(Pascal), name.span().clone())
    }
}
```

The reason it only bothers to convert from `snake_case` is because that's the convention for naming functions in Rust, and converting from other types of casing might lead to some extra edge cases. 

# Why?
- Leaving open the option to use `snake_case` function names for components (which are then converted to `CamelCase` to avoid the structs being confused for html elements) seems reasonable to me; sometimes it's the little things such as having to edit your IDE/`cargo fmt` config or dealing with a bunch of warnings when using a specific framework that can put people off. 
- When it comes to attribute macros which generate a struct from a function, I often prefer them to have different casing because it makes it quite clear (even if you don't understand what the macro really _does_) that it's generating a struct from your function, and you're not actually passing a function around whenever you use it. This is entirely a matter of preference, which is why I think it's a good idea to give people the option. 
- Reduces potential for new users of the framework to encounter errors. Time spent figuring out why your `snake_case` function doesn't want to become a component is time that could have been spent learning something more important within the framework. 

# Improvements/Limitations
- I'm unsure of how `convert_case` handles acronyms (e.g. `does_HTML_stuff`), so in cases like that it might not recognise the function name as `snake_case` and no conversion will be done.
- Leading or trailing underscores might be removed when converting to `CamelCase` (`_my_component -> MyComponent`, `my_component_ -> MyComponent`).
- Could be some other edge cases, but I didn't want to come in guns blazing and add a bunch of unit tests for such a small function. 

I am of course not as well versed in the internals of Leptos as the maintainers, so perhaps there's some reason that this can't be implemented. If that's the case then feel free to reject this PR, but I'd still be interested in understanding _why_ it won't work, just because I'm curious.  