### PR TITLE
fix: lint issues in `fetch` example

### DIFF
--- a/examples/fetch/Makefile.toml
+++ b/examples/fetch/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -14,7 +14,7 @@ pub enum FetchError {
     #[error("Error loading data from serving.")]
     Request,
     #[error("Error deserializaing cat data from request.")]
-    Json
+    Json,
 }
 
 async fn fetch_cats(count: u32) -> Result<Vec<String>, FetchError> {


### PR DESCRIPTION
This cleans up the lint issues in the `fetch` example.

Verification:

_From the **examples/fetch** directory..._

- Run `cargo make check-style`
- Run `trunk serve --open` and test manually