### PR TITLE
Bump tower-http upto 0.4.

### DIFF
--- a/examples/errors_axum/Cargo.toml
+++ b/examples/errors_axum/Cargo.toml
@@ -13,7 +13,7 @@ console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"
 leptos = { path = "../../../leptos/leptos", default-features = false, features = [
-	"serde",
+  "serde",
 ] }
 leptos_axum = { path = "../../../leptos/integrations/axum", default-features = false, optional = true }
 leptos_meta = { path = "../../../leptos/meta", default-features = false }
@@ -27,7 +27,7 @@ gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8" }
 thiserror = "1.0.38"
@@ -39,14 +39,14 @@ default = ["csr"]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
-	"dep:axum",
-	"dep:tower",
-	"dep:tower-http",
-	"dep:tokio",
-	"leptos/ssr",
-	"leptos_meta/ssr",
-	"leptos_router/ssr",
-	"dep:leptos_axum",
+  "dep:axum",
+  "dep:tower",
+  "dep:tower-http",
+  "dep:tokio",
+  "leptos/ssr",
+  "leptos_meta/ssr",
+  "leptos_router/ssr",
+  "dep:leptos_axum",
 ]
 
 [package.metadata.cargo-all-features]
@@ -54,12 +54,12 @@ denylist = ["axum", "tower", "tower-http", "tokio", "leptos_axum"]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
-# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
+# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
 output-name = "errors_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
-# Defaults to pkg	
+# Defaults to pkg
 site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -13,7 +13,7 @@ console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"
 leptos = { path = "../../leptos", default-features = false, features = [
-	"serde",
+  "serde",
 ] }
 leptos_axum = { path = "../../integrations/axum", optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
@@ -26,7 +26,7 @@ gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
@@ -38,15 +38,15 @@ default = ["csr"]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
-	"dep:axum",
-	"dep:tower",
-	"dep:tower-http",
-	"dep:tokio",
-	"dep:http",
-	"leptos/ssr",
-	"leptos_axum",
-	"leptos_meta/ssr",
-	"leptos_router/ssr",
+  "dep:axum",
+  "dep:tower",
+  "dep:tower-http",
+  "dep:tokio",
+  "dep:http",
+  "leptos/ssr",
+  "leptos_axum",
+  "leptos_meta/ssr",
+  "leptos_router/ssr",
 ]
 
 [package.metadata.cargo-all-features]
@@ -54,27 +54,27 @@ denylist = ["axum", "tower", "tower-http", "tokio", "http", "leptos_axum"]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
 
 [package.metadata.leptos]
-# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "hackernews_axum"	
+# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
+output-name = "hackernews_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
-# Defaults to pkg	
-site-pkg-dir = "pkg" 	
+# Defaults to pkg
+site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "./style.css"
 # [Optional] Files in the asset-dir will be copied to the site-root directory
 assets-dir = "public"
 # The IP and port (ex: 127.0.0.1:3000) where the server serves the content. Use it in your server setup.
-site-addr = "127.0.0.1:3000"	
+site-addr = "127.0.0.1:3000"
 # The port to use for automatic reload monitoring
-reload-port = 3001	
+reload-port = 3001
 # [Optional] Command to use when running end2end tests. It will run in the end2end dir.
 end2end-cmd = "npx playwright test"
 #  The browserlist query used for optimizing the CSS.
-browserquery = "defaults" 	
+browserquery = "defaults"
 # Set by cargo-leptos watch when building with tha tool. Controls whether autoreload JS will be included in the head
-watch = false 	
+watch = false
 # The environment Leptos will run in, usually either "DEV" or "PROD"
 env = "DEV"
 # The features to use when compiling the bin target

--- a/examples/login_with_token_csr_only/server/Cargo.toml
+++ b/examples/login_with_token_csr_only/server/Cargo.toml
@@ -14,5 +14,5 @@ mailparse = "0.14"
 pwhash = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
-tower-http = { version = "0.3", features = ["cors"] }
+tower-http = { version = "0.4", features = ["cors"] }
 uuid = { version = "1.3", features = ["v4"] }

--- a/examples/session_auth_axum/Cargo.toml
+++ b/examples/session_auth_axum/Cargo.toml
@@ -28,7 +28,7 @@ gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8" }
 sqlx = { version = "0.6.2", features = [

--- a/examples/ssr_modes_axum/Cargo.toml
+++ b/examples/ssr_modes_axum/Cargo.toml
@@ -23,7 +23,7 @@ simple_logger = "4"
 thiserror = "1"
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1", features = ["time"], optional = true}
 wasm-bindgen = "0.2"
 
@@ -41,12 +41,12 @@ ssr = [
 ]
 
 [package.metadata.leptos]
-# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
+# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
 output-name = "ssr_modes"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
-# Defaults to pkg	
+# Defaults to pkg
 site-pkg-dir = "pkg"
 # [Optional] The source CSS file. If it ends with .sass or .scss then it will be compiled by dart-sass into CSS. The CSS is optimized by Lightning CSS before being written to <site-root>/<site-pkg>/app.css
 style-file = "style/main.scss"

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -27,7 +27,7 @@ gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.3.4", features = ["fs"], optional = true }
+tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8" }
 sqlx = { version = "0.6.2", features = [


### PR DESCRIPTION
This is as result of looking at cargo outdated 

As the code base currently  stands there is a  inconsistent policy in the stating of of version number of tower-http

in many places the full MAJOR.MINOR.PATCH is used.

in one place it stated only as MAJOR.MINOR .. 

The MAJOR.MINOR option  relies on the goodness of the crate below to not break anything with a PATCH update.

As I updated the version number I changed/unified the policy to MAJOR.MINOR only, If any reviewer objects I will unify  the patch to the  MAJOR.MINOR.PATCH pattern

There are lots of tabulation changes, but I think that is as result of my IDE picking up on the recently introduced 

rustfmt.toml file.