### PR TITLE
Blocking resources

### DIFF
--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -133,7 +133,7 @@ pub fn render_to_stream_with_prefix_undisposed_with_context(
     let runtime = create_runtime();
 
     let (
-        (shell, prefix, pending_resources, pending_fragments, serializers),
+        (shell, pending_resources, pending_fragments, serializers),
         scope,
         disposer,
     ) = run_scope_undisposed(runtime, {
@@ -146,27 +146,75 @@ pub fn render_to_stream_with_prefix_undisposed_with_context(
 
             let resources = cx.pending_resources();
             let pending_resources = serde_json::to_string(&resources).unwrap();
-            let prefix = prefix(cx);
 
             (
                 shell,
-                prefix,
                 pending_resources,
                 cx.pending_fragments(),
                 cx.serialization_resolvers(),
             )
         }
     });
+    let cx = Scope { runtime, id: scope };
 
+    let deferred_fragments = FuturesUnordered::new();
     let fragments = FuturesUnordered::new();
-    for (fragment_id, (fut, _)) in pending_fragments {
-        fragments.push(async move { (fragment_id, fut.await) })
+
+    for (fragment_id, data) in pending_fragments {
+        if data.should_defer {
+            println!("deferred fragment");
+            deferred_fragments
+                .push(async move { (fragment_id, data.out_of_order.await) });
+        } else {
+            fragments
+                .push(async move { (fragment_id, data.out_of_order.await) });
+        }
     }
 
     // resources and fragments
     // stream HTML for each <Suspense/> as it resolves
-    // TODO can remove id_before_suspense entirely now
-    let fragments = fragments.map(|(fragment_id, html)| {
+    let fragments = fragments_to_chunks(fragments);
+    // stream data for each Resource as it resolves
+    let resources = render_serializers(serializers);
+
+    // HTML for the view function and script to store resources
+    let stream = futures::stream::once(async move {
+        let mut deferred = String::new();
+        let mut deferred_fragments = fragments_to_chunks(deferred_fragments);
+        while let Some(fragment) = deferred_fragments.next().await {
+            deferred.push_str(&fragment);
+        }
+        let prefix = prefix(cx);
+        format!(
+            r#"
+                {prefix}
+                {shell}
+                <script>
+                    __LEPTOS_PENDING_RESOURCES = {pending_resources};
+                    __LEPTOS_RESOLVED_RESOURCES = new Map();
+                    __LEPTOS_RESOURCE_RESOLVERS = new Map();
+                </script>
+                {deferred}
+            "#
+        )
+    })
+    // TODO these should be combined again in a way that chains them appropriately
+    // such that individual resources can resolve before all fragments are done
+    .chain(fragments)
+    .chain(resources)
+    // dispose of the root scope
+    .chain(futures::stream::once(async move {
+        disposer.dispose();
+        Default::default()
+    }));
+
+    (stream, runtime, scope)
+}
+
+fn fragments_to_chunks(
+    fragments: impl Stream<Item = (String, String)>,
+) -> impl Stream<Item = String> {
+    fragments.map(|(fragment_id, html)| {
       format!(
         r#"
                 <template id="{fragment_id}f">{html}</template>
@@ -191,35 +239,7 @@ pub fn render_to_stream_with_prefix_undisposed_with_context(
                 </script>
                 "#
       )
-    });
-    // stream data for each Resource as it resolves
-    let resources = render_serializers(serializers);
-
-    // HTML for the view function and script to store resources
-    let stream = futures::stream::once(async move {
-        format!(
-            r#"
-                {prefix}
-                {shell}
-                <script>
-                    __LEPTOS_PENDING_RESOURCES = {pending_resources};
-                    __LEPTOS_RESOLVED_RESOURCES = new Map();
-                    __LEPTOS_RESOURCE_RESOLVERS = new Map();
-                </script>
-            "#
-        )
     })
-    // TODO these should be combined again in a way that chains them appropriately
-    // such that individual resources can resolve before all fragments are done
-    .chain(fragments)
-    .chain(resources)
-    // dispose of the root scope
-    .chain(futures::stream::once(async move {
-        disposer.dispose();
-        Default::default()
-    }));
-
-    (stream, runtime, scope)
 }
 
 impl View {

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -163,8 +163,8 @@ impl View {
         match self {
             View::Suspense(id, _) => {
                 let id = id.to_string();
-                if let Some((_, fragment)) = cx.take_pending_fragment(&id) {
-                    chunks.push(StreamChunk::Async(fragment));
+                if let Some(data) = cx.take_pending_fragment(&id) {
+                    chunks.push(StreamChunk::Async(data.in_order));
                 }
             }
             View::Text(node) => chunks.push(StreamChunk::Sync(node.content)),

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -9,13 +9,15 @@ use crate::{
 };
 use async_recursion::async_recursion;
 use cfg_if::cfg_if;
-use futures::{channel::mpsc::UnboundedSender, Stream, StreamExt};
+use futures::{
+    channel::mpsc::UnboundedSender, Stream, StreamExt,
+};
 use itertools::Itertools;
 use leptos_reactive::{
     create_runtime, run_scope_undisposed, suspense::StreamChunk, RuntimeId,
     Scope, ScopeId,
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::VecDeque};
 
 /// Renders a view to HTML, waiting to return until all `async` [Resource](leptos_reactive::Resource)s
 /// loaded in `<Suspense/>` elements have finished loading.
@@ -80,29 +82,39 @@ pub fn render_to_stream_in_order_with_prefix_undisposed_with_context(
     // create the runtime
     let runtime = create_runtime();
 
-    let ((chunks, prefix, pending_resources, serializers), scope_id, disposer) =
-        run_scope_undisposed(runtime, |cx| {
-            // add additional context
-            additional_context(cx);
+    let (
+        (blocking_fragments_ready, chunks, prefix, pending_resources, serializers),
+        scope_id,
+        disposer,
+    ) = run_scope_undisposed(runtime, |cx| {
+        // add additional context
+        additional_context(cx);
 
-            // render view and return chunks
-            let view = view(cx);
+        // render view and return chunks
+        let view = view(cx);
 
-            let prefix = prefix(cx);
-            (
-                view.into_stream_chunks(cx),
-                prefix,
-                serde_json::to_string(&cx.pending_resources()).unwrap(),
-                cx.serialization_resolvers(),
-            )
-        });
+        (
+            cx.blocking_fragments_ready(),
+            view.into_stream_chunks(cx),
+            prefix,
+            serde_json::to_string(&cx.pending_resources()).unwrap(),
+            cx.serialization_resolvers(),
+        )
+    });
+    let cx = Scope { runtime, id: scope_id };
 
     let (tx, rx) = futures::channel::mpsc::unbounded();
+    let (prefix_tx, prefix_rx) = futures::channel::oneshot::channel();
     leptos_reactive::spawn_local(async move {
-        handle_chunks(tx, chunks).await;
+        blocking_fragments_ready.await;
+        let remaining_chunks = handle_blocking_chunks(tx.clone(), chunks).await;
+        let prefix = prefix(cx);
+        prefix_tx.send(prefix).expect("to send prefix");
+        handle_chunks(tx, remaining_chunks).await;
     });
 
     let stream = futures::stream::once(async move {
+        let prefix = prefix_rx.await.expect("to receive prefix");
         format!(
             r#"
         {prefix}
@@ -126,18 +138,49 @@ pub fn render_to_stream_in_order_with_prefix_undisposed_with_context(
 }
 
 #[async_recursion(?Send)]
-async fn handle_chunks(tx: UnboundedSender<String>, chunks: Vec<StreamChunk>) {
+async fn handle_blocking_chunks(tx: UnboundedSender<String>, mut queued_chunks: VecDeque<StreamChunk>) -> VecDeque<StreamChunk> {
+    let mut buffer = String::new();
+    while let Some(chunk) = queued_chunks.pop_front() {
+        match chunk {
+            StreamChunk::Sync(sync) => buffer.push_str(&sync),
+            StreamChunk::Async { chunks, should_block } => {
+                if should_block {
+                    // add static HTML before the Suspense and stream it down
+                    tx.unbounded_send(std::mem::take(&mut buffer))
+                        .expect("failed to send async HTML chunk");
+
+                    // send the inner stream
+                    let suspended = chunks.await;
+                    handle_blocking_chunks(tx.clone(), suspended).await;
+                } else {
+                    // TODO: should probably first check if there are any *other* blocking chunks
+                    queued_chunks.push_front(StreamChunk::Async { chunks, should_block: false });
+                    break;
+                }
+            }
+        }
+    }
+
+    // send final sync chunk
+    tx.unbounded_send(std::mem::take(&mut buffer))
+        .expect("failed to send final HTML chunk");
+
+    queued_chunks
+}
+
+#[async_recursion(?Send)]
+async fn handle_chunks(tx: UnboundedSender<String>, chunks: VecDeque<StreamChunk>) {
     let mut buffer = String::new();
     for chunk in chunks {
         match chunk {
             StreamChunk::Sync(sync) => buffer.push_str(&sync),
-            StreamChunk::Async(suspended) => {
+            StreamChunk::Async { chunks, .. } => {
                 // add static HTML before the Suspense and stream it down
                 tx.unbounded_send(std::mem::take(&mut buffer))
                     .expect("failed to send async HTML chunk");
 
                 // send the inner stream
-                let suspended = suspended.await;
+                let suspended = chunks.await;
                 handle_chunks(tx.clone(), suspended).await;
             }
         }
@@ -149,8 +192,8 @@ async fn handle_chunks(tx: UnboundedSender<String>, chunks: Vec<StreamChunk>) {
 
 impl View {
     /// Renders the view into a set of HTML chunks that can be streamed.
-    pub fn into_stream_chunks(self, cx: Scope) -> Vec<StreamChunk> {
-        let mut chunks = Vec::new();
+    pub fn into_stream_chunks(self, cx: Scope) -> VecDeque<StreamChunk> {
+        let mut chunks = VecDeque::new();
         self.into_stream_chunks_helper(cx, &mut chunks);
         chunks
     }
@@ -158,37 +201,40 @@ impl View {
     fn into_stream_chunks_helper(
         self,
         cx: Scope,
-        chunks: &mut Vec<StreamChunk>,
+        chunks: &mut VecDeque<StreamChunk>,
     ) {
         match self {
             View::Suspense(id, _) => {
                 let id = id.to_string();
                 if let Some(data) = cx.take_pending_fragment(&id) {
-                    chunks.push(StreamChunk::Async(data.in_order));
+                    chunks.push_back(StreamChunk::Async {
+                        chunks: data.in_order,
+                        should_block: data.should_block
+                    });
                 }
             }
-            View::Text(node) => chunks.push(StreamChunk::Sync(node.content)),
+            View::Text(node) => chunks.push_back(StreamChunk::Sync(node.content)),
             View::Component(node) => {
                 cfg_if! {
                   if #[cfg(debug_assertions)] {
                     let name = crate::ssr::to_kebab_case(&node.name);
-                    chunks.push(StreamChunk::Sync(format!(r#"<!--hk={}|leptos-{name}-start-->"#, HydrationCtx::to_string(&node.id, false)).into()));
+                    chunks.push_back(StreamChunk::Sync(format!(r#"<!--hk={}|leptos-{name}-start-->"#, HydrationCtx::to_string(&node.id, false)).into()));
                     for child in node.children {
                         child.into_stream_chunks_helper(cx, chunks);
                     }
-                    chunks.push(StreamChunk::Sync(format!(r#"<!--hk={}|leptos-{name}-end-->"#, HydrationCtx::to_string(&node.id, true)).into()));
+                    chunks.push_back(StreamChunk::Sync(format!(r#"<!--hk={}|leptos-{name}-end-->"#, HydrationCtx::to_string(&node.id, true)).into()));
                   } else {
                     for child in node.children {
                         child.into_stream_chunks_helper(cx, chunks);
                     }
-                    chunks.push(StreamChunk::Sync(format!(r#"<!--hk={}-->"#, HydrationCtx::to_string(&node.id, true)).into()))
+                    chunks.push_back(StreamChunk::Sync(format!(r#"<!--hk={}-->"#, HydrationCtx::to_string(&node.id, true)).into()))
                   }
                 }
             }
             View::Element(el) => {
                 #[cfg(debug_assertions)]
                 if let Some(id) = &el.view_marker {
-                    chunks.push(StreamChunk::Sync(
+                    chunks.push_back(StreamChunk::Sync(
                         format!("<!--leptos-view|{id}|open-->").into(),
                     ));
                 }
@@ -196,7 +242,7 @@ impl View {
                     for chunk in el_chunks {
                         match chunk {
                             StringOrView::String(string) => {
-                                chunks.push(StreamChunk::Sync(string))
+                                chunks.push_back(StreamChunk::Sync(string))
                             }
                             StringOrView::View(view) => {
                                 view().into_stream_chunks_helper(cx, chunks);
@@ -232,18 +278,18 @@ impl View {
                         .join("");
 
                     if el.is_void {
-                        chunks.push(StreamChunk::Sync(
+                        chunks.push_back(StreamChunk::Sync(
                             format!("<{tag_name}{attrs}/>").into(),
                         ));
                     } else if let Some(inner_html) = inner_html {
-                        chunks.push(StreamChunk::Sync(
+                        chunks.push_back(StreamChunk::Sync(
                             format!(
                                 "<{tag_name}{attrs}>{inner_html}</{tag_name}>"
                             )
                             .into(),
                         ));
                     } else {
-                        chunks.push(StreamChunk::Sync(
+                        chunks.push_back(StreamChunk::Sync(
                             format!("<{tag_name}{attrs}>").into(),
                         ));
 
@@ -255,20 +301,20 @@ impl View {
                                 }
                             }
                             ElementChildren::InnerHtml(inner_html) => {
-                                chunks.push(StreamChunk::Sync(inner_html));
+                                chunks.push_back(StreamChunk::Sync(inner_html));
                             }
                             // handled above
                             ElementChildren::Chunks(_) => unreachable!(),
                         }
 
-                        chunks.push(StreamChunk::Sync(
+                        chunks.push_back(StreamChunk::Sync(
                             format!("</{tag_name}>").into(),
                         ));
                     }
                 }
                 #[cfg(debug_assertions)]
                 if let Some(id) = &el.view_marker {
-                    chunks.push(StreamChunk::Sync(
+                    chunks.push_back(StreamChunk::Sync(
                         format!("<!--leptos-view|{id}|close-->").into(),
                     ));
                 }
@@ -280,10 +326,10 @@ impl View {
                         u.id.clone(),
                         "",
                         false,
-                        Box::new(move |chunks: &mut Vec<StreamChunk>| {
+                        Box::new(move |chunks: &mut VecDeque<StreamChunk>| {
                             #[cfg(debug_assertions)]
                             {
-                                chunks.push(StreamChunk::Sync(
+                                chunks.push_back(StreamChunk::Sync(
                                     format!(
                                         "<!--hk={}|leptos-unit-->",
                                         HydrationCtx::to_string(&u.id, true)
@@ -293,7 +339,7 @@ impl View {
                             }
 
                             #[cfg(not(debug_assertions))]
-                            chunks.push(StreamChunk::Sync(
+                            chunks.push_back(StreamChunk::Sync(
                                 format!(
                                     "<!--hk={}-->",
                                     HydrationCtx::to_string(&u.id, true)
@@ -301,7 +347,7 @@ impl View {
                                 .into(),
                             ));
                         })
-                            as Box<dyn FnOnce(&mut Vec<StreamChunk>)>,
+                            as Box<dyn FnOnce(&mut VecDeque<StreamChunk>)>,
                     ),
                     CoreComponent::DynChild(node) => {
                         let child = node.child.take();
@@ -309,7 +355,7 @@ impl View {
                             node.id,
                             "dyn-child",
                             true,
-                            Box::new(move |chunks: &mut Vec<StreamChunk>| {
+                            Box::new(move |chunks: &mut VecDeque<StreamChunk>| {
                                 if let Some(child) = *child {
                                     // On debug builds, `DynChild` has two marker nodes,
                                     // so there is no way for the text to be merged with
@@ -319,7 +365,7 @@ impl View {
                                     // into one single node, so we need to artificially make the
                                     // browser create the dynamic text as it's own text node
                                     if let View::Text(t) = child {
-                                        chunks.push(
+                                        chunks.push_back(
                                             if !cfg!(debug_assertions) {
                                                 StreamChunk::Sync(
                                                     format!("<!>{}", t.content)
@@ -336,7 +382,7 @@ impl View {
                                     }
                                 }
                             })
-                                as Box<dyn FnOnce(&mut Vec<StreamChunk>)>,
+                                as Box<dyn FnOnce(&mut VecDeque<StreamChunk>)>,
                         )
                     }
                     CoreComponent::Each(node) => {
@@ -345,13 +391,13 @@ impl View {
                             node.id,
                             "each",
                             true,
-                            Box::new(move |chunks: &mut Vec<StreamChunk>| {
+                            Box::new(move |chunks: &mut VecDeque<StreamChunk>| {
                                 for node in children.into_iter().flatten() {
                                     let id = node.id;
 
                                     #[cfg(debug_assertions)]
                                     {
-                                        chunks.push(StreamChunk::Sync(
+                                        chunks.push_back(StreamChunk::Sync(
                                             format!(
                         "<!--hk={}|leptos-each-item-start-->",
                         HydrationCtx::to_string(&id, false)
@@ -361,7 +407,7 @@ impl View {
                                         node.child.into_stream_chunks_helper(
                                             cx, chunks,
                                         );
-                                        chunks.push(StreamChunk::Sync(
+                                        chunks.push_back(StreamChunk::Sync(
                                             format!(
                         "<!--hk={}|leptos-each-item-end-->",
                         HydrationCtx::to_string(&id, true)
@@ -371,7 +417,7 @@ impl View {
                                     }
                                 }
                             })
-                                as Box<dyn FnOnce(&mut Vec<StreamChunk>)>,
+                                as Box<dyn FnOnce(&mut VecDeque<StreamChunk>)>,
                         )
                     }
                 };
@@ -379,13 +425,13 @@ impl View {
                 if wrap {
                     cfg_if! {
                       if #[cfg(debug_assertions)] {
-                        chunks.push(StreamChunk::Sync(format!("<!--hk={}|leptos-{name}-start-->", HydrationCtx::to_string(&id, false)).into()));
+                        chunks.push_back(StreamChunk::Sync(format!("<!--hk={}|leptos-{name}-start-->", HydrationCtx::to_string(&id, false)).into()));
                         content(chunks);
-                        chunks.push(StreamChunk::Sync(format!("<!--hk={}|leptos-{name}-end-->", HydrationCtx::to_string(&id, true)).into()));
+                        chunks.push_back(StreamChunk::Sync(format!("<!--hk={}|leptos-{name}-end-->", HydrationCtx::to_string(&id, true)).into()));
                       } else {
                         let _ = name;
                         content(chunks);
-                        chunks.push(StreamChunk::Sync(format!("<!--hk={}-->", HydrationCtx::to_string(&id, true)).into()))
+                        chunks.push_back(StreamChunk::Sync(format!("<!--hk={}-->", HydrationCtx::to_string(&id, true)).into()))
                       }
                     }
                 } else {

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 use crate::{runtime::PinnedFuture, suspense::StreamChunk, ResourceId};
 use cfg_if::cfg_if;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 pub struct SharedContext {
     pub events: Vec<()>,
@@ -16,9 +16,11 @@ pub struct FragmentData {
     /// Future that represents how it should be render for an out-of-order stream.
     pub out_of_order: PinnedFuture<String>,
     /// Future that represents how it should be render for an in-order stream.
-    pub in_order: PinnedFuture<Vec<StreamChunk>>,
+    pub in_order: PinnedFuture<VecDeque<StreamChunk>>,
     /// Whether the stream should wait for this fragment before sending any data.
     pub should_block: bool,
+    /// Future that will resolve when the fragment is ready.
+    pub is_ready: Option<PinnedFuture<()>>
 }
 
 impl std::fmt::Debug for SharedContext {

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -8,12 +8,6 @@ pub struct SharedContext {
     pub pending_resources: HashSet<ResourceId>,
     pub resolved_resources: HashMap<ResourceId, String>,
     #[allow(clippy::type_complexity)]
-    // index String is the fragment ID: tuple is
-    // `(
-    //    Future of <Suspense/> HTML when resolved (out-of-order)
-    //    Future of additional stream chunks when resolved (in-order)
-    //    whether this suspense is "deferred"
-    // )`
     pub pending_fragments: HashMap<String, FragmentData>,
 }
 
@@ -24,7 +18,7 @@ pub struct FragmentData {
     /// Future that represents how it should be render for an in-order stream.
     pub in_order: PinnedFuture<Vec<StreamChunk>>,
     /// Whether the stream should wait for this fragment before sending any data.
-    pub should_defer: bool,
+    pub should_block: bool,
 }
 
 impl std::fmt::Debug for SharedContext {

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -20,7 +20,7 @@ pub struct FragmentData {
     /// Whether the stream should wait for this fragment before sending any data.
     pub should_block: bool,
     /// Future that will resolve when the fragment is ready.
-    pub is_ready: Option<PinnedFuture<()>>
+    pub is_ready: Option<PinnedFuture<()>>,
 }
 
 impl std::fmt::Debug for SharedContext {

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -12,9 +12,19 @@ pub struct SharedContext {
     // `(
     //    Future of <Suspense/> HTML when resolved (out-of-order)
     //    Future of additional stream chunks when resolved (in-order)
+    //    whether this suspense is "deferred"
     // )`
-    pub pending_fragments:
-        HashMap<String, (PinnedFuture<String>, PinnedFuture<Vec<StreamChunk>>)>,
+    pub pending_fragments: HashMap<String, FragmentData>,
+}
+
+/// Represents its pending `<Suspense/>` fragment.
+pub struct FragmentData {
+    /// Future that represents how it should be render for an out-of-order stream.
+    pub out_of_order: PinnedFuture<String>,
+    /// Future that represents how it should be render for an in-order stream.
+    pub in_order: PinnedFuture<Vec<StreamChunk>>,
+    /// Whether the stream should wait for this fragment before sending any data.
+    pub should_defer: bool,
 }
 
 impl std::fmt::Debug for SharedContext {

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -131,8 +131,8 @@ where
 /// the title of the blog post in the page’s initial HTML `<title>` tag for SEO reasons
 /// might use a blocking resource to load blog post metadata, which will prevent the page from
 /// returning until that data has loaded.
-/// 
-/// **Note**: This is not “blocking” in the sense that it blocks the current thread. Rather, 
+///
+/// **Note**: This is not “blocking” in the sense that it blocks the current thread. Rather,
 /// it is blocking in the sense that it blocks the server from sending a response.
 #[cfg_attr(
     debug_assertions,

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -408,7 +408,7 @@ impl Scope {
                         rx2.next().await;
                         in_order_resolver()
                     }),
-                    should_defer: context.should_defer(),
+                    should_block: context.should_block(),
                 },
             );
         })

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -8,7 +8,10 @@ use crate::{
     PinnedFuture, ResourceId, StoredValueId, SuspenseContext,
 };
 use futures::stream::FuturesUnordered;
-use std::{collections::{HashMap, VecDeque}, fmt};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt,
+};
 
 #[doc(hidden)]
 #[must_use = "Scope will leak memory if the disposer function is never called"]
@@ -413,7 +416,7 @@ impl Scope {
                     should_block: context.should_block(),
                     is_ready: Some(Box::pin(async move {
                         rx3.next().await;
-                    }))
+                    })),
                 },
             );
         })
@@ -448,9 +451,7 @@ impl Scope {
             ready
         })
         .unwrap_or_default();
-        Box::pin(async move {
-            while ready.next().await.is_some() { }
-        })
+        Box::pin(async move { while ready.next().await.is_some() {} })
     }
 
     /// Takes the pending HTML for a single `<Suspense/>` node.

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -17,7 +17,7 @@ pub struct SuspenseContext {
     set_pending_resources: WriteSignal<usize>,
     pub(crate) pending_serializable_resources: RwSignal<usize>,
     pub(crate) has_local_only: StoredValue<bool>,
-    pub(crate) should_defer: StoredValue<bool>,
+    pub(crate) should_block: StoredValue<bool>,
 }
 
 impl SuspenseContext {
@@ -27,10 +27,10 @@ impl SuspenseContext {
         self.has_local_only.get_value()
     }
 
-    /// Whether any deferred resources are read under this suspense context,
+    /// Whether any blocking resources are read under this suspense context,
     /// meaning the HTML stream should not begin until it has resolved.
-    pub fn should_defer(&self) -> bool {
-        self.should_defer.get_value()
+    pub fn should_block(&self) -> bool {
+        self.should_block.get_value()
     }
 }
 
@@ -54,13 +54,13 @@ impl SuspenseContext {
         let (pending_resources, set_pending_resources) = create_signal(cx, 0);
         let pending_serializable_resources = create_rw_signal(cx, 0);
         let has_local_only = store_value(cx, true);
-        let should_defer = store_value(cx, false);
+        let should_block = store_value(cx, false);
         Self {
             pending_resources,
             set_pending_resources,
             pending_serializable_resources,
             has_local_only,
-            should_defer,
+            should_block,
         }
     }
 

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -6,7 +6,7 @@ use crate::{
     RwSignal, Scope, SignalUpdate, StoredValue, WriteSignal,
 };
 use futures::Future;
-use std::{borrow::Cow, pin::Pin};
+use std::{borrow::Cow, pin::Pin, collections::VecDeque};
 
 /// Tracks [Resource](crate::Resource)s that are read under a suspense context,
 /// i.e., within a [`Suspense`](https://docs.rs/leptos_core/latest/leptos_core/fn.Suspense.html) component.
@@ -111,14 +111,19 @@ pub enum StreamChunk {
     /// A chunk of synchronous HTML.
     Sync(Cow<'static, str>),
     /// A future that resolves to be a list of additional chunks.
-    Async(Pin<Box<dyn Future<Output = Vec<StreamChunk>>>>),
+    Async {
+        /// The HTML chunks this contains.
+        chunks: Pin<Box<dyn Future<Output = VecDeque<StreamChunk>>>>,
+        /// Whether this should block the stream.
+        should_block: bool
+    }
 }
 
 impl std::fmt::Debug for StreamChunk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             StreamChunk::Sync(data) => write!(f, "StreamChunk::Sync({data:?})"),
-            StreamChunk::Async(_) => write!(f, "StreamChunk::Async(_)"),
+            StreamChunk::Async { .. } => write!(f, "StreamChunk::Async(_)"),
         }
     }
 }

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -17,12 +17,20 @@ pub struct SuspenseContext {
     set_pending_resources: WriteSignal<usize>,
     pub(crate) pending_serializable_resources: RwSignal<usize>,
     pub(crate) has_local_only: StoredValue<bool>,
+    pub(crate) should_defer: StoredValue<bool>,
 }
 
 impl SuspenseContext {
-    /// Whether the suspense contains local resources at this moment, and therefore can't be
+    /// Whether the suspense contains local resources at this moment,
+    /// and therefore can't be serialized
     pub fn has_local_only(&self) -> bool {
         self.has_local_only.get_value()
+    }
+
+    /// Whether any deferred resources are read under this suspense context,
+    /// meaning the HTML stream should not begin until it has resolved.
+    pub fn should_defer(&self) -> bool {
+        self.should_defer.get_value()
     }
 }
 
@@ -46,11 +54,13 @@ impl SuspenseContext {
         let (pending_resources, set_pending_resources) = create_signal(cx, 0);
         let pending_serializable_resources = create_rw_signal(cx, 0);
         let has_local_only = store_value(cx, true);
+        let should_defer = store_value(cx, true);
         Self {
             pending_resources,
             set_pending_resources,
             pending_serializable_resources,
             has_local_only,
+            should_defer,
         }
     }
 

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -54,7 +54,7 @@ impl SuspenseContext {
         let (pending_resources, set_pending_resources) = create_signal(cx, 0);
         let pending_serializable_resources = create_rw_signal(cx, 0);
         let has_local_only = store_value(cx, true);
-        let should_defer = store_value(cx, true);
+        let should_defer = store_value(cx, false);
         Self {
             pending_resources,
             set_pending_resources,

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -6,7 +6,7 @@ use crate::{
     RwSignal, Scope, SignalUpdate, StoredValue, WriteSignal,
 };
 use futures::Future;
-use std::{borrow::Cow, pin::Pin, collections::VecDeque};
+use std::{borrow::Cow, collections::VecDeque, pin::Pin};
 
 /// Tracks [Resource](crate::Resource)s that are read under a suspense context,
 /// i.e., within a [`Suspense`](https://docs.rs/leptos_core/latest/leptos_core/fn.Suspense.html) component.
@@ -115,8 +115,8 @@ pub enum StreamChunk {
         /// The HTML chunks this contains.
         chunks: Pin<Box<dyn Future<Output = VecDeque<StreamChunk>>>>,
         /// Whether this should block the stream.
-        should_block: bool
-    }
+        should_block: bool,
+    },
 }
 
 impl std::fmt::Debug for StreamChunk {


### PR DESCRIPTION
This PR addresses #617 and makes streaming server rendering more granular by creating "blocking resources." If you read a blocking resource under a `<Suspense/>` component, it prevents the server from returning *any* HTML until that particular `<Suspense/>` has resolved.

This is very useful in cases in which you need to wait for a particular resource to resolve before sending any HTML response. Imagine, for example, that you have a blog. To know whether a blog post exists you need to do an async read from a database. You want to send a 404 status code if the post doesn't exist. This means you need to wait for the database read to load before sending any part of the response. Currently, you can opt into `SsrMode::Async`, but that waits for *everything* on the page to load before rendering any resource.

Blocking resources allow you to do this much more granularly. Basically, you could specify that you want to wait for this one particular resource to load before you send any response, including HTTP headers and `<head>` metadata (like `<title>` or `<meta>` tags needed for SEO or OG data), but still want out-of-order streaming for other content.

To dos
- [x] blocking resources
- [x] out-of-order streaming support
- [x] in-order streaming support