### PR TITLE
fix: Strip `&` from the end of params queries

### DIFF
--- a/router/src/history/params.rs
+++ b/router/src/history/params.rs
@@ -52,6 +52,9 @@ impl ParamsMap {
             buf.push_str(&escape(v));
             buf.push('&');
         }
+        if buf.len() > 1 {
+            buf.pop();
+        }
         buf
     }
 }


### PR DESCRIPTION
The method `ParamsMap.to_query_string()` currently appends a `&` character at the end of query strings when they have one param or more, which is very ugly, specially to share URLs copy- pasting them.