### PR TITLE
fix: lint issues in `router` example

### DIFF
--- a/examples/router/Makefile.toml
+++ b/examples/router/Makefile.toml
@@ -1,3 +1,5 @@
+extend = { path = "../cargo-make/common.toml" }
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -107,7 +107,7 @@ pub fn ContactList(cx: Scope) -> impl IntoView {
             <Suspense fallback=move || view! { cx,  <p>"Loading contacts..."</p> }>
                 {move || view! { cx, <ul>{contacts}</ul>}}
             </Suspense>
-            <AnimatedOutlet 
+            <AnimatedOutlet
                 class="outlet"
                 outro="fadeOut"
                 intro="fadeIn"


### PR DESCRIPTION
This cleans up the lint issues in the `router` example.

Verification:

_From the **examples/router** directory..._

- Run `cargo make check-style`
- Manually test web application