### PR TITLE
fix: escapes in doc comments on component properties

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,12 +69,19 @@ dependencies = [
 
 [tasks.test]
 clear = true
-dependencies = ["test-all"]
+dependencies = ["test-all", "test-leptos_macro-example"]
 
 [tasks.test-all]
 command = "cargo"
 args = ["+nightly", "test-all-features"]
 install_crate = "cargo-all-features"
+
+[tasks.test-leptos_macro-example]
+description = "Tests the leptos_macro/example to check if macro handles doc comments correctly"
+command = "cargo"
+args = ["+nightly", "test", "--doc"]
+cwd = "leptos_macro/example"
+install_crate = false
 
 [tasks.test-examples]
 description = "Run all unit and web tests for examples"

--- a/leptos_macro/example/Cargo.toml
+++ b/leptos_macro/example/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+leptos.path = "../../leptos"
+
+[workspace]

--- a/leptos_macro/example/src/lib.rs
+++ b/leptos_macro/example/src/lib.rs
@@ -1,0 +1,15 @@
+use leptos::*;
+
+#[component]
+fn TestComponent(
+    _cx: Scope,
+    /// ```
+    /// assert_eq!("hello", stringify!(hello));
+    /// ```
+    #[prop(into)]
+    key: String,
+) -> impl IntoView {
+    _ = key;
+    todo!()
+}
+


### PR DESCRIPTION
The current implementation mangled doc comments containing escapes.
