### PR TITLE
Better styling for router related components

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -176,3 +176,25 @@ pub type ChildrenFn = Box<dyn Fn(Scope) -> Fragment>;
 /// A type for the `children` property on components that can be called
 /// more than once, but may mutate the children.
 pub type ChildrenFnMut = Box<dyn FnMut(Scope) -> Fragment>;
+
+/// A type for taking anything that implements [`IntoAttribute`].
+/// Very usefull inside components.
+/// 
+/// ## Example
+/// ```rust
+/// use leptos::*;
+/// 
+/// #[component]
+/// pub fn MyHeading(
+///   cx: Scope,
+///   text: String,
+///   #[prop(optional, into)]
+///   class: Option<AttributeValue>
+/// ) -> impl IntoView {
+///   view!{
+///     cx,
+///     <h1 class=class>{text}</h1>
+///   }
+/// }
+/// ```
+pub type AttributeValue = Box<dyn IntoAttribute>;

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -179,11 +179,11 @@ pub type ChildrenFnMut = Box<dyn FnMut(Scope) -> Fragment>;
 
 /// A type for taking anything that implements [`IntoAttribute`].
 /// Very usefull inside components.
-/// 
+///
 /// ## Example
 /// ```rust
 /// use leptos::*;
-/// 
+///
 /// #[component]
 /// pub fn MyHeading(
 ///   cx: Scope,

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -186,6 +186,25 @@ impl<T: IntoAttribute> IntoAttribute for (Scope, T) {
   impl_into_attr_boxed! {}
 }
 
+impl IntoAttribute for (Scope, Option<Box<dyn IntoAttribute>>) {
+  fn into_attribute(self, _: Scope) -> Attribute {
+    match self.1 {
+        Some(bx) => bx.into_attribute_boxed(self.0),
+        None => Attribute::Option(self.0, None),
+    }
+  }
+
+  impl_into_attr_boxed! {}
+}
+
+impl IntoAttribute for (Scope, Box<dyn IntoAttribute>) {
+  fn into_attribute(self, _: Scope) -> Attribute {
+    self.1.into_attribute_boxed(self.0)
+  }
+
+  impl_into_attr_boxed! {}
+}
+
 macro_rules! attr_type {
   ($attr_type:ty) => {
     impl IntoAttribute for $attr_type {

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -124,15 +124,21 @@ impl IntoAttribute for Attribute {
   }
 }
 
+macro_rules! impl_into_attr_boxed {
+  () => {
+    #[inline]
+    fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
+      self.into_attribute(cx)
+    }
+  };
+}
+
 impl IntoAttribute for Option<Attribute> {
   fn into_attribute(self, cx: Scope) -> Attribute {
     self.unwrap_or(Attribute::Option(cx, None))
   }
 
-  #[inline]
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 impl IntoAttribute for String {
@@ -140,10 +146,7 @@ impl IntoAttribute for String {
     Attribute::String(self)
   }
 
-  #[inline]
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 impl IntoAttribute for bool {
@@ -151,10 +154,7 @@ impl IntoAttribute for bool {
     Attribute::Bool(self)
   }
 
-  #[inline]
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 impl IntoAttribute for Option<String> {
@@ -162,10 +162,7 @@ impl IntoAttribute for Option<String> {
     Attribute::Option(cx, self)
   }
 
-  #[inline]
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 impl<T, U> IntoAttribute for T
@@ -178,10 +175,7 @@ where
     Attribute::Fn(cx, modified_fn)
   }
 
-  #[inline]
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 impl<T: IntoAttribute> IntoAttribute for (Scope, T) {
@@ -189,9 +183,7 @@ impl<T: IntoAttribute> IntoAttribute for (Scope, T) {
     self.1.into_attribute(self.0)
   }
 
-  fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
-    self.into_attribute(cx)
-  }
+  impl_into_attr_boxed! {}
 }
 
 macro_rules! attr_type {
@@ -211,6 +203,8 @@ macro_rules! attr_type {
       fn into_attribute(self, cx: Scope) -> Attribute {
         Attribute::Option(cx, self.map(|n| n.to_string()))
       }
+
+      #[inline]
       fn into_attribute_boxed(self: Box<Self>, cx: Scope) -> Attribute {
         self.into_attribute(cx)
       }

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -189,8 +189,8 @@ impl<T: IntoAttribute> IntoAttribute for (Scope, T) {
 impl IntoAttribute for (Scope, Option<Box<dyn IntoAttribute>>) {
   fn into_attribute(self, _: Scope) -> Attribute {
     match self.1 {
-        Some(bx) => bx.into_attribute_boxed(self.0),
-        None => Attribute::Option(self.0, None),
+      Some(bx) => bx.into_attribute_boxed(self.0),
+      None => Attribute::Option(self.0, None),
     }
   }
 

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -32,7 +32,7 @@ pub fn Form<A>(
     #[prop(optional)]
     #[allow(clippy::type_complexity)]
     on_form_data: Option<Rc<dyn Fn(&web_sys::FormData)>>,
-    /// A class attribute for styling the form.
+    /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
     class: Option<Box<dyn IntoAttribute>>,
     /// A callback will be called with the [Response](web_sys::Response) the server sends in response
@@ -165,7 +165,7 @@ pub fn ActionForm<I, O>(
     /// by default using [create_server_action](leptos_server::create_server_action) or added
     /// manually using [leptos_server::Action::using_server_fn].
     action: Action<I, Result<O, ServerFnError>>,
-    /// A class attribute for styling the form.
+    /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
     class: Option<Box<dyn IntoAttribute>>,
     /// Component children; should include the HTML of the form elements.
@@ -243,7 +243,7 @@ pub fn MultiActionForm<I, O>(
     /// by default using [create_server_action](leptos_server::create_server_action) or added
     /// manually using [leptos_server::Action::using_server_fn].
     action: MultiAction<I, Result<O, ServerFnError>>,
-    /// A class attribute for styling the form.
+    /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
     class: Option<Box<dyn IntoAttribute>>,
     /// Component children; should include the HTML of the form elements.

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -34,7 +34,7 @@ pub fn Form<A>(
     on_form_data: Option<Rc<dyn Fn(&web_sys::FormData)>>,
     /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
-    class: Option<Box<dyn IntoAttribute>>,
+    class: Option<AttributeValue>,
     /// A callback will be called with the [Response](web_sys::Response) the server sends in response
     /// to a form submission.
     #[prop(optional)]
@@ -167,7 +167,7 @@ pub fn ActionForm<I, O>(
     action: Action<I, Result<O, ServerFnError>>,
     /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
-    class: Option<Box<dyn IntoAttribute>>,
+    class: Option<AttributeValue>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView
@@ -245,7 +245,7 @@ pub fn MultiActionForm<I, O>(
     action: MultiAction<I, Result<O, ServerFnError>>,
     /// Sets the `class` attribute on the underlying `<form>` tag, making it easier to style.
     #[prop(optional, into)]
-    class: Option<Box<dyn IntoAttribute>>,
+    class: Option<AttributeValue>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -32,6 +32,9 @@ pub fn Form<A>(
     #[prop(optional)]
     #[allow(clippy::type_complexity)]
     on_form_data: Option<Rc<dyn Fn(&web_sys::FormData)>>,
+    /// A class attribute for styling the form.
+    #[prop(optional, into)]
+    class: Option<Box<dyn IntoAttribute>>,
     /// A callback will be called with the [Response](web_sys::Response) the server sends in response
     /// to a form submission.
     #[prop(optional)]
@@ -52,6 +55,7 @@ where
         error: Option<RwSignal<Option<Box<dyn Error>>>>,
         #[allow(clippy::type_complexity)] on_form_data: Option<Rc<dyn Fn(&web_sys::FormData)>>,
         #[allow(clippy::type_complexity)] on_response: Option<Rc<dyn Fn(&web_sys::Response)>>,
+        class: Option<Attribute>,
         children: Children,
     ) -> HtmlElement<Form> {
         let action_version = version;
@@ -128,6 +132,7 @@ where
                 action=move || action.get()
                 enctype=enctype
                 on:submit=on_submit
+                class=class
             >
                 {children(cx)}
             </form>
@@ -135,6 +140,7 @@ where
     }
 
     let action = use_resolved_path(cx, move || action.to_href()());
+    let class = class.map(|bx| bx.into_attribute_boxed(cx));
     inner(
         cx,
         method,
@@ -144,6 +150,7 @@ where
         error,
         on_form_data,
         on_response,
+        class,
         children,
     )
 }
@@ -158,6 +165,9 @@ pub fn ActionForm<I, O>(
     /// by default using [create_server_action](leptos_server::create_server_action) or added
     /// manually using [leptos_server::Action::using_server_fn].
     action: Action<I, Result<O, ServerFnError>>,
+    /// A class attribute for styling the form.
+    #[prop(optional, into)]
+    class: Option<Box<dyn IntoAttribute>>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView
@@ -208,7 +218,7 @@ where
             action.set_pending(false);
         });
     });
-
+    let class = class.map(|bx| bx.into_attribute_boxed(cx));
     Form(
         cx,
         FormProps::builder()
@@ -217,6 +227,7 @@ where
             .on_form_data(on_form_data)
             .on_response(on_response)
             .method("post")
+            .class(class)
             .children(children)
             .build(),
     )
@@ -232,6 +243,9 @@ pub fn MultiActionForm<I, O>(
     /// by default using [create_server_action](leptos_server::create_server_action) or added
     /// manually using [leptos_server::Action::using_server_fn].
     action: MultiAction<I, Result<O, ServerFnError>>,
+    /// A class attribute for styling the form.
+    #[prop(optional, into)]
+    class: Option<Box<dyn IntoAttribute>>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView
@@ -265,10 +279,12 @@ where
         }
     };
 
+    let class = class.map(|bx| bx.into_attribute_boxed(cx));
     view! { cx,
         <form
             method="POST"
             action=action
+            class=class
             on:submit=on_submit
         >
             {children(cx)}

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -63,7 +63,7 @@ pub fn A<H>(
     replace: bool,
     /// Sets the `class` attribute on the underlying `<a>` tag, making it easier to style.
     #[prop(optional, into)]
-    class: Option<Box<dyn IntoAttribute>>,
+    class: Option<AttributeValue>,
     /// The nodes or elements to be shown inside the link.
     children: Children,
 ) -> impl IntoView
@@ -76,7 +76,7 @@ where
         exact: bool,
         state: Option<State>,
         replace: bool,
-        class: Option<Attribute>,
+        class: Option<AttributeValue>,
         children: Children,
     ) -> HtmlElement<A> {
         let location = use_location(cx);
@@ -112,6 +112,5 @@ where
     }
 
     let href = use_resolved_path(cx, move || href.to_href()());
-    let class = class.map(|bx| bx.into_attribute_boxed(cx));
     inner(cx, href, exact, state, replace, class, children)
 }

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -63,7 +63,7 @@ pub fn A<H>(
     replace: bool,
     /// Sets the `class` attribute on the underlying `<a>` tag, making it easier to style.
     #[prop(optional, into)]
-    class: Option<MaybeSignal<String>>,
+    class: Option<Box<dyn IntoAttribute>>,
     /// The nodes or elements to be shown inside the link.
     children: Children,
 ) -> impl IntoView
@@ -76,7 +76,7 @@ where
         exact: bool,
         state: Option<State>,
         replace: bool,
-        class: Option<MaybeSignal<String>>,
+        class: Option<Attribute>,
         children: Children,
     ) -> HtmlElement<A> {
         let location = use_location(cx);
@@ -104,7 +104,7 @@ where
                 prop:state={state.map(|s| s.to_js_value())}
                 prop:replace={replace}
                 aria-current=move || if is_active.get() { Some("page") } else { None }
-                class=move || class.as_ref().map(|class| class.get())
+                class=class
             >
                 {children(cx)}
             </a>
@@ -112,5 +112,6 @@ where
     }
 
     let href = use_resolved_path(cx, move || href.to_href()());
+    let class = class.map(|bx| bx.into_attribute_boxed(cx));
     inner(cx, href, exact, state, replace, class, children)
 }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -45,8 +45,10 @@
 //!           // LR will enhance the active <a> link with the [aria-current] attribute
 //!           // we can use this for styling them with CSS like `[aria-current] { font-weight: bold; }`
 //!           <A href="contacts">"Contacts"</A>
-//!           <A href="about">"About"</A>
-//!           <A href="settings">"Settings"</A>
+//!           // But we can also use a normal class attribute like it is a normal component
+//!           <A href="settings" class="my-class">"Settings"</A>
+//!           // It also supports signals!
+//!           <A href="about" class=move || "my-class">"About"</A>
 //!         </nav>
 //!         <main>
 //!           // <Routes/> both defines our routes and shows them on the page


### PR DESCRIPTION
Made a few changes to `IntoAttribute` to make it usable as `Box<dyn IntoAttribute>` to support styling similar to native tags.

Before the `<A>` tag took a `MaybeSignal<String>` so you needed to do: 
```rust
view!{cx,
  <A href="home" class="my-class".to_string()>
  <A href="home" class=Signal::derive(cx, move || "my-class".to_string())>
}
```

Now you can do:
```rust
view!{cx,
  <A href="home" class="my-class">
  <A href="home" class=move || "my-class">
}
```
And it also works for `Form`, `ActionForm` and `MultiActionForm`

I tried really hard to implement this using generics, but it does not seem possible. The type of the generic parameter needs to be inferred even if its value is `None` because it needs to know what `Option::<T>::None` it is.