### PR TITLE
Replace `serde_urlencoded` with `serde_html_form` to support cross-input vec serverfn

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -816,7 +816,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// - **Arguments must be implement [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
 ///   and [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).**
 ///   They are serialized as an `application/x-www-form-urlencoded`
-///   form data using [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) or as `application/cbor`
+///   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
 ///   using [`cbor`](https://docs.rs/cbor/latest/cbor/). **Note**: You should explicitly include `serde` with the
 ///   `derive` feature enabled in your `Cargo.toml`. You can do this by running `cargo add serde --features=derive`.
 /// - **The `Scope` comes from the server.** Optionally, the first argument of a server function

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -72,7 +72,7 @@
 //!   This should be fairly obvious: we have to serialize arguments to send them to the server, and we
 //!   need to deserialize the result to return it to the client.
 //! - **Arguments must be implement [serde::Serialize].** They are serialized as an `application/x-www-form-urlencoded`
-//!   form data using [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) or as `application/cbor`
+//!   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
 //!   using [`cbor`](https://docs.rs/cbor/latest/cbor/). **Note**: You should explicitly include `serde` with the
 //!   `derive` feature enabled in your `Cargo.toml`. You can do this by running `cargo add serde --features=derive`.
 //! - **The [Scope](leptos_reactive::Scope) comes from the server.** Optionally, the first argument of a server function

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -21,7 +21,7 @@ regex = { version = "1", optional = true }
 url = { version = "2", optional = true }
 percent-encoding = "2"
 thiserror = "1"
-serde_urlencoded = "0.7"
+serde_html_form = "0.2"
 serde = "1"
 tracing = "0.1"
 js-sys = { version = "0.3" }

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -539,12 +539,12 @@ where
     /// Tries to deserialize the data, given only the `submit` event.
     fn from_event(
         ev: &web_sys::Event,
-    ) -> Result<Self, serde_urlencoded::de::Error>;
+    ) -> Result<Self, serde_html_form::de::Error>;
 
     /// Tries to deserialize the data, given the actual form data.
     fn from_form_data(
         form_data: &web_sys::FormData,
-    ) -> Result<Self, serde_urlencoded::de::Error>;
+    ) -> Result<Self, serde_html_form::de::Error>;
 }
 
 impl<T> FromFormData for T
@@ -557,7 +557,7 @@ where
     )]
     fn from_event(
         ev: &web_sys::Event,
-    ) -> Result<Self, serde_urlencoded::de::Error> {
+    ) -> Result<Self, serde_html_form::de::Error> {
         let (form, _, _, _) = extract_form_attributes(ev);
 
         let form_data = web_sys::FormData::new_with_form(&form).unwrap_throw();
@@ -570,11 +570,11 @@ where
     )]
     fn from_form_data(
         form_data: &web_sys::FormData,
-    ) -> Result<Self, serde_urlencoded::de::Error> {
+    ) -> Result<Self, serde_html_form::de::Error> {
         let data =
             web_sys::UrlSearchParams::new_with_str_sequence_sequence(form_data)
                 .unwrap_throw();
         let data = data.to_string().as_string().unwrap_or_default();
-        serde_urlencoded::from_str::<Self>(&data)
+        serde_html_form::from_str::<Self>(&data)
     }
 }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 [dependencies]
 server_fn_macro_default = { workspace = true }
 serde = { version = "1", features = ["derive"] }
-serde_urlencoded = "0.7"
+serde_html_form = "0.2"
 thiserror = "1"
 serde_json = "1"
 quote = "1"

--- a/server_fn/server_fn_macro_default/src/lib.rs
+++ b/server_fn/server_fn_macro_default/src/lib.rs
@@ -49,7 +49,7 @@ use syn::__private::ToTokens;
 /// - **Arguments must be implement [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
 ///   and [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).**
 ///   They are serialized as an `application/x-www-form-urlencoded`
-///   form data using [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) or as `application/cbor`
+///   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
 ///   using [`cbor`](https://docs.rs/cbor/latest/cbor/).
 #[proc_macro_attribute]
 pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -75,7 +75,7 @@
 //!   This should be fairly obvious: we have to serialize arguments to send them to the server, and we
 //!   need to deserialize the result to return it to the client.
 //! - **Arguments must be implement [serde::Serialize].** They are serialized as an `application/x-www-form-urlencoded`
-//!   form data using [`serde_urlencoded`](https://docs.rs/serde_urlencoded/latest/serde_urlencoded/) or as `application/cbor`
+//!   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
 //!   using [`cbor`](https://docs.rs/cbor/latest/cbor/).
 
 // used by the macro
@@ -308,7 +308,7 @@ where
             // decode the args
             let value = match Self::encoding() {
                 Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => {
-                    serde_urlencoded::from_bytes(data).map_err(|e| {
+                    serde_html_form::from_bytes(data).map_err(|e| {
                         ServerFnError::Deserialization(e.to_string())
                     })
                 }
@@ -408,7 +408,7 @@ where
     }
     let args_encoded = match &enc {
         Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => Payload::Url(
-            serde_urlencoded::to_string(&args)
+            serde_html_form::to_string(&args)
                 .map_err(|e| ServerFnError::Serialization(e.to_string()))?,
         ),
         Encoding::Cbor => {


### PR DESCRIPTION
`serde_html_form` is a fork of `serde_urlencoded` that supports additional features that won't be supported by `urlencoded`.

The motivating example I have is an `ActionForm` with `create_server_action` where I want multiple fields to be combined into a single `Vec` argument to the `serverfn`, allowing for varying numbers of arguments. (Think: a todo list that you can select multiple items to mark done/delete in one action).

Typically this would be done with non-standard (from what I can tell) additions/encoding in www-form-urlencoded, `"field[]=1&field[]=2"` or `"field=1&field=2"`. The non-standard-ness is why it's not going to be added to urlencoded (https://github.com/nox/serde_urlencoded/issues/6 / https://github.com/nox/serde_urlencoded/issues/75).

The fork has already been adopted by axum for the axum-extras package https://github.com/tokio-rs/axum/issues/434 .

---

I have a hacked up [version of the todo-app-axum](https://gist.github.com/snapbug/d694398098697035a8395519f25127e8) as illustration that it mostly works correctly (there's still the an issue when non are selected, but that's work-aroundable with active state toggling the submit button at worst), and that form-encoding is needed even with a `"Cbor"` serverfn (makes total sense for an action form triggered server fn.