### PR TITLE
chore: Upgrade `console_log` dependency to stable

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { path = "../../leptos" }
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"
 

--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 broadcaster = "1"
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1"
 futures = "0.3"
 cfg-if = "1"

--- a/examples/counter_without_macros/Cargo.toml
+++ b/examples/counter_without_macros/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { path = "../../leptos", features = ["stable"] }
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"
 

--- a/examples/counters/Cargo.toml
+++ b/examples/counters/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { path = "../../leptos" }
 log = "0.4"
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]

--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { path = "../../leptos", features = ["stable"] }
 log = "0.4"
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]

--- a/examples/error_boundary/Cargo.toml
+++ b/examples/error_boundary/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 leptos = { path = "../../leptos" }
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"

--- a/examples/errors_axum/Cargo.toml
+++ b/examples/errors_axum/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-console_log = "0.2.0"
+console_log = "1.0.0"
 console_error_panic_hook = "0.1.7"
 cfg-if = "1.0.0"
 leptos = { path = "../../../leptos/leptos", default-features = false, features = [

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -9,7 +9,7 @@ leptos = { path = "../../leptos" }
 reqwasm = "0.5.0"
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1"
 cfg-if = "1"
 leptos = { path = "../../leptos", default-features = false, features = [

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-console_log = "0.2.0"
+console_log = "1.0.0"
 console_error_panic_hook = "0.1.7"
 cfg-if = "1.0.0"
 leptos = { path = "../../leptos", default-features = false, features = [

--- a/examples/login_with_token_csr_only/client/Cargo.toml
+++ b/examples/login_with_token_csr_only/client/Cargo.toml
@@ -12,7 +12,7 @@ leptos_router = { version = "0.2.0-alpha2", features = ["stable", "csr"] }
 
 log = "0.4"
 console_error_panic_hook = "0.1"
-console_log = "0.2"
+console_log = "1"
 gloo-net = "0.2"
 gloo-storage = "0.2"
 serde = "1.0"

--- a/examples/parent_child/Cargo.toml
+++ b/examples/parent_child/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { path = "../../leptos" }
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"
 web-sys = "0.3"

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 leptos = { path = "../../leptos" }
 leptos_router = { path = "../../router", features = ["csr"] }

--- a/examples/session_auth_axum/Cargo.toml
+++ b/examples/session_auth_axum/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0.66"
-console_log = "0.2.0"
+console_log = "1.0.0"
 rand = { version = "0.8.5", features = ["min_const_gen"], optional = true }
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"

--- a/examples/ssr_modes/Cargo.toml
+++ b/examples/ssr_modes/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 actix-files = { version = "0.6", optional = true }
 actix-web = { version = "4", optional = true, features = ["macros"] }
 console_error_panic_hook = "0.1"
-console_log = "0.2"
+console_log = "1"
 cfg-if = "1"
 lazy_static = "1"
 leptos = { path = "../../leptos", default-features = false, features = [

--- a/examples/ssr_modes_axum/Cargo.toml
+++ b/examples/ssr_modes_axum/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 console_error_panic_hook = "0.1"
-console_log = "0.2"
+console_log = "1"
 cfg-if = "1"
 lazy_static = "1"
 leptos = { path = "../../leptos", default-features = false, features = [

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 
 # dependecies for client (enable when csr or hydrate set)
 wasm-bindgen = { version = "0.2", optional = true }
-console_log = { version = "0.2", optional = true }
+console_log = { version = "1", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 
 # dependecies for server (enable when ssr set)

--- a/examples/tailwind_csr_trunk/Cargo.toml
+++ b/examples/tailwind_csr_trunk/Cargo.toml
@@ -16,6 +16,6 @@ gloo-net = { version = "0.2", features = ["http"] }
 
 # dependecies for client (enable when csr or hydrate set)
 wasm-bindgen = { version = "0.2" }
-console_log = { version = "0.2"}
+console_log = { version = "1"}
 console_error_panic_hook = { version = "0.1"}
 

--- a/examples/todo_app_sqlite/Cargo.toml
+++ b/examples/todo_app_sqlite/Cargo.toml
@@ -11,7 +11,7 @@ actix-files = { version = "0.6.2", optional = true }
 actix-web = { version = "4.2.1", optional = true, features = ["macros"] }
 anyhow = "1.0.68"
 broadcaster = "1.0.0"
-console_log = "0.2.0"
+console_log = "1.0.0"
 console_error_panic_hook = "0.1.7"
 serde = { version = "1.0.152", features = ["derive"] }
 futures = "0.3.25"

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-console_log = "0.2.0"
+console_log = "1.0.0"
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"

--- a/examples/todo_app_sqlite_viz/Cargo.toml
+++ b/examples/todo_app_sqlite_viz/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-console_log = "0.2.0"
+console_log = "1.0.0"
 console_error_panic_hook = "0.1.7"
 futures = "0.3.25"
 cfg-if = "1.0.0"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 leptos = { path = "../../leptos", default-features = false }
 log = "0.4"
-console_log = "0.2"
+console_log = "1"
 console_error_panic_hook = "0.1.7"
 uuid = { version = "1", features = ["v4", "js", "serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/leptos_dom/examples/view-tests/Cargo.toml
+++ b/leptos_dom/examples/view-tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 leptos = { path = "../../leptos" }
-console_log = "0.2"
+console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"
 


### PR DESCRIPTION
The crate [console_log](https://github.com/iamcodemaker/console_log) has re-released the version 0.2.2 as 1.0.0 without changes (see [release](https://github.com/iamcodemaker/console_log/releases/tag/1.0.0) and [full changelog](https://github.com/iamcodemaker/console_log/compare/0.2.2...1.0.0)).