### PR TITLE
chore: deny warnings on github actions

### DIFF
--- a/.github/workflows/check-stable.yml
+++ b/.github/workflows/check-stable.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check on all examples
-        run: cargo make check-stable
+        run: cargo make --profile=github-actions check-stable

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check on all libraries
-        run: cargo make check
+        run: cargo make --profile=github-actions check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run tests with all features
-        run: cargo make test
+        run: cargo make --profile=github-actions test

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -74,3 +74,9 @@ dependencies = ["test-all"]
 command = "cargo"
 args = ["+nightly", "test-all-features"]
 install_crate = "cargo-all-features"
+
+[env]
+RUSTFLAGS=""
+
+[env.github-actions]
+RUSTFLAGS="-D warnings"

--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -243,7 +243,7 @@ pub fn set_timeout_with_handle(
 pub fn debounce<T: 'static>(
     cx: Scope,
     delay: Duration,
-    mut cb: impl FnMut(T) + 'static,
+    #[allow(unused_mut)] mut cb: impl FnMut(T) + 'static,
 ) -> impl FnMut(T) {
     use std::{
         cell::{Cell, RefCell},

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -94,6 +94,7 @@ use std::{
 #[cfg(any(feature = "ssr", doc))]
 type ServerFnTraitObj = server_fn::ServerFnTraitObj<Scope>;
 
+#[cfg(any(feature = "ssr", doc))]
 type ServerFunction = server_fn::ServerFunction<Scope>;
 
 #[cfg(any(feature = "ssr", doc))]

--- a/router/src/components/redirect.rs
+++ b/router/src/components/redirect.rs
@@ -21,6 +21,7 @@ pub fn Redirect<P>(
     path: P,
     /// Navigation options to be used on the client side.
     #[prop(optional)]
+    #[allow(unused)]
     options: Option<NavigateOptions>,
 ) -> impl IntoView
 where
@@ -36,6 +37,7 @@ where
     }
     // redirect on the client
     else {
+        #[allow(unused)]
         let navigate = use_navigate(cx);
         #[cfg(any(feature = "csr", feature = "hydrate"))]
         leptos::request_animation_frame(move || {


### PR DESCRIPTION
Enabling on all except for checking examples to start. I'll fix those and add it as a follow up.

Fixes #795