### PR TITLE
fix: lint issues in `todomvc` example

### DIFF
--- a/examples/todomvc/Makefile.toml
+++ b/examples/todomvc/Makefile.toml
@@ -1,3 +1,5 @@
+extend = { path = "../cargo-make/common.toml" }
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -136,7 +136,7 @@ pub fn TodoMVC(cx: Scope) -> impl IntoView {
 
     // Handle the three filter modes: All, Active, and Completed
     let (mode, set_mode) = create_signal(cx, Mode::All);
-    window_event_listener("hashchange", move |_| {
+    window_event_listener_untyped("hashchange", move |_| {
         let new_mode =
             location_hash().map(|hash| route(&hash)).unwrap_or_default();
         set_mode(new_mode);
@@ -202,15 +202,15 @@ pub fn TodoMVC(cx: Scope) -> impl IntoView {
         }
     });
 
-    // focus the main input on load  
+    // focus the main input on load
     create_effect(cx, move |_| {
         if let Some(input) = input_ref.get() {
-            // We use request_animation_frame here because the NodeRef 
-            // is filled when the element is created, but before it's mounted 
+            // We use request_animation_frame here because the NodeRef
+            // is filled when the element is created, but before it's mounted
             // to the DOM. Calling .focus() before it's mounted does nothing.
             // So inside, we wait a tick for the browser to mount it, then .focus()
             request_animation_frame(move || {
-                input.focus();
+                let _ = input.focus();
             });
         }
     });
@@ -348,17 +348,12 @@ pub fn Todo(cx: Scope, todo: Todo) -> impl IntoView {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     Active,
     Completed,
+    #[default]
     All,
-}
-
-impl Default for Mode {
-    fn default() -> Self {
-        Mode::All
-    }
 }
 
 pub fn route(hash: &str) -> Mode {

--- a/examples/todomvc/src/storage.rs
+++ b/examples/todomvc/src/storage.rs
@@ -1,33 +1,27 @@
 use crate::Todo;
-use leptos::{
-  signal_prelude::*,
-  Scope,
-};
-use serde::{
-  Deserialize,
-  Serialize,
-};
+use leptos::{signal_prelude::*, Scope};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
 pub struct TodoSerialized {
-  pub id: Uuid,
-  pub title: String,
-  pub completed: bool,
+    pub id: Uuid,
+    pub title: String,
+    pub completed: bool,
 }
 
 impl TodoSerialized {
-  pub fn into_todo(self, cx: Scope) -> Todo {
-    Todo::new_with_completed(cx, self.id, self.title, self.completed)
-  }
+    pub fn into_todo(self, cx: Scope) -> Todo {
+        Todo::new_with_completed(cx, self.id, self.title, self.completed)
+    }
 }
 
 impl From<&Todo> for TodoSerialized {
-  fn from(todo: &Todo) -> Self {
-    Self {
-      id: todo.id,
-      title: todo.title.get(),
-      completed: todo.completed.get(),
+    fn from(todo: &Todo) -> Self {
+        Self {
+            id: todo.id,
+            title: todo.title.get(),
+            completed: todo.completed.get(),
+        }
     }
-  }
 }


### PR DESCRIPTION
This cleans up the lint issues in the `todomvc` example.

Verification:

_From the **examples/todomvc** directory..._

- Run `cargo make check-style`
- Manually test web application