### PR TITLE
impl `IntoView` for component props

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -208,6 +208,12 @@ impl ToTokens for Model {
                 }
             }
 
+            impl #generics ::leptos::IntoView for #props_name #generics #where_clause {
+                fn into_view(self, cx: Scope) -> ::leptos::View {
+                    #name(cx, self).into_view(cx)
+                }
+            }
+
             #docs
             #component_fn_prop_docs
             #[allow(non_snake_case, clippy::too_many_arguments)]


### PR DESCRIPTION
This PR implements the `IntoView` trait for props generated from the `#[component]` macro. This is a **MASSIVELY HUGE** DX improvement for the builder pattern, because it allows the following usage:

```rust
#[component]
fn Comp(cx: Scope, prop_1: String, prop_2: usize) -> impl IntoView {}

fn example(cx: Scope) -> impl IntoView {
  CompProps::builder()
    .prop_1("hello!")
    .prop_2(7)
    .build()
}
```