### PR TITLE
Use override key, if available, for server function calling

### DIFF
--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -195,8 +195,8 @@ pub fn server_macro_impl(
         .unwrap_or_else(|| quote! { server_fn });
 
     let key_env_var = match option_env!("SERVER_FN_OVERRIDE_KEY") {
-         Some(_) => "SERVER_FN_OVERRIDE_KEY",
-         None => "CARGO_MANIFEST_DIR",
+        Some(_) => "SERVER_FN_OVERRIDE_KEY",
+        None => "CARGO_MANIFEST_DIR",
     };
 
     Ok(quote::quote! {

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -194,6 +194,11 @@ pub fn server_macro_impl(
         .map(|path| quote!(#path))
         .unwrap_or_else(|| quote! { server_fn });
 
+    let key_env_var = match option_env!("SERVER_FN_OVERRIDE_KEY") {
+         Some(_) => "SERVER_FN_OVERRIDE_KEY",
+         None => "CARGO_MANIFEST_DIR",
+    };
+
     Ok(quote::quote! {
         #[derive(Clone, Debug, ::serde::Serialize, ::serde::Deserialize)]
         pub struct #struct_name {
@@ -208,7 +213,7 @@ pub fn server_macro_impl(
             }
 
             fn url() -> &'static str {
-                #server_fn_path::const_format::concatcp!(#fn_name_as_str, #server_fn_path::xxhash_rust::const_xxh64::xxh64(concat!(env!("CARGO_MANIFEST_DIR"), ":", file!(), ":", line!(), ":", column!()).as_bytes(), 0))
+                #server_fn_path::const_format::concatcp!(#fn_name_as_str, #server_fn_path::xxhash_rust::const_xxh64::xxh64(concat!(env!(#key_env_var), ":", file!(), ":", line!(), ":", column!()).as_bytes(), 0))
             }
 
             fn encoding() -> #server_fn_path::Encoding {


### PR DESCRIPTION
Following up on #857 

I tried the suggested `option_env!(...).unwrap_or(env!(...))`, but that runs into an error within the `concatcp` macro ([note: erroneous constant used](https://gist.github.com/snapbug/6c24a18d7c8998f93e76bc0d8d023a3a)). I tried to get multiple alternatives within the generated code to work, but all ran into this, or very similar variants of it.

I thought that the build context of `server_fn_macro` would probably be the same as that of the library being built, meaning the env that exists there probably exists when the lib using `#[server...]` is being built.

So, take advantage of that to decide which env var to use when building the library.

Results from cargo expand on counter isomorphic file:

Override env not set:
`cargo expand --bin counter_isomorphic --features="stable ssr" > output.rs`
```rust
::leptos::server_fn::xxhash_rust::const_xxh64::xxh64(
  "/Users/mcrane/tmp/leptos/examples/counter_isomorphic:src/counters.rs:26:1",
  0,
)
```

`SERVER_FN_OVERRIDE_KEY=test cargo expand --bin counter_isomorphic --features="stable ssr" > output.rs`
and with it set:
```rust
::leptos::server_fn::xxhash_rust::const_xxh64::xxh64(
  "test:src/counters.rs:26:1".as_bytes(),
  0,
)
```