### PR TITLE
fix: lint issues in `todo_app_sqlite_axum` example

### DIFF
--- a/examples/todo_app_sqlite_axum/Makefile.toml
+++ b/examples/todo_app_sqlite_axum/Makefile.toml
@@ -1,3 +1,5 @@
+extend = { path = "../cargo-make/common.toml" }
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/todo_app_sqlite_axum/src/lib.rs
+++ b/examples/todo_app_sqlite_axum/src/lib.rs
@@ -1,5 +1,4 @@
 use cfg_if::cfg_if;
-use leptos::*;
 pub mod error_template;
 pub mod errors;
 pub mod fallback;
@@ -8,6 +7,7 @@ pub mod todo;
 // Needs to be in lib.rs AFAIK because wasm-bindgen needs us to be compiling a lib. I may be wrong.
 cfg_if! {
     if #[cfg(feature = "hydrate")] {
+        use leptos::*;
         use wasm_bindgen::prelude::wasm_bindgen;
         use crate::todo::*;
 

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -1,8 +1,8 @@
 use cfg_if::cfg_if;
-use leptos::*;
 // boilerplate to run in different modes
 cfg_if! {
-if #[cfg(feature = "ssr")] {
+    if #[cfg(feature = "ssr")] {
+    use leptos::*;
     use axum::{
         routing::{post, get},
         extract::{Extension, Path},

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -1,4 +1,4 @@
-use crate::error_template::{ErrorTemplate, ErrorTemplateProps};
+use crate::error_template::ErrorTemplate;
 use cfg_if::cfg_if;
 use leptos::*;
 use leptos_meta::*;


### PR DESCRIPTION
This cleans up the lint issues in the `todo_app_sqlite_axum` example.

Verification:

_From the **examples/todo_app_sqlite_axum** directory..._

- Run `cargo make check-style`
- Manually test web application