### PR TITLE
feat: Added ProtectedRoute component to route file

### DIFF
--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -257,7 +257,7 @@ where
     P: std::fmt::Display + 'static,
     C: Fn(Scope) -> bool + 'static,
 {
-    if condition {
+    if condition(cx) {
         return view! {cx, <Route path=expose_path view=view />}.into_view(cx);
     } else {
         return view! {cx, <Redirect path=redirect_path /> }.into_view(cx);

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -238,3 +238,28 @@ impl std::fmt::Debug for RouteContextInner {
             .finish()
     }
 }
+
+#[component]
+pub fn ProtectedRoute<P, E, F, C>(
+    cx: Scope,
+    /// Path that will be exposed if the condition is resolved to true.
+    expose_path: P,
+    /// Path for the Redirect in case if the condition is resolved to false.
+    redirect_path: P,
+    /// Condition function that returns a boolean.
+    condition: C,
+    /// View that will be exposed if the condition is resolved to true.
+    view: F,
+) -> impl IntoView
+where
+    E: IntoView,
+    F: Fn(Scope) -> E + 'static,
+    P: std::fmt::Display + 'static,
+    C: Fn(Scope) -> bool + 'static,
+{
+    if condition {
+        return view! {cx, <Route path=expose_path view=view />}.into_view(cx);
+    } else {
+        return view! {cx, <Redirect path=redirect_path /> }.into_view(cx);
+    }
+}


### PR DESCRIPTION
As discussed on Discord with @gbj it might be a good idea to introduce some sort of a ```ProtectedRoute``` that evaluates a condition and either redirects the user, or exposes a Route.

I am unsure if the condition is called correctly in its current form.

The overarching idea was taken from:  https://www.robinwieruch.de/react-router-private-routes/