### PR TITLE
fix: lint issues in `hackernews_axum` example

### DIFF
--- a/examples/hackernews_axum/Makefile.toml
+++ b/examples/hackernews_axum/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/hackernews_axum/src/error_template.rs
+++ b/examples/hackernews_axum/src/error_template.rs
@@ -1,7 +1,4 @@
-use leptos::{
-    signal_prelude::*, view, Errors, For, ForProps, IntoView, RwSignal, Scope,
-    View,
-};
+use leptos::{view, Errors, For, IntoView, RwSignal, Scope, View};
 
 // A basic function to display errors served by the error boundaries. Feel free to do more complicated things
 // here than just displaying them

--- a/examples/hackernews_axum/src/lib.rs
+++ b/examples/hackernews_axum/src/lib.rs
@@ -7,10 +7,7 @@ pub mod error_template;
 pub mod fallback;
 pub mod handlers;
 mod routes;
-use routes::nav::*;
-use routes::stories::*;
-use routes::story::*;
-use routes::users::*;
+use routes::{nav::*, stories::*, story::*, users::*};
 
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {

--- a/examples/hackernews_axum/src/routes/nav.rs
+++ b/examples/hackernews_axum/src/routes/nav.rs
@@ -1,4 +1,4 @@
-use leptos::{component, Scope, IntoView, view};
+use leptos::{component, view, IntoView, Scope};
 use leptos_router::*;
 
 #[component]

--- a/examples/hackernews_axum/src/routes/stories.rs
+++ b/examples/hackernews_axum/src/routes/stories.rs
@@ -1,7 +1,6 @@
+use crate::api;
 use leptos::*;
 use leptos_router::*;
-
-use crate::api;
 
 fn category(from: &str) -> &'static str {
     match from {
@@ -37,8 +36,10 @@ pub fn Stories(cx: Scope) -> impl IntoView {
     );
     let (pending, set_pending) = create_signal(cx, false);
 
-    let hide_more_link =
-        move || pending() || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28;
+    let hide_more_link = move || {
+        pending()
+            || stories.read(cx).unwrap_or(None).unwrap_or_default().len() < 28
+    };
 
     view! {
         cx,

--- a/examples/hackernews_axum/src/routes/story.rs
+++ b/examples/hackernews_axum/src/routes/story.rs
@@ -13,11 +13,20 @@ pub fn Story(cx: Scope) -> impl IntoView {
             if id.is_empty() {
                 None
             } else {
-                api::fetch_api::<api::Story>(cx, &api::story(&format!("item/{id}"))).await
+                api::fetch_api::<api::Story>(
+                    cx,
+                    &api::story(&format!("item/{id}")),
+                )
+                .await
             }
         },
     );
-    let meta_description = move || story.read(cx).and_then(|story| story.map(|story| story.title)).unwrap_or_else(|| "Loading story...".to_string());
+    let meta_description = move || {
+        story
+            .read(cx)
+            .and_then(|story| story.map(|story| story.title))
+            .unwrap_or_else(|| "Loading story...".to_string())
+    };
 
     view! { cx,
         <>


### PR DESCRIPTION
This cleans up the lint issues in the `hackernews_axum` example.

Verification:

_From the **examples/hackernews_axum** directory..._

- Run `cargo make check-style`
- Run `cargo leptos watch` and test manually