### PR TITLE
Escape <HTML> and <BODY> tokens in documentation markup.

### DIFF
--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -10,7 +10,7 @@ pub struct BodyContext {
 }
 
 impl BodyContext {
-    /// Converts the <body> metadata into an HTML string.
+    /// Converts the `<body>` metadata into an HTML string.
     pub fn as_string(&self) -> Option<String> {
         self.class
             .borrow()

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -11,7 +11,7 @@ pub struct HtmlContext {
 }
 
 impl HtmlContext {
-    /// Converts the <html> metadata into an HTML string.
+    /// Converts the `<html>` metadata into an HTML string.
     pub fn as_string(&self) -> Option<String> {
         match (self.lang.borrow().as_ref(), self.dir.borrow().as_ref()) {
             (None, None) => None,


### PR DESCRIPTION
Clears warnings found by running

```cargo doc```

Markup not escaping HTML or BODY tokens could lead to "code injection" security problems.