### PR TITLE
In `Action::dispatch()` set new value before resetting input signal

### DIFF
--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -191,9 +191,9 @@ where
         pending.set(true);
         spawn_local(async move {
             let new_value = fut.await;
+            value.set(Some(new_value));
             input.set(None);
             pending.set(false);
-            value.set(Some(new_value));
             version.update(|n| *n += 1);
         })
     }

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -217,11 +217,11 @@ where
         spawn_local(async move {
             let new_value = fut.await;
             let canceled = cx.untrack(move || canceled.get());
-            input.set(None);
-            pending.set(false);
             if !canceled {
                 value.set(Some(new_value));
             }
+            input.set(None);
+            pending.set(false);
             version.update(|n| *n += 1);
         })
     }


### PR DESCRIPTION
This PR changes when the value signal is set during `Action::dispatch()` and `MultiAction::dispatch()`. This aligns the behavior of `Action::dispatch()` with `<ActionForm/>`, which already sets the value signal before resetting the input signal ([see form.rs](https://github.com/leptos-rs/leptos/blob/ceb7bd398df73ba3bb0059467a06a42299484283/router/src/components/form.rs#L238)).

Before there was a brief moment, after the future resolves, where the state of input and value were the same as before the dispatch call.