### PR TITLE
examples: remove duplicate `console_error_panic_hook::set_once()` calls

### DIFF
--- a/examples/counter_isomorphic/src/lib.rs
+++ b/examples/counter_isomorphic/src/lib.rs
@@ -10,7 +10,6 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
 

--- a/examples/counters/src/main.rs
+++ b/examples/counters/src/main.rs
@@ -2,7 +2,6 @@ use counters::{Counters, CountersProps};
 use leptos::*;
 
 fn main() {
-    console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(|cx| view! { cx,  <Counters/> })

--- a/examples/counters_stable/src/main.rs
+++ b/examples/counters_stable/src/main.rs
@@ -1,7 +1,6 @@
 use leptos::*;
 
 fn main() {
-    console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(|cx| view! { cx,  <Counters/> })

--- a/examples/errors_axum/src/lib.rs
+++ b/examples/errors_axum/src/lib.rs
@@ -13,7 +13,6 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
 

--- a/examples/fetch/src/main.rs
+++ b/examples/fetch/src/main.rs
@@ -2,7 +2,6 @@ use fetch::fetch_example;
 use leptos::*;
 
 pub fn main() {
-    console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(fetch_example)

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -46,7 +46,6 @@ if #[cfg(feature = "ssr")] {
         use hackernews_axum::*;
 
         pub fn main() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
             mount_to_body(|cx| {

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -2,7 +2,6 @@ use leptos::*;
 use router::*;
 
 pub fn main() {
-    console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(|cx| view! { cx, <RouterExample/> })

--- a/examples/session_auth_axum/src/lib.rs
+++ b/examples/session_auth_axum/src/lib.rs
@@ -15,7 +15,6 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
 

--- a/examples/tailwind/src/lib.rs
+++ b/examples/tailwind/src/lib.rs
@@ -9,14 +9,14 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-                console_error_panic_hook::set_once();
-                _ = console_log::init_with_level(log::Level::Debug);
+            _ = console_log::init_with_level(log::Level::Debug);
+            console_error_panic_hook::set_once();
 
-                log!("hydrate mode - hydrating");
+            log!("hydrate mode - hydrating");
 
-                leptos::mount_to_body(|cx| {
-                    view! { cx,  <App/> }
-                });
+            leptos::mount_to_body(|cx| {
+                view! { cx,  <App/> }
+            });
         }
     }
     else if #[cfg(feature = "csr")] {
@@ -35,5 +35,5 @@ cfg_if! {
                 view! { cx, <App /> }
             });
         }
-  }
+    }
 }

--- a/examples/todo_app_sqlite_axum/src/lib.rs
+++ b/examples/todo_app_sqlite_axum/src/lib.rs
@@ -13,7 +13,6 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
 

--- a/examples/todo_app_sqlite_viz/src/lib.rs
+++ b/examples/todo_app_sqlite_viz/src/lib.rs
@@ -13,7 +13,6 @@ cfg_if! {
 
         #[wasm_bindgen]
         pub fn hydrate() {
-            console_error_panic_hook::set_once();
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -1,7 +1,6 @@
 use leptos::*;
 pub use todomvc::*;
 fn main() {
-    console_error_panic_hook::set_once();
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(|cx| view! { cx,  <TodoMVC/> })


### PR DESCRIPTION
I noticed that in a lot of the examples, `console_error_panic_hook::set_once()` was being called twice:
```
console_error_panic_hook::set_once();
_ = console_log::init_with_level(log::Level::Debug);
console_error_panic_hook::set_once();
```
so I removed the first one since most of the other examples were using this pattern:
```
_ = console_log::init_with_level(log::Level::Debug);
console_error_panic_hook::set_once();
```
Lef me know if you would prefer that I instead delete the second one, so that the order would be like this:
```
console_error_panic_hook::set_once();
_ = console_log::init_with_level(log::Level::Debug);
```
Also, I noticed that the [examples/tailwind/src/lib.rs](https://github.com/leptos-rs/leptos/compare/main...elliotwaite:leptos:fix-duplicate-panic-hook-calls?expand=1#diff-e699beee9abb30108fa822048736e0e46473b21529e0c09e8d12b5bdeea6c644) example was using that other order (calling `console_error_panic_hook::set_once()` then `console_log::init_with_level(log::Level::Debug)`), so I swapped those calls so that all the examples would be consistent. I also fixed some indent issues I noticed in that file.