### PR TITLE
Test business logic for counter_without_macros

### DIFF
--- a/examples/counter_without_macros/Cargo.toml
+++ b/examples/counter_without_macros/Cargo.toml
@@ -17,6 +17,7 @@ console_error_panic_hook = "0.1.7"
 wasm-bindgen = "0.2.84"
 wasm-bindgen-test = "0.3.34"
 pretty_assertions = "1.3.0"
+rstest = "0.17.0"
 
 [dev-dependencies.web-sys]
 features = ["HtmlElement", "XPathResult"]

--- a/examples/counter_without_macros/Makefile.toml
+++ b/examples/counter_without_macros/Makefile.toml
@@ -1,6 +1,9 @@
 [env]
 CARGO_MAKE_WASM_TEST_ARGS = "--headless --chrome"
 
+[tasks.test-all]
+dependencies = ["test", "web-test"]
+
 [tasks.web-test]
 command = "cargo"
 args = ["make", "wasm-pack-test"]

--- a/examples/counter_without_macros/src/lib.rs
+++ b/examples/counter_without_macros/src/lib.rs
@@ -43,3 +43,34 @@ pub fn counter(cx: Scope, initial_value: i32, step: u32) -> impl IntoView {
                 .child("+1"),
         )
 }
+
+#[derive(Debug, Clone)]
+pub struct Count {
+    value: i32,
+    step: i32,
+}
+
+impl Count {
+    pub fn new(value: i32, step: u32) -> Self {
+        Count {
+            value,
+            step: step as i32,
+        }
+    }
+
+    pub fn value(&self) -> i32 {
+        self.value
+    }
+
+    pub fn increase(&mut self) {
+        self.value += self.step;
+    }
+
+    pub fn decrease(&mut self) {
+        self.value += -self.step;
+    }
+
+    pub fn clear(&mut self) {
+        self.value = 0;
+    }
+}

--- a/examples/counter_without_macros/src/lib.rs
+++ b/examples/counter_without_macros/src/lib.rs
@@ -3,8 +3,7 @@ use leptos::{ev, html::*, *};
 /// A simple counter view.
 // A component is really just a function call: it runs once to create the DOM and reactive system
 pub fn counter(cx: Scope, initial_value: i32, step: u32) -> impl IntoView {
-    let step = step as i32;
-    let (value, set_value) = create_signal(cx, initial_value);
+    let (count, set_count) = create_signal(cx, Count::new(initial_value, step));
 
     // elements are created by calling a function with a Scope argument
     // the function name is the same as the HTML tag name
@@ -17,13 +16,13 @@ pub fn counter(cx: Scope, initial_value: i32, step: u32) -> impl IntoView {
                 // typed events found in leptos::ev
                 // 1) prevent typos in event names
                 // 2) allow for correct type inference in callbacks
-                .on(ev::click, move |_| set_value.update(|value| *value = 0))
+                .on(ev::click, move |_| set_count.update(|count| count.clear()))
                 .child("Clear"),
         )
         .child(
             button(cx)
                 .on(ev::click, move |_| {
-                    set_value.update(|value| *value -= step)
+                    set_count.update(|count| count.decrease())
                 })
                 .child("-1"),
         )
@@ -32,13 +31,13 @@ pub fn counter(cx: Scope, initial_value: i32, step: u32) -> impl IntoView {
                 .child("Value: ")
                 // reactive values are passed to .child() as a tuple
                 // (Scope, [child function]) so an effect can be created
-                .child((cx, move || value.get()))
+                .child(move || count.get().value())
                 .child("!"),
         )
         .child(
             button(cx)
                 .on(ev::click, move |_| {
-                    set_value.update(|value| *value += step)
+                    set_count.update(|count| count.increase())
                 })
                 .child("+1"),
         )

--- a/examples/counter_without_macros/src/lib.rs
+++ b/examples/counter_without_macros/src/lib.rs
@@ -2,7 +2,8 @@ use leptos::{ev, html::*, *};
 
 /// A simple counter view.
 // A component is really just a function call: it runs once to create the DOM and reactive system
-pub fn counter(cx: Scope, initial_value: i32, step: i32) -> impl IntoView {
+pub fn counter(cx: Scope, initial_value: i32, step: u32) -> impl IntoView {
+    let step = step as i32;
     let (value, set_value) = create_signal(cx, initial_value);
 
     // elements are created by calling a function with a Scope argument

--- a/examples/counter_without_macros/tests/business.rs
+++ b/examples/counter_without_macros/tests/business.rs
@@ -1,0 +1,49 @@
+mod count {
+    use counter_without_macros::Count;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(-2, 1)]
+    #[case(-1, 1)]
+    #[case(0, 1)]
+    #[case(1, 1)]
+    #[case(2, 1)]
+    #[case(3, 2)]
+    #[case(4, 3)]
+    fn should_increase_count(#[case] initial_value: i32, #[case] step: u32) {
+        let mut count = Count::new(initial_value, step);
+        count.increase();
+        assert_eq!(count.value(), initial_value + step as i32);
+    }
+
+    #[rstest]
+    #[case(-2, 1)]
+    #[case(-1, 1)]
+    #[case(0, 1)]
+    #[case(1, 1)]
+    #[case(2, 1)]
+    #[case(3, 2)]
+    #[case(4, 3)]
+    #[trace]
+    fn should_decrease_count(#[case] initial_value: i32, #[case] step: u32) {
+        let mut count = Count::new(initial_value, step);
+        count.decrease();
+        assert_eq!(count.value(), initial_value - step as i32);
+    }
+
+    #[rstest]
+    #[case(-2, 1)]
+    #[case(-1, 1)]
+    #[case(0, 1)]
+    #[case(1, 1)]
+    #[case(2, 1)]
+    #[case(3, 2)]
+    #[case(4, 3)]
+    #[trace]
+    fn should_clear_count(#[case] initial_value: i32, #[case] step: u32) {
+        let mut count = Count::new(initial_value, step);
+        count.clear();
+        assert_eq!(count.value(), 0);
+    }
+}


### PR DESCRIPTION
This demonstrates extracting and testing business logic.

Run `cargo make test-all` from the `examples/counter_without_macros` directory

You can also run `cargo make test-examples` from the `leptos/examples` directory.