### PR TITLE
fix: lint issues in `todo_app_sqlite` example

### DIFF
--- a/examples/todo_app_sqlite/Makefile.toml
+++ b/examples/todo_app_sqlite/Makefile.toml
@@ -1,3 +1,5 @@
+extend = { path = "../cargo-make/common.toml" }
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/todo_app_sqlite/src/lib.rs
+++ b/examples/todo_app_sqlite/src/lib.rs
@@ -1,10 +1,10 @@
 use cfg_if::cfg_if;
-use leptos::*;
 pub mod todo;
 
 // Needs to be in lib.rs AFAIK because wasm-bindgen needs us to be compiling a lib. I may be wrong.
 cfg_if! {
     if #[cfg(feature = "hydrate")] {
+        use leptos::*;
         use wasm_bindgen::prelude::wasm_bindgen;
         use crate::todo::*;
 

--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -29,7 +29,7 @@ cfg_if! {
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
 
-            let addr = conf.leptos_options.site_addr.clone();
+            let addr = conf.leptos_options.site_addr;
 
             // Generate the list of routes in your Leptos App
             let routes = generate_route_list(|cx| view! { cx, <TodoApp/> });
@@ -43,7 +43,7 @@ cfg_if! {
                     .service(css)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
                     .leptos_routes(leptos_options.to_owned(), routes.to_owned(), |cx| view! { cx, <TodoApp/> })
-                    .service(Files::new("/", &site_root))
+                    .service(Files::new("/", site_root))
                     //.wrap(middleware::Compress::default())
             })
             .bind(addr)?

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -9,7 +9,7 @@ cfg_if! {
         use sqlx::{Connection, SqliteConnection};
 
         pub async fn db() -> Result<SqliteConnection, ServerFnError> {
-            Ok(SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))?)
+            SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
         }
 
         pub fn register_server_functions() {
@@ -37,18 +37,18 @@ cfg_if! {
 #[server(GetTodos, "/api")]
 pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     // this is just an example of how to access server context injected in the handlers
-    let req =
-        use_context::<actix_web::HttpRequest>(cx);
-    
-    if let Some(req) = req{
-    println!("req.path = {:#?}", req.path());
+    let req = use_context::<actix_web::HttpRequest>(cx);
+
+    if let Some(req) = req {
+        println!("req.path = {:#?}", req.path());
     }
     use futures::TryStreamExt;
 
     let mut conn = db().await?;
 
     let mut todos = Vec::new();
-    let mut rows = sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
+    let mut rows =
+        sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
     while let Some(row) = rows
         .try_next()
         .await
@@ -73,7 +73,7 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
         .execute(&mut conn)
         .await
     {
-        Ok(row) => Ok(()),
+        Ok(_row) => Ok(()),
         Err(e) => Err(ServerFnError::ServerError(e.to_string())),
     }
 }
@@ -130,7 +130,7 @@ pub fn Todos(cx: Scope) -> impl IntoView {
         cx,
         <div>
             <MultiActionForm
-                // we can handle client-side validation in the on:submit event 
+                // we can handle client-side validation in the on:submit event
                 // leptos_router implements a `FromFormData` trait that lets you
                 // parse deserializable types from form data and check them
                 on:submit=move |ev| {


### PR DESCRIPTION
This cleans up the lint issues in the `todo_app_sqlite` example.

Verification:

_From the **examples/todo_app_sqlite** directory..._

- Run `cargo make check-style`
- Manually test web application