### PR TITLE
feat: allow structs in server function arguments

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -816,7 +816,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// - **Arguments must be implement [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
 ///   and [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).**
 ///   They are serialized as an `application/x-www-form-urlencoded`
-///   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
+///   form data using [`serde_qs`](https://docs.rs/serde_qs/latest/serde_qs/) or as `application/cbor`
 ///   using [`cbor`](https://docs.rs/cbor/latest/cbor/). **Note**: You should explicitly include `serde` with the
 ///   `derive` feature enabled in your `Cargo.toml`. You can do this by running `cargo add serde --features=derive`.
 /// - **The `Scope` comes from the server.** Optionally, the first argument of a server function

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -72,7 +72,7 @@
 //!   This should be fairly obvious: we have to serialize arguments to send them to the server, and we
 //!   need to deserialize the result to return it to the client.
 //! - **Arguments must be implement [serde::Serialize].** They are serialized as an `application/x-www-form-urlencoded`
-//!   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
+//!   form data using [`serde_qs`](https://docs.rs/serde_qs/latest/serde_qs/) or as `application/cbor`
 //!   using [`cbor`](https://docs.rs/cbor/latest/cbor/). **Note**: You should explicitly include `serde` with the
 //!   `derive` feature enabled in your `Cargo.toml`. You can do this by running `cargo add serde --features=derive`.
 //! - **The [Scope](leptos_reactive::Scope) comes from the server.** Optionally, the first argument of a server function

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -21,7 +21,7 @@ regex = { version = "1", optional = true }
 url = { version = "2", optional = true }
 percent-encoding = "2"
 thiserror = "1"
-serde_html_form = "0.2"
+serde_qs = "0.12"
 serde = "1"
 tracing = "0.1"
 js-sys = { version = "0.3" }

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -537,9 +537,7 @@ where
     Self: Sized + serde::de::DeserializeOwned,
 {
     /// Tries to deserialize the data, given only the `submit` event.
-    fn from_event(
-        ev: &web_sys::Event,
-    ) -> Result<Self, serde_qs::Error>;
+    fn from_event(ev: &web_sys::Event) -> Result<Self, serde_qs::Error>;
 
     /// Tries to deserialize the data, given the actual form data.
     fn from_form_data(
@@ -555,9 +553,7 @@ where
         any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
-    fn from_event(
-        ev: &web_sys::Event,
-    ) -> Result<Self, serde_qs::Error> {
+    fn from_event(ev: &web_sys::Event) -> Result<Self, serde_qs::Error> {
         let (form, _, _, _) = extract_form_attributes(ev);
 
         let form_data = web_sys::FormData::new_with_form(&form).unwrap_throw();

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -539,12 +539,12 @@ where
     /// Tries to deserialize the data, given only the `submit` event.
     fn from_event(
         ev: &web_sys::Event,
-    ) -> Result<Self, serde_html_form::de::Error>;
+    ) -> Result<Self, serde_qs::Error>;
 
     /// Tries to deserialize the data, given the actual form data.
     fn from_form_data(
         form_data: &web_sys::FormData,
-    ) -> Result<Self, serde_html_form::de::Error>;
+    ) -> Result<Self, serde_qs::Error>;
 }
 
 impl<T> FromFormData for T
@@ -557,7 +557,7 @@ where
     )]
     fn from_event(
         ev: &web_sys::Event,
-    ) -> Result<Self, serde_html_form::de::Error> {
+    ) -> Result<Self, serde_qs::Error> {
         let (form, _, _, _) = extract_form_attributes(ev);
 
         let form_data = web_sys::FormData::new_with_form(&form).unwrap_throw();
@@ -570,11 +570,11 @@ where
     )]
     fn from_form_data(
         form_data: &web_sys::FormData,
-    ) -> Result<Self, serde_html_form::de::Error> {
+    ) -> Result<Self, serde_qs::Error> {
         let data =
             web_sys::UrlSearchParams::new_with_str_sequence_sequence(form_data)
                 .unwrap_throw();
         let data = data.to_string().as_string().unwrap_or_default();
-        serde_html_form::from_str::<Self>(&data)
+        serde_qs::from_str::<Self>(&data)
     }
 }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 [dependencies]
 server_fn_macro_default = { workspace = true }
 serde = { version = "1", features = ["derive"] }
-serde_html_form = "0.2"
+serde_qs = "0.12"
 thiserror = "1"
 serde_json = "1"
 quote = "1"

--- a/server_fn/server_fn_macro_default/src/lib.rs
+++ b/server_fn/server_fn_macro_default/src/lib.rs
@@ -49,7 +49,7 @@ use syn::__private::ToTokens;
 /// - **Arguments must be implement [`Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
 ///   and [`DeserializeOwned`](https://docs.rs/serde/latest/serde/de/trait.DeserializeOwned.html).**
 ///   They are serialized as an `application/x-www-form-urlencoded`
-///   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
+///   form data using [`serde_qs`](https://docs.rs/serde_qs/latest/serde_qs/) or as `application/cbor`
 ///   using [`cbor`](https://docs.rs/cbor/latest/cbor/).
 #[proc_macro_attribute]
 pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -75,7 +75,7 @@
 //!   This should be fairly obvious: we have to serialize arguments to send them to the server, and we
 //!   need to deserialize the result to return it to the client.
 //! - **Arguments must be implement [serde::Serialize].** They are serialized as an `application/x-www-form-urlencoded`
-//!   form data using [`serde_html_form`](https://docs.rs/serde_html_form/latest/serde_html_form/) or as `application/cbor`
+//!   form data using [`serde_qs`](https://docs.rs/serde_qs/latest/serde_qs/) or as `application/cbor`
 //!   using [`cbor`](https://docs.rs/cbor/latest/cbor/).
 
 // used by the macro
@@ -308,7 +308,7 @@ where
             // decode the args
             let value = match Self::encoding() {
                 Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => {
-                    serde_html_form::from_bytes(data).map_err(|e| {
+                    serde_qs::from_bytes(data).map_err(|e| {
                         ServerFnError::Deserialization(e.to_string())
                     })
                 }
@@ -408,7 +408,7 @@ where
     }
     let args_encoded = match &enc {
         Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => Payload::Url(
-            serde_html_form::to_string(&args)
+            serde_qs::to_string(&args)
                 .map_err(|e| ServerFnError::Serialization(e.to_string()))?,
         ),
         Encoding::Cbor => {

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -106,7 +106,7 @@ pub fn server_macro_impl(
                 }
                 FnArg::Typed(t) => t,
             };
-            quote! { #[serde(flatten)] pub #typed_arg }
+            quote! { pub #typed_arg }
         });
 
     let cx_arg = body.inputs.iter().next().and_then(|f| {

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -106,7 +106,7 @@ pub fn server_macro_impl(
                 }
                 FnArg::Typed(t) => t,
             };
-            quote! { pub #typed_arg }
+            quote! { #[serde(flatten)] pub #typed_arg }
         });
 
     let cx_arg = body.inputs.iter().next().and_then(|f| {


### PR DESCRIPTION
`serde_urlencoded` doesn't accept nested structs. (Makes sense: URL encoding is flat.) But server function arguments are already built into a struct, so they can be serialized. (Makes sense: otherwise how would you send named arguments?) But this means you can't send a struct as a server function argument: Sad panda.

~~I don't know if this will actually work so simply but there is a `#[serde(flatten)]` attribute that should allow this to be possible.~~

`#[serde(flatten)]` doesn't help without additional proc-macro work (because it can only be applied to structs, not primitives) but using `serde_qs` will solve the problem.