### PR TITLE
Add the ability for server fns to be submitted via GET requests

### DIFF
--- a/examples/todo_app_sqlite_viz/src/todo.rs
+++ b/examples/todo_app_sqlite_viz/src/todo.rs
@@ -51,7 +51,8 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     let mut conn = db().await?;
 
     let mut todos = Vec::new();
-    let mut rows = sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
+    let mut rows =
+        sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
     while let Some(row) = rows
         .try_next()
         .await

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -198,9 +198,7 @@ pub fn handle_server_fns_with_context(
                     let query = req.query_string().as_bytes();
 
                     let data = match &server_fn.encoding {
-                        Encoding::Url | Encoding::Cbor => {
-                            &body
-                        }
+                        Encoding::Url | Encoding::Cbor => &body,
                         Encoding::GetJSON | Encoding::GetCBOR => query,
                     };
                     match (server_fn.trait_obj)(cx, data).await {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -151,9 +151,9 @@ pub fn handle_server_fns() -> Route {
     handle_server_fns_with_context(|_cx| {})
 }
 
-/// An Actix [Route](actix_web::Route) that listens for a `POST` request with
-/// Leptos server function arguments in the body, runs the server function if found,
-/// and returns the resulting [HttpResponse].
+/// An Actix [Route](actix_web::Route) that listens for `GET` or `POST` requests with
+/// Leptos server function arguments in the URL (`GET`) or body (`POST`), 
+/// runs the server function if found, and returns the resulting [HttpResponse].
 ///
 /// This provides the [HttpRequest] to the server [Scope](leptos::Scope).
 ///
@@ -169,7 +169,7 @@ pub fn handle_server_fns() -> Route {
 pub fn handle_server_fns_with_context(
     additional_context: impl Fn(leptos::Scope) + 'static + Clone + Send,
 ) -> Route {
-    web::post().to(
+    web::to(
         move |req: HttpRequest, params: web::Path<String>, body: web::Bytes| {
             let additional_context = additional_context.clone();
             async move {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -152,7 +152,7 @@ pub fn handle_server_fns() -> Route {
 }
 
 /// An Actix [Route](actix_web::Route) that listens for `GET` or `POST` requests with
-/// Leptos server function arguments in the URL (`GET`) or body (`POST`), 
+/// Leptos server function arguments in the URL (`GET`) or body (`POST`),
 /// runs the server function if found, and returns the resulting [HttpResponse].
 ///
 /// This provides the [HttpRequest] to the server [Scope](leptos::Scope).

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -198,7 +198,7 @@ pub fn handle_server_fns_with_context(
                     let query = req.query_string().as_bytes();
 
                     let data = match &server_fn.encoding {
-                        Encoding::Url | Encoding::Cbor => &body,
+                        Encoding::Url | Encoding::Cbor => body,
                         Encoding::GetJSON | Encoding::GetCBOR => query,
                     };
                     match (server_fn.trait_obj)(cx, data).await {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -8,7 +8,7 @@
 
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
-    extract::Path,
+    extract::{Path, RawQuery},
     http::{
         header::{HeaderName, HeaderValue},
         HeaderMap, Request, StatusCode,
@@ -23,7 +23,8 @@ use futures::{
 use http::{header, method::Method, uri::Uri, version::Version, Response};
 use hyper::body;
 use leptos::{
-    leptos_server::{server_fn_by_path, Payload},
+    leptos_server::{server_fn_by_path, server_fn_encoding_by_path, Payload},
+    server_fn::Encoding,
     ssr::*,
     *,
 };
@@ -248,9 +249,10 @@ where
 pub async fn handle_server_fns(
     Path(fn_name): Path<String>,
     headers: HeaderMap,
+    RawQuery(query): RawQuery,
     req: Request<Body>,
 ) -> impl IntoResponse {
-    handle_server_fns_inner(fn_name, headers, |_| {}, req).await
+    handle_server_fns_inner(fn_name, headers, query, |_| {}, req).await
 }
 
 /// An Axum handlers to listens for a request with Leptos server function arguments in the body,
@@ -270,15 +272,18 @@ pub async fn handle_server_fns(
 pub async fn handle_server_fns_with_context(
     Path(fn_name): Path<String>,
     headers: HeaderMap,
+    RawQuery(query): RawQuery,
     additional_context: impl Fn(leptos::Scope) + 'static + Clone + Send,
     req: Request<Body>,
 ) -> impl IntoResponse {
-    handle_server_fns_inner(fn_name, headers, additional_context, req).await
+    handle_server_fns_inner(fn_name, headers, query, additional_context, req)
+        .await
 }
 
 async fn handle_server_fns_inner(
     fn_name: String,
     headers: HeaderMap,
+    query: Option<String>,
     additional_context: impl Fn(leptos::Scope) + 'static + Clone + Send,
     req: Request<Body>,
 ) -> impl IntoResponse {
@@ -312,7 +317,23 @@ async fn handle_server_fns_inner(
                             // Add this so that we can set headers and status of the response
                             provide_context(cx, ResponseOptions::default());
 
-                            match server_fn(cx, &req_parts.body).await {
+                            // Supply either the query string for Get* encodings or the body for
+                            // the rest
+                            let encoding: Encoding =
+                                server_fn_encoding_by_path(fn_name.as_str())
+                                    .expect(
+                                        "Every Server Fn should have an \
+                                         Encoding!",
+                                    );
+                            let query: &Bytes =
+                                &query.unwrap_or("".to_string()).into();
+                            let data = match encoding {
+                                Encoding::Url | Encoding::Cbor => {
+                                    &req_parts.body
+                                }
+                                Encoding::GetJSON | Encoding::GetCBOR => query,
+                            };
+                            match server_fn(cx, data).await {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -14,6 +14,7 @@ use http::{header, method::Method, uri::Uri, version::Version, StatusCode};
 use hyper::body;
 use leptos::{
     leptos_server::{server_fn_by_path, Payload},
+    server_fn::Encoding,
     ssr::*,
     *,
 };
@@ -185,6 +186,7 @@ async fn handle_server_fns_inner(
 ) -> Result<Response> {
     let fn_name = req.params::<String>()?;
     let headers = req.headers().clone();
+    let query= req.query_string().unwrap_or("").to_owned().into();
     let (tx, rx) = futures::channel::oneshot::channel();
     spawn_blocking({
         move || {
@@ -207,7 +209,14 @@ async fn handle_server_fns_inner(
                             // Add this so that we can set headers and status of the response
                             provide_context(cx, ResponseOptions::default());
 
-                            match server_fn(cx, &req_parts.body).await {
+                            let data = match &server_fn.encoding {
+                                Encoding::Url | Encoding::Cbor => {
+                                    &req_parts.body
+                                }
+                                Encoding::GetJSON | Encoding::GetCBOR => &query,
+                            };
+
+                            match (server_fn.trait_obj)(cx, data).await {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -186,7 +186,7 @@ async fn handle_server_fns_inner(
 ) -> Result<Response> {
     let fn_name = req.params::<String>()?;
     let headers = req.headers().clone();
-    let query= req.query_string().unwrap_or("").to_owned().into();
+    let query = req.query_string().unwrap_or("").to_owned().into();
     let (tx, rx) = futures::channel::oneshot::channel();
     spawn_blocking({
         move || {

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -697,6 +697,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///   can be a Leptos `Scope`. This scope can be used to inject dependencies like the HTTP request
 ///   or response or other server-only dependencies, but it does *not* have access to reactive state that exists in the client.
 #[proc_macro_attribute]
+#[proc_macro_error]
 pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let context = ServerContext {
         ty: syn::parse_quote!(Scope),

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -94,7 +94,6 @@ use std::{
 #[cfg(any(feature = "ssr", doc))]
 type ServerFnTraitObj = server_fn::ServerFnTraitObj<Scope>;
 
-#[cfg(any(feature = "ssr", doc))]
 type ServerFunction = server_fn::ServerFunction<Scope>;
 
 #[cfg(any(feature = "ssr", doc))]
@@ -106,7 +105,7 @@ lazy_static::lazy_static! {
 /// The registry of all Leptos server functions.
 pub struct LeptosServerFnRegistry;
 
-#[cfg(any(feature = "ssr"))]
+#[cfg(any(feature = "ssr", doc))]
 impl server_fn::ServerFunctionRegistry<Scope> for LeptosServerFnRegistry {
     type Error = ServerRegistrationFnError;
 

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -212,10 +212,13 @@ pub fn server_fn_by_path(path: &str) -> Option<ServerFunction> {
 ///         .headers()
 ///         .get("Accept")
 ///         .and_then(|value| value.to_str().ok());
-///
 ///     if let Some(server_fn) = server_fn_by_path(path.as_str()) {
-///         let body: &[u8] = &body;
-///         match server_fn(&body).await {
+///         let query = req.query_string().as_bytes();
+///         let data = match &server_fn.encoding {
+///             Encoding::Url | Encoding::Cbor => &body,
+///             Encoding::GetJSON | Encoding::GetCBOR => query,
+///         };
+///         match (server_fn.trait_obj)(data).await {
 ///             Ok(serialized) => {
 ///                 // if this is Accept: application/json then send a serialized JSON response
 ///                 if let Some("application/json") = accept_header {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -85,8 +85,7 @@ use proc_macro2::TokenStream;
 use quote::TokenStreamExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use server_fn_macro_default::server;
-use std::sync::Arc;
-use std::{future::Future, pin::Pin, str::FromStr};
+use std::{future::Future, pin::Pin, str::FromStr, sync::Arc};
 use syn::parse_quote;
 use thiserror::Error;
 // used by the macro
@@ -299,7 +298,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<Self::Output, ServerFnError>>>>;
 
     /// Registers the server function, allowing the server to query it by URL.
-    #[cfg(any(feature = "ssr", doc, ))]
+    #[cfg(any(feature = "ssr", doc,))]
     fn register_in<R: ServerFunctionRegistry<T>>() -> Result<(), ServerFnError>
     {
         // create the handler for this server function

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -85,7 +85,6 @@ use proc_macro2::TokenStream;
 use quote::TokenStreamExt;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use server_fn_macro_default::server;
-#[cfg(any(feature = "ssr", doc))]
 use std::sync::Arc;
 use std::{future::Future, pin::Pin, str::FromStr};
 use syn::parse_quote;
@@ -94,7 +93,6 @@ use thiserror::Error;
 #[doc(hidden)]
 pub use xxhash_rust;
 
-#[cfg(any(feature = "ssr", doc))]
 /// Something that can register a server function.
 pub trait ServerFunctionRegistry<T> {
     /// An error that can occur when registering a server function.
@@ -118,7 +116,6 @@ pub trait ServerFunctionRegistry<T> {
 }
 
 /// A Struct to hold information about a ServerFunction
-#[cfg(any(feature = "ssr", doc))]
 #[derive(Clone)]
 pub struct ServerFunction<T> {
     /// A trait obj for the server fn that can be called
@@ -302,7 +299,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<Self::Output, ServerFnError>>>>;
 
     /// Registers the server function, allowing the server to query it by URL.
-    #[cfg(any(feature = "ssr", doc))]
+    #[cfg(any(feature = "ssr", doc, ))]
     fn register_in<R: ServerFunctionRegistry<T>>() -> Result<(), ServerFnError>
     {
         // create the handler for this server function

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -463,7 +463,7 @@ where
                 .map_err(|e| ServerFnError::Request(e.to_string()))?,
         },
         Encoding::GetCBOR | Encoding::GetJSON => match args_encoded {
-            Payload::Binary(b) => panic!(
+            Payload::Binary(_) => panic!(
                 "Binary data cannot be transferred via GET request in a query \
                  string. Please try using the CBOR encoding."
             ),
@@ -499,7 +499,7 @@ where
                 .map_err(|e| ServerFnError::Request(e.to_string()))?,
         },
         Encoding::GetJSON | Encoding::GetCBOR => match args_encoded {
-            Payload::Binary(b) => panic!(
+            Payload::Binary(_) => panic!(
                 "Binary data cannot be transferred via GET request in a query \
                  string. Please try using the CBOR encoding."
             ),

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -164,7 +164,7 @@ pub enum Payload {
 ///
 ///     if let Some(server_fn) = server_fn_by_path::<MyRegistry>(path.as_str()) {
 ///         let body: &[u8] = &body;
-///         match server_fn(&body).await {
+///         match server_fn.trait_obj()(&body).await {
 ///             Ok(serialized) => {
 ///                 // if this is Accept: application/json then send a serialized JSON response
 ///                 if let Some("application/json") = accept_header {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -307,12 +307,12 @@ where
         let run_server_fn = Arc::new(|cx: T, data: &[u8]| {
             // decode the args
             let value = match Self::encoding() {
-                Encoding::Url | Encoding::GetJSON => {
+                Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => {
                     serde_urlencoded::from_bytes(data).map_err(|e| {
                         ServerFnError::Deserialization(e.to_string())
                     })
                 }
-                Encoding::Cbor | Encoding::GetCBOR => {
+                Encoding::Cbor => {
                     ciborium::de::from_reader(data).map_err(|e| {
                         ServerFnError::Deserialization(e.to_string())
                     })
@@ -410,11 +410,11 @@ where
         Url(String),
     }
     let args_encoded = match &enc {
-        Encoding::Url | Encoding::GetJSON => Payload::Url(
+        Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => Payload::Url(
             serde_urlencoded::to_string(&args)
                 .map_err(|e| ServerFnError::Serialization(e.to_string()))?,
         ),
-        Encoding::Cbor | Encoding::GetCBOR => {
+        Encoding::Cbor => {
             let mut buffer: Vec<u8> = Vec::new();
             into_writer(&args, &mut buffer)
                 .map_err(|e| ServerFnError::Serialization(e.to_string()))?;

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -312,11 +312,8 @@ where
                         ServerFnError::Deserialization(e.to_string())
                     })
                 }
-                Encoding::Cbor => {
-                    ciborium::de::from_reader(data).map_err(|e| {
-                        ServerFnError::Deserialization(e.to_string())
-                    })
-                }
+                Encoding::Cbor => ciborium::de::from_reader(data)
+                    .map_err(|e| ServerFnError::Deserialization(e.to_string())),
             };
             Box::pin(async move {
                 let value: Self = match value {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -164,7 +164,7 @@ pub enum Payload {
 ///
 ///     if let Some(server_fn) = server_fn_by_path::<MyRegistry>(path.as_str()) {
 ///         let body: &[u8] = &body;
-///         match server_fn.trait_obj()(&body).await {
+///         match (server_fn.trait_obj)(&body).await {
 ///             Ok(serialized) => {
 ///                 // if this is Accept: application/json then send a serialized JSON response
 ///                 if let Some("application/json") = accept_header {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -199,11 +199,12 @@ pub fn server_fns_by_path<T: 'static, R: ServerFunctionRegistry<T>>(
 
 /// Holds the current options for encoding types.
 /// More could be added, but they need to be serde
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub enum Encoding {
     /// A Binary Encoding Scheme Called Cbor
     Cbor,
     /// The Default URL-encoded encoding method
+    #[default]
     Url,
     /// Pass arguments to server fns as part of the query string. Cacheable. Returns JSON
     GetJSON,

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -276,7 +276,7 @@ impl Parse for ServerFnName {
                     "\"url\"" => syn::parse_quote!(Encoding::Url),
                     "\"cbor\"" => syn::parse_quote!(Encoding::Cbor),
                     "\"getcbor\"" => syn::parse_quote!(Encoding::GetCBOR),
-                    "\"getjson\"" => syn::parse_quote!(Encoding::GetCBOR),
+                    "\"getjson\"" => syn::parse_quote!(Encoding::GetJSON),
                     _ => abort!(encoding, "Encoding Not Found"),
                 }
             })

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -274,6 +274,10 @@ impl Parse for ServerFnName {
             .map(|encoding| match encoding.to_string().as_str() {
                 "\"Url\"" => syn::parse_quote!(Encoding::Url),
                 "\"Cbor\"" => syn::parse_quote!(Encoding::Cbor),
+                "\"GetCbor\"" => syn::parse_quote!(Encoding::GetCBOR),
+                "\"GetCBOR\"" => syn::parse_quote!(Encoding::GetCBOR),
+                "\"GetJSON\"" => syn::parse_quote!(Encoding::GetJSON),
+                "\"GETJson\"" => syn::parse_quote!(Encoding::GetJSON),
                 _ => abort!(encoding, "Encoding Not Found"),
             })
             .unwrap_or_else(|_| syn::parse_quote!(Encoding::Url));

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -271,12 +271,14 @@ impl Parse for ServerFnName {
         let _comma2 = input.parse()?;
         let encoding = input
             .parse::<Literal>()
-            .map(|encoding| match encoding.to_string().to_lowercase().as_str() {
-                "\"url\"" => syn::parse_quote!(Encoding::Url),
-                "\"cbor\"" => syn::parse_quote!(Encoding::Cbor),
-                "\"getcbor\"" => syn::parse_quote!(Encoding::GetCBOR),
-                "\"getjson\"" => syn::parse_quote!(Encoding::GetCBOR),
-                _ => abort!(encoding, "Encoding Not Found"),
+            .map(|encoding| {
+                match encoding.to_string().to_lowercase().as_str() {
+                    "\"url\"" => syn::parse_quote!(Encoding::Url),
+                    "\"cbor\"" => syn::parse_quote!(Encoding::Cbor),
+                    "\"getcbor\"" => syn::parse_quote!(Encoding::GetCBOR),
+                    "\"getjson\"" => syn::parse_quote!(Encoding::GetCBOR),
+                    _ => abort!(encoding, "Encoding Not Found"),
+                }
             })
             .unwrap_or_else(|_| syn::parse_quote!(Encoding::Url));
 

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -271,13 +271,11 @@ impl Parse for ServerFnName {
         let _comma2 = input.parse()?;
         let encoding = input
             .parse::<Literal>()
-            .map(|encoding| match encoding.to_string().as_str() {
-                "\"Url\"" => syn::parse_quote!(Encoding::Url),
-                "\"Cbor\"" => syn::parse_quote!(Encoding::Cbor),
-                "\"GetCbor\"" => syn::parse_quote!(Encoding::GetCBOR),
-                "\"GetCBOR\"" => syn::parse_quote!(Encoding::GetCBOR),
-                "\"GetJSON\"" => syn::parse_quote!(Encoding::GetJSON),
-                "\"GETJson\"" => syn::parse_quote!(Encoding::GetJSON),
+            .map(|encoding| match encoding.to_string().to_lowercase().as_str() {
+                "\"url\"" => syn::parse_quote!(Encoding::Url),
+                "\"cbor\"" => syn::parse_quote!(Encoding::Cbor),
+                "\"getcbor\"" => syn::parse_quote!(Encoding::GetCBOR),
+                "\"getjson\"" => syn::parse_quote!(Encoding::GetCBOR),
                 _ => abort!(encoding, "Encoding Not Found"),
             })
             .unwrap_or_else(|_| syn::parse_quote!(Encoding::Url));


### PR DESCRIPTION
Per popular request, I added the ability for server fns to be submitted via GET requests, with their args included in a query string! The encoding "GetJSON" and "GetCBOR" will do that, and return the response either via JSON or CBOR.

Let me know if I broke something, because I probably did. I modified the axum integration to make this work, but not the Actix one yet, and there's plenty of docs that still need to be updated.

Closes issue #788 
