### PR TITLE
bump bytecheck to 0.7, remove deprecated simdutf8_std.

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -20,9 +20,8 @@ rkyv = { version = "0.7.39", features = [
   "copy",
   "strict",
 ], optional = true }
-bytecheck = { version = "0.6.9", features = [
+bytecheck = { version = "0.7", features = [
   "uuid",
-  "simdutf8_std",
   "simdutf8",
 ], optional = true }
 serde-wasm-bindgen = "0.5"

--- a/leptos_reactive/src/serialization.rs
+++ b/leptos_reactive/src/serialization.rs
@@ -39,8 +39,7 @@ where
 
 cfg_if! {
     if #[cfg(feature = "rkyv")] {
-        use rkyv::{Archive, Deserialize, Serialize, ser::serializers::AllocSerializer, de::deserializers::SharedDeserializeMap, validation::validators::DefaultValidator};
-        use bytecheck::CheckBytes;
+        use rkyv::{Archive, CheckBytes, Deserialize, Serialize, ser::serializers::AllocSerializer, de::deserializers::SharedDeserializeMap, validation::validators::DefaultValidator};
         use base64::Engine as _;
         use base64::engine::general_purpose::STANDARD_NO_PAD;
 


### PR DESCRIPTION
Working on clearing the output of 'Cargo outdated'.