### PR TITLE
leptos-server: Removed  unused dependency on log, linear-map and  rmp-serde.

### DIFF
--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -14,12 +14,9 @@ leptos_reactive = { workspace = true }
 form_urlencoded = "1"
 gloo-net = "0.2"
 lazy_static = "1"
-linear-map = "1"
-log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_urlencoded = "0.7"
 thiserror = "1"
-rmp-serde = "1.1.1"
 serde_json = "1.0.89"
 quote = "1"
 syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
@@ -31,23 +28,23 @@ leptos = { path = "../leptos" }
 
 [features]
 csr = [
-	#"leptos/csr",
-	"leptos_dom/web",
-	"leptos_reactive/csr",
+  #"leptos/csr",
+  "leptos_dom/web",
+  "leptos_reactive/csr",
 ]
 hydrate = [
-	#"leptos/hydrate",
-	"leptos_dom/web",
-	"leptos_reactive/hydrate",
+  #"leptos/hydrate",
+  "leptos_dom/web",
+  "leptos_reactive/hydrate",
 ]
 ssr = [
-	#"leptos/ssr",
-	"leptos_reactive/ssr",
+  #"leptos/ssr",
+  "leptos_reactive/ssr",
 ]
 stable = [
-	#"leptos/stable",
-	"leptos_dom/stable",
-	"leptos_reactive/stable",
+  #"leptos/stable",
+  "leptos_dom/stable",
+  "leptos_reactive/stable",
 ]
 
 [package.metadata.cargo-all-features]


### PR DESCRIPTION
Ran ```cargo machete``` on this project 

Care must be taken with machete, False positives are common especially with a a project that was multiple build configurations like this one.

Stripping out stuff from the examples is a large effort form small gains 
So I am just going to do core stuff first, and take each one sub module by sub module.

leptos-serve first.


