### PR TITLE
Fix context in outlets

### DIFF
--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -234,6 +234,19 @@ impl Scope {
             f(&mut scope.borrow_mut());
         })
     }
+
+    /// Returns the the parent Scope, if any.
+    pub fn parent(&self) -> Option<Scope> {
+        with_runtime(self.runtime, |runtime| {
+            runtime.scope_parents.borrow().get(self.id).copied()
+        })
+        .ok()
+        .flatten()
+        .map(|id| Scope {
+            runtime: self.runtime,
+            id,
+        })
+    }
 }
 
 /// Creates a cleanup function, which will be run when a [Scope] is disposed.

--- a/router/src/components/outlet.rs
+++ b/router/src/components/outlet.rs
@@ -11,7 +11,7 @@ pub fn Outlet(cx: Scope) -> impl IntoView {
     let is_showing = Rc::new(Cell::new(None::<(usize, Scope)>));
     let (outlet, set_outlet) = create_signal(cx, None::<View>);
     create_isomorphic_effect(cx, move |_| {
-        match (route.child(), &is_showing.get()) {
+        match (route.child(cx), &is_showing.get()) {
             (None, prev) => {
                 if let Some(prev_scope) = prev.map(|(_, scope)| scope) {
                     prev_scope.dispose();

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -79,7 +79,7 @@ impl RouteContext {
     pub(crate) fn new(
         cx: Scope,
         router: &RouterContext,
-        child: impl Fn() -> Option<RouteContext> + 'static,
+        child: impl Fn(Scope) -> Option<RouteContext> + 'static,
         matcher: impl Fn() -> Option<RouteMatch> + 'static,
     ) -> Option<Self> {
         let base = router.base();
@@ -151,7 +151,7 @@ impl RouteContext {
                 cx,
                 id: 0,
                 base_path: path.to_string(),
-                child: Box::new(|| None),
+                child: Box::new(|_| None),
                 path: RefCell::new(path.to_string()),
                 original_path: path.to_string(),
                 params: create_memo(cx, |_| ParamsMap::new()),
@@ -166,8 +166,8 @@ impl RouteContext {
     }
 
     /// The nested child route, if any.
-    pub fn child(&self) -> Option<RouteContext> {
-        (self.inner.child)()
+    pub fn child(&self, cx: Scope) -> Option<RouteContext> {
+        (self.inner.child)(cx)
     }
 
     /// The view associated with the current route.
@@ -180,7 +180,7 @@ pub(crate) struct RouteContextInner {
     cx: Scope,
     base_path: String,
     pub(crate) id: usize,
-    pub(crate) child: Box<dyn Fn() -> Option<RouteContext>>,
+    pub(crate) child: Box<dyn Fn(Scope) -> Option<RouteContext>>,
     pub(crate) path: RefCell<String>,
     pub(crate) original_path: String,
     pub(crate) params: Memo<ParamsMap>,
@@ -202,7 +202,6 @@ impl std::fmt::Debug for RouteContextInner {
         f.debug_struct("RouteContextInner")
             .field("path", &self.path)
             .field("ParamsMap", &self.params)
-            .field("child", &(self.child)())
             .finish()
     }
 }


### PR DESCRIPTION
This makes changes to the router so that the reactive scopes created in nested routes are children of the scope of the previously-matched route, not the root scope. This closes #370 by ensuring that each nested route has access to contexts provided by its parent (or grandparent), not only in the root route.