### PR TITLE
fix: Align `<ActionForm/>` behavior with `Action`

### DIFF
--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -96,6 +96,11 @@ where
         self.0.with(|a| a.pending.read_only())
     }
 
+    /// Updates whether the action is currently pending.
+    pub fn set_pending(&self, pending: bool) {
+        self.0.with(|a| a.pending.set(pending))
+    }
+
     /// The URL associated with the action (typically as part of a server function.)
     /// This enables integration with the `ActionForm` component in `leptos_router`.
     pub fn url(&self) -> Option<String> {

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -167,11 +167,6 @@ where
                 JsFuture::from(resp.text().expect("couldn't get .text() from Response")).await;
             match body {
                 Ok(json) => {
-                    log::debug!(
-                        "body is {:?}\nO is {:?}",
-                        json.as_string().unwrap(),
-                        std::any::type_name::<O>()
-                    );
                     match O::from_json(
                         &json.as_string().expect("couldn't get String from JsString"),
                     ) {
@@ -182,7 +177,8 @@ where
                     }
                 }
                 Err(e) => log::error!("{e:?}"),
-            }
+            };
+            input.set(None);
         });
     });
 

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -155,7 +155,10 @@ where
     let on_form_data = Rc::new(move |form_data: &web_sys::FormData| {
         let data = action_input_from_form_data(form_data);
         match data {
-            Ok(data) => input.set(Some(data)),
+            Ok(data) => {
+                input.set(Some(data));
+                action.set_pending(true);
+            }
             Err(e) => log::error!("{e}"),
         }
     });
@@ -179,6 +182,7 @@ where
                 Err(e) => log::error!("{e:?}"),
             };
             input.set(None);
+            action.set_pending(false);
         });
     });
 


### PR DESCRIPTION
This one is a little tricky. Technically it is fixing a bug in `ActionForm` that led to it not resetting the action's `input` signal, which led to a discrepancy in behavior between `Action` and `ActionForm`. `Action.input()` should only be `Some(_)` if it is pending, and `None` if it is not pending, but `ActionForm` doesn't reset it.

So while this is a bugfix to bring `ActionForm` into alignment with the documented and expected behavior, it may also break some applications that were built on the buggy behavior... including my `example-darkmode` video! (Although it also explains the bug I encounter in that video around 49:24 — as I had built my implementation on top of the `ActionForm` bug, so could not figure out why the manual version with `Action` didn't work the same way.)