### PR TITLE
fix: escape `</script>` and other HTML tags in serialized resources

### DIFF
--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -509,12 +509,14 @@ pub(crate) fn render_serializers(
 ) -> impl Stream<Item = String> {
     serializers.map(|(id, json)| {
         let id = serde_json::to_string(&id).unwrap();
+        let json = json.replace('<', "\\u003c");
         format!(
             r#"<script>
+                  var val = {json:?};
                   if(__LEPTOS_RESOURCE_RESOLVERS.get({id})) {{
-                      __LEPTOS_RESOURCE_RESOLVERS.get({id})({json:?})
+                      __LEPTOS_RESOURCE_RESOLVERS.get({id})(val)
                   }} else {{
-                      __LEPTOS_RESOLVED_RESOURCES.set({id}, {json:?});
+                      __LEPTOS_RESOLVED_RESOURCES.set({id}, val);
                   }}
               </script>"#,
         )


### PR DESCRIPTION
Because resources are serialized as a JSON string within a `<script>` tag, it turned out that any instance of the string `"</string>"` within a resource's value causes issues: in its infinite wisdom, the browser reads this as the end of the inline `<script>` with a syntax error for an unclosed string rather than continuing on until the end of the string and matching `</script>`. This causes all sorts of junk to appear at the end of the document.

This simply escapes the `<` character to identical JS Unicode, which prevents the issue. It imposes an `O(n)` string replacement cost on every resource so is probably not ideal. (I also cleaned up accidentally duplicating the serialized resource string, so this is a net performance win over the current state of things but a deopt over the ideal.)