### PR TITLE
[Fix] Correct broken `MaybeSignal` link

### DIFF
--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -15,7 +15,7 @@ covered some of this in the material on [components and props](./03_components.m
 Basically if you want the parent to communicate to the child, you can pass a
 [`ReadSignal`](https://docs.rs/leptos/latest/leptos/struct.ReadSignal.html), a
 [`Signal`](https://docs.rs/leptos/latest/leptos/struct.Signal.html), or even a
-[`MaybeSignal`](https://docs.rs/leptos/latest/leptos/struct.MaybeSignal.html) as a prop.
+[`MaybeSignal`](https://docs.rs/leptos/latest/leptos/enum.MaybeSignal.html) as a prop.
 
 But what about the other direction? How can a child send notifications about events
 or state changes back up to the parent?


### PR DESCRIPTION
The `Parent-Child Communication` segment of the Leptos book contains a broken URL to the `MaybeSignal` enum...!

https://leptos-rs.github.io/leptos/view/08_parent_child.html#parent-child-communication

This PR address the issue...!

P/S - Great work, btw...! <3