### PR TITLE
Document cargo workspace feature resolver footgun

### DIFF
--- a/docs/COMMON_BUGS.md
+++ b/docs/COMMON_BUGS.md
@@ -61,3 +61,19 @@ view! {
 	<input prop:value=a on:input=on_input />
 }
 ```
+
+## Build configuration
+
+### Cargo feature resolution in workspaces 
+
+A new [version](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) of Cargo's feature resolver was introduced for the 2021 edition of Rust.
+For single crate projects it will select a resolver version based on the Rust edition in `Cargo.toml`. As there is no Rust edition present for `Cargo.toml` in a workspace, Cargo will default to the pre 2021 edition resolver.
+This can cause issues resulting in non WASM compatabile code being built for a WASM target. Seeing `mio` failing to build is often a sign that none WASM compatible code is being included in the build.
+
+The resolver version can be set in the workspace `Cargo.toml` to remedy this issue.
+
+```toml
+[workspace]
+members = ["member1", "member2"]
+resolver = "2"	
+```


### PR DESCRIPTION
Due to no rust edition being present in a workspac's Cargo.toml, non
WASM compatible code can end up being built for a WASM target.

This commit documents this error and how to resolve it.
