### PR TITLE
Remove the register function from server_fn

### DIFF
--- a/examples/counter_isomorphic/src/counters.rs
+++ b/examples/counter_isomorphic/src/counters.rs
@@ -9,13 +9,6 @@ use std::sync::atomic::{AtomicI32, Ordering};
 use broadcaster::BroadcastChannel;
 
 #[cfg(feature = "ssr")]
-pub fn register_server_functions() {
-    _ = GetServerCount::register();
-    _ = AdjustServerCount::register();
-    _ = ClearServerCount::register();
-}
-
-#[cfg(feature = "ssr")]
 static COUNT: AtomicI32 = AtomicI32::new(0);
 
 #[cfg(feature = "ssr")]

--- a/examples/counter_isomorphic/src/main.rs
+++ b/examples/counter_isomorphic/src/main.rs
@@ -30,9 +30,6 @@ cfg_if! {
 
         #[actix_web::main]
         async fn main() -> std::io::Result<()> {
-
-            crate::counters::register_server_functions();
-
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             // when not using cargo-leptos None must be replaced with Some("Cargo.toml")
             let conf = get_configuration(None).await.unwrap();
@@ -55,7 +52,7 @@ cfg_if! {
             .run()
             .await
         }
-        }
+    }
 
     // client-only main for Trunk
     else {

--- a/examples/errors_axum/src/landing.rs
+++ b/examples/errors_axum/src/landing.rs
@@ -6,11 +6,6 @@ use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 
-#[cfg(feature = "ssr")]
-pub fn register_server_functions() {
-    _ = CauseInternalServerError::register();
-}
-
 #[server(CauseInternalServerError, "/api")]
 pub async fn cause_internal_server_error() -> Result<(), ServerFnError> {
     // fake API delay

--- a/examples/errors_axum/src/main.rs
+++ b/examples/errors_axum/src/main.rs
@@ -39,8 +39,6 @@ async fn custom_handler(
 async fn main() {
     simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
-    crate::landing::register_server_functions();
-
     // Setting this to None means we'll be using cargo-leptos and its env vars
     let conf = get_configuration(None).await.unwrap();
     let leptos_options = conf.leptos_options;

--- a/examples/ssr_modes/src/main.rs
+++ b/examples/ssr_modes/src/main.rs
@@ -12,9 +12,6 @@ async fn main() -> std::io::Result<()> {
     // Generate the list of routes in your Leptos App
     let routes = generate_route_list(|cx| view! { cx, <App/> });
 
-    GetPost::register();
-    ListPostMetadata::register();
-
     HttpServer::new(move || {
         let leptos_options = &conf.leptos_options;
         let site_root = &leptos_options.site_root;

--- a/examples/ssr_modes_axum/src/main.rs
+++ b/examples/ssr_modes_axum/src/main.rs
@@ -14,9 +14,6 @@ async fn main(){
     // Generate the list of routes in your Leptos App
     let routes = generate_route_list(|cx| view! { cx, <App/> }).await;
 
-    GetPost::register();
-    ListPostMetadata::register();
-
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .leptos_routes(leptos_options.clone(), routes, |cx| view! { cx, <App/> })

--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -24,8 +24,6 @@ cfg_if! {
                 .await
                 .expect("could not run SQLx migrations");
 
-            crate::todo::register_server_functions();
-
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
 

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -12,12 +12,6 @@ cfg_if! {
             Ok(SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))?)
         }
 
-        pub fn register_server_functions() {
-            _ = GetTodos::register();
-            _ = AddTodo::register();
-            _ = DeleteTodo::register();
-        }
-
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
         pub struct Todo {
             id: u16,

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -38,8 +38,6 @@ if #[cfg(feature = "ssr")] {
             .await
             .expect("could not run SQLx migrations"); */
 
-        crate::todo::register_server_functions();
-
         // Setting this to None means we'll be using cargo-leptos and its env vars
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -14,12 +14,6 @@ cfg_if! {
             SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
         }
 
-        pub fn register_server_functions() {
-            _ = GetTodos::register();
-            _ = AddTodo::register();
-            _ = DeleteTodo::register();
-        }
-
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
         pub struct Todo {
             id: u16,

--- a/examples/todo_app_sqlite_viz/src/main.rs
+++ b/examples/todo_app_sqlite_viz/src/main.rs
@@ -40,8 +40,6 @@ if #[cfg(feature = "ssr")] {
         .await
         .expect("could not run SQLx migrations"); */
 
-        crate::todo::register_server_functions();
-
         // Setting this to None means we'll be using cargo-leptos and its env vars
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;

--- a/examples/todo_app_sqlite_viz/src/todo.rs
+++ b/examples/todo_app_sqlite_viz/src/todo.rs
@@ -14,12 +14,6 @@ cfg_if! {
             SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
         }
 
-        pub fn register_server_functions() {
-            _ = GetTodos::register();
-            _ = AddTodo::register();
-            _ = DeleteTodo::register();
-        }
-
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
         pub struct Todo {
             id: u16,

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -119,16 +119,9 @@ pub fn redirect(cx: leptos::Scope, path: &str) {
 /// ```
 /// use actix_web::*;
 ///
-/// fn register_server_functions() {
-///   // call ServerFn::register() for each of the server functions you've defined
-/// }
-///
 /// # if false { // don't actually try to run a server in a doctest...
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     // make sure you actually register your server functions
-///     register_server_functions();
-///
 ///     HttpServer::new(|| {
 ///         App::new()
 ///             // "/api" should match the prefix, if any, declared when defining server functions
@@ -194,7 +187,7 @@ pub fn handle_server_fns_with_context(
                     provide_context(cx, req.clone());
                     provide_context(cx, res_options.clone());
 
-                    match server_fn(cx, body).await {
+                    match server_fn.call(cx, body).await {
                         Ok(serialized) => {
                             let res_options =
                                 use_context::<ResponseOptions>(cx).unwrap();
@@ -262,10 +255,7 @@ pub fn handle_server_fns_with_context(
                     }
                 } else {
                     HttpResponse::BadRequest().body(format!(
-                        "Could not find a server function at the route {:?}. \
-                         \n\nIt's likely that you need to call \
-                         ServerFn::register() on the server function type, \
-                         somewhere in your `main` function.",
+                        "Could not find a server function at the route {:?}",
                         req.path()
                     ))
                 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -224,7 +224,7 @@ async fn handle_server_fns_inner(
                             // Add this so that we can set headers and status of the response
                             provide_context(cx, ResponseOptions::default());
 
-                            match server_fn(cx, &req_parts.body).await {
+                            match server_fn.call(cx, &req_parts.body).await {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =
@@ -317,10 +317,7 @@ async fn handle_server_fns_inner(
                                 .status(StatusCode::BAD_REQUEST)
                                 .body(Full::from(format!(
                                     "Could not find a server function at the \
-                                     route {fn_name}. \n\nIt's likely that \
-                                     you need to call ServerFn::register() on \
-                                     the server function type, somewhere in \
-                                     your `main` function."
+                                     route {fn_name}"
                                 )))
                         }
                         .expect("could not build Response");

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -207,7 +207,7 @@ async fn handle_server_fns_inner(
                             // Add this so that we can set headers and status of the response
                             provide_context(cx, ResponseOptions::default());
 
-                            match server_fn(cx, &req_parts.body).await {
+                            match server_fn.call(cx, &req_parts.body).await {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =
@@ -299,10 +299,7 @@ async fn handle_server_fns_inner(
                                 .status(StatusCode::BAD_REQUEST)
                                 .body(Body::from(format!(
                                     "Could not find a server function at the \
-                                     route {fn_name}. \n\nIt's likely that \
-                                     you need to call ServerFn::register() on \
-                                     the server function type, somewhere in \
-                                     your `main` function."
+                                     route {fn_name}"
                                 )))
                         }
                         .expect("could not build Response");

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -657,7 +657,6 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// ```
 ///
 /// Note the following:
-/// - You must **register** the server function by calling `T::register()` somewhere in your main function.
 /// - **Server functions must be `async`.** Even if the work being done inside the function body
 ///   can run synchronously on the server, from the client’s perspective it involves an asynchronous
 ///   function call.
@@ -684,6 +683,7 @@ pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     match server_macro_impl(
         args.into(),
         s.into(),
+        syn::parse_quote!(::leptos::leptos_server::ServerFnTraitObj),
         Some(context),
         Some(syn::parse_quote!(::leptos::server_fn)),
     ) {

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -24,6 +24,7 @@ quote = "1"
 syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
 proc-macro2 = "1.0.47"
 ciborium = "0.2.0"
+inventory = { version = "0.3.3", optional = true }
 
 [dev-dependencies]
 leptos = { path = "../leptos" }
@@ -43,6 +44,7 @@ ssr = [
   #"leptos/ssr",
   "leptos_reactive/ssr",
   "server_fn/ssr",
+  "inventory"
 ]
 stable = [
   #"leptos/stable",

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -124,7 +124,7 @@ lazy_static::lazy_static! {
     };
 }
 
-#[cfg(any(feature = "ssr", doc))]
+#[cfg(any(feature = "ssr"))]
 inventory::collect!(ServerFnTraitObj);
 
 /// Attempts to find a server function registered at the given path.

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -13,7 +13,6 @@ server_fn_macro_default = { path = "./server_fn_macro_default", version = "0.2.0
 form_urlencoded = "1"
 gloo-net = "0.2"
 js-sys = "0.3"
-lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 serde_urlencoded = "0.7"
 thiserror = "1"
@@ -25,5 +24,8 @@ cfg-if = "1"
 ciborium = "0.2.0"
 xxhash-rust = { version = "0.8.6", features = ["const_xxh64"] }
 const_format = "0.2.30"
+inventory = { version = "0.3.3", optional = true }
+lazy_static = "1.4.0"
+
 [features]
-ssr = []
+ssr = ["inventory"]

--- a/server_fn/server_fn_macro_default/src/lib.rs
+++ b/server_fn/server_fn_macro_default/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(not(feature = "stable"), feature(proc_macro_span))]
 //! This crate contains the default implementation of the #[macro@crate::server] macro without a context from the server. See the [server_fn_macro] crate for more information.
 #![forbid(unsafe_code)]
 
@@ -34,7 +33,6 @@ use syn::__private::ToTokens;
 /// ```
 ///
 /// Note the following:
-/// - You must **register** the server function by calling `T::register()` somewhere in your main function.
 /// - **Server functions must be `async`.** Even if the work being done inside the function body
 ///   can run synchronously on the server, from the client’s perspective it involves an asynchronous
 ///   function call.
@@ -54,6 +52,7 @@ pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     match server_macro_impl(
         args.into(),
         s.into(),
+        syn::parse_quote!(server_fn::default::DefaultServerFnTraitObj),
         None,
         Some(syn::parse_quote!(server_fn)),
     ) {

--- a/server_fn/src/default.rs
+++ b/server_fn/src/default.rs
@@ -1,0 +1,115 @@
+#[cfg(any(feature = "ssr", doc))]
+use crate::ServerFnTraitObj;
+pub use server_fn_macro_default::server;
+#[cfg(any(feature = "ssr", doc))]
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+#[cfg(any(feature = "ssr", doc))]
+lazy_static::lazy_static! {
+    static ref REGISTERED_SERVER_FUNCTIONS: Arc<RwLock<HashMap<&'static str, &'static DefaultServerFnTraitObj>>> = {
+        let mut map = HashMap::new();
+        for server_fn in inventory::iter::<DefaultServerFnTraitObj> {
+            map.insert(server_fn.0.url(), server_fn);
+        }
+        Arc::new(RwLock::new(map))
+    };
+}
+
+#[cfg(any(feature = "ssr", doc))]
+inventory::collect!(DefaultServerFnTraitObj);
+
+/// Attempts to find a server function registered at the given path.
+///
+/// This can be used by a server to handle the requests, as in the following example (using `actix-web`)
+///
+/// ```rust, ignore
+/// #[post("{tail:.*}")]
+/// async fn handle_server_fns(
+///     req: HttpRequest,
+///     params: web::Path<String>,
+///     body: web::Bytes,
+/// ) -> impl Responder {
+///     let path = params.into_inner();
+///     let accept_header = req
+///         .headers()
+///         .get("Accept")
+///         .and_then(|value| value.to_str().ok());
+///
+///     if let Some(server_fn) = server_fn_by_path(path.as_str()) {
+///         let body: &[u8] = &body;
+///         match server_fn(&body).await {
+///             Ok(serialized) => {
+///                 // if this is Accept: application/json then send a serialized JSON response
+///                 if let Some("application/json") = accept_header {
+///                     HttpResponse::Ok().body(serialized)
+///                 }
+///                 // otherwise, it's probably a <form> submit or something: redirect back to the referrer
+///                 else {
+///                     HttpResponse::SeeOther()
+///                         .insert_header(("Location", "/"))
+///                         .content_type("application/json")
+///                         .body(serialized)
+///                 }
+///             }
+///             Err(e) => {
+///                 eprintln!("server function error: {e:#?}");
+///                 HttpResponse::InternalServerError().body(e.to_string())
+///             }
+///         }
+///     } else {
+///         HttpResponse::BadRequest().body(format!("Could not find a server function at that route."))
+///     }
+/// }
+/// ```
+#[cfg(any(feature = "ssr", doc))]
+pub fn server_fn_by_path(
+    path: &str,
+) -> Option<&'static DefaultServerFnTraitObj> {
+    REGISTERED_SERVER_FUNCTIONS
+        .read()
+        .expect("Server function registry is poisoned")
+        .get(path)
+        .copied()
+}
+
+/// Returns the set of currently-registered server function paths, for debugging purposes.
+#[cfg(any(feature = "ssr", doc))]
+pub fn server_fns_by_path() -> Vec<&'static str> {
+    REGISTERED_SERVER_FUNCTIONS
+        .read()
+        .expect("Server function registry is poisoned")
+        .keys()
+        .copied()
+        .collect()
+}
+
+#[cfg(any(feature = "ssr", doc))]
+/// A server function that can be called from the client without any context from the server.
+pub struct DefaultServerFnTraitObj(ServerFnTraitObj<()>);
+
+#[cfg(any(feature = "ssr", doc))]
+impl DefaultServerFnTraitObj {
+    /// Creates a new server function with the given prefix, URL, encoding, and function.
+    pub const fn from_generic_server_fn(f: ServerFnTraitObj<()>) -> Self {
+        Self(f)
+    }
+}
+
+#[cfg(any(feature = "ssr", doc))]
+impl std::ops::Deref for DefaultServerFnTraitObj {
+    type Target = ServerFnTraitObj<()>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(any(feature = "ssr", doc))]
+impl std::ops::DerefMut for DefaultServerFnTraitObj {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/server_fn/src/default.rs
+++ b/server_fn/src/default.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
     };
 }
 
-#[cfg(any(feature = "ssr", doc))]
+#[cfg(any(feature = "ssr"))]
 inventory::collect!(DefaultServerFnTraitObj);
 
 /// Attempts to find a server function registered at the given path.

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -70,7 +70,7 @@
 // used by the macro
 #[doc(hidden)]
 pub use const_format;
-#[cfg(any(feature = "ssr", doc))]
+#[cfg(any(feature = "ssr"))]
 // used by the macro
 #[doc(hidden)]
 pub use inventory;
@@ -333,7 +333,6 @@ where
     }
 }
 
-#[cfg(any(feature = "ssr", doc))]
 /// A server function that can be called from the client.
 pub type SerializedFnTraitObj<T> =
     fn(
@@ -341,7 +340,6 @@ pub type SerializedFnTraitObj<T> =
         &[u8],
     ) -> Pin<Box<dyn Future<Output = Result<Payload, ServerFnError>>>>;
 
-#[cfg(any(feature = "ssr", doc))]
 /// A concrete type for a registered server function
 pub struct ServerFnTraitObj<T> {
     prefix: &'static str,
@@ -350,7 +348,6 @@ pub struct ServerFnTraitObj<T> {
     run: SerializedFnTraitObj<T>,
 }
 
-#[cfg(any(feature = "ssr", doc))]
 impl<T> ServerFnTraitObj<T> {
     /// Creates a new server function with the given prefix, URL, encoding, and function.
     pub const fn new(


### PR DESCRIPTION
This removes the register function from the ServerFn trait and instead uses the [inventory](https://github.com/dtolnay/inventory) crate to collect the functions.
This requires each framework to create it's own wrapper around server functions that has a const function called from_generic_sever_fn and implement a small amount of boilerplate in there own crate.

I have tried to update any docs around the register function I could find, but I'm not familiar with Leptos' docs so I could have missed some areas

**This is a breaking change**
- [x] Fix docs building