### PR TITLE
docs: fix instruction typos

### DIFF
--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -84,7 +84,7 @@ impl RouterContext {
             } else {
                 let history = use_context::<RouterIntegrationContext>(cx).unwrap_or_else(|| {
                     let msg = "No router integration found.\n\nIf you are using this in the browser, \
-                        you should enable `feature = [\"csr\"]` or `feature = [\"hydrate\"] in your \
+                        you should enable `features = [\"csr\"]` or `features = [\"hydrate\"] in your \
                         `leptos_router` import.\n\nIf you are using this on the server without a \
                         Leptos server integration, you must call provide_context::<RouterIntegrationContext>(cx, ...) \
                         somewhere above the <Router/>.";


### PR DESCRIPTION
Previously, the console warning message tells user to add `feature = ["csr"]`. However, it's incorrect. This change rectifies the instruction to be adding `features = ["csr"]`.