### PR TITLE
Remove unused fs dependency from leptos_config

### DIFF
--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -10,7 +10,6 @@ readme = "../README.md"
 
 [dependencies]
 config = "0.13.3"
-fs = "0.0.5"
 regex = "1.7.0"
 serde = { version = "1.0.151", features = ["derive"] }
 thiserror = "1.0.38"


### PR DESCRIPTION
This removes an unused outdated dependency from `leptos_config`.

It was tripping up my `cargo deny` as it was pulling in a very old `bytes` and `futures 0.1` version that I blacklisted.

I found one function that I think it was intended to be used in, as said function is async despite not using any await.