### PR TITLE
Added get_untracked for node_ref.

### DIFF
--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -99,6 +99,18 @@ impl<T: ElementDescriptor + 'static> NodeRef<T> {
         self.0.get()
     }
 
+    /// Gets the element that is currently stored in the reference.
+    ///
+    /// This **does not** track reactively.
+    #[track_caller]
+    #[inline(always)]
+    pub fn get_untracked(&self) -> Option<HtmlElement<T>>
+    where
+        T: Clone,
+    {
+        self.0.get_untracked()
+    }
+
     #[doc(hidden)]
     /// Loads an element into the reference. This tracks reactively,
     /// so that effects that use the node reference will rerun once it is loaded,


### PR DESCRIPTION
Avoids getting messages of unused reactivity.

When working with simple event handlers the use of NodeRef::get() triggers a diagnostic due to inner RwSignal that gets it `get` called. For this cases the simple get_untracked avoids this diagnostic message.