### PR TITLE
Add methods to take Actix/Axum Extractors/Route Info/Stuff and pass it to Leptos

### DIFF
--- a/examples/hackernews_axum/src/handlers.rs
+++ b/examples/hackernews_axum/src/handlers.rs
@@ -11,7 +11,6 @@ if #[cfg(feature = "ssr")] {
 
     pub async fn file_handler(uri: Uri) -> Result<Response<BoxBody>, (StatusCode, String)> {
         let res = get_static_file(uri.clone(), "/pkg").await?;
-        println!("FIRST URI{:?}", uri);
 
         if res.status() == StatusCode::NOT_FOUND {
             // try with `.html`
@@ -27,7 +26,6 @@ if #[cfg(feature = "ssr")] {
 
     pub async fn get_static_file_handler(uri: Uri) -> Result<Response<BoxBody>, (StatusCode, String)> {
         let res = get_static_file(uri.clone(), "/static").await?;
-        println!("FIRST URI{:?}", uri);
 
         if res.status() == StatusCode::NOT_FOUND {
           Err((StatusCode::INTERNAL_SERVER_ERROR, "Invalid URI".to_string()))
@@ -41,7 +39,6 @@ if #[cfg(feature = "ssr")] {
 
         // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
         // When run normally, the root should be the crate root
-      println!("Base: {:#?}", base);
         if base == "/static" {
             match ServeDir::new("./static").oneshot(req).await {
                 Ok(res) => Ok(res.map(boxed)),

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -18,6 +18,7 @@ leptos = { path = "../../../leptos/leptos", default-features = false, features =
 leptos_axum = { path = "../../../leptos/integrations/axum", default-features = false, optional = true }
 leptos_meta = { path = "../../../leptos/meta", default-features = false }
 leptos_router = { path = "../../../leptos/router", default-features = false }
+leptos_reactive = { path = "../../../leptos/leptos_reactive", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
 serde = { version = "1.0.148", features = ["derive"] }

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -21,9 +21,10 @@ if #[cfg(feature = "ssr")] {
 
     //Define a handler to test extractor with state
     async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<AxumBody>) -> Response{
-            println!("Matching CUSTOM");
             let handler = leptos_axum::render_app_to_stream_with_context((*options).clone(),
-            move |cx| { provide_context(cx, id.clone()); },
+            move |cx| {
+                provide_context(cx, id.clone());
+            },
             |cx| view! { cx, <TodoApp/> }
         );
             handler(req).await.into_response()
@@ -50,7 +51,7 @@ if #[cfg(feature = "ssr")] {
         // build our application with a route
         let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-        .route("/:id", get(custom_handler))
+        .route("/special/:id", get(custom_handler))
         .leptos_routes(leptos_options.clone(), routes, |cx| view! { cx, <TodoApp/> } )
         .fallback(file_and_error_handler)
         .layer(Extension(Arc::new(leptos_options)));

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -4,15 +4,30 @@ use leptos::*;
 cfg_if! {
 if #[cfg(feature = "ssr")] {
     use axum::{
-        routing::post,
-        extract::Extension,
+        routing::{post, get},
+        extract::{Extension, Path},
+        http::Request,
+        body::StreamBody,
+        response::{IntoResponse, Response},
         Router,
     };
+    use axum::body::Body as AxumBody;
     use crate::todo::*;
     use todo_app_sqlite_axum::*;
     use crate::fallback::file_and_error_handler;
     use leptos_axum::{generate_route_list, LeptosRoutes};
     use std::sync::Arc;
+    use leptos_reactive::run_scope;
+
+    //Define a handler to test extractor with state
+    async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<AxumBody>) -> Response{
+            println!("Matching CUSTOM");
+            let handler = leptos_axum::render_app_to_stream_with_context((*options).clone(),
+            move |cx| { provide_context(cx, id.clone()); },
+            |cx| view! { cx, <TodoApp/> }
+        );
+            handler(req).await.into_response()
+    }
 
     #[tokio::main]
     async fn main() {
@@ -35,6 +50,7 @@ if #[cfg(feature = "ssr")] {
         // build our application with a route
         let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
+        .route("/:id", get(custom_handler))
         .leptos_routes(leptos_options.clone(), routes, |cx| view! { cx, <TodoApp/> } )
         .fallback(file_and_error_handler)
         .layer(Extension(Arc::new(leptos_options)));

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -108,7 +108,6 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
 	let id = use_context::<String>(cx);
-	println!("ID is {:#?}", id);
     provide_meta_context(cx);
     view! {
         cx,

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -107,6 +107,8 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
 
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
+	let id = use_context::<String>(cx);
+	println!("ID is {:#?}", id);
     provide_meta_context(cx);
     view! {
         cx,
@@ -122,7 +124,6 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
                         cx,
                             <Todos/>
                     }/>
-
                 </Routes>
             </main>
         </Router>

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -622,7 +622,7 @@ where
 /// This version allows us to pass Axum State/Extension/Extractor or other infro from Axum or network
 /// layers above Leptos itself. To use it, you'll need to write your own handler function that provides
 /// the data to leptos in a closure. An example is below
-/// ```rust
+/// ```no_run
 /// async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<AxumBody>) -> Response{
 ///     let handler = leptos_axum::render_app_to_stream_with_context((*options).clone(),
 ///     move |cx| {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -485,6 +485,197 @@ where
     }
 }
 
+pub fn render_app_to_stream_with_context<IV>(
+    options: LeptosOptions,
+    additional_context: impl Fn(leptos::Scope) + 'static + Clone + Send,
+    app_fn: impl Fn(leptos::Scope) -> IV + Clone + Send + 'static,
+) -> impl Fn(
+    Request<Body>,
+) -> Pin<Box<dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>> + Send + 'static>>
+       + Clone
+       + Send
+       + 'static
+where
+    IV: IntoView,
+{
+    move |req: Request<Body>| {
+        Box::pin({
+            let options = options.clone();
+            let app_fn = app_fn.clone();
+            let add_context = additional_context.clone();
+            let default_res_options = ResponseOptions::default();
+            let res_options2 = default_res_options.clone();
+            let res_options3 = default_res_options.clone();
+
+            async move {
+                // Need to get the path and query string of the Request
+                // For reasons that escape me, if the incoming URI protocol is https, it provides the absolute URI
+                // if http, it returns a relative path. Adding .path() seems to make it explicitly return the relative uri
+                let path = req.uri().path_and_query().unwrap().as_str();
+
+                let full_path = format!("http://leptos.dev{path}");
+
+                let pkg_path = &options.site_pkg_dir;
+                let output_name = &options.output_name;
+
+                // Because wasm-pack adds _bg to the end of the WASM filename, and we want to mantain compatibility with it's default options
+                // we add _bg to the wasm files if cargo-leptos doesn't set the env var LEPTOS_OUTPUT_NAME
+                // Otherwise we need to add _bg because wasm_pack always does. This is not the same as options.output_name, which is set regardless
+                let mut wasm_output_name = output_name.clone();
+                if std::env::var("LEPTOS_OUTPUT_NAME").is_err() {
+                    wasm_output_name.push_str("_bg");
+                }
+
+                let site_ip = &options.site_address.ip().to_string();
+                let reload_port = options.reload_port;
+
+                let leptos_autoreload = match std::env::var("LEPTOS_WATCH").is_ok() {
+                    true => format!(
+                        r#"
+                        <script crossorigin="">(function () {{
+                            var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
+                            ws.onmessage = (ev) => {{
+                                let msg = JSON.parse(ev.data);
+                                if (msg.all) window.location.reload();
+                                if (msg.css) {{
+                                    const link = document.querySelector("link#leptos");
+                                    if (link) {{
+                                        let href = link.getAttribute('href').split('?')[0];
+                                        let newHref = href + '?version=' + new Date().getMilliseconds();
+                                        link.setAttribute('href', newHref);
+                                    }} else {{
+                                        console.warn("Could not find link#leptos");
+                                    }}
+                                }};
+                            }};
+                            ws.onclose = () => console.warn('Live-reload stopped. Manual reload necessary.');
+                        }})()
+                        </script>
+                        "#
+                    ),
+                    false => "".to_string(),
+                };
+
+                let head = format!(
+                    r#"<!DOCTYPE html>
+                    <html lang="en">
+                        <head>
+                            <meta charset="utf-8"/>
+                            <meta name="viewport" content="width=device-width, initial-scale=1"/>
+                            <link rel="modulepreload" href="/{pkg_path}/{output_name}.js">
+                            <link rel="preload" href="/{pkg_path}/{wasm_output_name}.wasm" as="fetch" type="application/wasm" crossorigin="">
+                            <script type="module">import init, {{ hydrate }} from '/{pkg_path}/{output_name}.js'; init('/{pkg_path}/{wasm_output_name}.wasm').then(hydrate);</script>
+                            {leptos_autoreload}
+                            "#
+                );
+                let tail = "</body></html>";
+
+                let (mut tx, rx) = futures::channel::mpsc::channel(8);
+
+                spawn_blocking({
+                    let app_fn = app_fn.clone();
+                    let add_context = add_context.clone();
+                    move || {
+                        tokio::runtime::Runtime::new()
+                            .expect("couldn't spawn runtime")
+                            .block_on({
+                                let app_fn = app_fn.clone();
+                                let add_context = add_context.clone();
+                                async move {
+                                    tokio::task::LocalSet::new()
+                                        .run_until(async {
+                                            let app = {
+                                                let full_path = full_path.clone();
+                                                let req_parts = generate_request_parts(req).await;
+                                                move |cx| {
+                                                    let integration = ServerIntegration {
+                                                        path: full_path.clone(),
+                                                    };
+                                                    provide_context(
+                                                        cx,
+                                                        RouterIntegrationContext::new(integration),
+                                                    );
+                                                    provide_context(cx, MetaContext::new());
+                                                    provide_context(cx, req_parts);
+                                                    provide_context(cx, default_res_options);
+                                                    app_fn(cx).into_view(cx)
+                                                }
+                                            };
+
+                                            let (bundle, runtime, scope) =
+                                                render_to_stream_with_prefix_undisposed_with_context(
+                                                    app,
+                                                    |cx| {
+                                                        let head = use_context::<MetaContext>(cx)
+                                                            .map(|meta| meta.dehydrate())
+                                                            .unwrap_or_default();
+                                                        format!("{head}</head><body>").into()
+                                                    },
+                                                    add_context,
+                                                );
+                                            let mut shell = Box::pin(bundle);
+                                            while let Some(fragment) = shell.next().await {
+                                                _ = tx.send(fragment).await;
+                                            }
+
+                                            // Extract the value of ResponseOptions from here
+                                            let cx = Scope { runtime, id: scope };
+                                            let res_options =
+                                                use_context::<ResponseOptions>(cx).unwrap();
+
+                                            let new_res_parts = res_options.0.read().await.clone();
+
+                                            let mut writable = res_options2.0.write().await;
+                                            *writable = new_res_parts;
+
+                                            runtime.dispose();
+
+                                            tx.close_channel();
+                                        })
+                                        .await;
+                                }
+                            });
+                    }
+                });
+
+                let mut stream = Box::pin(
+                    futures::stream::once(async move { head.clone() })
+                        .chain(rx)
+                        .chain(futures::stream::once(async { tail.to_string() }))
+                        .map(|html| Ok(Bytes::from(html))),
+                );
+
+                // Get the first, second, and third chunks in the stream, which renders the app shell, and thus allows Resources to run
+                let first_chunk = stream.next().await;
+                let second_chunk = stream.next().await;
+                let third_chunk = stream.next().await;
+
+                // Extract the resources now that they've been rendered
+                let res_options = res_options3.0.read().await;
+
+                let complete_stream = futures::stream::iter([
+                    first_chunk.unwrap(),
+                    second_chunk.unwrap(),
+                    third_chunk.unwrap(),
+                ])
+                .chain(stream);
+
+                let mut res = Response::new(StreamBody::new(
+                    Box::pin(complete_stream) as PinnedHtmlStream
+                ));
+
+                if let Some(status) = res_options.status {
+                    *res.status_mut() = status
+                }
+                let mut res_headers = res_options.headers.clone();
+                res.headers_mut().extend(res_headers.drain());
+
+                res
+            }
+        })
+    }
+}
+
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
 /// create routes in Axum's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
 /// as an argument so it can walk you app tree. This version is tailored to generate Axum compatible paths.

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -622,8 +622,8 @@ where
 /// This version allows us to pass Axum State/Extension/Extractor or other infro from Axum or network
 /// layers above Leptos itself. To use it, you'll need to write your own handler function that provides
 /// the data to leptos in a closure. An example is below
-/// ```no_run
-/// async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<AxumBody>) -> Response{
+/// ```ignore
+/// async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<Body>) -> Response{
 ///     let handler = leptos_axum::render_app_to_stream_with_context((*options).clone(),
 ///     move |cx| {
 ///         provide_context(cx, id.clone());

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -97,6 +97,29 @@ pub fn render_to_stream_with_prefix_undisposed(
   view: impl FnOnce(Scope) -> View + 'static,
   prefix: impl FnOnce(Scope) -> Cow<'static, str> + 'static,
 ) -> (impl Stream<Item = String>, RuntimeId, ScopeId) {
+  render_to_stream_with_prefix_undisposed_with_context(view, prefix, |_cx| {})
+}
+
+/// Renders a function to a stream of HTML strings and returns the [Scope] and [Runtime] that were created, so
+/// they can be disposed when appropriate. After the `view` runs, the `prefix` will run with
+/// the same scope. This can be used to generate additional HTML that has access to the same `Scope`.
+///
+/// This renders:
+/// 1) the prefix
+/// 2) the application shell
+///   a) HTML for everything that is not under a `<Suspense/>`,
+///   b) the `fallback` for any `<Suspense/>` component that is not already resolved, and
+///   c) JavaScript necessary to receive streaming [Resource](leptos_reactive::Resource) data.
+/// 3) streaming [Resource](leptos_reactive::Resource) data. Resources begin loading on the
+///    server and are sent down to the browser to resolve. On the browser, if the app sees that
+///    it is waiting for a resource to resolve from the server, it doesn't run it initially.
+/// 4) HTML fragments to replace each `<Suspense/>` fallback with its actual data as the resources
+///    read under that `<Suspense/>` resolve.
+pub fn render_to_stream_with_prefix_undisposed_with_context(
+  view: impl FnOnce(Scope) -> View + 'static,
+  prefix: impl FnOnce(Scope) -> Cow<'static, str> + 'static,
+  additional_context: impl FnOnce(Scope) + 'static,
+) -> (impl Stream<Item = String>, RuntimeId, ScopeId) {
   HydrationCtx::reset_id();
 
   // create the runtime
@@ -115,6 +138,8 @@ pub fn render_to_stream_with_prefix_undisposed(
       let resources = cx.pending_resources();
       let pending_resources = serde_json::to_string(&resources).unwrap();
       let prefix = prefix(cx);
+      // Add additional context items
+      additional_context(cx);
 
       (
         shell,

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -131,6 +131,8 @@ pub fn render_to_stream_with_prefix_undisposed_with_context(
     _,
   ) = run_scope_undisposed(runtime, {
     move |cx| {
+      // Add additional context items
+      additional_context(cx);
       // the actual app body/template code
       // this does NOT contain any of the data being loaded asynchronously in resources
       let shell = view(cx).render_to_string(cx);
@@ -138,8 +140,6 @@ pub fn render_to_stream_with_prefix_undisposed_with_context(
       let resources = cx.pending_resources();
       let pending_resources = serde_json::to_string(&resources).unwrap();
       let prefix = prefix(cx);
-      // Add additional context items
-      additional_context(cx);
 
       (
         shell,


### PR DESCRIPTION
This closes #238 by adding `handle_server_fns_with_context()` and `render_app_to_stream_with_context()` functions to leptos_actix and leptos_axum. This lets you write your own handlers with whatever extractors you desire, and pass them in.

Here's an example for Axum:
```rust
  //Define a handler to test extractor with state
  async fn custom_handler(Path(id): Path<String>, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<AxumBody>) -> Response{
          let handler = leptos_axum::render_app_to_stream_with_context((*options).clone(),
          move |cx| {
              provide_context(cx, id.clone());
          },
          |cx| view! { cx, <TodoApp/> }
      );
          handler(req).await.into_response()
  }
```