### PR TITLE
Check output name at build time

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -51,7 +51,7 @@ pub fn html_parts(
     // we add _bg to the wasm files if cargo-leptos doesn't set the env var LEPTOS_OUTPUT_NAME
     // Otherwise we need to add _bg because wasm_pack always does. This is not the same as options.output_name, which is set regardless
     let mut wasm_output_name = output_name.clone();
-    if std::env::var("LEPTOS_OUTPUT_NAME").is_err() {
+    if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
         wasm_output_name.push_str("_bg");
     }
 
@@ -86,7 +86,7 @@ pub fn html_parts_separated(
     // we add _bg to the wasm files if cargo-leptos doesn't set the env var LEPTOS_OUTPUT_NAME
     // Otherwise we need to add _bg because wasm_pack always does. This is not the same as options.output_name, which is set regardless
     let mut wasm_output_name = output_name.clone();
-    if std::env::var("LEPTOS_OUTPUT_NAME").is_err() {
+    if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
         wasm_output_name.push_str("_bg");
     }
 

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -53,12 +53,18 @@ pub struct LeptosOptions {
 
 impl LeptosOptions {
     fn try_from_env() -> Result<Self, LeptosConfigError> {
+        let output_name = std::env::var("LEPTOS_OUTPUT_NAME").or_else(|e| {
+            std::option_env!("LEPTOS_OUTPUT_NAME")
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    LeptosConfigError::EnvVarError(format!(
+                        "LEPTOS_OUTPUT_NAME: {e}"
+                    ))
+                })
+        })?;
+
         Ok(LeptosOptions {
-            output_name: std::env::var("LEPTOS_OUTPUT_NAME").map_err(|e| {
-                LeptosConfigError::EnvVarError(format!(
-                    "LEPTOS_OUTPUT_NAME: {e}"
-                ))
-            })?,
+            output_name,
             site_root: env_w_default("LEPTOS_SITE_ROOT", "target/site")?,
             site_pkg_dir: env_w_default("LEPTOS_SITE_PKG_DIR", "pkg")?,
             env: Env::default(),


### PR DESCRIPTION
This removes the requirement to provide `LEPTOS_OUTPUT_NAME` at run time.