### PR TITLE
fix: lint issues in `erros_axum` example

### DIFF
--- a/examples/errors_axum/Makefile.toml
+++ b/examples/errors_axum/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/errors_axum/src/landing.rs
+++ b/examples/errors_axum/src/landing.rs
@@ -1,7 +1,4 @@
-use crate::{
-    error_template::{ErrorTemplate, ErrorTemplateProps},
-    errors::AppError,
-};
+use crate::{error_template::ErrorTemplate, errors::AppError};
 use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
@@ -54,7 +51,8 @@ pub fn App(cx: Scope) -> impl IntoView {
 
 #[component]
 pub fn ExampleErrors(cx: Scope) -> impl IntoView {
-    let generate_internal_error = create_server_action::<CauseInternalServerError>(cx);
+    let generate_internal_error =
+        create_server_action::<CauseInternalServerError>(cx);
 
     view! { cx,
         <p>

--- a/examples/errors_axum/src/lib.rs
+++ b/examples/errors_axum/src/lib.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-use leptos::*;
 pub mod error_template;
 pub mod errors;
 pub mod fallback;
@@ -8,6 +7,7 @@ pub mod landing;
 // Needs to be in lib.rs AFAIK because wasm-bindgen needs us to be compiling a lib. I may be wrong.
 cfg_if! {
     if #[cfg(feature = "hydrate")] {
+        use leptos::*;
         use wasm_bindgen::prelude::wasm_bindgen;
         use crate::landing::*;
 

--- a/examples/errors_axum/src/main.rs
+++ b/examples/errors_axum/src/main.rs
@@ -37,7 +37,8 @@ async fn custom_handler(
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() {
-    simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
+    simple_logger::init_with_level(log::Level::Debug)
+        .expect("couldn't initialize logging");
 
     crate::landing::register_server_functions();
 
@@ -51,7 +52,11 @@ async fn main() {
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .route("/special/:id", get(custom_handler))
-        .leptos_routes(leptos_options.clone(), routes, |cx| view! { cx, <App/> })
+        .leptos_routes(
+            leptos_options.clone(),
+            routes,
+            |cx| view! { cx, <App/> },
+        )
         .fallback(file_and_error_handler)
         .layer(Extension(Arc::new(leptos_options)));
 


### PR DESCRIPTION
This cleans up the lint issues in the `erros_axum` example.

Verification:

_From the **examples/erros_axum** directory..._

- Run `cargo make check-style`
- Run `cargo leptos watch` and test manually