### PR TITLE
impl From<&str> for MaybeSignal<String>

### DIFF
--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -586,6 +586,12 @@ impl<T> From<Signal<T>> for MaybeSignal<T> {
     }
 }
 
+impl From<&str> for MaybeSignal<String> {
+    fn from(value: &str) -> Self {
+        Self::Static(value.to_string())
+    }
+}
+
 #[cfg(not(feature = "stable"))]
 impl<T> FnOnce<()> for MaybeSignal<T>
 where


### PR DESCRIPTION
Once again I'm not sure if there are any unforeseen consequences of doing this, just something I ran into while writing some code.
Enables not having to call `.to_string()` on a `&str` passed as a `MaybeSignal` like this:
```rust
<A class="navbar-brand" href="/">"link text"</A>
```
instead of this:
```rust
<A class="navbar-brand".to_string() href="/">"link text"</A>
```