### PR TITLE
URLs with a scheme in A component rendered correctly

### DIFF
--- a/router/src/hooks.rs
+++ b/router/src/hooks.rs
@@ -70,7 +70,7 @@ pub fn use_resolved_path(
         if path.starts_with('/') {
             Some(path)
         } else {
-            route.resolve_path(&path).map(String::from)
+            route.resolve_path(&path).or(Some(path)).map(String::from)
         }
     })
 }

--- a/router/src/matching/resolve_path.rs
+++ b/router/src/matching/resolve_path.rs
@@ -74,7 +74,7 @@ pub fn join_paths<'a>(from: &'a str, to: &'a str) -> String {
 
 const TRIM_PATH: &str = r#"^/+|/+$"#;
 const BEGINS_WITH_QUERY_OR_HASH: &str = r#"^[?#]"#;
-const HAS_SCHEME: &str = r#"^(?:[a-z0-9]+:)?//"#;
+const HAS_SCHEME: &str = r#"^[a-z0-9+.-]+:"#;
 const QUERY: &str = r#"/*(\*.*)?$"#;
 
 #[cfg(not(feature = "ssr"))]


### PR DESCRIPTION
Currently if you supply a URL to an `A` component that has a scheme or something that looks like a scheme it will silently fail. Notice this is the capital `A` component not the lowercase `a` component.

This code:
```rust
<A href="http://google.com">"Url"</A>
<A href="google.com">"No Http"</A>
<A href="localhost:3000">"No Http with port"</A>
<A href="mailto:greg@greg.greg">"Mailto"</A>
<A href="tel:+11111111111">"Tel"</A>
```

Currently produces:
<img width="345" alt="Screenshot 2023-02-13 at 2 48 01 PM" src="https://user-images.githubusercontent.com/123515925/218560500-2e336e45-ae9c-4135-80bd-c064e3e37d41.png">

In which all but the second one are not what a normal `a` tag would do.

After this PR it produces:
<img width="311" alt="Screenshot 2023-02-13 at 2 47 21 PM" src="https://user-images.githubusercontent.com/123515925/218560658-2e714451-f9ab-4fe4-b3a7-dd5ed65e4bbc.png">

Which are all what a normal `a` would produce.


The other option here is to not compile and recommend that the user use an `a` tag rather than an `A` tag which I also think is a reasonable solution but I picked this one simply so there's less friction for a user. Happy to make it do whatever folks think is best!



