### PR TITLE
leptos-reactive: Bumped serde-lite from 0.3 to 0.4.

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -10,7 +10,7 @@ description = "Reactive system for the Leptos web framework."
 [dependencies]
 slotmap = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
-serde-lite = { version = "0.3", optional = true }
+serde-lite = { version = "0.4", optional = true }
 futures = { version = "0.3" }
 js-sys = { version = "0.3", optional = true }
 miniserde = { version = "0.1", optional = true }
@@ -50,8 +50,18 @@ leptos = { path = "../leptos" }
 
 [features]
 default = []
-csr = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
-hydrate = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
+csr = [
+  "dep:js-sys",
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:web-sys",
+]
+hydrate = [
+  "dep:js-sys",
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:web-sys",
+]
 ssr = ["dep:tokio"]
 stable = []
 serde = []


### PR DESCRIPTION
Just a minor change. 

PS by way of discussion when I look at bumping 

syn   1.0.109  ->   2.0.8 

it not possible at the moment, there is a messy sub dependency issue 

syn-rsx is moving more slowly that syn. -- in needs to internal starting using syn 2.x before we can increment to syn2.x