### PR TITLE
fix: dispose of scope when server fns return error

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -924,7 +924,7 @@ where
         .into_iter()
         .map(|listing| {
             let path = wildcard_re
-                .replace_all(&listing.path(), "{tail:.*}")
+                .replace_all(listing.path(), "{tail:.*}")
                 .to_string();
             let path = capture_re.replace_all(&path, "{$1}").to_string();
             RouteListing::new(path, listing.mode(), listing.methods())

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -323,14 +323,10 @@ async fn handle_server_fns_inner(
                     Encoding::Url | Encoding::Cbor => &req_parts.body,
                     Encoding::GetJSON | Encoding::GetCBOR => query,
                 };
-                match (server_fn.trait_obj)(cx, data).await {
+                let res = match (server_fn.trait_obj)(cx, data).await {
                     Ok(serialized) => {
                         // If ResponseOptions are set, add the headers and status to the request
                         let res_options = use_context::<ResponseOptions>(cx);
-
-                        // clean up the scope, which we only needed to run the server fn
-                        disposer.dispose();
-                        runtime.dispose();
 
                         // if this is Accept: application/json then send a serialized JSON response
                         let accept_header = headers
@@ -396,7 +392,11 @@ async fn handle_server_fns_inner(
                             serde_json::to_string(&e)
                                 .unwrap_or_else(|_| e.to_string()),
                         )),
-                }
+                };
+                // clean up the scope
+                disposer.dispose();
+                runtime.dispose();
+                res
             } else {
                 Response::builder().status(StatusCode::BAD_REQUEST).body(
                     Full::from(format!(

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -216,7 +216,9 @@ async fn handle_server_fns_inner(
                                 Encoding::GetJSON | Encoding::GetCBOR => &query,
                             };
 
-                            let res = match (server_fn.trait_obj)(cx, data).await {
+                            let res = match (server_fn.trait_obj)(cx, data)
+                                .await
+                            {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -216,15 +216,11 @@ async fn handle_server_fns_inner(
                                 Encoding::GetJSON | Encoding::GetCBOR => &query,
                             };
 
-                            match (server_fn.trait_obj)(cx, data).await {
+                            let res = match (server_fn.trait_obj)(cx, data).await {
                                 Ok(serialized) => {
                                     // If ResponseOptions are set, add the headers and status to the request
                                     let res_options =
                                         use_context::<ResponseOptions>(cx);
-
-                                    // clean up the scope, which we only needed to run the server fn
-                                    disposer.dispose();
-                                    runtime.dispose();
 
                                     // if this is Accept: application/json then send a serialized JSON response
                                     let accept_header = headers
@@ -305,7 +301,11 @@ async fn handle_server_fns_inner(
                                         serde_json::to_string(&e)
                                             .unwrap_or_else(|_| e.to_string()),
                                     )),
-                            }
+                            };
+                            // clean up the scope
+                            disposer.dispose();
+                            runtime.dispose();
+                            res
                         } else {
                             Response::builder()
                                 .status(StatusCode::BAD_REQUEST)


### PR DESCRIPTION
Closes issue #862 and a memory leak with potential security implications, which could be triggered by intentionally submitting bad inputs to a server function.