### PR TITLE
Reduce size of RuntimeId when slotmap is not used

### DIFF
--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -314,10 +314,16 @@ pub fn create_runtime() -> RuntimeId {
     }
 }
 
+#[cfg(not(any(feature = "csr", feature = "hydrate")))]
 slotmap::new_key_type! {
     /// Unique ID assigned to a [Runtime](crate::Runtime).
     pub struct RuntimeId;
 }
+
+/// Unique ID assigned to a [Runtime](crate::Runtime).
+#[cfg(any(feature = "csr", feature = "hydrate"))]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RuntimeId;
 
 impl RuntimeId {
     /// Removes the runtime, disposing all its child [Scope](crate::Scope)s.


### PR DESCRIPTION
This also shrinks the size of signals and `Scope` by 8 bytes. 

Before:
```
print-type-size type: `signal::WriteSignal<usize>`: 24 bytes, alignment: 8 bytes
print-type-size     field `.ty`: 0 bytes
print-type-size     field `.runtime`: 8 bytes
print-type-size     field `.id`: 8 bytes
print-type-size     field `.defined_at`: 8 bytes
```
After:
```
print-type-size type: `signal::WriteSignal<usize>`: 16 bytes, alignment: 8 bytes
print-type-size     field `.runtime`: 0 bytes
print-type-size     field `.ty`: 0 bytes
print-type-size     field `.id`: 8 bytes
print-type-size     field `.defined_at`: 8 bytes
```

Then without `debug_assertions` it'll drop to 8 bytes for a single Signal. 