### PR TITLE
fix: lint issues in `hackernews` example

### DIFF
--- a/examples/hackernews/Makefile.toml
+++ b/examples/hackernews/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/hackernews/src/lib.rs
+++ b/examples/hackernews/src/lib.rs
@@ -4,10 +4,7 @@ use leptos_meta::*;
 use leptos_router::*;
 mod api;
 mod routes;
-use routes::nav::*;
-use routes::stories::*;
-use routes::story::*;
-use routes::users::*;
+use routes::{nav::*, stories::*, story::*, users::*};
 
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {

--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -7,7 +7,7 @@ cfg_if! {
     if #[cfg(feature = "ssr")] {
         use actix_files::{Files};
         use actix_web::*;
-        use hackernews::{App,AppProps};
+        use hackernews::{App};
         use leptos_actix::{LeptosRoutes, generate_route_list};
 
         #[get("/style.css")]
@@ -46,7 +46,7 @@ cfg_if! {
         }
     } else {
         fn main() {
-            use hackernews::{App, AppProps};
+            use hackernews::{App};
 
             _ = console_log::init_with_level(log::Level::Debug);
             console_error_panic_hook::set_once();

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -1,7 +1,6 @@
+use crate::api;
 use leptos::*;
 use leptos_router::*;
-
-use crate::api;
 
 fn category(from: &str) -> &'static str {
     match from {
@@ -37,8 +36,10 @@ pub fn Stories(cx: Scope) -> impl IntoView {
     );
     let (pending, set_pending) = create_signal(cx, false);
 
-    let hide_more_link =
-        move |cx| pending() || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28;
+    let hide_more_link = move |cx| {
+        pending()
+            || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28
+    };
 
     view! {
         cx,

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -13,11 +13,20 @@ pub fn Story(cx: Scope) -> impl IntoView {
             if id.is_empty() {
                 None
             } else {
-                api::fetch_api::<api::Story>(cx, &api::story(&format!("item/{id}"))).await
+                api::fetch_api::<api::Story>(
+                    cx,
+                    &api::story(&format!("item/{id}")),
+                )
+                .await
             }
         },
     );
-    let meta_description = move || story.read(cx).and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || {
+        story
+            .read(cx)
+            .and_then(|story| story.map(|story| story.title))
+            .unwrap_or_else(|| "Loading story...".to_string())
+    };
 
     view! { cx,
         <>

--- a/examples/hackernews/src/routes/users.rs
+++ b/examples/hackernews/src/routes/users.rs
@@ -31,7 +31,7 @@ pub fn User(cx: Scope) -> impl IntoView {
                                 <li>
                                 <span class="label">"Karma: "</span> {user.karma}
                                 </li>
-                                {user.about.as_ref().map(|about| view! { cx,  <li inner_html=about class="about"></li> })}
+                                <li inner_html={user.about} class="about"></li>
                             </ul>
                             <p class="links">
                                 <a href=format!("https://news.ycombinator.com/submitted?id={}", user.id)>"submissions"</a>


### PR DESCRIPTION
This cleans up the lint issues in the `hackernews` example.

Verification:

_From the **examples/hackernews** directory..._

- Run `cargo make check-style`
- Run `cargo leptos watch` and test manually