### PR TITLE
Identify CSS to reload from the href

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -589,14 +589,15 @@ fn html_parts(
                     let msg = JSON.parse(ev.data);
                     if (msg.all) window.location.reload();
                     if (msg.css) {{
-                        const link = document.querySelector("link#leptos");
-                        if (link) {{
-                            let href = link.getAttribute('href').split('?')[0];
-                            let newHref = href + '?version=' + new Date().getMilliseconds();
-                            link.setAttribute('href', newHref);
-                        }} else {{
-                            console.warn("Could not find link#leptos");
-                        }}
+                        let found = false;
+                        document.querySelectorAll("link").forEach((link) => {{
+                            if (link.getAttribute('href').includes("fail")) {{
+                                let newHref = '/' + msg.css + '?version=' + new Date().getMilliseconds();
+                                link.setAttribute('href', newHref);
+                                found = true;
+                            }}
+                        }});
+                        if (!found) console.warn(`CSS hot-reload: Could not find a <link href=/\"${{msg.css}}\"> element`);
                     }};
                 }};
                 ws.onclose = () => console.warn('Live-reload stopped. Manual reload necessary.');

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -591,7 +591,7 @@ fn html_parts(
                     if (msg.css) {{
                         let found = false;
                         document.querySelectorAll("link").forEach((link) => {{
-                            if (link.getAttribute('href').includes("fail")) {{
+                            if (link.getAttribute('href').includes(msg.css)) {{
                                 let newHref = '/' + msg.css + '?version=' + new Date().getMilliseconds();
                                 link.setAttribute('href', newHref);
                                 found = true;

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -594,14 +594,15 @@ fn html_parts(
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();
                         if (msg.css) {{
-                            const link = document.querySelector("link#leptos");
-                            if (link) {{
-                                let href = link.getAttribute('href').split('?')[0];
-                                let newHref = href + '?version=' + new Date().getMilliseconds();
-                                link.setAttribute('href', newHref);
-                            }} else {{
-                                console.warn("Could not find link#leptos");
-                            }}
+                            let found = false;
+                            document.querySelectorAll("link").forEach((link) => {{
+                                if (link.getAttribute('href').includes(msg.css)) {{
+                                    let newHref = '/' + href + '?version=' + new Date().getMilliseconds();
+                                    link.setAttribute('href', newHref);
+                                    found = true;
+                                }}
+                            }});
+                            if (!found) console.warn(`CSS hot-reload: Could not find a <link href=/\"${{msg.css}}\"> element`);
                         }};
                     }};
                     ws.onclose = () => console.warn('Live-reload stopped. Manual reload necessary.');


### PR DESCRIPTION
Identify the CSS to reload from the href, which is already sent to the browser in the WebSocket message, instead of using the CSS `id`. 

This opens the possibility to have more than one CSS file that is hot-reloaded by `cargo-leptos`. I plan on using that for the Tailwind implementation.

This is backwards compatible with previous `cargo-leptos` versions.

@benwis Ok for you? I have to admit that I didn't test it with an Axum setup as I don't have one easily available. Would appreciate it if you could test it!

@gbj I would be really good to include this in release 0.2.0.