### PR TITLE
fix: proper disposal of nested route scopes

### DIFF
--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -3,171 +3,74 @@ mod api;
 use leptos::*;
 use leptos_router::*;
 
-use crate::api::{get_contact, get_contacts};
-
 #[component]
-pub fn RouterExample(cx: Scope) -> impl IntoView {
-    log::debug!("rendering <RouterExample/>");
+pub fn App(cx: Scope) -> impl IntoView {
+    console_error_panic_hook::set_once();
 
-    view! { cx,
+    view! {cx,
         <Router>
             <nav>
-                // ordinary <a> elements can be used for client-side navigation
-                // using <A> has two effects:
-                // 1) ensuring that relative routing works properly for nested routes
-                // 2) setting the `aria-current` attribute on the current link,
-                //    for a11y and styling purposes
-                <A exact=true href="/">"Contacts"</A>
-                <A href="about">"About"</A>
-                <A href="settings">"Settings"</A>
-                <A href="redirect-home">"Redirect to Home"</A>
+                <a href="/">"home"</a> " | "
+                <a href="/a">"a"</a> " | "
+                <a href="/b">"b"</a> " | "
+                <a href="/some-page">"some page"</a>
             </nav>
-            <main>
-                <Routes>
-                    <Route
-                        path=""
-                        view=move |cx| view! { cx,  <ContactList/> }
-                    >
-                        <Route
-                            path=":id"
-                            view=move |cx| view! { cx,  <Contact/> }
-                        />
-                        <Route
-                            path="/"
-                            view=move |_| view! { cx,  <p>"Select a contact."</p> }
-                        />
-                    </Route>
-                    <Route
-                        path="about"
-                        view=move |cx| view! { cx,  <About/> }
-                    />
-                    <Route
-                        path="settings"
-                        view=move |cx| view! { cx,  <Settings/> }
-                    />
-                    <Route
-                        path="redirect-home"
-                        view=move |cx| view! { cx, <Redirect path="/"/> }
-                    />
-                </Routes>
-            </main>
-        </Router>
-    }
-}
+            <Routes>
+                <Route path="/" view=|cx| {
+                    log!("/ rendering on {:?}", cx.id());
 
-#[component]
-pub fn ContactList(cx: Scope) -> impl IntoView {
-    log::debug!("rendering <ContactList/>");
+                    on_cleanup(cx, || {
+                        log!("home: cleaning up");
+                    });
 
-    let location = use_location(cx);
-    let contacts = create_resource(cx, move || location.search.get(), get_contacts);
-    let contacts = move || {
-        contacts.read().map(|contacts| {
-            // this data doesn't change frequently so we can use .map().collect() instead of a keyed <For/>
-            contacts
-                .into_iter()
-                .map(|contact| {
-                    view! { cx,
-                        <li><A href=contact.id.to_string()><span>{&contact.first_name} " " {&contact.last_name}</span></A></li>
+                    view!{cx,
+                        <main><Outlet/></main>
                     }
-                })
-                .collect::<Vec<_>>()
-        })
-    };
+                }>
+                    <Route path="/a" view=|cx| {
+                        log!("/a rendering on {:?}", cx.id());
 
-    view! { cx,
-        <div class="contact-list">
-            <h1>"Contacts"</h1>
-            <Suspense fallback=move || view! { cx,  <p>"Loading contacts..."</p> }>
-                {move || view! { cx, <ul>{contacts}</ul>}}
-            </Suspense>
-            <Outlet/>
-        </div>
-    }
-}
+                        on_cleanup(cx, || {
+                            log!("A: cleaning up");
+                        });
 
-#[derive(Params, PartialEq, Clone, Debug)]
-pub struct ContactParams {
-    id: usize,
-}
+                        view!{cx,
+                            <p>"I am A"</p>
+                        }
+                    } />
+                    <Route path="/b" view=|cx| {
+                        log!("/b rendering on {:?}", cx.id());
+                        on_cleanup(cx, || {
+                            log!("B: cleaning up");
+                        });
 
-#[component]
-pub fn Contact(cx: Scope) -> impl IntoView {
-    log::debug!("rendering <Contact/>");
+                        view!{cx,
+                            <p>"I am B"</p>
+                        }
+                    } />
+                    <Route path="" view=|cx| {
+                        log!("/(home) rendering on {:?}", cx.ancestry());
 
-    let params = use_params::<ContactParams>(cx);
-    let contact = create_resource(
-        cx,
-        move || params().map(|params| params.id).ok(),
-        // any of the following would work (they're identical)
-        // move |id| async move { get_contact(id).await }
-        // move |id| get_contact(id),
-        // get_contact
-        get_contact,
-    );
+                        on_cleanup(cx, || {
+                            log!("home 2: cleaning up");
+                        });
 
-    let contact_display = move || match contact.read() {
-        // None => loading, but will be caught by Suspense fallback
-        // I'm only doing this explicitly for the example
-        None => None,
-        // Some(None) => has loaded and found no contact
-        Some(None) => Some(view! { cx, <p>"No contact with this ID was found."</p> }.into_any()),
-        // Some(Some) => has loaded and found a contact
-        Some(Some(contact)) => Some(
-            view! { cx,
-                <section class="card">
-                    <h1>{contact.first_name} " " {contact.last_name}</h1>
-                    <p>{contact.address_1}<br/>{contact.address_2}</p>
-                </section>
-            }
-            .into_any(),
-        ),
-    };
+                        view!{cx,
+                            <p>"I am home"</p>
+                        }
+                    } />
+                </Route>
+                <Route path="/some-page" view=|cx| {
+                    on_cleanup(cx, || {
+                        log!("some-page: cleaning up");
+                    });
 
-    view! { cx,
-        <div class="contact">
-            <Transition fallback=move || view! { cx,  <p>"Loading..."</p> }>
-                {contact_display}
-            </Transition>
-        </div>
-    }
-}
+                    view!{cx,
+                        <p>"I am some page"</p>
+                    }
+                }/>
 
-#[component]
-pub fn About(cx: Scope) -> impl IntoView {
-    log::debug!("rendering <About/>");
-    // use_navigate allows you to navigate programmatically by calling a function
-    let navigate = use_navigate(cx);
-
-    view! { cx,
-        <>
-            // note: this is just an illustration of how to use `use_navigate`
-            // <button on:click> to navigate is an *anti-pattern*
-            // you should ordinarily use a link instead,
-            // both semantically and so your link will work before WASM loads
-            <button on:click=move |_| { _ = navigate("/", Default::default()); }>
-                "Home"
-            </button>
-            <h1>"About"</h1>
-            <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
-        </>
-    }
-}
-
-#[component]
-pub fn Settings(cx: Scope) -> impl IntoView {
-    log::debug!("rendering <Settings/>");
-    view! { cx,
-        <>
-            <h1>"Settings"</h1>
-            <form>
-                <fieldset>
-                    <legend>"Name"</legend>
-                    <input type="text" name="first_name" placeholder="First"/>
-                    <input type="text" name="last_name" placeholder="Last"/>
-                </fieldset>
-                <pre>"This page is just a placeholder."</pre>
-            </form>
-        </>
+            </Routes>
+        </Router>
     }
 }

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -1,76 +1,208 @@
 mod api;
-
+use crate::api::*;
 use leptos::*;
 use leptos_router::*;
 
-#[component]
-pub fn App(cx: Scope) -> impl IntoView {
-    console_error_panic_hook::set_once();
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct ExampleContext(i32);
 
-    view! {cx,
+#[component]
+pub fn RouterExample(cx: Scope) -> impl IntoView {
+    log::debug!("rendering <RouterExample/>");
+
+    // contexts are passed down through the route tree
+    provide_context(cx, ExampleContext(0));
+
+    view! { cx,
         <Router>
             <nav>
-                <a href="/">"home"</a> " | "
-                <a href="/a">"a"</a> " | "
-                <a href="/b">"b"</a> " | "
-                <a href="/some-page">"some page"</a>
+                // ordinary <a> elements can be used for client-side navigation
+                // using <A> has two effects:
+                // 1) ensuring that relative routing works properly for nested routes
+                // 2) setting the `aria-current` attribute on the current link,
+                //    for a11y and styling purposes
+                <A exact=true href="/">"Contacts"</A>
+                <A href="about">"About"</A>
+                <A href="settings">"Settings"</A>
+                <A href="redirect-home">"Redirect to Home"</A>
             </nav>
-            <Routes>
-                <Route path="/" view=|cx| {
-                    log!("/ rendering on {:?}", cx.id());
-
-                    on_cleanup(cx, || {
-                        log!("home: cleaning up");
-                    });
-
-                    view!{cx,
-                        <main><Outlet/></main>
-                    }
-                }>
-                    <Route path="/a" view=|cx| {
-                        log!("/a rendering on {:?}", cx.id());
-
-                        on_cleanup(cx, || {
-                            log!("A: cleaning up");
-                        });
-
-                        view!{cx,
-                            <p>"I am A"</p>
-                        }
-                    } />
-                    <Route path="/b" view=|cx| {
-                        log!("/b rendering on {:?}", cx.id());
-                        on_cleanup(cx, || {
-                            log!("B: cleaning up");
-                        });
-
-                        view!{cx,
-                            <p>"I am B"</p>
-                        }
-                    } />
-                    <Route path="" view=|cx| {
-                        log!("/(home) rendering on {:?}", cx.ancestry());
-
-                        on_cleanup(cx, || {
-                            log!("home 2: cleaning up");
-                        });
-
-                        view!{cx,
-                            <p>"I am home"</p>
-                        }
-                    } />
-                </Route>
-                <Route path="/some-page" view=|cx| {
-                    on_cleanup(cx, || {
-                        log!("some-page: cleaning up");
-                    });
-
-                    view!{cx,
-                        <p>"I am some page"</p>
-                    }
-                }/>
-
-            </Routes>
+            <main>
+                <Routes>
+                    <Route
+                        path=""
+                        view=move |cx| view! { cx,  <ContactList/> }
+                    >
+                        <Route
+                            path=":id"
+                            view=move |cx| view! { cx,  <Contact/> }
+                        />
+                        <Route
+                            path="/"
+                            view=move |_| view! { cx,  <p>"Select a contact."</p> }
+                        />
+                    </Route>
+                    <Route
+                        path="about"
+                        view=move |cx| view! { cx,  <About/> }
+                    />
+                    <Route
+                        path="settings"
+                        view=move |cx| view! { cx,  <Settings/> }
+                    />
+                    <Route
+                        path="redirect-home"
+                        view=move |cx| view! { cx, <Redirect path="/"/> }
+                    />
+                </Routes>
+            </main>
         </Router>
+    }
+}
+
+#[component]
+pub fn ContactList(cx: Scope) -> impl IntoView {
+    log::debug!("rendering <ContactList/>");
+
+    // contexts are passed down through the route tree
+    provide_context(cx, ExampleContext(42));
+
+    on_cleanup(cx, || {
+        log!("cleaning up <ContactList/>");
+    });
+
+    let location = use_location(cx);
+    let contacts = create_resource(cx, move || location.search.get(), get_contacts);
+    let contacts = move || {
+        contacts.read().map(|contacts| {
+            // this data doesn't change frequently so we can use .map().collect() instead of a keyed <For/>
+            contacts
+                .into_iter()
+                .map(|contact| {
+                    view! { cx,
+                        <li><A href=contact.id.to_string()><span>{&contact.first_name} " " {&contact.last_name}</span></A></li>
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+    };
+
+    view! { cx,
+        <div class="contact-list">
+            <h1>"Contacts"</h1>
+            <Suspense fallback=move || view! { cx,  <p>"Loading contacts..."</p> }>
+                {move || view! { cx, <ul>{contacts}</ul>}}
+            </Suspense>
+            <Outlet/>
+        </div>
+    }
+}
+
+#[derive(Params, PartialEq, Clone, Debug)]
+pub struct ContactParams {
+    id: usize,
+}
+
+#[component]
+pub fn Contact(cx: Scope) -> impl IntoView {
+    log::debug!("rendering <Contact/>");
+
+    log::debug!(
+        "ExampleContext should be Some(42). It is {:?}",
+        use_context::<ExampleContext>(cx)
+    );
+
+    on_cleanup(cx, || {
+        log!("cleaning up <Contact/>");
+    });
+
+    let params = use_params::<ContactParams>(cx);
+    let contact = create_resource(
+        cx,
+        move || params().map(|params| params.id).ok(),
+        // any of the following would work (they're identical)
+        // move |id| async move { get_contact(id).await }
+        // move |id| get_contact(id),
+        // get_contact
+        get_contact,
+    );
+
+    let contact_display = move || match contact.read() {
+        // None => loading, but will be caught by Suspense fallback
+        // I'm only doing this explicitly for the example
+        None => None,
+        // Some(None) => has loaded and found no contact
+        Some(None) => Some(view! { cx, <p>"No contact with this ID was found."</p> }.into_any()),
+        // Some(Some) => has loaded and found a contact
+        Some(Some(contact)) => Some(
+            view! { cx,
+                <section class="card">
+                    <h1>{contact.first_name} " " {contact.last_name}</h1>
+                    <p>{contact.address_1}<br/>{contact.address_2}</p>
+                </section>
+            }
+            .into_any(),
+        ),
+    };
+
+    view! { cx,
+        <div class="contact">
+            <Transition fallback=move || view! { cx,  <p>"Loading..."</p> }>
+                {contact_display}
+            </Transition>
+        </div>
+    }
+}
+
+#[component]
+pub fn About(cx: Scope) -> impl IntoView {
+    log::debug!("rendering <About/>");
+
+    on_cleanup(cx, || {
+        log!("cleaning up <About/>");
+    });
+
+    log::debug!(
+        "ExampleContext should be Some(0). It is {:?}",
+        use_context::<ExampleContext>(cx)
+    );
+
+    // use_navigate allows you to navigate programmatically by calling a function
+    let navigate = use_navigate(cx);
+
+    view! { cx,
+        <>
+            // note: this is just an illustration of how to use `use_navigate`
+            // <button on:click> to navigate is an *anti-pattern*
+            // you should ordinarily use a link instead,
+            // both semantically and so your link will work before WASM loads
+            <button on:click=move |_| { _ = navigate("/", Default::default()); }>
+                "Home"
+            </button>
+            <h1>"About"</h1>
+            <p>"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+        </>
+    }
+}
+
+#[component]
+pub fn Settings(cx: Scope) -> impl IntoView {
+    log::debug!("rendering <Settings/>");
+
+    on_cleanup(cx, || {
+        log!("cleaning up <Settings/>");
+    });
+
+    view! { cx,
+        <>
+            <h1>"Settings"</h1>
+            <form>
+                <fieldset>
+                    <legend>"Name"</legend>
+                    <input type="text" name="first_name" placeholder="First"/>
+                    <input type="text" name="last_name" placeholder="Last"/>
+                </fieldset>
+                <pre>"This page is just a placeholder."</pre>
+            </form>
+        </>
     }
 }

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -5,5 +5,5 @@ pub fn main() {
     console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
-    mount_to_body(|cx| view! { cx, <App/> })
+    mount_to_body(|cx| view! { cx, <RouterExample/> })
 }

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -5,5 +5,5 @@ pub fn main() {
     console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
-    mount_to_body(|cx| view! { cx, <RouterExample/> })
+    mount_to_body(|cx| view! { cx, <App/> })
 }

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -191,7 +191,6 @@ impl Scope {
                     .dispose();
                 }
             }
-
             // run cleanups
             if let Some(cleanups) = runtime.scope_cleanups.borrow_mut().remove(self.id) {
                 for cleanup in cleanups {

--- a/router/src/components/outlet.rs
+++ b/router/src/components/outlet.rs
@@ -7,6 +7,7 @@ use leptos::*;
 /// that child route is displayed. Renders nothing if there is no nested child.
 #[component]
 pub fn Outlet(cx: Scope) -> impl IntoView {
+    log!("rendering <Outlet/> on {:?}", cx.id());
     let id = HydrationCtx::id();
     let route = use_route(cx);
     let is_showing = Rc::new(Cell::new(None::<(usize, Scope)>));
@@ -26,9 +27,11 @@ pub fn Outlet(cx: Scope) -> impl IntoView {
                 if let Some(prev_scope) = prev.map(|(_, scope)| scope) {
                     prev_scope.dispose();
                 }
-                is_showing.set(Some((child.id(), child.cx())));
-                provide_context(cx, child.clone());
-                set_outlet.set(Some(child.outlet(cx).into_view(cx)))
+                _ = cx.child_scope(|child_cx| {
+                    provide_context(child_cx, child.clone());
+                    set_outlet.set(Some(child.outlet(child_cx).into_view(child_cx)));
+                    is_showing.set(Some((child.id(), child_cx)));
+                });
             }
         }
     });

--- a/router/src/components/outlet.rs
+++ b/router/src/components/outlet.rs
@@ -7,7 +7,6 @@ use leptos::*;
 /// that child route is displayed. Renders nothing if there is no nested child.
 #[component]
 pub fn Outlet(cx: Scope) -> impl IntoView {
-    log!("rendering <Outlet/> on {:?}", cx.id());
     let id = HydrationCtx::id();
     let route = use_route(cx);
     let is_showing = Rc::new(Cell::new(None::<(usize, Scope)>));

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -59,9 +59,6 @@ pub fn Routes(
         move |_| get_route_matches(branches.clone(), router.pathname().get())
     });
 
-    // Rebuild the list of nested routes conservatively, and show the root route here
-    let disposers = RefCell::new(Vec::<ScopeDisposer>::new());
-
     // iterate over the new matches, reusing old routes when they are the same
     // and replacing them with new routes when they differ
     let next: Rc<RefCell<Vec<RouteContext>>> = Default::default();
@@ -69,7 +66,7 @@ pub fn Routes(
     let root_equal = Rc::new(Cell::new(true));
 
     let route_states: Memo<RouterState> = create_memo(cx, {
-        let root_equal = root_equal.clone();
+        let root_equal = Rc::clone(&root_equal);
         move |prev: Option<&RouterState>| {
             root_equal.set(true);
             next.borrow_mut().clear();
@@ -82,8 +79,6 @@ pub fn Routes(
             let mut equal = prev_matches
                 .map(|prev_matches| next_matches.len() == prev_matches.len())
                 .unwrap_or(false);
-
-            let prev_cx = Rc::new(Cell::new(cx));
 
             for i in 0..next_matches.len() {
                 let next = next.clone();
@@ -111,59 +106,38 @@ pub fn Routes(
                             root_equal.set(false);
                         }
 
-                        let disposer = prev_cx.get().child_scope({
-                            let next = next.clone();
-                            let router = Rc::clone(&router.inner);
-                            let prev_cx = Rc::clone(&prev_cx);
-                            move |cx| {
-                                prev_cx.set(cx);
-                                let next = next.clone();
-                                let next_ctx = RouteContext::new(
-                                    cx,
-                                    &RouterContext { inner: router },
-                                    {
-                                        let next = next.clone();
-                                        move |cx| {
-                                            if let Some(route_states) =
-                                                use_context::<Memo<RouterState>>(cx)
-                                            {
-                                                route_states.with(|route_states| {
-                                                    let routes = route_states.routes.borrow();
-                                                    routes.get(i + 1).cloned()
-                                                })
-                                            } else {
-                                                next.borrow().get(i + 1).cloned()
-                                            }
-                                        }
-                                    },
-                                    move || matches.with(|m| m.get(i).cloned()),
-                                );
+                        let next = next.clone();
+                        let router = Rc::clone(&router.inner);
 
-                                if let Some(next_ctx) = next_ctx {
-                                    if next.borrow().len() > i + 1 {
-                                        next.borrow_mut()[i] = next_ctx;
+                        let next = next.clone();
+                        let next_ctx = RouteContext::new(
+                            cx,
+                            &RouterContext { inner: router },
+                            {
+                                let next = next.clone();
+                                move |cx| {
+                                    if let Some(route_states) = use_context::<Memo<RouterState>>(cx)
+                                    {
+                                        route_states.with(|route_states| {
+                                            let routes = route_states.routes.borrow();
+                                            routes.get(i + 1).cloned()
+                                        })
                                     } else {
-                                        next.borrow_mut().push(next_ctx);
+                                        next.borrow().get(i + 1).cloned()
                                     }
                                 }
-                            }
-                        });
+                            },
+                            move || matches.with(|m| m.get(i).cloned()),
+                        );
 
-                        if disposers.borrow().len() > i {
-                            let mut disposers = disposers.borrow_mut();
-                            let old_route_disposer = std::mem::replace(&mut disposers[i], disposer);
-                            old_route_disposer.dispose();
-                        } else {
-                            disposers.borrow_mut().push(disposer);
+                        if let Some(next_ctx) = next_ctx {
+                            if next.borrow().len() > i + 1 {
+                                next.borrow_mut()[i] = next_ctx;
+                            } else {
+                                next.borrow_mut().push(next_ctx);
+                            }
                         }
                     }
-                }
-            }
-
-            if disposers.borrow().len() > next_matches.len() {
-                let surplus_disposers = disposers.borrow_mut().split_off(next_matches.len() + 1);
-                for disposer in surplus_disposers {
-                    disposer.dispose();
                 }
             }
 
@@ -195,6 +169,7 @@ pub fn Routes(
 
     // show the root route
     let id = HydrationCtx::id();
+    let root_cx = RefCell::new(None);
     let root = create_memo(cx, move |prev| {
         provide_context(cx, route_states);
         route_states.with(|state| {
@@ -208,7 +183,14 @@ pub fn Routes(
                 }
 
                 if prev.is_none() || !root_equal.get() {
-                    root.as_ref().map(|route| route.outlet(cx).into_view(cx))
+                    let (root_view, _) = cx.run_child_scope(|cx| {
+                        let prev_cx = std::mem::replace(&mut *root_cx.borrow_mut(), Some(cx));
+                        if let Some(prev_cx) = prev_cx {
+                            prev_cx.dispose();
+                        }
+                        root.as_ref().map(|route| route.outlet(cx).into_view(cx))
+                    });
+                    root_view
                 } else {
                     prev.cloned().unwrap()
                 }


### PR DESCRIPTION
This addresses #498. It also involved cleaning up the `<Routes/>` code significantly, in a way that I think was *very* sorely needed and that makes me more comfortable with what's going on there now.