### PR TITLE
remove `Leptos guide` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ Leptos is a full-stack, isomorphic Rust web framework leveraging fine-grained re
 
 Here are some resources for learning more about Leptos:
 
-- [Book (work in progress)](https://leptos-rs.github.io/leptos/)
+- [Book](https://leptos-rs.github.io/leptos/) (work in progress)
 - [Examples](https://github.com/leptos-rs/leptos/tree/main/examples)
 - [API Documentation](https://docs.rs/leptos/latest/leptos/)
 - [Common Bugs](https://github.com/leptos-rs/leptos/tree/main/docs/COMMON_BUGS.md) (and how to fix them!)
-- Leptos Guide (in progress)
 
 ## `nightly` Note
 


### PR DESCRIPTION
I assume the leptos guide is the same as the book?