### PR TITLE
fix: unused warning on cx in server functions

### DIFF
--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -140,9 +140,9 @@ pub fn server_macro_impl(
             FnArg::Typed(t) => t,
         };
         let is_cx = if let Some(ctx) = &server_context {
-            !fn_arg_is_cx(f, ctx)
+            fn_arg_is_cx(f, ctx)
         } else {
-            true
+            false
         };
         if is_cx {
             quote! {


### PR DESCRIPTION
When running cargo clippy on server functions that use `cx: Scope` it has an unused variable error.

It appears that the logic for adding an `#[allow(unused)]` notation is inverted.