### PR TITLE
Derive debug for params struct in server macro

### DIFF
--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -137,7 +137,7 @@ pub fn server_macro_impl(args: proc_macro::TokenStream, s: TokenStream2) -> Resu
     };
 
     Ok(quote::quote! {
-        #[derive(Clone, ::serde::Serialize, ::serde::Deserialize)]
+        #[derive(Clone, Debug, ::serde::Serialize, ::serde::Deserialize)]
         pub struct #struct_name {
             #(#fields),*
         }


### PR DESCRIPTION
Is this something worth doing? I came across wanting this while writing a little app to get more familiar with leptos. It means that all params to `#[server]` functions need to implement `Debug` but they already must implement `Serialize` and `Deserialize` so I imagine that's fine? In any case, feel free to close if not wanted / needed!

The specific use where I came across this was something like:
```rust
let pending_todos = move || {
  submissions
  .get()
  .filter(|submission| submission.pending().get())
  .into_iter()
  .map(|submission| {
      view! {cx,
      // Inspect the whole struct not just one field
       <li class="pending">{move || format!("{:?}", submission.input.get()) }</li>
      }
    })
  .collect::<Vec<_>>()
};
```