### PR TITLE
fix: lint issues in `counters` example

### DIFF
--- a/examples/counters/src/lib.rs
+++ b/examples/counters/src/lib.rs
@@ -1,4 +1,4 @@
-use leptos::{For, ForProps, *};
+use leptos::{For, *};
 
 const MANY_COUNTERS: usize = 1000;
 


### PR DESCRIPTION
This cleans up the lint issues in the `counters` example.

Verification:

- Run `cargo make check-style` from the `examples/counters` directory
- Run `cargo make verify-example`s from the leptos root directory (`counters` passes but other examples fail)