### PR TITLE
Switch RwLock to parking_lot so they are no longer async

### DIFF
--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -13,5 +13,5 @@ futures = "0.3"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
+parking_lot = "0.12.1"
 regex = "1.7.0"
-tokio = "1.24.1"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -17,3 +17,4 @@ leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }
 tokio = { version = "1.0", features = ["full"] }
+parking_lot = "0.12.1"


### PR DESCRIPTION
Basically we're making ResponseOptions functions synchronous so that they can be called from either server functions or a non async component. parking_lot's RwLock is nice because it doesn't panic