### PR TITLE
docs: warn if you are using `leptos_meta` without features

### DIFF
--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -83,6 +83,9 @@ pub fn Body(
     #[prop(optional, into)]
     attributes: Option<MaybeSignal<AdditionalAttributes>>,
 ) -> impl IntoView {
+    #[cfg(debug_assertions)]
+    crate::feature_warning();
+
     cfg_if! {
         if #[cfg(any(feature = "csr", feature = "hydrate"))] {
             let el = document().body().expect("there to be a <body> element");

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -100,7 +100,7 @@ pub fn Html(
 ) -> impl IntoView {
     #[cfg(debug_assertions)]
     crate::feature_warning();
-    
+
     cfg_if! {
         if #[cfg(any(feature = "csr", feature = "hydrate"))] {
             let el = document().document_element().expect("there to be a <html> element");

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -98,6 +98,9 @@ pub fn Html(
     #[prop(optional, into)]
     attributes: Option<MaybeSignal<AdditionalAttributes>>,
 ) -> impl IntoView {
+    #[cfg(debug_assertions)]
+    crate::feature_warning();
+    
     cfg_if! {
         if #[cfg(any(feature = "csr", feature = "hydrate"))] {
             let el = document().document_element().expect("there to be a <html> element");

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -206,6 +206,9 @@ pub fn provide_meta_context(cx: Scope) {
 /// call `use_head()` but a single [MetaContext] has not been provided at the application root.
 /// The best practice is always to call [provide_meta_context] early in the application.
 pub fn use_head(cx: Scope) -> MetaContext {
+    #[cfg(debug_assertions)]
+    feature_warning();
+
     match use_context::<MetaContext>(cx) {
         None => {
             debug_warn!(
@@ -341,5 +344,12 @@ where
 {
     fn from(s: F) -> Self {
         TextProp(Rc::new(s))
+    }
+}
+
+#[cfg(debug_assertions)]
+pub(crate) fn feature_warning() {
+    if !cfg!(any(feature = "csr", feature = "hydrate", feature = "ssr")) {
+        leptos::debug_warn!("WARNING: `leptos_meta` does nothing unless you enable one of its features (`csr`, `hydrate`, or `ssr`). See the docs at https://docs.rs/leptos_meta/latest/leptos_meta/ for more information.");
     }
 }


### PR DESCRIPTION
This was documented in the crate docs, but fails silently at runtime. So adding a debug-mode warning about it should avoid issues like #796 in the future and make it easier for people to understand what's going on.