### PR TITLE
fix: suppress spurious hydration warnings for tags in `leptos_meta`

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -229,7 +229,8 @@ impl Custom {
             } else {
                 if !is_meta_tag() {
                     crate::warn!(
-                        "element with id {id} not found, ignoring it for hydration"
+                        "element with id {id} not found, ignoring it for \
+                         hydration"
                     );
                 }
 
@@ -1020,7 +1021,7 @@ fn create_leptos_element(
             if !is_meta_tag() {
                 crate::warn!(
                     "element with id {id} not found, ignoring it for hydration"
-                    );
+                );
             }
 
             clone_element()

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -8,6 +8,7 @@ cfg_if! {
     use crate::macro_helpers::*;
     use crate::{mount_child, MountKind};
     use once_cell::unsync::Lazy as LazyCell;
+    use std::cell::Cell;
     use wasm_bindgen::JsCast;
 
     /// Trait alias for the trait bounts on [`ElementDescriptor`].
@@ -19,6 +20,22 @@ cfg_if! {
     impl<El> ElementDescriptorBounds for El where
       El: fmt::Debug + AsRef<web_sys::HtmlElement> + Clone
     {
+    }
+
+    thread_local! {
+        static IS_META: Cell<bool> = Cell::new(false);
+    }
+
+    #[doc(hidden)]
+    pub fn as_meta_tag<T>(f: impl FnOnce() -> T) -> T {
+        IS_META.with(|m| m.set(true));
+        let v = f();
+        IS_META.with(|m| m.set(false));
+        v
+    }
+
+    fn is_meta_tag() -> bool {
+        IS_META.with(|m| m.get())
     }
   } else {
     use crate::hydration::HydrationKey;
@@ -35,6 +52,11 @@ cfg_if! {
     pub trait ElementDescriptorBounds: fmt::Debug {}
 
     impl<El> ElementDescriptorBounds for El where El: fmt::Debug {}
+
+    #[doc(hidden)]
+    pub fn as_meta_tag<T>(f: impl FnOnce() -> T) -> T {
+        f()
+    }
   }
 }
 
@@ -205,9 +227,11 @@ impl Custom {
 
                 el.unchecked_into()
             } else {
-                crate::warn!(
-                    "element with id {id} not found, ignoring it for hydration"
-                );
+                if !is_meta_tag() {
+                    crate::warn!(
+                        "element with id {id} not found, ignoring it for hydration"
+                    );
+                }
 
                 crate::document().create_element(&name).unwrap()
             }
@@ -993,9 +1017,11 @@ fn create_leptos_element(
 
             el.unchecked_into()
         } else {
-            crate::warn!(
-                "element with id {id} not found, ignoring it for hydration"
-            );
+            if !is_meta_tag() {
+                crate::warn!(
+                    "element with id {id} not found, ignoring it for hydration"
+                    );
+            }
 
             clone_element()
         }

--- a/meta/src/link.rs
+++ b/meta/src/link.rs
@@ -85,25 +85,30 @@ pub fn Link(
     let next_id = meta.tags.get_next_id();
     let id = id.unwrap_or_else(|| format!("leptos-link-{}", next_id.0));
 
-    let builder_el = leptos::leptos_dom::html::link(cx)
-        .attr("id", &id)
-        .attr("as", as_)
-        .attr("crossorigin", crossorigin)
-        .attr("disabled", disabled.unwrap_or(false))
-        .attr("fetchpriority", fetchpriority)
-        .attr("href", href)
-        .attr("hreflang", hreflang)
-        .attr("imagesizes", imagesizes)
-        .attr("imagesrcset", imagesrcset)
-        .attr("integrity", integrity)
-        .attr("media", media)
-        .attr("prefetch", prefetch)
-        .attr("referrerpolicy", referrerpolicy)
-        .attr("rel", rel)
-        .attr("sizes", sizes)
-        .attr("title", title)
-        .attr("type", type_)
-        .attr("blocking", blocking);
+    let builder_el = leptos::leptos_dom::html::as_meta_tag({
+        let id = id.clone();
+        move || {
+            leptos::leptos_dom::html::link(cx)
+                .attr("id", &id)
+                .attr("as", as_)
+                .attr("crossorigin", crossorigin)
+                .attr("disabled", disabled.unwrap_or(false))
+                .attr("fetchpriority", fetchpriority)
+                .attr("href", href)
+                .attr("hreflang", hreflang)
+                .attr("imagesizes", imagesizes)
+                .attr("imagesrcset", imagesrcset)
+                .attr("integrity", integrity)
+                .attr("media", media)
+                .attr("prefetch", prefetch)
+                .attr("referrerpolicy", referrerpolicy)
+                .attr("rel", rel)
+                .attr("sizes", sizes)
+                .attr("title", title)
+                .attr("type", type_)
+                .attr("blocking", blocking)
+        }
+    });
 
     meta.tags.register(cx, id, builder_el.into_any());
 }

--- a/meta/src/meta_tags.rs
+++ b/meta/src/meta_tags.rs
@@ -41,11 +41,13 @@ pub fn Meta(
     let next_id = meta.tags.get_next_id();
     let id = format!("leptos-link-{}", next_id.0);
 
-    let builder_el = leptos::leptos_dom::html::meta(cx)
-        .attr("charset", move || charset.as_ref().map(|v| v.get()))
-        .attr("name", move || name.as_ref().map(|v| v.get()))
-        .attr("http-equiv", move || http_equiv.as_ref().map(|v| v.get()))
-        .attr("content", move || content.as_ref().map(|v| v.get()));
+    let builder_el = leptos::leptos_dom::html::as_meta_tag(move || {
+        leptos::leptos_dom::html::meta(cx)
+            .attr("charset", move || charset.as_ref().map(|v| v.get()))
+            .attr("name", move || name.as_ref().map(|v| v.get()))
+            .attr("http-equiv", move || http_equiv.as_ref().map(|v| v.get()))
+            .attr("content", move || content.as_ref().map(|v| v.get()))
+    });
 
     meta.tags.register(cx, id, builder_el.into_any());
 }

--- a/meta/src/script.rs
+++ b/meta/src/script.rs
@@ -67,19 +67,24 @@ pub fn Script(
     let next_id = meta.tags.get_next_id();
     let id = id.unwrap_or_else(|| format!("leptos-link-{}", next_id.0));
 
-    let builder_el = leptos::leptos_dom::html::script(cx)
-        .attr("id", &id)
-        .attr("async", async_)
-        .attr("crossorigin", crossorigin)
-        .attr("defer", defer)
-        .attr("fetchpriority ", fetchpriority)
-        .attr("integrity", integrity)
-        .attr("nomodule", nomodule)
-        .attr("nonce", nonce)
-        .attr("referrerpolicy", referrerpolicy)
-        .attr("src", src)
-        .attr("type", type_)
-        .attr("blocking", blocking);
+    let builder_el = leptos::leptos_dom::html::as_meta_tag({
+        let id = id.clone();
+        move || {
+            leptos::leptos_dom::html::script(cx)
+                .attr("id", &id)
+                .attr("async", async_)
+                .attr("crossorigin", crossorigin)
+                .attr("defer", defer)
+                .attr("fetchpriority ", fetchpriority)
+                .attr("integrity", integrity)
+                .attr("nomodule", nomodule)
+                .attr("nonce", nonce)
+                .attr("referrerpolicy", referrerpolicy)
+                .attr("src", src)
+                .attr("type", type_)
+                .attr("blocking", blocking)
+        }
+    });
     let builder_el = if let Some(children) = children {
         let frag = children(cx);
         let mut script = String::new();

--- a/meta/src/style.rs
+++ b/meta/src/style.rs
@@ -46,12 +46,17 @@ pub fn Style(
     let next_id = meta.tags.get_next_id();
     let id = id.unwrap_or_else(|| format!("leptos-link-{}", next_id.0));
 
-    let builder_el = leptos::leptos_dom::html::style(cx)
-        .attr("id", &id)
-        .attr("media", media)
-        .attr("nonce", nonce)
-        .attr("title", title)
-        .attr("blocking", blocking);
+    let builder_el = leptos::leptos_dom::html::as_meta_tag({
+        let id = id.clone();
+        move || {
+            leptos::leptos_dom::html::style(cx)
+                .attr("id", &id)
+                .attr("media", media)
+                .attr("nonce", nonce)
+                .attr("title", title)
+                .attr("blocking", blocking)
+        }
+    });
     let builder_el = if let Some(children) = children {
         let frag = children(cx);
         let mut style = String::new();


### PR DESCRIPTION
Closes issue #576.

Various tags created by `leptos_meta` under a `<Suspense/>` would give hydration errors in streaming rendering because they were not found in the `<head>`. These warnings are not real—the framework simply creates the tags and makes sure they are injected into the head properly—so this PR suppresses them to avoid confusion with actual mismatches/bugs.