### PR TITLE
chore(readme): add link to Matrix bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![crates.io](https://img.shields.io/crates/v/leptos.svg)](https://crates.io/crates/leptos)
 [![docs.rs](https://docs.rs/leptos/badge.svg)](https://docs.rs/leptos)
 [![Discord](https://img.shields.io/discord/1031524867910148188?color=%237289DA&label=discord)](https://discord.gg/YdRAhS7eQB)
+[![Matrix](https://img.shields.io/badge/Matrix-leptos-grey?logo=matrix&labelColor=white&logoColor=black)](https://matrix.to/#/#leptos:matrix.org)
 
 # Leptos
 


### PR DESCRIPTION
While the project offers a [Matrix][matrix] bridge, it is nowhere shown. One would need to join the [Discord][discord] server and search through it to find it.

To make it easier to join through [Matrix][matrix], add a badge in the project `README.md`.

[matrix]: https://matrix.org/
[discord]: https://discord.com/

Fixes: #893