### PR TITLE
Fix #457

### DIFF
--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -150,6 +150,7 @@ generate_event_types! {
   canplaythrough: Event,
   change: Event,
   click: MouseEvent,
+  #[does_not_bubble]
   close: Event,
   compositionend: CompositionEvent,
   compositionstart: CompositionEvent,


### PR DESCRIPTION
Fix close event not being marked as `does_not_bubble`.