### PR TITLE
Replace urlencoding with percent-encoding

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4"
 regex = { version = "1", optional = true }
 bincode = "1"
 url = { version = "2", optional = true }
-urlencoding = "2"
+percent-encoding = "2"
 thiserror = "1"
 serde_urlencoded = "0.7"
 serde = "1"

--- a/router/src/history/url.rs
+++ b/router/src/history/url.rs
@@ -22,7 +22,7 @@ pub fn unescape(s: &str) -> String {
 
 #[cfg(feature = "ssr")]
 pub fn escape(s: &str) -> String {
-    urlencoding::encode(s).into()
+    percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC).to_string()
 }
 
 #[cfg(not(feature = "ssr"))]


### PR DESCRIPTION
Motivation: `percent-encoding` is from the Servo team and part of the `url` crate.