### PR TITLE
fix: include query params in navigation when `<ActionForm>` response redirects.

### DIFF
--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -120,7 +120,10 @@ where
                                     Ok(url) => {
                                         request_animation_frame(move || {
                                             if let Err(e) = navigate(
-                                                &url.pathname,
+                                                &format!(
+                                                    "{}{}",
+                                                    url.pathname, url.search,
+                                                ),
                                                 Default::default(),
                                             ) {
                                                 warn!("{}", e);


### PR DESCRIPTION
Solution based on previous solution in #727. @gbj's PR included a manually inserted `?` when a leading `?` is present automatically in `Url.search`.

Context in Discord topic: https://discordapp.com/channels/1031524867910148188/1088151782766694490/1088151782766694490