### PR TITLE
fix: lint issues in `login_with_token_csr_only` example

### DIFF
--- a/examples/login_with_token_csr_only/Makefile.toml
+++ b/examples/login_with_token_csr_only/Makefile.toml
@@ -1,3 +1,5 @@
+extend = { path = "../cargo-make/common.toml" }
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/login_with_token_csr_only/api-boundary/Makefile.toml
+++ b/examples/login_with_token_csr_only/api-boundary/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/common.toml" }

--- a/examples/login_with_token_csr_only/client/Makefile.toml
+++ b/examples/login_with_token_csr_only/client/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/common.toml" }

--- a/examples/login_with_token_csr_only/client/src/api.rs
+++ b/examples/login_with_token_csr_only/client/src/api.rs
@@ -1,8 +1,7 @@
+use api_boundary::*;
 use gloo_net::http::{Request, Response};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
-
-use api_boundary::*;
 
 #[derive(Clone, Copy)]
 pub struct UnauthorizedApi {

--- a/examples/login_with_token_csr_only/client/src/components/credentials.rs
+++ b/examples/login_with_token_csr_only/client/src/components/credentials.rs
@@ -20,54 +20,56 @@ pub fn CredentialsForm(
     });
 
     view! { cx,
-      <form on:submit=|ev|ev.prevent_default()>
-        <p>{ title }</p>
-        {move || error.get().map(|err| view!{ cx,
-          <p style ="color:red;" >{ err }</p>
-        })}
-        <input
-          type = "email"
-          required
-          placeholder = "Email address"
-          prop:disabled = move || disabled.get()
-          on:keyup = move |ev: ev::KeyboardEvent| {
-            let val = event_target_value(&ev);
-            set_email.update(|v|*v = val);
-          }
-          // The `change` event fires when the browser fills the form automatically,
-          on:change = move |ev| {
-            let val = event_target_value(&ev);
-            set_email.update(|v|*v = val);
-          }
-        />
-        <input
-          type = "password"
-          required
-          placeholder = "Password"
-          prop:disabled = move || disabled.get()
-          on:keyup = move |ev: ev::KeyboardEvent| {
-            match &*ev.key() {
-                "Enter" => {
-                   dispatch_action();
+        <form on:submit=|ev| ev.prevent_default()>
+            <p>{title}</p>
+            {move || {
+                error
+                    .get()
+                    .map(|err| {
+                        view! { cx, <p style="color:red;">{err}</p> }
+                    })
+            }}
+            <input
+                type="email"
+                required
+                placeholder="Email address"
+                prop:disabled=move || disabled.get()
+                on:keyup=move |ev: ev::KeyboardEvent| {
+                    let val = event_target_value(&ev);
+                    set_email.update(|v| *v = val);
                 }
-                _=> {
-                   let val = event_target_value(&ev);
-                   set_password.update(|p|*p = val);
+                on:change=move |ev| {
+                    let val = event_target_value(&ev);
+                    set_email.update(|v| *v = val);
                 }
-            }
-          }
-          // The `change` event fires when the browser fills the form automatically,
-          on:change = move |ev| {
-            let val = event_target_value(&ev);
-            set_password.update(|p|*p = val);
-          }
-        />
-        <button
-          prop:disabled = move || button_is_disabled.get()
-          on:click = move |_| dispatch_action()
-        >
-        { action_label }
-        </button>
-      </form>
+            />
+            <input
+                type="password"
+                required
+                placeholder="Password"
+                prop:disabled=move || disabled.get()
+                on:keyup=move |ev: ev::KeyboardEvent| {
+                    match &*ev.key() {
+                        "Enter" => {
+                            dispatch_action();
+                        }
+                        _ => {
+                            let val = event_target_value(&ev);
+                            set_password.update(|p| *p = val);
+                        }
+                    }
+                }
+                on:change=move |ev| {
+                    let val = event_target_value(&ev);
+                    set_password.update(|p| *p = val);
+                }
+            />
+            <button
+                prop:disabled=move || button_is_disabled.get()
+                on:click=move |_| dispatch_action()
+            >
+                {action_label}
+            </button>
+        </form>
     }
 }

--- a/examples/login_with_token_csr_only/client/src/components/navbar.rs
+++ b/examples/login_with_token_csr_only/client/src/components/navbar.rs
@@ -1,7 +1,6 @@
+use crate::Page;
 use leptos::*;
 use leptos_router::*;
-
-use crate::Page;
 
 #[component]
 pub fn NavBar<F>(
@@ -13,20 +12,27 @@ where
     F: Fn() + 'static + Clone,
 {
     view! { cx,
-      <nav>
-        <Show
-          when = move || logged_in.get()
-          fallback = |cx| view! { cx,
-            <A href=Page::Login.path() >"Login"</A>
-            " | "
-            <A href=Page::Register.path() >"Register"</A>
-          }
-        >
-          <a href="#" on:click={
-            let on_logout = on_logout.clone();
-            move |_| on_logout()
-          }>"Logout"</a>
-        </Show>
-      </nav>
+        <nav>
+            <Show
+                when=move || logged_in.get()
+                fallback=|cx| {
+                    view! { cx,
+                        <A href=Page::Login.path()>"Login"</A>
+                        " | "
+                        <A href=Page::Register.path()>"Register"</A>
+                    }
+                }
+            >
+                <a
+                    href="#"
+                    on:click={
+                        let on_logout = on_logout.clone();
+                        move |_| on_logout()
+                    }
+                >
+                    "Logout"
+                </a>
+            </Show>
+        </nav>
     }
 }

--- a/examples/login_with_token_csr_only/client/src/lib.rs
+++ b/examples/login_with_token_csr_only/client/src/lib.rs
@@ -1,8 +1,7 @@
+use api_boundary::*;
 use gloo_storage::{LocalStorage, Storage};
 use leptos::*;
 use leptos_router::*;
-
-use api_boundary::*;
 
 mod api;
 mod components;
@@ -86,45 +85,51 @@ pub fn App(cx: Scope) -> impl IntoView {
                     .expect("LocalStorage::set");
             }
             None => {
-                log::debug!("API is no longer authorized: delete token from LocalStorage");
+                log::debug!(
+                    "API is no longer authorized: delete token from \
+                     LocalStorage"
+                );
                 LocalStorage::delete(API_TOKEN_STORAGE_KEY);
             }
         }
     });
 
     view! { cx,
-      <Router>
-        <NavBar logged_in on_logout />
-        <main>
-          <Routes>
-            <Route
-              path=Page::Home.path()
-              view=move |cx| view! { cx,
-                <Home user_info = user_info.into() />
-              }
-            />
-            <Route
-              path=Page::Login.path()
-              view=move |cx| view! { cx,
-                <Login
-                  api = unauthorized_api
-                  on_success = move |api| {
-                      log::info!("Successfully logged in");
-                      authorized_api.update(|v| *v = Some(api));
-                      let navigate = use_navigate(cx);
-                      navigate(Page::Home.path(), Default::default()).expect("Home route");
-                      fetch_user_info.dispatch(());
-                  } />
-              }
-            />
-            <Route
-              path=Page::Register.path()
-              view=move |cx| view! { cx,
-                <Register api = unauthorized_api />
-              }
-            />
-          </Routes>
-        </main>
-      </Router>
+        <Router>
+            <NavBar logged_in on_logout/>
+            <main>
+                <Routes>
+                    <Route
+                        path=Page::Home.path()
+                        view=move |cx| {
+                            view! { cx, <Home user_info=user_info.into()/> }
+                        }
+                    />
+                    <Route
+                        path=Page::Login.path()
+                        view=move |cx| {
+                            view! { cx,
+                                <Login
+                                    api=unauthorized_api
+                                    on_success=move |api| {
+                                        log::info!("Successfully logged in");
+                                        authorized_api.update(|v| *v = Some(api));
+                                        let navigate = use_navigate(cx);
+                                        navigate(Page::Home.path(), Default::default()).expect("Home route");
+                                        fetch_user_info.dispatch(());
+                                    }
+                                />
+                            }
+                        }
+                    />
+                    <Route
+                        path=Page::Register.path()
+                        view=move |cx| {
+                            view! { cx, <Register api=unauthorized_api/> }
+                        }
+                    />
+                </Routes>
+            </main>
+        </Router>
     }
 }

--- a/examples/login_with_token_csr_only/client/src/main.rs
+++ b/examples/login_with_token_csr_only/client/src/main.rs
@@ -1,9 +1,8 @@
-use leptos::*;
-
 use client::*;
+use leptos::*;
 
 pub fn main() {
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
-    mount_to_body(|cx| view! { cx, <App /> })
+    mount_to_body(|cx| view! { cx, <App/> })
 }

--- a/examples/login_with_token_csr_only/client/src/pages/home.rs
+++ b/examples/login_with_token_csr_only/client/src/pages/home.rs
@@ -6,15 +6,19 @@ use leptos_router::*;
 #[component]
 pub fn Home(cx: Scope, user_info: Signal<Option<UserInfo>>) -> impl IntoView {
     view! { cx,
-      <h2>"Leptos Login example"</h2>
-      {move || match user_info.get() {
-        Some(info) => view!{ cx,
-          <p>"You are logged in with "{ info.email }"."</p>
-        }.into_view(cx),
-        None => view!{ cx,
-          <p>"You are not logged in."</p>
-          <A href=Page::Login.path() >"Login now."</A>
-        }.into_view(cx)
-      }}
+        <h2>"Leptos Login example"</h2>
+        {move || match user_info.get() {
+            Some(info) => {
+                view! { cx, <p>"You are logged in with " {info.email} "."</p> }
+                    .into_view(cx)
+            }
+            None => {
+                view! { cx,
+                    <p>"You are not logged in."</p>
+                    <A href=Page::Login.path()>"Login now."</A>
+                }
+                    .into_view(cx)
+            }
+        }}
     }
 }

--- a/examples/login_with_token_csr_only/client/src/pages/login.rs
+++ b/examples/login_with_token_csr_only/client/src/pages/login.rs
@@ -1,13 +1,11 @@
-use leptos::*;
-use leptos_router::*;
-
-use api_boundary::*;
-
 use crate::{
     api::{self, AuthorizedApi, UnauthorizedApi},
     components::credentials::*,
     Page,
 };
+use api_boundary::*;
+use leptos::*;
+use leptos_router::*;
 
 #[component]
 pub fn Login<F>(cx: Scope, api: UnauthorizedApi, on_success: F) -> impl IntoView
@@ -53,14 +51,14 @@ where
     let disabled = Signal::derive(cx, move || wait_for_response.get());
 
     view! { cx,
-      <CredentialsForm
-        title = "Please login to your account"
-        action_label = "Login"
-        action = login_action
-        error = login_error.into()
-        disabled
-      />
-      <p>"Don't have an account?"</p>
-      <A href=Page::Register.path()>"Register"</A>
+        <CredentialsForm
+            title="Please login to your account"
+            action_label="Login"
+            action=login_action
+            error=login_error.into()
+            disabled
+        />
+        <p>"Don't have an account?"</p>
+        <A href=Page::Register.path()>"Register"</A>
     }
 }

--- a/examples/login_with_token_csr_only/client/src/pages/register.rs
+++ b/examples/login_with_token_csr_only/client/src/pages/register.rs
@@ -1,13 +1,11 @@
-use leptos::*;
-use leptos_router::*;
-
-use api_boundary::*;
-
 use crate::{
     api::{self, UnauthorizedApi},
     components::credentials::*,
     Page,
 };
+use api_boundary::*;
+use leptos::*;
+use leptos_router::*;
 
 #[component]
 pub fn Register(cx: Scope, api: UnauthorizedApi) -> impl IntoView {
@@ -52,26 +50,24 @@ pub fn Register(cx: Scope, api: UnauthorizedApi) -> impl IntoView {
     let disabled = Signal::derive(cx, move || wait_for_response.get());
 
     view! { cx,
-      <Show
-        when = move || register_response.get().is_some()
-        fallback = move |_| view!{ cx,
-          <CredentialsForm
-            title = "Please enter the desired credentials"
-            action_label = "Register"
-            action = register_action
-            error = register_error.into()
-            disabled
-          />
-          <p>"Your already have an account?"</p>
-          <A href=Page::Login.path()>"Login"</A>
-        }
-      >
-        <p>"You have successfully registered."</p>
-        <p>
-         "You can now "
-         <A href=Page::Login.path()>"login"</A>
-         " with your new account."
-        </p>
-      </Show>
+        <Show
+            when=move || register_response.get().is_some()
+            fallback=move |_| {
+                view! { cx,
+                    <CredentialsForm
+                        title="Please enter the desired credentials"
+                        action_label="Register"
+                        action=register_action
+                        error=register_error.into()
+                        disabled
+                    />
+                    <p>"Your already have an account?"</p>
+                    <A href=Page::Login.path()>"Login"</A>
+                }
+            }
+        >
+            <p>"You have successfully registered."</p>
+            <p>"You can now " <A href=Page::Login.path()>"login"</A> " with your new account."</p>
+        </Show>
     }
 }

--- a/examples/login_with_token_csr_only/server/Makefile.toml
+++ b/examples/login_with_token_csr_only/server/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/common.toml" }

--- a/examples/login_with_token_csr_only/server/src/adapters.rs
+++ b/examples/login_with_token_csr_only/server/src/adapters.rs
@@ -2,8 +2,7 @@ use crate::{application::*, Error};
 use api_boundary as json;
 use axum::{
     http::StatusCode,
-    response::Json,
-    response::{IntoResponse, Response},
+    response::{IntoResponse, Json, Response},
 };
 use thiserror::Error;
 

--- a/examples/login_with_token_csr_only/server/src/main.rs
+++ b/examples/login_with_token_csr_only/server/src/main.rs
@@ -1,5 +1,4 @@
-use std::{env, sync::Arc};
-
+use api_boundary as json;
 use axum::{
     extract::{State, TypedHeader},
     headers::{authorization::Bearer, Authorization},
@@ -8,9 +7,8 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use std::{env, sync::Arc};
 use tower_http::cors::{Any, CorsLayer};
-
-use api_boundary as json;
 
 mod adapters;
 mod application;
@@ -25,7 +23,10 @@ async fn main() -> anyhow::Result<()> {
                 env::set_var("RUST_LOG", "debug");
             }
             env::VarError::NotUnicode(_) => {
-                return Err(anyhow::anyhow!("The value of 'RUST_LOG' does not contain valid unicode data."));
+                return Err(anyhow::anyhow!(
+                    "The value of 'RUST_LOG' does not contain valid unicode \
+                     data."
+                ));
             }
         }
     }


### PR DESCRIPTION
This cleans up the lint issues in the `login_with_token_csr_only` example.

Verification:

- Run `cargo make check-style` from the **examples/login_with_token_csr_only** directory
- Run `cargo make check-style` from the **examples/login_with_token_csr_only/api-boundary** directory
- Run `cargo make check-style` from the **examples/login_with_token_csr_only/client** directory
- Run `cargo make check-style` from the **examples/login_with_token_csr_only/server** directory
- Manually test web application