### PR TITLE
Add arbitrary attributes to Html meta tag

### DIFF
--- a/meta/src/additional_attributes.rs
+++ b/meta/src/additional_attributes.rs
@@ -1,7 +1,9 @@
 use crate::TextProp;
 
-#[derive(Default)]
-pub struct AdditionalAttributes(pub Option<Vec<(String, TextProp)>>);
+/// A collection of additional HTML attributes to be applied to an element,
+/// each of which may or may not be reactive.
+#[derive(Default, Clone)]
+pub struct AdditionalAttributes(pub(crate) Vec<(String, TextProp)>);
 
 impl<I, T, U> From<I> for AdditionalAttributes
 where
@@ -10,11 +12,33 @@ where
     U: Into<TextProp>,
 {
     fn from(value: I) -> Self {
-        Self(Some(
+        Self(
             value
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
-        ))
+        )
+    }
+}
+
+/// Iterator over additional HTML attributes.
+pub struct AdditionalAttributesIter<'a>(
+    std::slice::Iter<'a, (String, TextProp)>,
+);
+
+impl<'a> Iterator for AdditionalAttributesIter<'a> {
+    type Item = &'a (String, TextProp);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a> IntoIterator for &'a AdditionalAttributes {
+    type Item = &'a (String, TextProp);
+    type IntoIter = AdditionalAttributesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        todo!()
     }
 }

--- a/meta/src/additional_attributes.rs
+++ b/meta/src/additional_attributes.rs
@@ -1,0 +1,20 @@
+use crate::TextProp;
+
+#[derive(Default)]
+pub struct AdditionalAttributes(pub Option<Vec<(String, TextProp)>>);
+
+impl<I, T, U> From<I> for AdditionalAttributes
+where
+    I: IntoIterator<Item = (T, U)>,
+    T: Into<String>,
+    U: Into<TextProp>,
+{
+    fn from(value: I) -> Self {
+        Self(Some(
+            value
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        ))
+    }
+}

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -72,7 +72,12 @@ impl std::fmt::Debug for HtmlContext {
 ///
 ///     view! { cx,
 ///       <main>
-///         <Html lang="he" dir="rtl" attributes=vec![("data-theme", "dark")]/>
+///         <Html
+///           lang="he"
+///           dir="rtl"
+///           // arbitrary additional attributes can be passed via `attributes`
+///           attributes=AdditionalAttributes::from(vec![("data-theme", "dark")])
+///         />
 ///       </main>
 ///     }
 /// }

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -9,7 +9,7 @@ pub struct HtmlContext {
     lang: Rc<RefCell<Option<TextProp>>>,
     dir: Rc<RefCell<Option<TextProp>>>,
     class: Rc<RefCell<Option<TextProp>>>,
-    attributes: Rc<RefCell<AdditionalAttributes>>,
+    attributes: Rc<RefCell<Option<MaybeSignal<AdditionalAttributes>>>>,
 }
 
 impl HtmlContext {
@@ -30,11 +30,14 @@ impl HtmlContext {
             .borrow()
             .as_ref()
             .map(|val| format!("class=\"{}\"", val.get()));
-        let attributes = self.attributes.borrow().0.as_ref().map(|val| {
-            val.iter()
-                .map(|(n, v)| format!("{}=\"{}\"", n, v.get()))
-                .collect::<Vec<_>>()
-                .join(" ")
+        let attributes = self.attributes.borrow().as_ref().map(|val| {
+            val.with(|val| {
+                val.0
+                    .iter()
+                    .map(|(n, v)| format!("{}=\"{}\"", n, v.get()))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
         });
         let mut val = [lang, dir, class, attributes]
             .into_iter()
@@ -88,7 +91,7 @@ pub fn Html(
     class: Option<TextProp>,
     /// Arbitrary attributes to add to the `<html>`
     #[prop(optional, into)]
-    attributes: AdditionalAttributes,
+    attributes: Option<MaybeSignal<AdditionalAttributes>>,
 ) -> impl IntoView {
     cfg_if! {
         if #[cfg(any(feature = "csr", feature = "hydrate"))] {
@@ -118,14 +121,15 @@ pub fn Html(
                 });
             }
 
-            if let Some(attributes) = attributes.0 {
-                for (attr_name, attr_value) in attributes.into_iter() {
+            if let Some(attributes) = attributes {
+                let attributes = attributes.get();
+                for (attr_name, attr_value) in attributes.0.into_iter() {
                     let el = el.clone();
                     create_render_effect(cx, move |_|{
                         let value = attr_value.get();
                             _ = el.set_attribute(&attr_name, &value);
                     });
-                };
+                }
             }
         } else {
             let meta = crate::use_head(cx);

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -9,6 +9,7 @@ pub struct HtmlContext {
     lang: Rc<RefCell<Option<TextProp>>>,
     dir: Rc<RefCell<Option<TextProp>>>,
     class: Rc<RefCell<Option<TextProp>>>,
+    attributes: Rc<RefCell<Option<Vec<(String, TextProp)>>>>,
 }
 
 impl HtmlContext {
@@ -29,7 +30,13 @@ impl HtmlContext {
             .borrow()
             .as_ref()
             .map(|val| format!("class=\"{}\"", val.get()));
-        let mut val = [lang, dir, class]
+        let attributes = self.attributes.borrow().as_ref().map(|val| {
+            val.iter()
+                .map(|(n, v)| format!("{}=\"{}\"", n, v.get()))
+                .collect::<Vec<_>>()
+                .join(" ")
+        });
+        let mut val = [lang, dir, class, attributes]
             .into_iter()
             .flatten()
             .collect::<Vec<_>>()
@@ -60,9 +67,11 @@ impl std::fmt::Debug for HtmlContext {
 /// fn MyApp(cx: Scope) -> impl IntoView {
 ///     provide_meta_context(cx);
 ///
+///     let attrs = vec![(String::from("data-theme"), TextProp::from("dark"))];
+///
 ///     view! { cx,
 ///       <main>
-///         <Html lang="he" dir="rtl"/>
+///         <Html lang="he" dir="rtl" attributes=attrs/>
 ///       </main>
 ///     }
 /// }
@@ -79,6 +88,9 @@ pub fn Html(
     /// The `class` attribute on the `<html>`.
     #[prop(optional, into)]
     class: Option<TextProp>,
+    /// Arbitrary attributes to add to the `<html>`
+    #[prop(optional, into)]
+    attributes: Option<Vec<(String, TextProp)>>,
 ) -> impl IntoView {
     cfg_if! {
         if #[cfg(any(feature = "csr", feature = "hydrate"))] {
@@ -101,16 +113,28 @@ pub fn Html(
             }
 
             if let Some(class) = class {
+                let el = el.clone();
                 create_render_effect(cx, move |_| {
                     let value = class.get();
                     _ = el.set_attribute("class", &value);
                 });
+            }
+
+            if let Some(attributes) = attributes {
+                for (attr_name, attr_value) in attributes.into_iter(){
+                    let el=el.clone();
+                    create_render_effect(cx, move |_|{
+                        let value = attr_value.get();
+                            _ = el.set_attribute(&attr_name, &value);
+                    });
+                };
             }
         } else {
             let meta = crate::use_head(cx);
             *meta.html.lang.borrow_mut() = lang;
             *meta.html.dir.borrow_mut() = dir;
             *meta.html.class.borrow_mut() = class;
+            *meta.html.attributes.borrow_mut() = attributes;
         }
     }
 }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -58,6 +58,7 @@ use std::{
 #[cfg(any(feature = "csr", feature = "hydrate"))]
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 
+mod additional_attributes;
 mod body;
 mod html;
 mod link;

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -67,6 +67,7 @@ mod script;
 mod style;
 mod stylesheet;
 mod title;
+pub use additional_attributes::*;
 pub use body::*;
 pub use html::*;
 pub use link::*;


### PR DESCRIPTION
Adds a additional `attributes` property to the Html component so one can add several arbitrary attributes to the document's `<html>` element.
