### PR TITLE
fix: hydration IDs for elements following `<Suspense/>`

### DIFF
--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -87,6 +87,7 @@ where
                 } else {
                     // run the child; we'll probably throw this away, but it will register resource reads
                     let child = orig_child(cx).into_view(cx);
+                    let after_original_child = HydrationCtx::id();
 
                     let initial = {
                         // no resources were read under this, so just return the child
@@ -118,8 +119,7 @@ where
                         }
                     };
 
-                    HydrationCtx::continue_from(current_id.clone());
-
+                    HydrationCtx::continue_from(after_original_child);
                     initial
                 }
             }

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -69,6 +69,50 @@ pub fn create_signal<T>(
     s
 }
 
+/// Works exactly as [create_signal], but creates multiple signals at once.
+#[cfg_attr(
+    debug_assertions,
+    instrument(
+        level = "trace",
+        skip_all,
+        fields(
+            scope = ?cx.id,
+            ty = %std::any::type_name::<T>()
+        )
+    )
+)]
+#[track_caller]
+pub fn create_many_signals<T>(
+    cx: Scope,
+    values: impl IntoIterator<Item = T>,
+) -> Vec<(ReadSignal<T>, WriteSignal<T>)> {
+    cx.runtime.create_many_signals_with_map(cx, values, |x| x)
+}
+
+/// Works exactly as [create_many_signals], but applies the map function to each signal pair.
+#[cfg_attr(
+    debug_assertions,
+    instrument(
+        level = "trace",
+        skip_all,
+        fields(
+            scope = ?cx.id,
+            ty = %std::any::type_name::<T>()
+        )
+    )
+)]
+#[track_caller]
+pub fn create_many_signals_mapped<T, U>(
+    cx: Scope,
+    values: impl IntoIterator<Item = T>,
+    map_fn: impl Fn((ReadSignal<T>, WriteSignal<T>)) -> U + 'static,
+) -> Vec<U>
+where
+    T: 'static,
+{
+    cx.runtime.create_many_signals_with_map(cx, values, map_fn)
+}
+
 /// Creates a signal that always contains the most recent value emitted by a
 /// [Stream](futures::stream::Stream).
 /// If the stream has not yet emitted a value since the signal was created, the signal's


### PR DESCRIPTION
Closes issue #527.