### PR TITLE
examples: improve `counter_without_macros`

### DIFF
--- a/examples/counter_without_macros/src/lib.rs
+++ b/examples/counter_without_macros/src/lib.rs
@@ -1,48 +1,44 @@
 use leptos::{ev, html::*, *};
 
-pub struct Props {
-    /// The starting value for the counter
-    pub initial_value: i32,
-    /// The change that should be applied each time the button is clicked.
-    pub step: i32,
-}
-
 /// A simple counter view.
-pub fn view(cx: Scope, props: Props) -> impl IntoView {
-    let Props {
-        initial_value,
-        step,
-    } = props;
+// A component is really just a function call: it runs once to create the DOM and reactive system
+pub fn counter(cx: Scope, initial_value: i32, step: i32) -> impl IntoView {
     let (value, set_value) = create_signal(cx, initial_value);
 
+    // elements are created by calling a function with a Scope argument
+    // the function name is the same as the HTML tag name
     div(cx)
-        .child((
-            cx,
+        // children can be added with .child()
+        // this takes any type that implements IntoView as its argument
+        // for example, a string or an HtmlElement<_>
+        .child(
             button(cx)
+                // typed events found in leptos::ev
+                // 1) prevent typos in event names
+                // 2) allow for correct type inference in callbacks
                 .on(ev::click, move |_| set_value.update(|value| *value = 0))
-                .child((cx, "Clear")),
-        ))
-        .child((
-            cx,
+                .child("Clear"),
+        )
+        .child(
             button(cx)
                 .on(ev::click, move |_| {
                     set_value.update(|value| *value -= step)
                 })
-                .child((cx, "-1")),
-        ))
-        .child((
-            cx,
+                .child("-1"),
+        )
+        .child(
             span(cx)
-                .child((cx, "Value: "))
+                .child("Value: ")
+                // reactive values are passed to .child() as a tuple
+                // (Scope, [child function]) so an effect can be created
                 .child((cx, move || value.get()))
-                .child((cx, "!")),
-        ))
-        .child((
-            cx,
+                .child("!"),
+        )
+        .child(
             button(cx)
                 .on(ev::click, move |_| {
                     set_value.update(|value| *value += step)
                 })
-                .child((cx, "+1")),
-        ))
+                .child("+1"),
+        )
 }

--- a/examples/counter_without_macros/src/main.rs
+++ b/examples/counter_without_macros/src/main.rs
@@ -1,16 +1,8 @@
-use counter_without_macros as counter;
+use counter_without_macros::counter;
 use leptos::*;
 
 pub fn main() {
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
-    mount_to_body(|cx| {
-        counter::view(
-            cx,
-            counter::Props {
-                initial_value: 0,
-                step: 1,
-            },
-        )
-    })
+    mount_to_body(|cx| counter(cx, 0, 1))
 }


### PR DESCRIPTION
The `counter_without_macros` example was generated originally by expanding the `component` and `view` macros. Both of these generates code that's kind of ugly and overkill if you're not using any of the macros, but the ugliness is usually just hidden behind the prettiness of the macro DX so it's fine.

I've gone through, simplified it to look more like human-written code, and added some comments to explain aspects of the builder pattern.