### PR TITLE
make counter test compile

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -10,5 +10,7 @@ log = "0.4"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
+wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3.0"
+web-sys ="0.3"
 

--- a/examples/counter/tests/mod.rs
+++ b/examples/counter/tests/mod.rs
@@ -1,9 +1,9 @@
+use counter::*;
+use leptos::*;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
-use counter::*;
-use leptos::*;
-use web_sys::HtmlElement;
 
 #[wasm_bindgen_test]
 fn clear() {
@@ -84,22 +84,22 @@ fn inc() {
     let clear = div
         .first_child()
         .unwrap()
-        .dyn_into::<HtmlElement>()
+        .dyn_into::<web_sys::HtmlElement>()
         .unwrap();
     let dec = clear
         .next_sibling()
         .unwrap()
-        .dyn_into::<HtmlElement>()
+        .dyn_into::<web_sys::HtmlElement>()
         .unwrap();
     let text = dec
         .next_sibling()
         .unwrap()
-        .dyn_into::<HtmlElement>()
+        .dyn_into::<web_sys::HtmlElement>()
         .unwrap();
     let inc = text
         .next_sibling()
         .unwrap()
-        .dyn_into::<HtmlElement>()
+        .dyn_into::<web_sys::HtmlElement>()
         .unwrap();
 
     inc.click();


### PR DESCRIPTION
a had to make some small tweaks to let the counter test example compile and pass.

I am not sure if web-sys is really needed, but it is used with websys::HtmlElement in the test.

please have a look at it.