### PR TITLE
Minor: Simplifiy Box::Pin() call.

### DIFF
--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -286,7 +286,7 @@ where
     let pending = create_rw_signal(cx, false);
     let action_fn = Rc::new(move |input: &I| {
         let fut = action_fn(input);
-        Box::pin(async move { fut.await }) as Pin<Box<dyn Future<Output = O>>>
+        Box::pin(fut) as Pin<Box<dyn Future<Output = O>>>
     });
 
     Action(store_value(

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -297,7 +297,7 @@ where
     let submissions = create_rw_signal(cx, Vec::new());
     let action_fn = Rc::new(move |input: &I| {
         let fut = action_fn(input);
-        Box::pin(async move { fut.await }) as Pin<Box<dyn Future<Output = O>>>
+        Box::pin(fut) as Pin<Box<dyn Future<Output = O>>>
     });
 
     MultiAction(store_value(


### PR DESCRIPTION
-        Box::pin(async move { fut.await }) as Pin<Box<dyn Future<Output = O>>>
+        Box::pin(fut) as Pin<Box<dyn Future<Output = O>>>

My reading of this is the simplification: - 
The type coercion into the final concrete type only relies "Can I make what I have  into a 'Pin<Box<dyn Future<Output = O>>>'