### PR TITLE
fix: correct types for top-level `<option>` and `<use>` in SSR `view` macro

### DIFF
--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -129,3 +129,22 @@ fn ssr_with_styles() {
         );
     });
 }
+
+#[cfg(not(any(feature = "csr", feature = "hydrate")))]
+#[test]
+fn ssr_option() {
+    use leptos::*;
+
+    _ = create_scope(create_runtime(), |cx| {
+        let (value, set_value) = create_signal(cx, 0);
+        let rendered = view! {
+            cx,
+            <option/>
+        };
+
+        assert_eq!(
+            rendered.into_view(cx).render_to_string(cx),
+            "<option id=\"_0-1\"></option>"
+        );
+    });
+}

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1063,11 +1063,17 @@ fn is_self_closing(node: &NodeElement) -> bool {
 fn camel_case_tag_name(tag_name: &str) -> String {
     let mut chars = tag_name.chars();
     let first = chars.next();
+    let underscore = if tag_name == "option" || tag_name == "use" {
+        "_"
+    } else {
+        ""
+    };
     first
         .map(|f| f.to_ascii_uppercase())
         .into_iter()
         .chain(chars)
-        .collect()
+        .collect::<String>()
+        + underscore
 }
 
 fn is_svg_element(tag: &str) -> bool {


### PR DESCRIPTION
Closes issue #411.