### PR TITLE
docs: switch from compile errors to runtime warnings for incompatible feature flags

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -240,24 +240,3 @@ pub fn component_props_builder<P: Props>(
 ) -> <P as Props>::Builder {
     <P as Props>::builder()
 }
-
-#[cfg(all(not(doc), feature = "csr", feature = "ssr"))]
-compile_error!(
-    "You have both `csr` and `ssr` enabled as features, which may cause \
-     issues like <Suspense/>` failing to work silently. `csr` is enabled by \
-     default on `leptos`, and can be disabled by adding `default-features = \
-     false` to your `leptos` dependency."
-);
-
-#[cfg(all(not(doc), feature = "hydrate", feature = "ssr"))]
-compile_error!(
-    "You have both `hydrate` and `ssr` enabled as features, which may cause \
-     issues like <Suspense/>` failing to work silently."
-);
-
-#[cfg(all(not(doc), feature = "hydrate", feature = "csr"))]
-compile_error!(
-    "You have both `hydrate` and `csr` enabled as features, which may cause \
-     issues. `csr` is enabled by default on `leptos`, and can be disabled by \
-     adding `default-features = false` to your `leptos` dependency."
-);

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -836,10 +836,11 @@ where
 {
     #[cfg(all(feature = "web", feature = "ssr"))]
     crate::console_warn(
-        "You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
-        issues like <Suspense/>` failing to work silently. `csr` is enabled by \
-        default on `leptos`, and can be disabled by adding `default-features = \
-        false` to your `leptos` dependency."
+        "You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as \
+         features, which may cause issues like <Suspense/>` failing to work \
+         silently. `csr` is enabled by default on `leptos`, and can be \
+         disabled by adding `default-features = false` to your `leptos` \
+         dependency.",
     );
 
     cfg_if! {

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -834,6 +834,14 @@ where
     F: FnOnce(Scope) -> N + 'static,
     N: IntoView,
 {
+    #[cfg(all(feature = "web", feature = "ssr"))]
+    crate::console_warn(
+        "You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
+        issues like <Suspense/>` failing to work silently. `csr` is enabled by \
+        default on `leptos`, and can be disabled by adding `default-features = \
+        false` to your `leptos` dependency."
+    );
+
     cfg_if! {
       if #[cfg(all(target_arch = "wasm32", feature = "web"))] {
         mount_to(crate::document().body().expect("body element to exist"), f)

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -273,10 +273,11 @@ impl View {
     pub fn render_to_string(self, _cx: Scope) -> Cow<'static, str> {
         #[cfg(all(feature = "web", feature = "ssr"))]
         crate::console_error(
-            "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
-            issues like <Suspense/>` failing to work silently. `csr` is enabled by \
-            default on `leptos`, and can be disabled by adding `default-features = \
-            false` to your `leptos` dependency.\n"
+            "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` \
+             enabled as features, which may cause issues like <Suspense/>` \
+             failing to work silently. `csr` is enabled by default on \
+             `leptos`, and can be disabled by adding `default-features = \
+             false` to your `leptos` dependency.\n",
         );
 
         self.render_to_string_helper(false)

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -271,6 +271,14 @@ impl View {
         instrument(level = "info", skip_all,)
     )]
     pub fn render_to_string(self, _cx: Scope) -> Cow<'static, str> {
+        #[cfg(all(feature = "web", feature = "ssr"))]
+        crate::console_error(
+            "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
+            issues like <Suspense/>` failing to work silently. `csr` is enabled by \
+            default on `leptos`, and can be disabled by adding `default-features = \
+            false` to your `leptos` dependency.\n"
+        );
+
         self.render_to_string_helper(false)
     }
 

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -55,6 +55,14 @@ pub fn render_to_stream_in_order_with_prefix(
     view: impl FnOnce(Scope) -> View + 'static,
     prefix: impl FnOnce(Scope) -> Cow<'static, str> + 'static,
 ) -> impl Stream<Item = String> {
+    #[cfg(all(feature = "web", feature = "ssr"))]
+        crate::console_error(
+            "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
+            issues like <Suspense/>` failing to work silently. `csr` is enabled by \
+            default on `leptos`, and can be disabled by adding `default-features = \
+            false` to your `leptos` dependency.\n"
+        );
+
     let (stream, runtime, _) =
         render_to_stream_in_order_with_prefix_undisposed_with_context(
             view,

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -56,12 +56,13 @@ pub fn render_to_stream_in_order_with_prefix(
     prefix: impl FnOnce(Scope) -> Cow<'static, str> + 'static,
 ) -> impl Stream<Item = String> {
     #[cfg(all(feature = "web", feature = "ssr"))]
-        crate::console_error(
-            "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as features, which may cause \
-            issues like <Suspense/>` failing to work silently. `csr` is enabled by \
-            default on `leptos`, and can be disabled by adding `default-features = \
-            false` to your `leptos` dependency.\n"
-        );
+    crate::console_error(
+        "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` \
+         enabled as features, which may cause issues like <Suspense/>` \
+         failing to work silently. `csr` is enabled by default on `leptos`, \
+         and can be disabled by adding `default-features = false` to your \
+         `leptos` dependency.\n",
+    );
 
     let (stream, runtime, _) =
         render_to_stream_in_order_with_prefix_undisposed_with_context(


### PR DESCRIPTION
Compile errors for incompatible feature flag sets cause issues with tools that assume there's no such thing — which is best practice in terms of feature flags, so fair enough. This shifts to runtime warnings in some obvious places if you've goofed up.