### PR TITLE
chore: apply `cargo machete` systematically

### DIFF
--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -12,7 +12,6 @@ actix-web = { version = "4", optional = true, features = ["macros"] }
 broadcaster = "1"
 console_log = "0.2"
 console_error_panic_hook = "0.1"
-serde = { version = "1", features = ["derive"] }
 futures = "0.3"
 cfg-if = "1"
 lazy_static = "1"
@@ -23,9 +22,9 @@ leptos_actix = { path = "../../integrations/actix", optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
-simple_logger = "4.0.0"
 gloo-net = { git = "https://github.com/rustwasm/gloo" }
 wasm-bindgen = "0.2"
+serde = { version = "1", features = ["derive"] }
 
 [features]
 default = []

--- a/examples/errors_axum/Cargo.toml
+++ b/examples/errors_axum/Cargo.toml
@@ -17,6 +17,7 @@ leptos_axum = { path = "../../../leptos/integrations/axum", default-features = f
 leptos_meta = { path = "../../../leptos/meta", default-features = false }
 leptos_router = { path = "../../../leptos/router", default-features = false }
 log = "0.4.17"
+serde = { version = "1", features = ["derive"] }
 simple_logger = "4.0.0"
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }

--- a/examples/errors_axum/Cargo.toml
+++ b/examples/errors_axum/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.66"
 console_log = "0.2.0"
 console_error_panic_hook = "0.1.7"
-futures = "0.3.25"
 cfg-if = "1.0.0"
 leptos = { path = "../../../leptos/leptos", default-features = false, features = [
   "serde",
@@ -18,20 +16,14 @@ leptos = { path = "../../../leptos/leptos", default-features = false, features =
 leptos_axum = { path = "../../../leptos/integrations/axum", default-features = false, optional = true }
 leptos_meta = { path = "../../../leptos/meta", default-features = false }
 leptos_router = { path = "../../../leptos/router", default-features = false }
-leptos_reactive = { path = "../../../leptos/leptos_reactive", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
-gloo-net = { version = "0.2.5", features = ["http"] }
-reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8" }
 thiserror = "1.0.38"
-tracing = "0.1.37"
 wasm-bindgen = "0.2"
 
 [features]

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1"
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 console_log = "0.2"
 console_error_panic_hook = "0.1"
-futures = "0.3"
 cfg-if = "1"
 leptos = { path = "../../leptos", default-features = false, features = [
 	"serde",
@@ -21,15 +19,12 @@ leptos_meta = { path = "../../meta", default-features = false }
 leptos_actix = { path = "../../integrations/actix", default-features = false, optional = true }
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
-simple_logger = "4.0.0"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 gloo-net = { version = "0.2", features = ["http"] }
 reqwest = { version = "0.11", features = ["json"] }
 # openssl = { version = "0.10", features = ["v110"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
-tracing = "0.1"
 
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"] }
 gloo-net = { version = "0.2", features = ["http"] }
 reqwest = { version = "0.11", features = ["json"] }
+tracing = "0.1"
 # openssl = { version = "0.10", features = ["v110"] }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -19,6 +19,7 @@ leptos_router = { path = "../../router", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
 serde = { version = "1.0.148", features = ["derive"] }
+tracing = "0.1"
 gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.66"
 console_log = "0.2.0"
 console_error_panic_hook = "0.1.7"
-futures = "0.3.25"
 cfg-if = "1.0.0"
 leptos = { path = "../../leptos", default-features = false, features = [
   "serde",
@@ -21,7 +19,6 @@ leptos_router = { path = "../../router", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
 serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
 gloo-net = { version = "0.2.5", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
@@ -31,7 +28,6 @@ tokio = { version = "1.22.0", features = ["full"], optional = true }
 http = { version = "0.2.8", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
 wasm-bindgen = "0.2"
-tracing = "0.1"
 
 [features]
 default = ["csr"]

--- a/examples/session_auth_axum/Cargo.toml
+++ b/examples/session_auth_axum/Cargo.toml
@@ -13,10 +13,12 @@ rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"
-leptos = { workspace = true, default-features = false, features = ["serde"] }
-leptos_meta = { workspace = true, default-features = false }
-leptos_axum = { workspace = true, optional = true }
-leptos_router = { workspace = true, default-features = false }
+leptos = { path = "../../leptos", default-features = false, features = [
+	"serde",
+] }
+leptos_meta = { path = "../../meta", default-features = false }
+leptos_axum = { path = "../../integrations/axum", optional = true }
+leptos_router = { path = "../../router", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
 serde = { version = "1.0.148", features = ["derive"] }

--- a/examples/session_auth_axum/Cargo.toml
+++ b/examples/session_auth_axum/Cargo.toml
@@ -13,19 +13,13 @@ rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"
-leptos = { version = "0.2.0", default-features = false, features = [
-  "serde",
-] }
-leptos_meta = { version = "0.2.0", default-features = false }
-leptos_axum = { version = "0.2.0", optional = true }
-leptos_router = { version = "0.2.0", default-features = false }
-leptos_reactive = { version = "0.2.0", default-features = false }
+leptos = { workspace = true, default-features = false, features = ["serde"] }
+leptos_meta = { workspace = true, default-features = false }
+leptos_axum = { workspace = true, optional = true }
+leptos_router = { workspace = true, default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
 serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
-gloo-net = { version = "0.2.5", features = ["http"] }
-reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
@@ -36,12 +30,15 @@ sqlx = { version = "0.6.2", features = [
 	"sqlite",
 ], optional = true }
 thiserror = "1.0.38"
-tracing = "0.1.37"
 wasm-bindgen = "0.2"
-axum_sessions_auth = { version = "7.0.0", features = [ "sqlite-rustls" ], optional = true }
-axum_database_sessions = { version = "7.0.0", features = [ "sqlite-rustls" ], optional = true }
+axum_sessions_auth = { version = "7.0.0", features = [
+	"sqlite-rustls",
+], optional = true }
+axum_database_sessions = { version = "7.0.0", features = [
+	"sqlite-rustls",
+], optional = true }
 bcrypt = { version = "0.14", optional = true }
-async-trait = {version = "0.1.64", optional = true }
+async-trait = { version = "0.1.64", optional = true }
 
 [features]
 default = ["csr"]

--- a/examples/ssr_modes/Cargo.toml
+++ b/examples/ssr_modes/Cargo.toml
@@ -21,7 +21,6 @@ leptos_actix = { path = "../../integrations/actix", default-features = false, op
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-simple_logger = "4"
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }
 wasm-bindgen = "0.2"

--- a/examples/ssr_modes_axum/Cargo.toml
+++ b/examples/ssr_modes_axum/Cargo.toml
@@ -19,12 +19,11 @@ leptos_axum = { path = "../../integrations/axum", default-features = false, opti
 leptos_router = { path = "../../router", default-features = false }
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
-simple_logger = "4"
 thiserror = "1"
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
-tokio = { version = "1", features = ["time"], optional = true}
+tokio = { version = "1", features = ["time"], optional = true }
 wasm-bindgen = "0.2"
 
 [features]

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.66"
 console_log = "0.2.0"
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
@@ -18,13 +17,9 @@ leptos = { path = "../../leptos", default-features = false, features = [
 leptos_axum = { path = "../../integrations/axum", default-features = false, optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
 leptos_router = { path = "../../router", default-features = false }
-leptos_reactive = { path = "../../leptos_reactive", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
-gloo-net = { version = "0.2.5", features = ["http"] }
-reqwest = { version = "0.11.13", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
 axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
@@ -35,7 +30,6 @@ sqlx = { version = "0.6.2", features = [
 	"sqlite",
 ], optional = true }
 thiserror = "1.0.38"
-tracing = "0.1.37"
 wasm-bindgen = "0.2"
 
 [features]

--- a/examples/todo_app_sqlite_viz/Cargo.toml
+++ b/examples/todo_app_sqlite_viz/Cargo.toml
@@ -7,13 +7,12 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-anyhow = "1.0.66"
 console_log = "0.2.0"
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"
 leptos = { path = "../../leptos", default-features = false, features = [
-	"serde",
+  "serde",
 ] }
 leptos_viz = { path = "../../integrations/viz", default-features = false, optional = true }
 leptos_meta = { path = "../../meta", default-features = false }
@@ -21,19 +20,15 @@ leptos_router = { path = "../../router", default-features = false }
 leptos_reactive = { path = "../../leptos_reactive", default-features = false }
 log = "0.4.17"
 simple_logger = "4.0.0"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
-gloo-net = { version = "0.2.5", features = ["http"] }
-reqwest = { version = "0.11.13", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
 viz = { version = "0.4.8", features = ["serve"], optional = true }
 tokio = { version = "1.25.0", features = ["full"], optional = true }
 http = { version = "0.2.8" }
 sqlx = { version = "0.6.2", features = [
-	"runtime-tokio-rustls",
-	"sqlite",
+  "runtime-tokio-rustls",
+  "sqlite",
 ], optional = true }
 thiserror = "1.0.38"
-tracing = "0.1.37"
 wasm-bindgen = "0.2"
 
 [features]
@@ -47,7 +42,7 @@ ssr = [
   "leptos/ssr",
   "leptos_meta/ssr",
   "leptos_router/ssr",
-  "dep:leptos_viz"
+  "dep:leptos_viz",
 ]
 
 [package.metadata.cargo-all-features]

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -15,7 +15,6 @@ hyper = "0.14.23"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
-leptos_config = { workspace = true }
 leptos_integration_utils = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12.1"

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -12,5 +12,4 @@ futures = "0.3"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_hot_reload = { workspace = true }
 leptos_meta = { workspace = true, features = ["ssr"] }
-leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }

--- a/integrations/viz/Cargo.toml
+++ b/integrations/viz/Cargo.toml
@@ -15,7 +15,6 @@ hyper = "0.14.23"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
-leptos_config = { workspace = true }
 leptos_integration_utils = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12.1"

--- a/leptos_dom/examples/hydration-test/Cargo.toml
+++ b/leptos_dom/examples/hydration-test/Cargo.toml
@@ -10,11 +10,9 @@ crate-type = ["cdylib", "rlib"]
 leptos = { path = "../../../leptos", default-features = false }
 actix-web = { version = "4", optional = true }
 actix-files = { version = "0.6", optional = true }
-wasm-bindgen = { version = "0.2", optional = true}
+wasm-bindgen = { version = "0.2", optional = true }
 gloo = { version = "0.8", optional = true }
 console_error_panic_hook = "0.1.7"
-cfg-if = "1.0.0"
-gloo-timers = { version = "0.2", features = ["futures"] }
 futures = "0.3"
 
 [features]

--- a/leptos_dom/examples/test-bench/Cargo.toml
+++ b/leptos_dom/examples/test-bench/Cargo.toml
@@ -9,7 +9,5 @@ gloo = { version = "0.8", features = ["futures"] }
 leptos = { path = "../../../leptos", features = ["tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-wasm-bindgen-futures = "0.4"
-web-sys = "0.3"
 
 [workspace]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -24,7 +24,6 @@ syn = { version = "1", features = ["full"] }
 syn-rsx = "0.9"
 leptos_dom = { workspace = true }
 leptos_hot_reload = { workspace = true }
-leptos_reactive = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"
 uuid = { version = "1", features = ["v4"] }
@@ -37,10 +36,10 @@ leptos = { path = "../leptos" }
 
 [features]
 default = ["ssr"]
-csr = ["leptos_dom/web", "leptos_reactive/csr"]
-hydrate = ["leptos_dom/web", "leptos_reactive/hydrate"]
-ssr = ["leptos_dom/ssr", "leptos_reactive/ssr"]
-stable = ["leptos_dom/stable", "leptos_reactive/stable"]
+csr = ["leptos_dom/web"]
+hydrate = ["leptos_dom/web"]
+ssr = ["leptos_dom/ssr"]
+stable = ["leptos_dom/stable"]
 tracing = []
 
 [package.metadata.cargo-all-features]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -22,7 +22,6 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }
 syn-rsx = "0.9"
-leptos_dom = { workspace = true }
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"
@@ -36,10 +35,10 @@ leptos = { path = "../leptos" }
 
 [features]
 default = ["ssr"]
-csr = ["leptos_dom/web"]
-hydrate = ["leptos_dom/web"]
-ssr = ["leptos_dom/ssr"]
-stable = ["leptos_dom/stable"]
+csr = []
+hydrate = []
+ssr = []
+stable = []
 tracing = []
 
 [package.metadata.cargo-all-features]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -9,38 +9,20 @@ description = "RPC for the Leptos web framework."
 readme = "../README.md"
 
 [dependencies]
-leptos_dom = { workspace = true }
 leptos_reactive = { workspace = true }
 server_fn = { workspace = true }
 lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
-serde_urlencoded = "0.7"
 thiserror = "1"
 
 [dev-dependencies]
 leptos = { path = "../leptos" }
 
 [features]
-csr = [
-  #"leptos/csr",
-  "leptos_dom/web",
-  "leptos_reactive/csr",
-]
-hydrate = [
-  #"leptos/hydrate",
-  "leptos_dom/web",
-  "leptos_reactive/hydrate",
-]
-ssr = [
-  #"leptos/ssr",
-  "leptos_reactive/ssr",
-  "server_fn/ssr",
-]
-stable = [
-  #"leptos/stable",
-  "leptos_dom/stable",
-  "leptos_reactive/stable",
-]
+csr = ["leptos_reactive/csr"]
+hydrate = ["leptos_reactive/hydrate"]
+ssr = ["leptos_reactive/ssr", "server_fn/ssr"]
+stable = ["leptos_reactive/stable"]
 
 [package.metadata.cargo-all-features]
 denylist = ["stable"]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -10,8 +10,6 @@ description = "Tools to set HTML metadata in the Leptos web framework."
 [dependencies]
 cfg-if = "1"
 leptos = { workspace = true }
-tracing = "0.1"
-typed-builder = "0.14"
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -10,6 +10,7 @@ description = "Tools to set HTML metadata in the Leptos web framework."
 [dependencies]
 cfg-if = "1"
 leptos = { workspace = true }
+tracing = "0.1"
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -22,7 +22,6 @@ percent-encoding = "2"
 thiserror = "1"
 serde_urlencoded = "0.7"
 serde = "1"
-tracing = "0.1"
 js-sys = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -22,6 +22,7 @@ percent-encoding = "2"
 thiserror = "1"
 serde_urlencoded = "0.7"
 serde = "1"
+tracing = "0.1"
 js-sys = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -10,7 +10,6 @@ readme = "../README.md"
 
 [dependencies]
 server_fn_macro_default = { path = "./server_fn_macro_default", version = "0.2.0" }
-form_urlencoded = "1"
 serde = { version = "1", features = ["derive"] }
 serde_urlencoded = "0.7"
 thiserror = "1"
@@ -18,7 +17,6 @@ serde_json = "1.0.89"
 quote = "1"
 syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
 proc-macro2 = "1"
-cfg-if = "1"
 ciborium = "0.2.0"
 xxhash-rust = { version = "0.8.6", features = ["const_xxh64"] }
 const_format = "0.2.30"

--- a/server_fn/server_fn_macro_default/Cargo.toml
+++ b/server_fn/server_fn_macro_default/Cargo.toml
@@ -11,7 +11,6 @@ description = "The default implementation of the server_fn macro without a conte
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
 syn = { version = "1", features = ["full"] }
 server_fn_macro = { workspace = true }
 

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -10,8 +10,6 @@ readme = "../README.md"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_urlencoded = "0.7"
-serde_json = "1.0.89"
 quote = "1"
 syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
 proc-macro2 = "1"


### PR DESCRIPTION
There are a lot of unused dependencies in the repo at this point, especially in examples. This applies `cargo machete` to remove them systematically. See #657.