### PR TITLE
use latest tokio in leptos_axum

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -16,5 +16,5 @@ leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12.1"


### PR DESCRIPTION
there was a version number error in Cargo.toml which caused leptos_axum to depend on a separate older version of tokio