### PR TITLE
Reduce WASM binary sizes by 3-5%

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -493,22 +493,12 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
 
     #[cfg(all(target_arch = "wasm32", feature = "web"))]
     {
-      let el = self.element.as_ref();
-      let value = attr.into_attribute(self.cx);
-      match value {
-        Attribute::Fn(cx, f) => {
-          let el = el.clone();
-          create_render_effect(cx, move |old| {
-            let new = f();
-            if old.as_ref() != Some(&new) {
-              attribute_expression(&el, &name, new.clone());
-            }
-            new
-          });
-        }
-        _ => attribute_expression(el, &name, value),
-      };
-      self
+        crate::macro_helpers::attribute_helper(
+            &self.element.as_ref(),
+            name,
+            attr.into_attribute(self.cx)
+        );
+        self
     }
 
     #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
@@ -552,20 +542,12 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
     #[cfg(all(target_arch = "wasm32", feature = "web"))]
     {
       let el = self.element.as_ref();
-      let class_list = el.class_list();
       let value = class.into_class(self.cx);
-      match value {
-        Class::Fn(cx, f) => {
-          create_render_effect(cx, move |old| {
-            let new = f();
-            if old.as_ref() != Some(&new) && (old.is_some() || new) {
-              class_expression(&class_list, &name, new)
-            }
-            new
-          });
-        }
-        Class::Value(value) => class_expression(&class_list, &name, value),
-      };
+      crate::macro_helpers::class_helper(
+        &el,
+        name.into(),
+        value
+      );
 
       self
     }
@@ -607,25 +589,11 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
       let name = name.into();
       let value = value.into_property(self.cx);
       let el = self.element.as_ref();
-      match value {
-        Property::Fn(cx, f) => {
-          let el = el.clone();
-          create_render_effect(cx, move |old| {
-            let new = f();
-            let prop_name = wasm_bindgen::intern(&name);
-            if old.as_ref() != Some(&new)
-              && !(old.is_none() && new == wasm_bindgen::JsValue::UNDEFINED)
-            {
-              property_expression(&el, prop_name, new.clone())
-            }
-            new
-          });
-        }
-        Property::Value(value) => {
-          let prop_name = wasm_bindgen::intern(&name);
-          property_expression(el, prop_name, value)
-        }
-      };
+      crate::macro_helpers::property_helper(
+          el,
+          name,
+          value
+      );
     }
 
     #[cfg(not(all(target_arch = "wasm32", feature = "web")))]

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -21,7 +21,7 @@ cfg_if! {
         while let Ok(Some(node)) = walker.next_node() {
           if let Some(content) = node.text_content() {
             if let Some(hk) = content.strip_prefix("hk=") {
-              if let Some(hk) = hk.split("|").next() {
+              if let Some(hk) = hk.split('|').next() {
                 map.insert(hk.into(), node.unchecked_into());
               }
             }

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -171,22 +171,25 @@ attr_type!(char);
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 use std::borrow::Cow;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
-pub(crate) fn attribute_helper(el: &web_sys::Element, name: Cow<'static, str>, value: Attribute) {
-
-    use leptos_reactive::create_render_effect;
-      match value {
-        Attribute::Fn(cx, f) => {
-          let el = el.clone();
-          create_render_effect(cx, move |old| {
-            let new = f();
-            if old.as_ref() != Some(&new) {
-              attribute_expression(&el, &name, new.clone());
-            }
-            new
-          });
+pub(crate) fn attribute_helper(
+  el: &web_sys::Element,
+  name: Cow<'static, str>,
+  value: Attribute,
+) {
+  use leptos_reactive::create_render_effect;
+  match value {
+    Attribute::Fn(cx, f) => {
+      let el = el.clone();
+      create_render_effect(cx, move |old| {
+        let new = f();
+        if old.as_ref() != Some(&new) {
+          attribute_expression(&el, &name, new.clone());
         }
-        _ => attribute_expression(el, &name, value),
-      };
+        new
+      });
+    }
+    _ => attribute_expression(el, &name, value),
+  };
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -169,6 +169,27 @@ attr_type!(f64);
 attr_type!(char);
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
+use std::borrow::Cow;
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+pub(crate) fn attribute_helper(el: &web_sys::Element, name: Cow<'static, str>, value: Attribute) {
+
+    use leptos_reactive::create_render_effect;
+      match value {
+        Attribute::Fn(cx, f) => {
+          let el = el.clone();
+          create_render_effect(cx, move |old| {
+            let new = f();
+            if old.as_ref() != Some(&new) {
+              attribute_expression(&el, &name, new.clone());
+            }
+            new
+          });
+        }
+        _ => attribute_expression(el, &name, value),
+      };
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub(crate) fn attribute_expression(
   el: &web_sys::Element,
   attr_name: &str,

--- a/leptos_dom/src/macro_helpers/into_class.rs
+++ b/leptos_dom/src/macro_helpers/into_class.rs
@@ -71,25 +71,25 @@ use std::borrow::Cow;
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub(crate) fn class_helper(
-    el: &web_sys::Element,
-    name: Cow<'static, str>,
-    value: Class
+  el: &web_sys::Element,
+  name: Cow<'static, str>,
+  value: Class,
 ) {
-    use leptos_reactive::create_render_effect;
+  use leptos_reactive::create_render_effect;
 
-      let class_list = el.class_list();
-      match value {
-        Class::Fn(cx, f) => {
-          create_render_effect(cx, move |old| {
-            let new = f();
-            if old.as_ref() != Some(&new) && (old.is_some() || new) {
-              class_expression(&class_list, &name, new)
-            }
-            new
-          });
+  let class_list = el.class_list();
+  match value {
+    Class::Fn(cx, f) => {
+      create_render_effect(cx, move |old| {
+        let new = f();
+        if old.as_ref() != Some(&new) && (old.is_some() || new) {
+          class_expression(&class_list, &name, new)
         }
-        Class::Value(value) => class_expression(&class_list, &name, value),
-      };
+        new
+      });
+    }
+    Class::Value(value) => class_expression(&class_list, &name, value),
+  };
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/macro_helpers/into_class.rs
+++ b/leptos_dom/src/macro_helpers/into_class.rs
@@ -67,6 +67,32 @@ impl<T: IntoClass> IntoClass for (Scope, T) {
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
+use std::borrow::Cow;
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+pub(crate) fn class_helper(
+    el: &web_sys::Element,
+    name: Cow<'static, str>,
+    value: Class
+) {
+    use leptos_reactive::create_render_effect;
+
+      let class_list = el.class_list();
+      match value {
+        Class::Fn(cx, f) => {
+          create_render_effect(cx, move |old| {
+            let new = f();
+            if old.as_ref() != Some(&new) && (old.is_some() || new) {
+              class_expression(&class_list, &name, new)
+            }
+            new
+          });
+        }
+        Class::Value(value) => class_expression(&class_list, &name, value),
+      };
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub(crate) fn class_expression(
   class_list: &web_sys::DomTokenList,
   class_name: &str,

--- a/leptos_dom/src/macro_helpers/into_property.rs
+++ b/leptos_dom/src/macro_helpers/into_property.rs
@@ -81,31 +81,31 @@ use std::borrow::Cow;
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub(crate) fn property_helper(
-    el: &web_sys::Element,
-    name: Cow<'static, str>,
-    value: Property
+  el: &web_sys::Element,
+  name: Cow<'static, str>,
+  value: Property,
 ) {
-    use leptos_reactive::create_render_effect;
+  use leptos_reactive::create_render_effect;
 
-      match value {
-        Property::Fn(cx, f) => {
-          let el = el.clone();
-          create_render_effect(cx, move |old| {
-            let new = f();
-            let prop_name = wasm_bindgen::intern(&name);
-            if old.as_ref() != Some(&new)
-              && !(old.is_none() && new == wasm_bindgen::JsValue::UNDEFINED)
-            {
-              property_expression(&el, prop_name, new.clone())
-            }
-            new
-          });
+  match value {
+    Property::Fn(cx, f) => {
+      let el = el.clone();
+      create_render_effect(cx, move |old| {
+        let new = f();
+        let prop_name = wasm_bindgen::intern(&name);
+        if old.as_ref() != Some(&new)
+          && !(old.is_none() && new == wasm_bindgen::JsValue::UNDEFINED)
+        {
+          property_expression(&el, prop_name, new.clone())
         }
-        Property::Value(value) => {
-          let prop_name = wasm_bindgen::intern(&name);
-          property_expression(el, prop_name, value)
-        }
-      };
+        new
+      });
+    }
+    Property::Value(value) => {
+      let prop_name = wasm_bindgen::intern(&name);
+      property_expression(el, prop_name, value)
+    }
+  };
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/macro_helpers/into_property.rs
+++ b/leptos_dom/src/macro_helpers/into_property.rs
@@ -77,6 +77,38 @@ prop_type!(f64);
 prop_type!(bool);
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
+use std::borrow::Cow;
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+pub(crate) fn property_helper(
+    el: &web_sys::Element,
+    name: Cow<'static, str>,
+    value: Property
+) {
+    use leptos_reactive::create_render_effect;
+
+      match value {
+        Property::Fn(cx, f) => {
+          let el = el.clone();
+          create_render_effect(cx, move |old| {
+            let new = f();
+            let prop_name = wasm_bindgen::intern(&name);
+            if old.as_ref() != Some(&new)
+              && !(old.is_none() && new == wasm_bindgen::JsValue::UNDEFINED)
+            {
+              property_expression(&el, prop_name, new.clone())
+            }
+            new
+          });
+        }
+        Property::Value(value) => {
+          let prop_name = wasm_bindgen::intern(&name);
+          property_expression(el, prop_name, value)
+        }
+      };
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub(crate) fn property_expression(
   el: &web_sys::Element,
   prop_name: &str,


### PR DESCRIPTION
This PR moves some client-side rendering and/or hydration code out of generic functions into concrete functions, allowing some small-but-respectable WASM binary size wins: about 5% for `todomvc` and about 2.5% for `hackernews` (more of which consists of serde/HTTP request code than in `todomvc`).