### PR TITLE
docs: compile error on mutually-exclusive features

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -240,3 +240,24 @@ pub fn component_props_builder<P: Props>(
 ) -> <P as Props>::Builder {
     <P as Props>::builder()
 }
+
+#[cfg(all(not(doc), feature = "csr", feature = "ssr"))]
+compile_error!(
+    "You have both `csr` and `ssr` enabled as features, which may cause \
+     issues like <Suspense/>` failing to work silently. `csr` is enabled by \
+     default on `leptos`, and can be disabled by adding `default-features = \
+     false` to your `leptos` dependency."
+);
+
+#[cfg(all(not(doc), feature = "hydrate", feature = "ssr"))]
+compile_error!(
+    "You have both `hydrate` and `ssr` enabled as features, which may cause \
+     issues like <Suspense/>` failing to work silently."
+);
+
+#[cfg(all(not(doc), feature = "hydrate", feature = "csr"))]
+compile_error!(
+    "You have both `hydrate` and `csr` enabled as features, which may cause \
+     issues. `csr` is enabled by default on `leptos`, and can be disabled by \
+     adding `default-features = false` to your `leptos` dependency."
+);


### PR DESCRIPTION
Having `csr` and `ssr` enabled simultaneously sometimes happens accidentally. (Because `leptos` has the `csr` feature enabled by default, if you activate `ssr` without disabling default features, this will happen.) This can cause some very difficult to debug issues, such as silently breaking `<Suspense/>` rendering on the server. This PR adds a compile error if you have these features enabled simultaneously. I *think* our CI is now set up so this shouldn't happen, but am expecting a few blow-ups here. Still, I'm hoping this will make it a little less painful for people to get started with the framework.