### PR TITLE
Optimize Runtime::mark_dirty

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -42,6 +42,7 @@ web-sys = { version = "0.3", optional = true, features = [
 ] }
 cfg-if = "1"
 indexmap = "1"
+ouroboros = { version = "0.15.6", default-features = false }
 
 [dev-dependencies]
 log = "0.4"

--- a/leptos_reactive/src/node.rs
+++ b/leptos_reactive/src/node.rs
@@ -25,4 +25,7 @@ pub(crate) enum ReactiveNodeState {
     Clean,
     Check,
     Dirty,
+
+    /// Dirty and Marked as visited
+    DirtyMarked,
 }

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -209,13 +209,13 @@ impl Runtime {
              */
 
             #[ouroboros::self_referencing]
-            struct RefIter<'a, T> {
+            struct RefIter<'a> {
                 set: std::cell::Ref<'a, FxIndexSet<NodeId>>,
 
                 // Boxes the iterator internally
                 #[borrows(set)]
                 #[covariant]
-                iter: indexmap::set::Iter<'this, T>,
+                iter: indexmap::set::Iter<'this, NodeId>,
             }
 
             /// Due to the limitations of ouroboros, we cannot borrow the
@@ -225,7 +225,7 @@ impl Runtime {
             enum IterResult<'a> {
                 Continue,
                 Empty,
-                NewIter(RefIter<'a, NodeId>),
+                NewIter(RefIter<'a>),
             }
 
             let mut stack = Vec::new();


### PR DESCRIPTION
Looking for places to remove memory allocations. Found this intermediate buffer and removed it.

I also marked `Runtime::mark` as `#[inline(always)]`. Due to opt-level s and z aggressively _avoiding_ inlining, such a hot function as `mark` would likely incur significant overhead to call in the loops.

Might even be worth looking into rerunning the js benchmarks after this.