### PR TITLE
Updated proxy settings to work on all OS

### DIFF
--- a/examples/login_with_token_csr_only/client/Trunk.toml
+++ b/examples/login_with_token_csr_only/client/Trunk.toml
@@ -1,3 +1,3 @@
 [[proxy]]
 rewrite = "/api/"
-backend = "http://0.0.0.0:3000/"
+backend = "http://127.0.0.1:3000/"


### PR DESCRIPTION
When testing this example on Windows OS the initial value of ```0.0.0.0:3000``` for the IP did not work.