### PR TITLE
feat: add Actix `extract` helper

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1104,7 +1104,7 @@ where
 /// # use leptos::*;
 /// use leptos_actix::extract;
 /// use serde::Deserialize;
-/// 
+///
 /// #[derive(Deserialize)]
 /// struct Search {
 ///     q: String,
@@ -1130,7 +1130,10 @@ where
 ///     .await
 /// }
 /// ```
-pub async fn extract<F, E, T>(cx: leptos::Scope, f: F) -> Result<T, ServerFnError>
+pub async fn extract<F, E, T>(
+    cx: leptos::Scope,
+    f: F,
+) -> Result<T, ServerFnError>
 where
     F: FnOnce(E) -> T,
     E: actix_web::FromRequest,

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1101,9 +1101,8 @@ where
 /// will be extracted from the request and returns some value.
 ///
 /// ```rust,ignore
-/// use serde::Deserialize;
 /// use leptos::*;
-///
+/// use serde::Deserialize;
 /// #[derive(Deserialize)]
 /// struct Search {
 ///     q: String,
@@ -1129,7 +1128,7 @@ where
 /// }
 /// ```
 pub async fn extract<F, E>(
-    cx: Scope,
+    cx: leptos::Scope,
     f: F,
 ) -> Result<<<F as Extractor<E>>::Future as Future>::Output, ServerFnError>
 where

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1097,20 +1097,25 @@ where
 
 /// A helper to make it easier to use Axum extractors in server functions. This takes
 /// a callback function that takes any valid Actix extractor (or tuple of extractors)
-/// as its argument, and returns its value, converting any Actix errors into server 
+/// as its argument, and returns its value, converting any Actix errors into server
 /// function errors.
-/// 
+///
 /// ```rust
 /// #[derive(Deserialize)]
 /// struct Search {
 ///     q: String,
 /// }
-/// 
+///
 /// #[server(ExtractoServerFn, "/api")]
-/// pub async fn extractor_server_fn(cx: Scope) -> Result<String, ServerFnError> {
+/// pub async fn extractor_server_fn(
+///     cx: Scope,
+/// ) -> Result<String, ServerFnError> {
 ///     extract(
 ///         cx,
-///         |(data, search): (actix_web::web::Data<String>, actix_web::web::Query<Search>)| {
+///         |(data, search): (
+///             actix_web::web::Data<String>,
+///             actix_web::web::Query<Search>,
+///         )| {
 ///             format!(
 ///                 "data = {} and search = {}",
 ///                 data.into_inner().to_string(),

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -13,7 +13,7 @@ use actix_web::{
     web::Bytes,
     *,
 };
-use futures::{Future, Stream, StreamExt};
+use futures::{Stream, StreamExt};
 use http::StatusCode;
 use leptos::{
     leptos_dom::ssr::render_to_stream_with_prefix_undisposed_with_context,
@@ -1102,6 +1102,7 @@ where
 ///
 /// ```rust,ignore
 /// use serde::Deserialize;
+/// use leptos::*;
 ///
 /// #[derive(Deserialize)]
 /// struct Search {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1096,23 +1096,23 @@ where
 }
 
 /// A helper to make it easier to use Axum extractors in server functions. This takes
-/// a handler function as its argument. The handler follows similar rules to an Actix 
+/// a handler function as its argument. The handler follows similar rules to an Actix
 /// [Handler](actix_web::Handler): it is an async function that receives arguments that  
 /// will be extracted from the request and returns some value.
 ///
 /// ```rust,ignore
 /// use serde::Deserialize;
-/// 
+///
 /// #[derive(Deserialize)]
 /// struct Search {
 ///     q: String,
 /// }
-/// 
+///
 /// #[server(ExtractoServerFn, "/api")]
 /// pub async fn extractor_server_fn(cx: Scope) -> Result<String, ServerFnError> {
 ///     use actix_web::dev::ConnectionInfo;
 ///     use actix_web::web::{Data, Query};
-/// 
+///
 ///     extract(
 ///         cx,
 ///         |data: Data<String>, search: Query<Search>, connection: ConnectionInfo| async move {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1100,13 +1100,17 @@ where
 /// as its argument, and returns its value, converting any Actix errors into server
 /// function errors.
 ///
-/// ```rust
+/// ```rust,ignore
+/// # use leptos::*;
+/// use leptos_actix::extract;
+/// use serde::Deserialize;
+/// 
 /// #[derive(Deserialize)]
 /// struct Search {
 ///     q: String,
 /// }
 ///
-/// #[server(ExtractoServerFn, "/api")]
+/// #[server(ExtractorServerFn, "/api")]
 /// pub async fn extractor_server_fn(
 ///     cx: Scope,
 /// ) -> Result<String, ServerFnError> {
@@ -1126,7 +1130,7 @@ where
 ///     .await
 /// }
 /// ```
-pub async fn extract<F, E, T>(cx: Scope, f: F) -> Result<T, ServerFnError>
+pub async fn extract<F, E, T>(cx: leptos::Scope, f: F) -> Result<T, ServerFnError>
 where
     F: FnOnce(E) -> T,
     E: actix_web::FromRequest,


### PR DESCRIPTION
Using Actix and Axum extractors in server functions is a frequently-requested feature and has been a pain point for users so far. This is somewhat easier to tackle with Actix than with Axum, but I suspect we can find a similar solution there. 

This function essentially lets you use Actix extractors directly in your server functions, with a similar syntax to the one that's familiar from Actix route handlers:
```rust
use serde::Deserialize;

#[derive(Deserialize)]
struct Search {
    q: String,
}

#[server(ExtractoServerFn, "/api")]
pub async fn extractor_server_fn(cx: Scope) -> Result<String, ServerFnError> {
    use actix_web::web;
    extract(
        cx,
        |(data, search): (web::Data<String>, web::Query<Search>)| {
            format!(
                "data = {} and search = {}",
                data.into_inner().to_string(),
                search.q
            )
        },
    )
    .await
}
```