### PR TITLE
Minor: Clippy - Simplified conditional logic in transition.rs.

### DIFF
--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -119,9 +119,7 @@ where
                 if is_first_run(&first_run, &suspense_context) {
                     let has_local_only = suspense_context.has_local_only();
                     *prev_children.borrow_mut() = Some(frag.nodes.clone());
-                    if (has_local_only && child_runs.get() > 0)
-                        || !has_local_only
-                    {
+                    if !has_local_only || child_runs.get() > 0 {
                         first_run.set(false);
                     }
                 }

--- a/router/src/matching/resolve_path.rs
+++ b/router/src/matching/resolve_path.rs
@@ -52,7 +52,7 @@ fn has_scheme(path: &str) -> bool {
 #[doc(hidden)]
 fn normalize(path: &str, omit_slash: bool) -> Cow<'_, str> {
     let s = path.trim_start_matches('/').trim_end_matches('/');
-    if s.is_empty() || omit_slash || begins_with_query_or_hash(&s) {
+    if s.is_empty() || omit_slash || begins_with_query_or_hash(s) {
         s.into()
     } else {
         format!("/{s}").into()


### PR DESCRIPTION
Just a couple of clippy fixes, only one is worth highlighting

all I have to say is when I draw out the equivalent logic elements this makes sense to me.


```
warning: this boolean expression can be simplified
   --> leptos/src/transition.rs:122:24
    |
122 |                       if (has_local_only && child_runs.get() > 0)
    |  ________________________^
123 | |                         || !has_local_only
    | |__________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
    = note: `#[warn(clippy::nonminimal_bool)]` on by default
```
