### PR TITLE
feat: maintain order of sources and dependencies

### DIFF
--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -127,6 +127,10 @@ pub fn Contact(cx: Scope) -> impl IntoView {
         get_contact,
     );
 
+    create_effect(cx, move |_| {
+        log!("params = {:#?}", params.get());
+    });
+
     let contact_display = move || match contact.read(cx) {
         // None => loading, but will be caught by Suspense fallback
         // I'm only doing this explicitly for the example

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -41,6 +41,7 @@ web-sys = { version = "0.3", features = [
   "Window",
 ] }
 cfg-if = "1.0.0"
+indexmap = "1.9.2"
 
 [dev-dependencies]
 log = "0.4"


### PR DESCRIPTION
This one is... a little difficult to describe but very important. Switching to using an `IndexSet` rather than a `HashSet` ensures that the iteration order of both sources and dependencies in the reactive graph is always the same. This means that reactive nodes (memos) are updated in the same order on every update, which is important to maintaining efficient dynamic dependency arrays  Taken together with the laziness of memos, it has the effect of closing #339 by ensuring (I hope) that route params are not updated for an old route after navigation, etc.