### PR TITLE
Fixes #890 that was using OnceLock, which is nightly only, by adding the once_cell crate as a dependency.

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12.1"
 tokio-util = {version = "0.7.7", features = ["rt"] }
+once_cell = "1.17"

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -31,14 +31,9 @@ use leptos::{
 use leptos_integration_utils::{build_async_response, html_parts_separated};
 use leptos_meta::{generate_head_metadata_separated, MetaContext};
 use leptos_router::*;
-use parking_lot::RwLock;
-use std::{
-    io,
-    pin::Pin,
-    sync::Arc,
-    thread::available_parallelism,
-};
 use once_cell::sync::OnceCell;
+use parking_lot::RwLock;
+use std::{io, pin::Pin, sync::Arc, thread::available_parallelism};
 use tokio::task::LocalSet;
 use tokio_util::task::LocalPoolHandle;
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -35,9 +35,10 @@ use parking_lot::RwLock;
 use std::{
     io,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::Arc,
     thread::available_parallelism,
 };
+use once_cell::sync::OnceCell;
 use tokio::task::LocalSet;
 use tokio_util::task::LocalPoolHandle;
 
@@ -1193,7 +1194,7 @@ impl LeptosRoutes for axum::Router {
 }
 
 fn get_leptos_pool() -> LocalPoolHandle {
-    static LOCAL_POOL: OnceLock<LocalPoolHandle> = OnceLock::new();
+    static LOCAL_POOL: OnceCell<LocalPoolHandle> = OnceCell::new();
     LOCAL_POOL
         .get_or_init(|| {
             tokio_util::task::LocalPoolHandle::new(


### PR DESCRIPTION
This fixes #890 where leptos_axum is using the nightly only `OnceLock`, switching to use the `once_cell` dependency for now as per gbj.