### PR TITLE
chore: specify dependency version for cached

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -10,7 +10,7 @@ description = "Router for the Leptos web framework."
 
 [dependencies]
 leptos = { workspace = true }
-cached = { optional = true }
+cached = { version = "0.43.0", optional = true }
 cfg-if = "1"
 common_macros = "0.1"
 gloo-net = { version = "0.2", features = ["http"] }


### PR DESCRIPTION
This eliminates cargo warning:

```
dependency (cached) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
```
