### PR TITLE
leptos_reactive base64 bump version to 0.21.

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -17,7 +17,7 @@ js-sys = "0.3"
 miniserde = { version = "0.1", optional = true }
 serde-wasm-bindgen = "0.4"
 serde_json = "1"
-base64 = "0.13"
+base64 = "0.21"
 thiserror = "1"
 tokio = { version = "1", features = ["rt"], optional = true }
 tracing = "0.1"


### PR DESCRIPTION
Minor: version needs bumping.