### PR TITLE
fix: correct out-of-order streaming behavior (closes #473)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -487,22 +487,17 @@ async fn stream_app(
             .map(|html| Ok(web::Bytes::from(html)) as Result<web::Bytes>),
     );
 
-    // Get the first, second, and third chunks in the stream, which renders the app shell, and thus allows Resources to run
+    // Get the first and second in the stream, which renders the app shell, and thus allows Resources to run
     let first_chunk = stream.next().await;
     let second_chunk = stream.next().await;
-    let third_chunk = stream.next().await;
 
     let res_options = res_options.0.read();
 
     let (status, mut headers) = (res_options.status, res_options.headers.clone());
     let status = status.unwrap_or_default();
 
-    let complete_stream = futures::stream::iter([
-        first_chunk.unwrap(),
-        second_chunk.unwrap(),
-        third_chunk.unwrap(),
-    ])
-    .chain(stream);
+    let complete_stream =
+        futures::stream::iter([first_chunk.unwrap(), second_chunk.unwrap()]).chain(stream);
     let mut res = HttpResponse::Ok()
         .content_type("text/html")
         .streaming(complete_stream);

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -495,20 +495,16 @@ where
 
                 let mut stream = Box::pin(rx.map(|html| Ok(Bytes::from(html))));
 
-                // Get the first, second, and third chunks in the stream, which renders the app shell, and thus allows Resources to run
+                // Get the first and second chunks in the stream, which renders the app shell, and thus allows Resources to run
                 let first_chunk = stream.next().await;
                 let second_chunk = stream.next().await;
-                let third_chunk = stream.next().await;
 
                 // Extract the resources now that they've been rendered
                 let res_options = res_options3.0.read();
 
-                let complete_stream = futures::stream::iter([
-                    first_chunk.unwrap(),
-                    second_chunk.unwrap(),
-                    third_chunk.unwrap(),
-                ])
-                .chain(stream);
+                let complete_stream =
+                    futures::stream::iter([first_chunk.unwrap(), second_chunk.unwrap()])
+                        .chain(stream);
 
                 let mut res = Response::new(StreamBody::new(
                     Box::pin(complete_stream) as PinnedHtmlStream


### PR DESCRIPTION
The integrations initially sent I added the `<Html/>` component I merged the first two chunks in the HTML stream, leading to a bugged implementation that waited for the first `<Suspense/>` fragment to resolve instead of waiting for the point immediately before that. This fixes HTTP streaming behavior.