### PR TITLE
Fix server functions default macro on stable

### DIFF
--- a/server_fn/server_fn_macro_default/Cargo.toml
+++ b/server_fn/server_fn_macro_default/Cargo.toml
@@ -19,4 +19,4 @@ server_fn = { version = "0.2" }
 serde = "1"
 
 [features]
-stable = []
+stable = ["server_fn_macro/stable"]


### PR DESCRIPTION
Fixes server function support on stable by forwarding the stable flag to the server_fn_macro crate in the default macro implementation.