### PR TITLE
Clippy: less .clone() calls, simpler pointer passing.

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -322,7 +322,7 @@ impl Element {
                 cx,
                 element,
                 attrs,
-                children: children.clone(),
+                children,
                 #[cfg(debug_assertions)]
                 view_marker,
             }

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -126,10 +126,7 @@ pub fn render_to_stream_in_order_with_prefix_undisposed_with_context(
 }
 
 #[async_recursion(?Send)]
-async fn handle_chunks(
-    mut tx: UnboundedSender<String>,
-    chunks: Vec<StreamChunk>,
-) {
+async fn handle_chunks(tx: UnboundedSender<String>, chunks: Vec<StreamChunk>) {
     let mut buffer = String::new();
     for chunk in chunks {
         match chunk {

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -186,12 +186,12 @@ impl Runtime {
         let current_observer = self.observer.get();
 
         // mark self dirty
-        if let Some(mut current_node) = nodes.get_mut(node) {
+        if let Some(current_node) = nodes.get_mut(node) {
             Runtime::mark(
                 node,
-                &mut current_node,
+                current_node,
                 ReactiveNodeState::Dirty,
-                &mut *pending_effects,
+                &mut pending_effects,
                 current_observer,
             );
 
@@ -200,10 +200,10 @@ impl Runtime {
             let mut descendants = Default::default();
             Runtime::gather_descendants(&subscribers, node, &mut descendants);
             for descendant in descendants {
-                if let Some(mut node) = nodes.get_mut(descendant) {
+                if let Some(node) = nodes.get_mut(descendant) {
                     Runtime::mark(
                         descendant,
-                        &mut node,
+                        node,
                         ReactiveNodeState::Check,
                         &mut pending_effects,
                         current_observer,


### PR DESCRIPTION
As usual less .clone() calls

Just to signal things to come, there are two warnings which I am keeping behind, because I am going to suggest a change is approach which needs a different kind of review.

Here is the warning which I will cover in a upcomming PR

```
warning: unused `std::result::Result` that must be used
   --> leptos_dom/src/ssr_in_order.rs:145:5
    |
145 |     tx.unbounded_send(std::mem::take(&mut buffer));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
```