### PR TITLE
Fix some small issues in `axum_errors` example

### DIFF
--- a/examples/errors_axum/src/error_template.rs
+++ b/examples/errors_axum/src/error_template.rs
@@ -16,10 +16,7 @@ pub fn ErrorTemplate(
     #[prop(optional)] errors: Option<RwSignal<Errors>>,
 ) -> impl IntoView {
     let errors = match outside_errors {
-        Some(e) => {
-            let errors = create_rw_signal(cx, e);
-            errors
-        }
+        Some(e) => create_rw_signal(cx, e),
         None => match errors {
             Some(e) => e,
             None => panic!("No Errors found and we expected errors!"),
@@ -32,8 +29,7 @@ pub fn ErrorTemplate(
     // Downcast lets us take a type that implements `std::error::Error`
     let errors: Vec<AppError> = errors
         .into_iter()
-        .map(|(_k, v)| v.downcast_ref::<AppError>().cloned())
-        .flatten()
+        .filter_map(|(_k, v)| v.downcast_ref::<AppError>().cloned())
         .collect();
     println!("Errors: {errors:#?}");
 
@@ -54,7 +50,7 @@ pub fn ErrorTemplate(
         // a function that returns the items we're iterating over; a signal is fine
         each= move || {errors.clone().into_iter().enumerate()}
         // a unique key for each item as a reference
-        key=|(index, _error)| index.clone()
+        key=|(index, _error)| *index
         // renders each item to a view
         view= move |error| {
         let error_string = error.1.to_string();

--- a/examples/errors_axum/src/fallback.rs
+++ b/examples/errors_axum/src/fallback.rs
@@ -33,14 +33,13 @@ if #[cfg(feature = "ssr")] {
 
     async fn get_static_file(uri: Uri, root: &str) -> Result<Response<BoxBody>, (StatusCode, String)> {
         let req = Request::builder().uri(uri.clone()).body(Body::empty()).unwrap();
-        let root_path = format!("{root}");
         // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
         // This path is relative to the cargo root
-        match ServeDir::new(&root_path).oneshot(req).await {
+        match ServeDir::new(root).oneshot(req).await {
             Ok(res) => Ok(res.map(boxed)),
             Err(err) => Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Something went wrong: {}", err),
+                format!("Something went wrong: {err}"),
             )),
         }
     }

--- a/examples/errors_axum/src/landing.rs
+++ b/examples/errors_axum/src/landing.rs
@@ -64,7 +64,7 @@ pub fn ExampleErrors(cx: Scope) -> impl IntoView {
                 <a href="/404">"This Page Does not Exist"</a>
             </p>
             <p>
-                "The following &ltdiv&gt will always contain an error and cause the page to produce status 500. Check browser dev tools. "
+                "The following <div> will always contain an error and cause the page to produce status 500. Check browser dev tools. "
             </p>
             <div>
             <ErrorBoundary fallback=|cx, errors| view!{cx, <ErrorTemplate errors=errors/>}>

--- a/examples/errors_axum/src/main.rs
+++ b/examples/errors_axum/src/main.rs
@@ -37,7 +37,7 @@ if #[cfg(feature = "ssr")] {
         // Setting this to None means we'll be using cargo-leptos and its env vars
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;
-        let addr = leptos_options.site_address.clone();
+        let addr = leptos_options.site_address;
         let routes = generate_route_list(|cx| view! { cx, <App/> }).await;
 
         // build our application with a route

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 [dependencies]
 cfg-if = "1"
 doc-comment = "0.3"
+html-escape = "0.2"
 itertools = "0.10"
 pad-adapter = "0.1"
 prettyplease = "0.1"

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -336,7 +336,7 @@ fn element_to_tokens_ssr(
                     ),
                     Node::Text(text) => {
                         if let Some(value) = value_to_string(&text.value) {
-                            template.push_str(&value);
+                            template.push_str(&html_escape::encode_safe(&value));
                         } else {
                             template.push_str("{}");
                             let value = text.value.as_ref();


### PR DESCRIPTION
Includes correctly escaping HTML-unsafe characters in the `view` macro