### PR TITLE
impl FromIterator for View

### DIFF
--- a/leptos_dom/src/components/fragment.rs
+++ b/leptos_dom/src/components/fragment.rs
@@ -45,6 +45,21 @@ impl From<View> for Fragment {
     }
 }
 
+impl From<Fragment> for View {
+    fn from(value: Fragment) -> Self {
+        let mut frag = ComponentRepr::new_with_id("", value.id.clone());
+
+        #[cfg(debug_assertions)]
+        {
+            frag.view_marker = value.view_marker;
+        }
+
+        frag.children = value.nodes;
+
+        frag.into()
+    }
+}
+
 impl Fragment {
     /// Creates a new [`Fragment`] from a [`Vec<Node>`].
     #[inline(always)]
@@ -91,16 +106,7 @@ impl Fragment {
 
 impl IntoView for Fragment {
     #[cfg_attr(debug_assertions, instrument(level = "info", name = "</>", skip_all, fields(children = self.nodes.len())))]
-    fn into_view(self, cx: leptos_reactive::Scope) -> View {
-        let mut frag = ComponentRepr::new_with_id("", self.id.clone());
-
-        #[cfg(debug_assertions)]
-        {
-            frag.view_marker = self.view_marker;
-        }
-
-        frag.children = self.nodes;
-
-        frag.into_view(cx)
+    fn into_view(self, _: leptos_reactive::Scope) -> View {
+        self.into()
     }
 }

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -533,6 +533,12 @@ impl IntoView for &Fragment {
     }
 }
 
+impl FromIterator<View> for View {
+    fn from_iter<T: IntoIterator<Item = View>>(iter: T) -> Self {
+        iter.into_iter().collect::<Fragment>().into()
+    }
+}
+
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 impl Mountable for View {
     fn get_mountable_node(&self) -> web_sys::Node {


### PR DESCRIPTION
This implementation chooses to use `View::from(Fragment/ComponentRepr)` inside of their `IntoView` implementations.

Alternatively those could maybe be replaced by a generic: `impl<T: Into<View>> IntoView for T`, but I'm not sure if this would run into any issues with conflicting trait implementations, and I didn't know how the `#[instrument]` attributes would need to be placed.

fixes #941
