### PR TITLE
feat: add allow missing_docs to `children` field

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -458,10 +458,18 @@ fn prop_builder_fields(vis: &Visibility, props: &[Prop]) -> TokenStream {
 
             let builder_docs = prop_to_doc(prop, PropDocStyle::Inline);
 
+            // Children won't need documentation in many cases
+            let allow_missing_docs = if name.ident == "children" {
+                quote!(#[allow(missing_docs)])
+            } else {
+                quote!()
+            };
+
             quote! {
                 #docs
                 #builder_docs
                 #builder_attrs
+                #allow_missing_docs
                 #vis #name: #ty,
             }
         })


### PR DESCRIPTION
I use `#[warn(missing_docs)]` to spot missing docs. But children don't need
documentation in many cases.

An alternative would be to allow passing-through a `#[allow(missing_docs)]` put
on the parameter, which is currently only supported for doc attributes.

