### PR TITLE
avoid panic in counter_isomorphic Multi-User counter

### DIFF
--- a/examples/counter_isomorphic/src/counters.rs
+++ b/examples/counter_isomorphic/src/counters.rs
@@ -198,13 +198,13 @@ pub fn MultiuserCounter(cx: Scope) -> impl IntoView {
         let s = create_signal_from_stream(
             cx,
             source.subscribe("message").unwrap().map(|value| {
-                value
-                    .expect("no message event")
-                    .1
-                    .data()
-                    .as_string()
-                    .expect("expected string value")
-            }),
+                match value {
+                    Ok(value) => {
+                        value.1.data().as_string().expect("expected string value")
+                    },
+                    Err(_) => "0".to_string(),
+                }
+            })
         );
 
         on_cleanup(cx, move || source.close());


### PR DESCRIPTION
This is a trivial fix for what I think is a bug in the counter_isomorphic example.  Whenever you visit the Multi-User counter, and then click away to one of the other counters.  The EventSource is closed `on_cleanup`, however an `EventSourceSubscription` seems to be sent after the source is closed, with a value of Err.

[Kooha-2023-03-22-22-34-54.webm](https://user-images.githubusercontent.com/364615/227088506-a4b06829-c87d-4f12-a24b-9022d838a61e.webm)

This PR simply matches the Result and takes the happy path in the Ok branch.  In the Err branch, I had to create and return a useless string, which makes me think there's probably a more idiomatic Leptos way to handle this kind of thing.  Any suggestions?  Thanks!