### PR TITLE
feat: Add ability to include options to event listeners

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -50,6 +50,7 @@ features = [
   "TreeWalker",
 
   # Events we cast to in leptos_macro -- added here so we don't force users to import them
+  "AddEventListenerOptions",
   "AnimationEvent",
   "BeforeUnloadEvent",
   "ClipboardEvent",

--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -28,9 +28,15 @@ pub fn add_event_helper<E: crate::ev::EventDescriptor + 'static>(
             event.event_delegation_key(),
             event_name,
             event_handler,
+            &None,
         );
     } else {
-        add_event_listener_undelegated(target, &event_name, event_handler);
+        add_event_listener_undelegated(
+            target,
+            &event_name,
+            event_handler,
+            &None,
+        );
     }
 }
 
@@ -43,6 +49,7 @@ pub fn add_event_listener<E>(
     event_name: Cow<'static, str>,
     #[cfg(debug_assertions)] mut cb: impl FnMut(E) + 'static,
     #[cfg(not(debug_assertions))] cb: impl FnMut(E) + 'static,
+    options: &Option<web_sys::AddEventListenerOptions>,
 ) where
     E: FromWasmAbi + 'static,
 {
@@ -61,7 +68,7 @@ pub fn add_event_listener<E>(
     let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(E)>).into_js_value();
     let key = intern(&key);
     _ = js_sys::Reflect::set(target, &JsValue::from_str(&key), &cb);
-    add_delegated_event_listener(&key, event_name);
+    add_delegated_event_listener(&key, event_name, options);
 }
 
 #[doc(hidden)]
@@ -71,6 +78,7 @@ pub(crate) fn add_event_listener_undelegated<E>(
     event_name: &str,
     #[cfg(debug_assertions)] mut cb: impl FnMut(E) + 'static,
     #[cfg(not(debug_assertions))] cb: impl FnMut(E) + 'static,
+    options: &Option<web_sys::AddEventListenerOptions>,
 ) where
     E: FromWasmAbi + 'static,
 {
@@ -88,7 +96,17 @@ pub(crate) fn add_event_listener_undelegated<E>(
 
     let event_name = intern(event_name);
     let cb = Closure::wrap(Box::new(cb) as Box<dyn FnMut(E)>).into_js_value();
-    _ = target.add_event_listener_with_callback(event_name, cb.unchecked_ref());
+    if let Some(options) = options {
+        _ = target
+            .add_event_listener_with_callback_and_add_event_listener_options(
+                event_name,
+                cb.unchecked_ref(),
+                options,
+            );
+    } else {
+        _ = target
+            .add_event_listener_with_callback(event_name, cb.unchecked_ref());
+    }
 }
 
 // cf eventHandler in ryansolid/dom-expressions
@@ -96,6 +114,7 @@ pub(crate) fn add_event_listener_undelegated<E>(
 pub(crate) fn add_delegated_event_listener(
     key: &str,
     event_name: Cow<'static, str>,
+    options: &Option<web_sys::AddEventListenerOptions>,
 ) {
     GLOBAL_EVENTS.with(|global_events| {
         let mut events = global_events.borrow_mut();
@@ -167,10 +186,19 @@ pub(crate) fn add_delegated_event_listener(
 
             let handler = Box::new(handler) as Box<dyn FnMut(web_sys::Event)>;
             let handler = Closure::wrap(handler).into_js_value();
-            _ = crate::window().add_event_listener_with_callback(
-                &event_name,
-                handler.unchecked_ref(),
-            );
+            if let Some(options) = options {
+                _ = crate::window().add_event_listener_with_callback_and_add_event_listener_options(
+                    &event_name,
+                    handler.unchecked_ref(),
+                    options,
+                );
+            } else {
+                _ = crate::window().add_event_listener_with_callback(
+                    &event_name,
+                    handler.unchecked_ref(),
+                );
+
+            }
 
             // register that we've created handler
             events.insert(event_name);

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -849,12 +849,14 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
                     key,
                     event_name,
                     event_handler,
+                    event.options(),
                 );
             } else {
                 add_event_listener_undelegated(
                     self.element.as_ref(),
                     &event_name,
                     event_handler,
+                    event.options(),
                 );
             }
 

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -681,12 +681,13 @@ impl View {
             match &self {
               Self::Element(el) => {
                 if event.bubbles() {
-                  add_event_listener(&el.element, event.event_delegation_key(), event.name(), event_handler);
+                  add_event_listener(&el.element, event.event_delegation_key(), event.name(), event_handler, &None);
                 } else {
                   add_event_listener_undelegated(
                     &el.element,
                     &event.name(),
                     event_handler,
+                    &None,
                   );
                 }
               }


### PR DESCRIPTION
I found myself needing to set options for events. I chose between putting it in the `Custom` event or creating a new `on_with_options` in `HtmlElement`. With arguments for and against both, I chose the event to avoid the combinatory explosion of optional parameters.

Comments are welcome. 