### PR TITLE
Split counter without macros web test

### DIFF
--- a/examples/counter_without_macros/Cargo.toml
+++ b/examples/counter_without_macros/Cargo.toml
@@ -19,5 +19,5 @@ wasm-bindgen-test = "0.3.34"
 pretty_assertions = "1.3.0"
 
 [dev-dependencies.web-sys]
-features = ["HtmlElement"]
+features = ["HtmlElement", "XPathResult"]
 version = "0.3.61"

--- a/examples/counter_without_macros/tests/web.rs
+++ b/examples/counter_without_macros/tests/web.rs
@@ -53,15 +53,19 @@ fn remove_existing_counter() {
 }
 
 fn click_clear() {
-    find_by_text("Clear").click();
+    click("Clear");
 }
 
 fn click_decrement() {
-    find_by_text("-1").click();
+    click("-1");
 }
 
 fn click_increment() {
-    find_by_text("+1").click();
+    click("+1");
+}
+
+fn click(text: &str) {
+    find_by_text(text).click();
 }
 
 fn see_text() -> Option<String> {

--- a/examples/counter_without_macros/tests/web.rs
+++ b/examples/counter_without_macros/tests/web.rs
@@ -10,42 +10,48 @@ wasm_bindgen_test_configure!(run_in_browser);
 fn inc() {
     mount_to_body(move |cx| counter(cx, 0, 1));
 
+    click_increment();
+    click_increment();
+
+    assert_eq!(see_text(), Some("Value: 2!".to_string()));
+
+    click_decrement();
+    click_decrement();
+    click_decrement();
+    click_decrement();
+
+    assert_eq!(see_text(), Some("Value: -2!".to_string()));
+
+    click_clear();
+
+    assert_eq!(see_text(), Some("Value: 0!".to_string()));
+}
+
+fn click_clear() {
+    find_by_text("Clear").click();
+}
+
+fn click_decrement() {
+    find_by_text("-1").click();
+}
+
+fn click_increment() {
+    find_by_text("+1").click();
+}
+
+fn see_text() -> Option<String> {
+    find_by_text("Value: ").text_content()
+}
+
+fn find_by_text(text: &str) -> HtmlElement {
+    let xpath = format!("//*[text()='{}']", text);
     let document = leptos::document();
-    let div = document.query_selector("div").unwrap().unwrap();
-    let clear = div
-        .first_child()
+    document
+        .evaluate(&xpath, &document)
+        .unwrap()
+        .iterate_next()
+        .unwrap()
         .unwrap()
         .dyn_into::<HtmlElement>()
-        .unwrap();
-    let dec = clear
-        .next_sibling()
         .unwrap()
-        .dyn_into::<HtmlElement>()
-        .unwrap();
-    let text = dec
-        .next_sibling()
-        .unwrap()
-        .dyn_into::<HtmlElement>()
-        .unwrap();
-    let inc = text
-        .next_sibling()
-        .unwrap()
-        .dyn_into::<HtmlElement>()
-        .unwrap();
-
-    inc.click();
-    inc.click();
-
-    assert_eq!(text.text_content(), Some("Value: 2!".to_string()));
-
-    dec.click();
-    dec.click();
-    dec.click();
-    dec.click();
-
-    assert_eq!(text.text_content(), Some("Value: -2!".to_string()));
-
-    clear.click();
-
-    assert_eq!(text.text_content(), Some("Value: 0!".to_string()));
 }

--- a/examples/counter_without_macros/tests/web.rs
+++ b/examples/counter_without_macros/tests/web.rs
@@ -9,7 +9,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn should_increment_counter() {
-    mount_counter();
+    open_counter();
 
     click_increment();
     click_increment();
@@ -19,7 +19,7 @@ fn should_increment_counter() {
 
 #[wasm_bindgen_test]
 fn should_decrement_counter() {
-    mount_counter();
+    open_counter();
 
     click_decrement();
     click_decrement();
@@ -29,7 +29,7 @@ fn should_decrement_counter() {
 
 #[wasm_bindgen_test]
 fn should_clear_counter() {
-    mount_counter();
+    open_counter();
 
     click_increment();
     click_increment();
@@ -39,7 +39,7 @@ fn should_clear_counter() {
     assert_eq!(see_text(), Some("Value: 0!".to_string()));
 }
 
-fn mount_counter() {
+fn open_counter() {
     remove_existing_counter();
     mount_to_body(move |cx| counter(cx, 0, 1));
 }

--- a/examples/counter_without_macros/tests/web.rs
+++ b/examples/counter_without_macros/tests/web.rs
@@ -1,5 +1,6 @@
 use counter_without_macros::counter;
 use leptos::*;
+use pretty_assertions::assert_eq;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::HtmlElement;
@@ -7,24 +8,48 @@ use web_sys::HtmlElement;
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-fn inc() {
-    mount_to_body(move |cx| counter(cx, 0, 1));
+fn should_increment_counter() {
+    mount_counter();
 
     click_increment();
     click_increment();
 
     assert_eq!(see_text(), Some("Value: 2!".to_string()));
+}
 
-    click_decrement();
-    click_decrement();
+#[wasm_bindgen_test]
+fn should_decrement_counter() {
+    mount_counter();
+
     click_decrement();
     click_decrement();
 
     assert_eq!(see_text(), Some("Value: -2!".to_string()));
+}
+
+#[wasm_bindgen_test]
+fn should_clear_counter() {
+    mount_counter();
+
+    click_increment();
+    click_increment();
 
     click_clear();
 
     assert_eq!(see_text(), Some("Value: 0!".to_string()));
+}
+
+fn mount_counter() {
+    remove_existing_counter();
+    mount_to_body(move |cx| counter(cx, 0, 1));
+}
+
+fn remove_existing_counter() {
+    if let Some(counter) =
+        leptos::document().query_selector("body div").unwrap()
+    {
+        counter.remove();
+    }
 }
 
 fn click_clear() {

--- a/examples/counter_without_macros/tests/web.rs
+++ b/examples/counter_without_macros/tests/web.rs
@@ -53,18 +53,18 @@ fn remove_existing_counter() {
 }
 
 fn click_clear() {
-    click("Clear");
+    click_text("Clear");
 }
 
 fn click_decrement() {
-    click("-1");
+    click_text("-1");
 }
 
 fn click_increment() {
-    click("+1");
+    click_text("+1");
 }
 
-fn click(text: &str) {
+fn click_text(text: &str) {
     find_by_text(text).click();
 }
 


### PR DESCRIPTION
This improves the test by extracting distinct scenarios. 

It also demonstrates how you can:

- Remount the counter
- Frame tests from the user's point of view
- Query elements by exact text

Run `cargo make test-flow` to verify.