### PR TITLE
Allow literal string as class in view macro

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -213,8 +213,8 @@ mod server;
 /// ```
 ///
 /// 9. You can add the same class to every element in the view by passing in a special
-///    `class = {/* ... */}` argument after `cx, `. This is useful for injecting a class
-///    providing by a scoped styling library.
+///    `class = {/* ... */},` argument after `cx, `. This is useful for injecting a class
+///    provided by a scoped styling library.
 /// ```rust
 /// # use leptos::*;
 /// # run_scope(create_runtime(), |cx| {
@@ -287,17 +287,20 @@ pub fn view(tokens: TokenStream) -> TokenStream {
             let second = tokens.next();
             let third = tokens.next();
             let fourth = tokens.next();
-            let global_class = match (&first, &second, &third, &fourth) {
-                (
-                    Some(TokenTree::Ident(first)),
-                    Some(TokenTree::Punct(eq)),
-                    Some(val),
-                    Some(TokenTree::Punct(comma)),
-                ) if *first == "class"
-                    && eq.to_string() == '='.to_string()
-                    && comma.to_string() == ','.to_string() =>
+            let global_class = match (&first, &second) {
+                (Some(TokenTree::Ident(first)), Some(TokenTree::Punct(eq)))
+                    if *first == "class" && eq.as_char() == '=' =>
                 {
-                    Some(val.clone())
+                    match &fourth {
+                        Some(TokenTree::Punct(comma)) if comma.as_char() == ',' => third.clone(),
+                        _ => {
+                            let error_msg = concat!(
+                                "To create a scope class with the view! macro you must put a comma `,` after the value.\n",
+                                "e.g., view!{cx, class=\"my-class\", <div>...</div>}"
+                            );
+                            panic!("{error_msg}")
+                        }
+                    }
                 }
                 _ => None,
             };


### PR DESCRIPTION
Render literal string as class in view macro correctly. This is currently allowed but produces incorrect html.

this code:
```rust
// Notice that "scope-class" doesn't have braces around it `{ ... }`
view!{cx, class="scope-class", ...}
```

Pre this PR:
<img width="467" alt="Screenshot 2023-02-10 at 7 51 12 PM" src="https://user-images.githubusercontent.com/123515925/218228081-da9573e0-6f4a-4d46-b54f-5c5b32b5786b.png">

Notice there's an extra attribute `scope-class""=""`.
This is because the quotes in `"scope-class"` get rendered and the browser turns that into its own attribute.

Post this PR:
<img width="348" alt="Screenshot 2023-02-10 at 7 50 00 PM" src="https://user-images.githubusercontent.com/123515925/218228219-a1ed5d90-5c8f-44e5-b342-e979f58fb02f.png">

The class renders correctly.

As a side note, the `Header` and `Banner` component that are inside of the `scope-class` scope don't have the `scope-class` applied. I don't know if this is intentional because they are components, but there it is.

This PR also includes updated error messaging if a user tries to use a class but forgets the trailing comma.

Pre this PR it would say:
```
error: expected literal                                                                                                                                           
   --> src/app.rs:299:17                                                                                                                                          
    |                                                                                                                                                             
299 |     view! { cx, class="scope-class"                                                                                                                         
    |                 ^^^^^        
```

Now it says:
```
   --> src/app.rs:299:5
    |
299 | /     view! { cx, class="scope-class"
300 | |       <div class="home-page">
301 | |         // Header
302 | |         <Header />
...   |
340 | |       <Footer/>
341 | |     }
    | |_____^
    |
    = help: message: To create a scope class with the view! macro you must put a comma `,` after the value.
            e.g., view!{cx, class="my-class", <div>...</div>}
```






