### PR TITLE
change: pass `Scope` into `Resource::read()` and `Resource::with()`

### DIFF
--- a/examples/counter_isomorphic/src/counters.rs
+++ b/examples/counter_isomorphic/src/counters.rs
@@ -97,10 +97,10 @@ pub fn Counter(cx: Scope) -> impl IntoView {
         |_| get_server_count(),
     );
 
-    let value = move || counter.read().map(|count| count.unwrap_or(0)).unwrap_or(0);
+    let value = move || counter.read(cx).map(|count| count.unwrap_or(0)).unwrap_or(0);
     let error_msg = move || {
         counter
-            .read()
+            .read(cx)
             .map(|res| match res {
                 Ok(_) => None,
                 Err(e) => Some(e),
@@ -143,7 +143,7 @@ pub fn FormCounter(cx: Scope) -> impl IntoView {
     let value = move || {
         log::debug!("FormCounter looking for value");
         counter
-            .read()
+            .read(cx)
             .map(|n| n.ok())
             .flatten()
             .map(|n| n)

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -60,7 +60,7 @@ pub fn fetch_example(cx: Scope) -> impl IntoView {
     // and by using the ErrorBoundary fallback to catch Err(_)
     // so we'll just implement our happy path and let the framework handle the rest
     let cats_view = move || {
-        cats.with(|data| {
+        cats.with(cx, |data| {
             data.iter()
                 .flatten()
                 .map(|cat| view! { cx, <img src={cat}/> })

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -38,7 +38,7 @@ pub fn Stories(cx: Scope) -> impl IntoView {
     let (pending, set_pending) = create_signal(cx, false);
 
     let hide_more_link =
-        move || pending() || stories.read().unwrap_or(None).unwrap_or_default().len() < 28;
+        move || pending() || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28;
 
     view! {
         cx,
@@ -82,7 +82,7 @@ pub fn Stories(cx: Scope) -> impl IntoView {
                         fallback=move || view! { cx,  <p>"Loading..."</p> }
                         set_pending=set_pending.into()
                     >
-                        {move || match stories.read() {
+                        {move || match stories.read(cx) {
                             None => None,
                             Some(None) => Some(view! { cx,  <p>"Error loading stories."</p> }.into_any()),
                             Some(Some(stories)) => {

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -17,13 +17,13 @@ pub fn Story(cx: Scope) -> impl IntoView {
             }
         },
     );
-    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || story.read(cx).and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
 
     view! { cx,
         <>
             <Meta name="description" content=meta_description/>
                 <Suspense fallback=|| view! { cx, "Loading..." }>
-                    {move || story.read().map(|story| match story {
+                    {move || story.read(cx).map(|story| match story {
                         None => view! { cx,  <div class="item-view">"Error loading this story."</div> },
                         Some(story) => view! { cx,
                             <div class="item-view">

--- a/examples/hackernews/src/routes/users.rs
+++ b/examples/hackernews/src/routes/users.rs
@@ -19,7 +19,7 @@ pub fn User(cx: Scope) -> impl IntoView {
     view! { cx,
         <div class="user-view">
             <Suspense fallback=|| view! { cx, "Loading..." }>
-                {move || user.read().map(|user| match user {
+                {move || user.read(cx).map(|user| match user {
                     None => view! { cx,  <h1>"User not found."</h1> }.into_any(),
                     Some(user) => view! { cx,
                         <div>

--- a/examples/hackernews_axum/src/routes/stories.rs
+++ b/examples/hackernews_axum/src/routes/stories.rs
@@ -38,7 +38,7 @@ pub fn Stories(cx: Scope) -> impl IntoView {
     let (pending, set_pending) = create_signal(cx, false);
 
     let hide_more_link =
-        move || pending() || stories.read().unwrap_or(None).unwrap_or_default().len() < 28;
+        move || pending() || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28;
 
     view! {
         cx,
@@ -82,7 +82,7 @@ pub fn Stories(cx: Scope) -> impl IntoView {
                         fallback=move || view! { cx,  <p>"Loading..."</p> }
                         set_pending=set_pending.into()
                     >
-                        {move || match stories.read() {
+                        {move || match stories.read(cx) {
                             None => None,
                             Some(None) => Some(view! { cx,  <p>"Error loading stories."</p> }.into_any()),
                             Some(Some(stories)) => {

--- a/examples/hackernews_axum/src/routes/story.rs
+++ b/examples/hackernews_axum/src/routes/story.rs
@@ -17,13 +17,13 @@ pub fn Story(cx: Scope) -> impl IntoView {
             }
         },
     );
-    let meta_description = move || story.read().and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || story.read(cx).and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
 
     view! { cx,
         <>
             <Meta name="description" content=meta_description/>
                 <Suspense fallback=|| view! { cx, "Loading..." }>
-                    {move || story.read().map(|story| match story {
+                    {move || story.read(cx).map(|story| match story {
                         None => view! { cx,  <div class="item-view">"Error loading this story."</div> },
                         Some(story) => view! { cx,
                             <div class="item-view">

--- a/examples/hackernews_axum/src/routes/users.rs
+++ b/examples/hackernews_axum/src/routes/users.rs
@@ -19,7 +19,7 @@ pub fn User(cx: Scope) -> impl IntoView {
     view! { cx,
         <div class="user-view">
             <Suspense fallback=|| view! { cx, "Loading..." }>
-                {move || user.read().map(|user| match user {
+                {move || user.read(cx).map(|user| match user {
                     None => view! { cx,  <h1>"User not found."</h1> }.into_any(),
                     Some(user) => view! { cx,
                         <div>

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -71,9 +71,10 @@ pub fn ContactList(cx: Scope) -> impl IntoView {
     });
 
     let location = use_location(cx);
-    let contacts = create_resource(cx, move || location.search.get(), get_contacts);
+    let contacts =
+        create_resource(cx, move || location.search.get(), get_contacts);
     let contacts = move || {
-        contacts.read().map(|contacts| {
+        contacts.read(cx).map(|contacts| {
             // this data doesn't change frequently so we can use .map().collect() instead of a keyed <For/>
             contacts
                 .into_iter()
@@ -126,12 +127,15 @@ pub fn Contact(cx: Scope) -> impl IntoView {
         get_contact,
     );
 
-    let contact_display = move || match contact.read() {
+    let contact_display = move || match contact.read(cx) {
         // None => loading, but will be caught by Suspense fallback
         // I'm only doing this explicitly for the example
         None => None,
         // Some(None) => has loaded and found no contact
-        Some(None) => Some(view! { cx, <p>"No contact with this ID was found."</p> }.into_any()),
+        Some(None) => Some(
+            view! { cx, <p>"No contact with this ID was found."</p> }
+                .into_any(),
+        ),
         // Some(Some) => has loaded and found a contact
         Some(Some(contact)) => Some(
             view! { cx,

--- a/examples/ssr_modes/src/app.rs
+++ b/examples/ssr_modes/src/app.rs
@@ -39,7 +39,7 @@ fn HomePage(cx: Scope) -> impl IntoView {
     let posts =
         create_resource(cx, || (), |_| async { list_post_metadata().await });
     let posts_view = move || {
-        posts.with(|posts| posts
+        posts.with(cx, |posts| posts
             .clone()
             .map(|posts| {
                 posts.iter()
@@ -82,7 +82,7 @@ fn Post(cx: Scope) -> impl IntoView {
     });
 
     let post_view = move || {
-        post.with(|post| {
+        post.with(cx, |post| {
             post.clone().map(|post| {
                 view! { cx,
                     // render content

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -140,7 +140,7 @@ pub fn Todos(cx: Scope) -> impl IntoView {
                 {move || {
                     let existing_todos = {
                         move || {
-                            todos.read()
+                            todos.read(cx)
                                 .map(move |todos| match todos {
                                     Err(e) => {
                                         vec![view! { cx, <pre class="error">"Server Error: " {e.to_string()}</pre>}.into_any()]

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -159,7 +159,7 @@ pub fn Todos(cx: Scope) -> impl IntoView {
                 {move || {
                     let existing_todos = {
                         move || {
-                            todos.read()
+                            todos.read(cx)
                                 .map(move |todos| match todos {
                                     Err(e) => {
                                         vec![view! { cx, <pre class="error">"Server Error: " {e.to_string()}</pre>}.into_any()]

--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -28,7 +28,7 @@ use std::rc::Rc;
 ///   <div>
 ///     <Suspense fallback=move || view! { cx, <p>"Loading (Suspense Fallback)..."</p> }>
 ///       {move || {
-///           cats.read().map(|data| match data {
+///           cats.read(cx).map(|data| match data {
 ///             None => view! { cx,  <pre>"Error"</pre> }.into_any(),
 ///             Some(cats) => view! { cx,
 ///               <div>{

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -35,7 +35,7 @@ use std::{cell::RefCell, rc::Rc};
 ///       set_pending=set_pending.into()
 ///     >
 ///       {move || {
-///           cats.read().map(|data| match data {
+///           cats.read(cx).map(|data| match data {
 ///             None => view! { cx,  <pre>"Error"</pre> }.into_any(),
 ///             Some(cats) => view! { cx,
 ///               <div>{

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -369,7 +369,7 @@ where
     /// resource.
     ///
     /// If you want to get the value without cloning it, use [Resource::with].
-    /// (`value.read()` is equivalent to `value.with(T::clone)`.)
+    /// (`value.read(cx)` is equivalent to `value.with(cx, T::clone)`.)
     pub fn read(&self, cx: Scope) -> Option<T>
     where
         T: Clone,

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -54,11 +54,11 @@ use std::{
 /// // when we read the signal, it contains either
 /// // 1) None (if the Future isn't ready yet) or
 /// // 2) Some(T) (if the future's already resolved)
-/// assert_eq!(cats(), Some(vec!["1".to_string()]));
+/// assert_eq!(cats.read(cx), Some(vec!["1".to_string()]));
 ///
 /// // when the signal's value changes, the `Resource` will generate and run a new `Future`
 /// set_how_many_cats(2);
-/// assert_eq!(cats(), Some(vec!["2".to_string()]));
+/// assert_eq!(cats.read(cx), Some(vec!["2".to_string()]));
 /// # }
 /// # }).dispose();
 /// ```
@@ -480,11 +480,11 @@ where
 /// // when we read the signal, it contains either
 /// // 1) None (if the Future isn't ready yet) or
 /// // 2) Some(T) (if the future's already resolved)
-/// assert_eq!(cats(), Some(vec!["1".to_string()]));
+/// assert_eq!(cats.read(cx), Some(vec!["1".to_string()]));
 ///
 /// // when the signal's value changes, the `Resource` will generate and run a new `Future`
 /// set_how_many_cats(2);
-/// assert_eq!(cats(), Some(vec!["2".to_string()]));
+/// assert_eq!(cats.read(cx), Some(vec!["2".to_string()]));
 /// # }
 /// # }).dispose();
 /// ```

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -421,11 +421,12 @@ impl Runtime {
 
     pub(crate) fn serialization_resolvers(
         &self,
+        cx: Scope,
     ) -> FuturesUnordered<PinnedFuture<(ResourceId, String)>> {
         let f = FuturesUnordered::new();
         for (id, resource) in self.resources.borrow().iter() {
             if let AnyResource::Serializable(resource) = resource {
-                f.push(resource.to_serialization_resolver(id));
+                f.push(resource.to_serialization_resolver(cx, id));
             }
         }
         f

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -353,8 +353,10 @@ impl Scope {
     pub fn serialization_resolvers(
         &self,
     ) -> FuturesUnordered<PinnedFuture<(ResourceId, String)>> {
-        with_runtime(self.runtime, |runtime| runtime.serialization_resolvers())
-            .unwrap_or_default()
+        with_runtime(self.runtime, |runtime| {
+            runtime.serialization_resolvers(*self)
+        })
+        .unwrap_or_default()
     }
 
     /// Registers the given [SuspenseContext](crate::SuspenseContext) with the current scope,

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -104,7 +104,7 @@
 //!     <div>
 //!       // show the contacts
 //!       <ul>
-//!         {move || contacts.read().map(|contacts| view! { cx, <li>"todo contact info"</li> } )}
+//!         {move || contacts.read(cx).map(|contacts| view! { cx, <li>"todo contact info"</li> } )}
 //!       </ul>
 //!
 //!       // insert the nested child route here


### PR DESCRIPTION
Calling `Resource::read()` or `Resource::with()` crawls up the `Scope` tree, looking for the nearest `<Suspense/>` component, if any. This is used for streaming resource and suspense data from the server to the client during initial load, which is a significant optimization over waiting to start loading data until Wasm has loaded on the client.

Previously, a `Scope` was given to the `Resource` when it was created, and it carried this `Scope` around with it. Unfortunately, this meant that a `Resource` created in a "higher" scope couldn't be read correctly under a "lower" `<Suspense/>`. For example, if you created a resource in the root of your application, reading it under a `<Suspense/>` in one of your routes would not correctly register with the suspense, so would not properly stream.

This PR corrects that behavior for the hopefully-small cost of passing the omnipresent `cx` as the first argument to `Resource::read()` and `Resource::with()`. Now, you can create a single `Resource` somewhere in your app, pass it to multiple parts of the app via `provide_context`, and read it under multiple streaming `<Suspense/>` components while only actually loading the resource once.