### PR TITLE
Typo fixes and other small changes to the docs

### DIFF
--- a/docs/book/src/14_create_effect.md
+++ b/docs/book/src/14_create_effect.md
@@ -2,7 +2,7 @@
 
 Believe it or not, we’ve made it this far without having mentioned half of the reactive system: effects.
 
-Leptos is built on a fine-grained reactive system, which means that individual reactive values (“signals,” sometimes known as observables) trigger the code that reacts to them (“effects,” sometimes known as observers) to re-run. These two halves of the reactive system are inter-dependent. Without effects, signals can change within the reactive system but never be observed in a way that interacts with the outside world. Without signals, effects run once but never again, as there’s no observable value to subscribe to.
+Leptos is built on a fine-grained reactive system, which means that individual reactive values (“signals,” sometimes known as observables) trigger rerunning the code that reacts to them (“effects,” sometimes known as observers). These two halves of the reactive system are inter-dependent. Without effects, signals can change within the reactive system but never be observed in a way that interacts with the outside world. Without signals, effects run once but never again, as there’s no observable value to subscribe to.
 
 [`create_effect`](https://docs.rs/leptos_reactive/latest/leptos_reactive/fn.create_effect.html) takes a function as its argument. It immediately runs the function. If you access any reactive signal inside that function, it registers the fact that the effect depends on that signal with the reactive runtime. Whenever one of the signals that the effect depends on changes, the effect runs again.
 
@@ -22,7 +22,7 @@ By default, effects **do not run on the server**. This means you can call browse
 
 ## Autotracking and Dynamic Dependencies
 
-If you’re familiar with a framework like React, you might notice one key difference. React and similar frameworks typically require you to pass a “dependency array,” an explicit set of variables that determine when the effect should re-run.
+If you’re familiar with a framework like React, you might notice one key difference. React and similar frameworks typically require you to pass a “dependency array,” an explicit set of variables that determine when the effect should rerun.
 
 Because Leptos comes from the tradition of synchronous reactive programming, we don’t need this explicit dependency list. Instead, we automatically track dependencies depending on which signals are accessed within the effect.
 
@@ -47,14 +47,14 @@ let (use_last, set_use_last) = create_signal(cx, true);
 // this will add the name to the log
 // any time one of the source signals changes
 create_effect(cx, move |_| {
-	log(
-		cx,
-		if use_last() {
-			format!("{} {}", first(), last())
-		} else {
-			first()
-		},
-	)
+    log(
+        cx,
+        if use_last() {
+            format!("{} {}", first(), last())
+        } else {
+            first()
+        },
+    )
 });
 ```
 
@@ -78,11 +78,11 @@ We’ve managed to get this far without mentioning effects because they’re bui
 let (count, set_count) = create_signal(cx, 0);
 
 view! { cx,
-	<p>{count}</p>
+    <p>{count}</p>
 }
 ```
 
-This works because the framework essentially creates an effect wrapping this update. You can imagine Leptos translating this view something like this:
+This works because the framework essentially creates an effect wrapping this update. You can imagine Leptos translating this view into something like this:
 
 ```rust
 let (count, set_count) = create_signal(cx, 0);
@@ -92,16 +92,16 @@ let p = create_element("p");
 
 // create an effect to reactively update the text
 create_effect(cx, move |prev_value| {
-	// first, access the signal’s value and convert it to a string
-	let text = count().to_string();
+    // first, access the signal’s value and convert it to a string
+    let text = count().to_string();
 
-	// if this is different from the previous value, update the node
-	if prev_value != Some(text) {
-		p.set_text_content(&text);
-	}
+    // if this is different from the previous value, update the node
+    if prev_value != Some(text) {
+        p.set_text_content(&text);
+    }
 
-	// return this value so we can memoize the next update
-	text
+    // return this value so we can memoize the next update
+    text
 });
 ```
 

--- a/docs/book/src/15_global_state.md
+++ b/docs/book/src/15_global_state.md
@@ -35,7 +35,7 @@ fn App(cx: Scope) -> impl IntoView {
     // here we create a signal in the root that can be consumed
     // anywhere in the app.
     let (count, set_count) = create_signal(cx, 0);
-	// we'll pass the setter to specific components,
+    // we'll pass the setter to specific components,
     // but provide the count itself to the whole app via context
     provide_context(cx, count);
 
@@ -44,8 +44,8 @@ fn App(cx: Scope) -> impl IntoView {
         <SetterButton set_count/>
         // These consumers can only read from it
         // But we could give them write access by passing `set_count` if we wanted
-		<FancyMath/>
-		<ListItems/>
+        <FancyMath/>
+        <ListItems/>
     }
 }
 ```
@@ -121,7 +121,7 @@ fn App(cx: Scope) -> impl IntoView {
     let state = create_rw_signal(cx, GlobalState::default());
     provide_context(cx, state);
 
-	// ...
+    // ...
 ```
 
 Then child components can access “slices” of that state with fine-grained

--- a/docs/book/src/async/10_resources.md
+++ b/docs/book/src/async/10_resources.md
@@ -15,12 +15,12 @@ let (count, set_count) = create_signal(cx, 0);
 
 // our resource
 let async_data = create_resource(cx,
-	count,
-	// every time `count` changes, this will run
-	|value| async move {
-		log!("loading data from API");
-		load_data(value).await
-	},
+    count,
+    // every time `count` changes, this will run
+    |value| async move {
+        log!("loading data from API");
+        load_data(value).await
+    },
 );
 ```
 
@@ -40,14 +40,14 @@ So, you can show the current state of a resource in your view:
 ```rust
 let once = create_resource(cx, || (), |_| async move { load_data().await });
 view! { cx,
-	<h1>"My Data"</h1>
-	{move || match once.read(cx) {
-		None => view! { cx, <p>"Loading..."</p> }.into_view(cx),
-		Some(data) => view! { cx, <ShowData data/> }.into_view(cx)
-	}}
+    <h1>"My Data"</h1>
+    {move || match once.read(cx) {
+        None => view! { cx, <p>"Loading..."</p> }.into_view(cx),
+        Some(data) => view! { cx, <ShowData data/> }.into_view(cx)
+    }}
 }
 ```
 
-Resources also provide a `refetch()` method that allow you to manually reload the data (for example, in response to a button click) and a `loading()` method that returns a `ReadSignal<bool>` indicating whether the resource is currently loading or not.
+Resources also provide a `refetch()` method that allows you to manually reload the data (for example, in response to a button click) and a `loading()` method that returns a `ReadSignal<bool>` indicating whether the resource is currently loading or not.
 
 <iframe src="https://codesandbox.io/p/sandbox/10-async-resources-4z0qt3?file=%2Fsrc%2Fmain.rs&selection=%5B%7B%22endColumn%22%3A1%2C%22endLineNumber%22%3A3%2C%22startColumn%22%3A1%2C%22startLineNumber%22%3A3%7D%5D" width="100%" height="1000px"></iframe>

--- a/docs/book/src/async/11_suspense.md
+++ b/docs/book/src/async/11_suspense.md
@@ -7,11 +7,11 @@ let (count, set_count) = create_signal(cx, 0);
 let a = create_resource(cx, count, |count| async move { load_a(count).await });
 
 view! { cx,
-	<h1>"My Data"</h1>
-	{move || match once.read(cx) {
-		None => view! { cx, <p>"Loading..."</p> }.into_view(cx),
-		Some(data) => view! { cx, <ShowData data/> }.into_view(cx)
-	}}
+    <h1>"My Data"</h1>
+    {move || match once.read(cx) {
+        None => view! { cx, <p>"Loading..."</p> }.into_view(cx),
+        Some(data) => view! { cx, <ShowData data/> }.into_view(cx)
+    }}
 }
 ```
 
@@ -24,14 +24,14 @@ let a = create_resource(cx, count, |count| async move { load_a(count).await });
 let b = create_resource(cx, count2, |count| async move { load_b(count).await });
 
 view! { cx,
-	<h1>"My Data"</h1>
-	{move || match (a.read(cx), b.read(cx)) {
-		_ => view! { cx, <p>"Loading..."</p> }.into_view(cx),
-		(Some(a), Some(b)) => view! { cx,
-			<ShowA a/>
-			<ShowA b/>
-		}.into_view(cx)
-	}}
+    <h1>"My Data"</h1>
+    {move || match (a.read(cx), b.read(cx)) {
+        _ => view! { cx, <p>"Loading..."</p> }.into_view(cx),
+        (Some(a), Some(b)) => view! { cx,
+            <ShowA a/>
+            <ShowA b/>
+        }.into_view(cx)
+    }}
 }
 ```
 
@@ -46,22 +46,22 @@ let a = create_resource(cx, count, |count| async move { load_a(count).await });
 let b = create_resource(cx, count2, |count| async move { load_b(count).await });
 
 view! { cx,
-	<h1>"My Data"</h1>
-	<Suspense
-		fallback=move || view! { cx, <p>"Loading..."</p> }
-	>
-		<h2>"My Data"</h2>
-		<h3>"A"</h3>
-		{move || {
-			a.read(cx)
-				.map(|a| view! { cx, <ShowA a/> })
-		}}
-		<h3>"B"</h3>
-		{move || {
-			b.read(cx)
-				.map(|b| view! { cx, <ShowB b/> })
-		}}
-	</Suspense>
+    <h1>"My Data"</h1>
+    <Suspense
+        fallback=move || view! { cx, <p>"Loading..."</p> }
+    >
+        <h2>"My Data"</h2>
+        <h3>"A"</h3>
+        {move || {
+            a.read(cx)
+                .map(|a| view! { cx, <ShowA a/> })
+        }}
+        <h3>"B"</h3>
+        {move || {
+            b.read(cx)
+                .map(|b| view! { cx, <ShowB b/> })
+        }}
+    </Suspense>
 }
 ```
 

--- a/docs/book/src/async/13_actions.md
+++ b/docs/book/src/async/13_actions.md
@@ -42,8 +42,8 @@ So in this case, all we need to do to create an action is
 
 ```rust
 let add_todo = create_action(cx, |input: &String| {
-	let input = input.to_owned();
-	async move { add_todo(&input).await }
+    let input = input.to_owned();
+    async move { add_todo(&input).await }
 });
 ```
 
@@ -69,23 +69,23 @@ This makes it easy to track the current state of your request, show a loading in
 let input_ref = create_node_ref::<Input>(cx);
 
 view! { cx,
-	<form
-		on:submit=move |ev| {
-			ev.prevent_default(); // don't reload the page...
-			let input = input_ref.get().expect("input to exist");
-			add_todo.dispatch(input.value());
-		}
-	>
-		<label>
-			"What do you need to do?"
-			<input type="text"
-				node_ref=input_ref
-			/>
-		</label>
-		<button type="submit">"Add Todo"</button>
-	</form>
-	// use our loading state
-	<p>{move || pending().then("Loading...")}</p>
+    <form
+        on:submit=move |ev| {
+            ev.prevent_default(); // don't reload the page...
+            let input = input_ref.get().expect("input to exist");
+            add_todo.dispatch(input.value());
+        }
+    >
+        <label>
+            "What do you need to do?"
+            <input type="text"
+                node_ref=input_ref
+            />
+        </label>
+        <button type="submit">"Add Todo"</button>
+    </form>
+    // use our loading state
+    <p>{move || pending().then("Loading...")}</p>
 }
 ```
 

--- a/docs/book/src/interlude_functions.md
+++ b/docs/book/src/interlude_functions.md
@@ -12,19 +12,19 @@ let (count, set_count) = create_signal(cx, 0);
 let double_count = move || count() * 2;
 let count_is_odd = move || count() & 1 == 1;
 let text = move || if count_is_odd() {
-	"odd"
+    "odd"
 } else {
-	"even"
+    "even"
 };
 
 // an effect automatically tracks the signals it depends on
-// and re-runs when they change
+// and reruns when they change
 create_effect(cx, move |_| {
-	log!("text = {}", text());
+    log!("text = {}", text());
 });
 
 view! { cx,
-	<p>{move || text().to_uppercase()}</p>
+    <p>{move || text().to_uppercase()}</p>
 }
 ```
 
@@ -45,7 +45,7 @@ The key phrase here is “runs some kind of code.” The natural way to “run s
 
 1. virtual DOM (VDOM) frameworks like React, Yew, or Dioxus rerun a component or render function over and over, to generate a virtual DOM tree that can be reconciled with the previous result to patch the DOM
 2. compiled frameworks like Angular and Svelte divide your component templates into “create” and “update” functions, rerunning the update function when they detect a change to the component’s state
-3. in fine-grained reactive frameworks like SolidJS, Sycamore, or Leptos, _you_ define the functions that re-run
+3. in fine-grained reactive frameworks like SolidJS, Sycamore, or Leptos, _you_ define the functions that rerun
 
 That’s what all our components are doing.
 
@@ -59,16 +59,16 @@ pub fn SimpleCounter(cx: Scope) -> impl IntoView {
     let increment = move |_| set_value.update(|value| *value += 1);
 
     view! { cx,
-		<button on:click=increment>
-			{value}
-		</button>
+        <button on:click=increment>
+            {value}
+        </button>
     }
 }
 ```
 
 The `SimpleCounter` function itself runs once. The `value` signal is created once. The framework hands off the `increment` function to the browser as an event listener. When you click the button, the browser calls `increment`, which updates `value` via `set_value`. And that updates the single text node represented in our view by `{value}`.
 
-Closures are key to reactivity. They provide the framework with the ability to re-run the smallest possible unit of your application in responsive to a change.
+Closures are key to reactivity. They provide the framework with the ability to rerun the smallest possible unit of your application in responsive to a change.
 
 So remember two things:
 

--- a/docs/book/src/testing.md
+++ b/docs/book/src/testing.md
@@ -15,11 +15,11 @@ For example, instead of embedding logic in a component directly like this:
 ```rust
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
-	let (todos, set_todos) = create_signal(cx, vec![Todo { /* ... */ }]);
-	// ⚠️ this is hard to test because it's embedded in the component
-	let maximum = move || todos.with(|todos| {
-		todos.iter().filter(|todo| todo.completed).sum()
-	});
+    let (todos, set_todos) = create_signal(cx, vec![Todo { /* ... */ }]);
+    // ⚠️ this is hard to test because it's embedded in the component
+    let num_remaining = move || todos.with(|todos| {
+        todos.iter().filter(|todo| !todo.completed).sum()
+    });
 }
 ```
 
@@ -29,24 +29,24 @@ You could pull that logic out into a separate data structure and test it:
 pub struct Todos(Vec<Todo>);
 
 impl Todos {
-	pub fn remaining(&self) -> usize {
-		todos.iter().filter(|todo| todo.completed).sum()
-	}
+    pub fn num_remaining(&self) -> usize {
+        todos.iter().filter(|todo| !todo.completed).sum()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	#[test]
-	fn test_remaining {
-		// ...
-	}
+    #[test]
+    fn test_remaining {
+        // ...
+    }
 }
 
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
-	let (todos, set_todos) = create_signal(cx, Todos(vec![Todo { /* ... */ }]));
-	// ✅ this has a test associated with it
-	let maximum = move || todos.with(Todos::remaining);
+    let (todos, set_todos) = create_signal(cx, Todos(vec![Todo { /* ... */ }]));
+    // ✅ this has a test associated with it
+    let num_remaining = move || todos.with(Todos::num_remaining);
 }
 ```
 

--- a/docs/book/src/view/01_basic_component.md
+++ b/docs/book/src/view/01_basic_component.md
@@ -31,7 +31,7 @@ fn App(cx: Scope) -> impl IntoView {
                 set_count.update(|n| *n += 1);
             }
         >
-            "Click me"
+            "Click me: "
             {move || count.get()}
         </button>
     }
@@ -61,7 +61,7 @@ Every component is a function with the following characteristics
 
 ## The Component Body
 The body of the component function is a set-up function that runs once, not a 
-render function that re-runs multiple times. You’ll typically use it to create a
+render function that reruns multiple times. You’ll typically use it to create a
 few reactive variables, define any side effects that run in response to those values
 changing, and describe the user interface.
 
@@ -110,7 +110,7 @@ than they’ve ever used in their lives. And fair enough. Basically, passing a f
 into the view tells the framework: “Hey, this is something that might change.”
 
 When we click the button and call `set_count`, the `count` signal is updated. This 
-`move || count.get()` closure, whose value depends on the value of `count`, re-runs, 
+`move || count.get()` closure, whose value depends on the value of `count`, reruns, 
 and the framework makes a targeted update to that one specific text node, touching 
 nothing else in your application. This is what allows for extremely efficient updates
 to the DOM.

--- a/docs/book/src/view/06_control_flow.md
+++ b/docs/book/src/view/06_control_flow.md
@@ -26,7 +26,7 @@ things:
    all of which can be rendered. Spending time in the `Option` and `Result` docs in particular
    is one of the best ways to level up your Rust game.
 4. And always remember: to be reactive, values must be functions. You’ll see me constantly
-   wrap things in a `move ||` closure, below. This is to ensure that they actually re-run
+   wrap things in a `move ||` closure, below. This is to ensure that they actually rerun
    when the signal they depend on changes, keeping the UI reactive.
 
 ## So What?
@@ -55,13 +55,13 @@ if it’s even. Well, how about this?
 
 ```rust
 view! { cx,
-	<p>
-	{move || if is_odd() {
-		"Odd"
-	} else {
-		"Even"
-	}}
-	</p>
+    <p>
+    {move || if is_odd() {
+        "Odd"
+    } else {
+        "Even"
+    }}
+    </p>
 }
 ```
 
@@ -74,15 +74,15 @@ Let’s say we want to render some text if it’s odd, and nothing if it’s eve
 
 ```rust
 let message = move || {
-	if is_odd() {
-		Some("Ding ding ding!")
-	} else {
-		None
-	}
+    if is_odd() {
+        Some("Ding ding ding!")
+    } else {
+        None
+    }
 };
 
 view! { cx,
-	<p>{message}</p>
+    <p>{message}</p>
 }
 ```
 
@@ -91,7 +91,7 @@ This works fine. We can make it a little shorter if we’d like, using `bool::th
 ```rust
 let message = move || is_odd().then(|| "Ding ding ding!");
 view! { cx,
-	<p>{message}</p>
+    <p>{message}</p>
 }
 ```
 
@@ -105,15 +105,15 @@ pattern matching at your disposal.
 
 ```rust
 let message = move || {
-	match value() {
-		0 => "Zero",
-		1 => "One",
-		n if is_odd() => "Odd",
-		_ => "Even"
-	}
+    match value() {
+        0 => "Zero",
+        1 => "One",
+        n if is_odd() => "Odd",
+        _ => "Even"
+    }
 };
 view! { cx,
-	<p>{message}</p>
+    <p>{message}</p>
 }
 ```
 
@@ -134,13 +134,13 @@ But consider the following example:
 let (value, set_value) = create_signal(cx, 0);
 
 let message = move || if value() > 5 {
-	"Big"
+    "Big"
 } else {
-	"Small"
+    "Small"
 };
 
 view! { cx,
-	<p>{message}</p>
+    <p>{message}</p>
 }
 ```
 
@@ -148,11 +148,11 @@ This _works_, for sure. But if you added a log, you might be surprised
 
 ```rust
 let message = move || if value() > 5 {
-	log!("{}: rendering Big", value());
-	"Big"
+    log!("{}: rendering Big", value());
+    "Big"
 } else {
-	log!("{}: rendering Small", value());
-	"Small"
+    log!("{}: rendering Small", value());
+    "Small"
 };
 ```
 
@@ -177,9 +177,9 @@ like this:
 
 ```rust
 let message = move || if value() > 5 {
-	<Big/>
+    <Big/>
 } else {
-	<Small/>
+    <Small/>
 };
 ```
 
@@ -228,20 +228,20 @@ different branches of a conditional:
 
 ```rust,compile_error
 view! { cx,
-	<main>
-		{move || match is_odd() {
-			true if value() == 1 => {
-				// returns HtmlElement<Pre>
-				view! { cx, <pre>"One"</pre> }
-			},
-			false if value() == 2 => {
-				// returns HtmlElement<P>
-				view! { cx, <p>"Two"</p> }
-			}
-			// returns HtmlElement<Textarea>
-			_ => view! { cx, <textarea>{value()}</textarea> }
-		}}
-	</main>
+    <main>
+        {move || match is_odd() {
+            true if value() == 1 => {
+                // returns HtmlElement<Pre>
+                view! { cx, <pre>"One"</pre> }
+            },
+            false if value() == 2 => {
+                // returns HtmlElement<P>
+                view! { cx, <p>"Two"</p> }
+            }
+            // returns HtmlElement<Textarea>
+            _ => view! { cx, <textarea>{value()}</textarea> }
+        }}
+    </main>
 }
 ```
 
@@ -265,20 +265,20 @@ Here’s the same example, with the conversion added:
 
 ```rust,compile_error
 view! { cx,
-	<main>
-		{move || match is_odd() {
-			true if value() == 1 => {
-				// returns HtmlElement<Pre>
-				view! { cx, <pre>"One"</pre> }.into_any()
-			},
-			false if value() == 2 => {
-				// returns HtmlElement<P>
-				view! { cx, <p>"Two"</p> }.into_any()
-			}
-			// returns HtmlElement<Textarea>
-			_ => view! { cx, <textarea>{value()}</textarea> }.into_any()
-		}}
-	</main>
+    <main>
+        {move || match is_odd() {
+            true if value() == 1 => {
+                // returns HtmlElement<Pre>
+                view! { cx, <pre>"One"</pre> }.into_any()
+            },
+            false if value() == 2 => {
+                // returns HtmlElement<P>
+                view! { cx, <p>"Two"</p> }.into_any()
+            }
+            // returns HtmlElement<Textarea>
+            _ => view! { cx, <textarea>{value()}</textarea> }.into_any()
+        }}
+    </main>
 }
 ```
 

--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -30,11 +30,11 @@ it in the child. This lets you manipulate the state of the parent from the child
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		<ButtonA setter=set_toggled/>
-	}
+    let (toggled, set_toggled) = create_signal(cx, false);
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        <ButtonA setter=set_toggled/>
+    }
 }
 
 #[component]
@@ -63,11 +63,11 @@ Another approach would be to pass a callback to the child: say, `on_click`.
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		<ButtonB on_click=move |_| set_toggled.update(|value| *value = !*value)/>
-	}
+    let (toggled, set_toggled) = create_signal(cx, false);
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        <ButtonB on_click=move |_| set_toggled.update(|value| *value = !*value)/>
+    }
 }
 
 
@@ -106,13 +106,13 @@ in your `view` macro in `<App/>`.
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		// note the on:click instead of on_click
-		// this is the same syntax as an HTML element event listener
-		<ButtonC on:click=move |_| set_toggled.update(|value| *value = !*value)/>
-	}
+    let (toggled, set_toggled) = create_signal(cx, false);
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        // note the on:click instead of on_click
+        // this is the same syntax as an HTML element event listener
+        <ButtonC on:click=move |_| set_toggled.update(|value| *value = !*value)/>
+    }
 }
 
 
@@ -142,31 +142,32 @@ tree:
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		<Layout/>
-	}
+    let (toggled, set_toggled) = create_signal(cx, false);
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        <Layout/>
+    }
 }
 
 #[component]
 pub fn Layout(cx: Scope) -> impl IntoView {
-	view! { cx,
-		<header>
-			<h1>"My Page"</h1>
-		<main>
-			<Content/>
-		</main>
-	}
+    view! { cx,
+        <header>
+            <h1>"My Page"</h1>
+        </header>
+        <main>
+            <Content/>
+        </main>
+    }
 }
 
 #[component]
 pub fn Content(cx: Scope) -> impl IntoView {
-	view! { cx,
-		<div class="content">
-			<ButtonD/>
-		</div>
-	}
+    view! { cx,
+        <div class="content">
+            <ButtonD/>
+        </div>
+    }
 }
 
 #[component]
@@ -182,31 +183,32 @@ pass your `WriteSignal` to its props. You could do what’s sometimes called
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		<Layout set_toggled/>
-	}
+    let (toggled, set_toggled) = create_signal(cx, false);
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        <Layout set_toggled/>
+    }
 }
 
 #[component]
 pub fn Layout(cx: Scope, set_toggled: WriteSignal<bool>) -> impl IntoView {
-	view! { cx,
-		<header>
-			<h1>"My Page"</h1>
-		<main>
-			<Content set_toggled/>
-		</main>
-	}
+    view! { cx,
+        <header>
+            <h1>"My Page"</h1>
+        </header>
+        <main>
+            <Content set_toggled/>
+        </main>
+    }
 }
 
 #[component]
 pub fn Content(cx: Scope, set_toggled: WriteSignal<bool>) -> impl IntoView {
-	view! { cx,
-		<div class="content">
-			<ButtonD set_toggled/>
-		</div>
-	}
+    view! { cx,
+        <div class="content">
+            <ButtonD set_toggled/>
+        </div>
+    }
 }
 
 #[component]
@@ -236,26 +238,26 @@ unnecessary prop drilling.
 ```rust
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
-	let (toggled, set_toggled) = create_signal(cx, false);
+    let (toggled, set_toggled) = create_signal(cx, false);
 
-	// share `set_toggled` with all children of this component
-	provide_context(cx, set_toggled);
+    // share `set_toggled` with all children of this component
+    provide_context(cx, set_toggled);
 
-	view! { cx,
-		<p>"Toggled? " {toggled}</p>
-		<Layout/>
-	}
+    view! { cx,
+        <p>"Toggled? " {toggled}</p>
+        <Layout/>
+    }
 }
 
 // <Layout/> and <Content/> omitted
 
 #[component]
 pub fn ButtonD(cx: Scope) -> impl IntoView {
-	// use_context searches up the context tree, hoping to
-	// find a `WriteSignal<bool>`
-	// in this case, I .expect() because I know I provided it
-	let setter = use_context::<WriteSignal<bool>>(cx)
-		.expect("to have found the setter provided");
+    // use_context searches up the context tree, hoping to
+    // find a `WriteSignal<bool>`
+    // in this case, I .expect() because I know I provided it
+    let setter = use_context::<WriteSignal<bool>>(cx)
+        .expect("to have found the setter provided");
 
     view! { cx,
         <button

--- a/docs/book/src/view/09_component_children.md
+++ b/docs/book/src/view/09_component_children.md
@@ -6,15 +6,15 @@ that enhances an HTML `<form>`. I need some way to pass all its inputs.
 
 ```rust
 view! { cx,
-	<Form>
-		<fieldset>
-			<label>
-				"Some Input"
-				<input type="text" name="something"/>
-			</label>
-		</fieldset>
-		<button>"Submit"</button>
-	</Form>
+    <Form>
+        <fieldset>
+            <label>
+                "Some Input"
+                <input type="text" name="something"/>
+            </label>
+        </fieldset>
+        <button>"Submit"</button>
+    </Form>
 }
 ```
 
@@ -30,13 +30,13 @@ In fact, you’ve already seen these both in action in the [`<Show/>`](/view/06_
 ```rust
 view! { cx,
   <Show
-	// `when` is a normal prop
+    // `when` is a normal prop
     when=move || value() > 5
-	// `fallback` is a "render prop": a function that returns a view
+    // `fallback` is a "render prop": a function that returns a view
     fallback=|cx| view! { cx, <Small/> }
   >
-	// `<Big/>` (and anything else here)
-	// will be given to the `children` prop
+    // `<Big/>` (and anything else here)
+    // will be given to the `children` prop
     <Big/>
   </Show>
 }
@@ -62,7 +62,7 @@ where
         <h2>"Render Prop"</h2>
         {render_prop()}
 
-		<h2>"Children"</h2>
+        <h2>"Children"</h2>
         {children(cx)}
     }
 }
@@ -79,11 +79,11 @@ We can use the component like this:
 
 ```rust
 view! { cx,
-	<TakesChildren render_prop=|| view! { cx, <p>"Hi, there!"</p> }>
-		// these get passed to `children`
-		"Some text"
-		<span>"A span"</span>
-	</TakesChildren>
+    <TakesChildren render_prop=|| view! { cx, <p>"Hi, there!"</p> }>
+        // these get passed to `children`
+        "Some text"
+        <span>"A span"</span>
+    </TakesChildren>
 }
 ```
 
@@ -115,11 +115,11 @@ Calling it like this will create a list:
 
 ```rust
 view! { cx,
-	<WrappedChildren>
-		"A"
-		"B"
-		"C"
-	</WrappedChildren>
+    <WrappedChildren>
+        "A"
+        "B"
+        "C"
+    </WrappedChildren>
 }
 ```
 


### PR DESCRIPTION
- I converted all tabs to 4 spaces since some code examples were using a mix of both, which was making them display strangely on GitHub when I had my GitHub setting for "Tab size preference" set to something other than 4.
- I noticed that "rerun" and "re-run" were both used a lot, so I converted them all to "rerun" for consistency.
- In one of the test examples, it seemed like the intention was to calculate the number of remaining todos, but the variable was named "maximum", and it was actually calculating the number of completed todos, so I changed the code and the variable name to "num_remaining", and also used the variable name "num_remaining" in the other parts of that test example since I thought that made more sense, but if you would prefer that it be the shorter "remaining" instead of "num_remaining", let me know and I can change it.
- Some other typo fixes and small changes.