### PR TITLE
Clippy: signal_wrappers_read, was using .clone() when copy is available.

### DIFF
--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -520,7 +520,7 @@ impl<T: Clone> Clone for MaybeSignal<T> {
     fn clone(&self) -> Self {
         match self {
             Self::Static(item) => Self::Static(item.clone()),
-            Self::Dynamic(signal) => Self::Dynamic(signal.clone()),
+            Self::Dynamic(signal) => Self::Dynamic(*signal),
         }
     }
 }


### PR DESCRIPTION
Clippy's way of saying this is : -

warning: using `clone` on type `Signal<T>` which implements the `Copy` trait
   --> leptos_reactive/src/signal_wrappers_read.rs:523:52
    |
523 |             Self::Dynamic(signal) => Self::Dynamic(signal.clone()),
    |                                                    ^^^^^^^^^^^^^^ help: try dereferencing it: `*signal`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default
