### PR TITLE
Remove need for LEPTOS_OUTPUT_NAME env var after compilation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -77,6 +77,7 @@ install_crate = "cargo-all-features"
 
 [env]
 RUSTFLAGS=""
+LEPTOS_OUTPUT_NAME="ci" # allows examples to check/build without cargo-leptos
 
 [env.github-actions]
 RUSTFLAGS="-D warnings"

--- a/examples/todo_app_sqlite_axum/src/errors.rs
+++ b/examples/todo_app_sqlite_axum/src/errors.rs
@@ -13,7 +13,9 @@ impl TodoAppError {
     pub fn status_code(&self) -> StatusCode {
         match self {
             TodoAppError::NotFound => StatusCode::NOT_FOUND,
-            TodoAppError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
+            TodoAppError::InternalServerError => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
         }
     }
 }

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -52,7 +52,8 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     let mut conn = db().await?;
 
     let mut todos = Vec::new();
-    let mut rows = sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
+    let mut rows =
+        sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
     while let Some(row) = rows
         .try_next()
         .await
@@ -109,19 +110,25 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct FormData {
-    hi: String
+    hi: String,
 }
 
 #[server(FormDataHandler, "/api")]
 pub async fn form_data(cx: Scope) -> Result<FormData, ServerFnError> {
     use axum::extract::FromRequest;
 
-    let req = use_context::<leptos_axum::LeptosRequest<axum::body::Body>>(cx).and_then(|req| req.take_request()).unwrap();
+    let req = use_context::<leptos_axum::LeptosRequest<axum::body::Body>>(cx)
+        .and_then(|req| req.take_request())
+        .unwrap();
     if req.method() == http::Method::POST {
-        let form = axum::Form::from_request(req, &()).await.map_err(|e| ServerFnError::ServerError(e.to_string()))?;
+        let form = axum::Form::from_request(req, &())
+            .await
+            .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
         Ok(form.0)
     } else {
-        Err(ServerFnError::ServerError("wrong form fields submitted".to_string()))
+        Err(ServerFnError::ServerError(
+            "wrong form fields submitted".to_string(),
+        ))
     }
 }
 
@@ -146,7 +153,7 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
                         </ErrorBoundary>
                     }/> //Route
                     <Route path="weird" methods=&[Method::Get, Method::Post]
-                        ssr=SsrMode::Async 
+                        ssr=SsrMode::Async
                         view=|cx| {
                             let res = create_resource(cx, || (), move |_| async move {
                                 form_data(cx).await

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -48,10 +48,10 @@ pub fn html_parts(
     let output_name = &options.output_name;
 
     // Because wasm-pack adds _bg to the end of the WASM filename, and we want to mantain compatibility with it's default options
-    // we add _bg to the wasm files if cargo-leptos doesn't set the env var LEPTOS_OUTPUT_NAME
-    // Otherwise we need to add _bg because wasm_pack always does. This is not the same as options.output_name, which is set regardless
+    // we add _bg to the wasm files if cargo-leptos doesn't set the env var LEPTOS_OUTPUT_NAME at compile time
+    // Otherwise we need to add _bg because wasm_pack always does.
     let mut wasm_output_name = output_name.clone();
-    if std::env::var("LEPTOS_OUTPUT_NAME").is_err() {
+    if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
         wasm_output_name.push_str("_bg");
     }
 

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -53,8 +53,9 @@ pub struct LeptosOptions {
 
 impl LeptosOptions {
     fn try_from_env() -> Result<Self, LeptosConfigError> {
+
         Ok(LeptosOptions {
-            output_name: env_w_default("LEPTOS_OUTPUT_NAME", std::env!("LEPTOS_OUTPUT_NAME"))?,
+            output_name: env_w_default("LEPTOS_OUTPUT_NAME", std::env!("LEPTOS_OUTPUT_NAME", "It looks like you're trying to compile Leptos without the LEPTOS_OUTPUT_NAME environment variable being set. There are two options\n 1. cargo-leptos is not being used, but get_configuration() is being passed None. This needs to be changed to Some(\"Cargo.toml\")\n 2. You are compiling Leptos without LEPTOS_OUTPUT_NAME being set with cargo-leptos. This shouldn't be possible!"))?,
             site_root: env_w_default("LEPTOS_SITE_ROOT", "target/site")?,
             site_pkg_dir: env_w_default("LEPTOS_SITE_PKG_DIR", "pkg")?,
             env: Env::default(),

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -53,9 +53,20 @@ pub struct LeptosOptions {
 
 impl LeptosOptions {
     fn try_from_env() -> Result<Self, LeptosConfigError> {
-
         Ok(LeptosOptions {
-            output_name: env_w_default("LEPTOS_OUTPUT_NAME", std::env!("LEPTOS_OUTPUT_NAME", "It looks like you're trying to compile Leptos without the LEPTOS_OUTPUT_NAME environment variable being set. There are two options\n 1. cargo-leptos is not being used, but get_configuration() is being passed None. This needs to be changed to Some(\"Cargo.toml\")\n 2. You are compiling Leptos without LEPTOS_OUTPUT_NAME being set with cargo-leptos. This shouldn't be possible!"))?,
+            output_name: env_w_default(
+                "LEPTOS_OUTPUT_NAME",
+                std::env!(
+                    "LEPTOS_OUTPUT_NAME",
+                    "It looks like you're trying to compile Leptos without \
+                     the LEPTOS_OUTPUT_NAME environment variable being set. \
+                     There are two options\n 1. cargo-leptos is not being \
+                     used, but get_configuration() is being passed None. This \
+                     needs to be changed to Some(\"Cargo.toml\")\n 2. You are \
+                     compiling Leptos without LEPTOS_OUTPUT_NAME being set \
+                     with cargo-leptos. This shouldn't be possible!"
+                ),
+            )?,
             site_root: env_w_default("LEPTOS_SITE_ROOT", "target/site")?,
             site_pkg_dir: env_w_default("LEPTOS_SITE_PKG_DIR", "pkg")?,
             env: Env::default(),

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -54,11 +54,7 @@ pub struct LeptosOptions {
 impl LeptosOptions {
     fn try_from_env() -> Result<Self, LeptosConfigError> {
         Ok(LeptosOptions {
-            output_name: std::env::var("LEPTOS_OUTPUT_NAME").map_err(|e| {
-                LeptosConfigError::EnvVarError(format!(
-                    "LEPTOS_OUTPUT_NAME: {e}"
-                ))
-            })?,
+            output_name: env_w_default("LEPTOS_OUTPUT_NAME", std::env!("LEPTOS_OUTPUT_NAME"))?,
             site_root: env_w_default("LEPTOS_SITE_ROOT", "target/site")?,
             site_pkg_dir: env_w_default("LEPTOS_SITE_PKG_DIR", "pkg")?,
             env: Env::default(),

--- a/leptos_config/src/tests.rs
+++ b/leptos_config/src/tests.rs
@@ -31,9 +31,6 @@ fn env_w_default_test() {
 
 #[test]
 fn try_from_env_test() {
-    std::env::remove_var("LEPTOS_OUTPUT_NAME");
-    assert!(LeptosOptions::try_from_env().is_err());
-
     // Test config values from environment variables
     std::env::set_var("LEPTOS_OUTPUT_NAME", "app_test");
     std::env::set_var("LEPTOS_SITE_ROOT", "my_target/site");
@@ -51,19 +48,4 @@ fn try_from_env_test() {
         SocketAddr::from_str("0.0.0.0:80").unwrap()
     );
     assert_eq!(config.reload_port, 8080);
-
-    // Test default config values
-    std::env::remove_var("LEPTOS_SITE_ROOT");
-    std::env::remove_var("LEPTOS_SITE_PKG_DIR");
-    std::env::remove_var("LEPTOS_SITE_ADDR");
-    std::env::remove_var("LEPTOS_RELOAD_PORT");
-
-    let config = LeptosOptions::try_from_env().unwrap();
-    assert_eq!(config.site_root, "target/site");
-    assert_eq!(config.site_pkg_dir, "pkg");
-    assert_eq!(
-        config.site_addr,
-        SocketAddr::from_str("127.0.0.1:3000").unwrap()
-    );
-    assert_eq!(config.reload_port, 3001);
 }

--- a/leptos_config/tests/config.rs
+++ b/leptos_config/tests/config.rs
@@ -140,9 +140,6 @@ fn get_config_from_str_content() {
 
 #[tokio::test]
 async fn get_config_from_env() {
-    std::env::remove_var("LEPTOS_OUTPUT_NAME");
-    assert!(get_configuration(None).await.is_err());
-
     // Test config values from environment variables
     std::env::set_var("LEPTOS_OUTPUT_NAME", "app_test");
     std::env::set_var("LEPTOS_SITE_ROOT", "my_target/site");


### PR DESCRIPTION
Tweaked the get_configuration function and the checks to make LEPTOS_OUTPUT_NAME required for compilation, but not with the compiled binary. 