### PR TITLE
Link to actual type instead of Into trait for component properties

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -606,12 +606,11 @@ fn prop_to_doc(
         PropDocStyle::List => {
             let arg_ty_doc = LitStr::new(
                 &if !prop_opts.into {
-                    format!("- **{}**: [`{}`]", quote!(#name), pretty_ty)
+                    format!("- **{}**: [`{pretty_ty}`]", quote!(#name))
                 } else {
                     format!(
-                        "- **{}**: `impl`[`Into<{}>`]",
+                        "- **{}**: [`impl Into<{pretty_ty}>`]({pretty_ty})",
                         quote!(#name),
-                        pretty_ty
                     )
                 },
                 name.ident.span(),

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -628,9 +628,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let is_transparent = if !args.is_empty() {
         let transparent = parse_macro_input!(args as syn::Ident);
 
-        let transparent_token: syn::Ident = syn::parse_quote!(transparent);
-
-        if transparent != transparent_token {
+        if transparent != "transparent" {
             abort!(
                 transparent,
                 "only `transparent` is supported";


### PR DESCRIPTION
The link-region could be done differently as well, but the main point is to not link to std's `Into` but the actual type in question.