### PR TITLE
Adds the GetCbor and GetJson to server macro documentation.

### DIFF
--- a/server_fn/server_fn_macro_default/src/lib.rs
+++ b/server_fn/server_fn_macro_default/src/lib.rs
@@ -16,9 +16,10 @@ use syn::__private::ToTokens;
 /// 2. *Optional*: A URL prefix at which the function will be mounted when it’s registered
 ///   (e.g., `"/api"`). Defaults to `"/"`.
 /// 3. *Optional*: either `"Cbor"` (specifying that it should use the binary `cbor` format for
-///   serialization) or `"Url"` (specifying that it should be use a URL-encoded form-data string).
+///   serialization), `"Url"` (specifying that it should be use a URL-encoded form-data string).
 ///   Defaults to `"Url"`. If you want to use this server function to power a `<form>` that will
-///   work without WebAssembly, the encoding must be `"Url"`.
+///   work without WebAssembly, the encoding must be `"Url"`. If you want to use this server function
+///   using Get instead of Post methods, the encoding must be `"GetCbor"` or `"GetJson"`.
 ///
 /// The server function itself can take any number of arguments, each of which should be serializable
 /// and deserializable with `serde`.


### PR DESCRIPTION
I was looking into how I could use the Get (for caching) and found out that it was missing documentation for the `server` macro for those encodings. This PR add that documentation. Of course the user must register the leptos_axum::handle_server_fns for `get`.