### PR TITLE
test: lint examples with --all-features

### DIFF
--- a/examples/cargo-make/common.toml
+++ b/examples/cargo-make/common.toml
@@ -1,5 +1,5 @@
-[env]
-CARGO_MAKE_CLIPPY_ARGS = "--all-targets -- -D warnings"
+[tasks.pre-clippy]
+env = { CARGO_MAKE_CLIPPY_ARGS = "--all-targets --all-features -- -D warnings" }
 
 [tasks.check-style]
 description = "Check for style violations"

--- a/examples/counter_isomorphic/src/main.rs
+++ b/examples/counter_isomorphic/src/main.rs
@@ -37,7 +37,7 @@ cfg_if! {
             // when not using cargo-leptos None must be replaced with Some("Cargo.toml")
             let conf = get_configuration(None).await.unwrap();
 
-            let addr = conf.leptos_options.site_addr.clone();
+            let addr = conf.leptos_options.site_addr;
             let routes = generate_route_list(|cx| view! { cx, <Counters/> });
 
             HttpServer::new(move || {
@@ -48,7 +48,7 @@ cfg_if! {
                     .service(counter_events)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
                     .leptos_routes(leptos_options.to_owned(), routes.to_owned(), |cx| view! { cx, <Counters/> })
-                    .service(Files::new("/", &site_root))
+                    .service(Files::new("/", site_root))
                     //.wrap(middleware::Compress::default())
             })
             .bind(&addr)?

--- a/examples/errors_axum/src/fallback.rs
+++ b/examples/errors_axum/src/fallback.rs
@@ -11,8 +11,8 @@ cfg_if! { if #[cfg(feature = "ssr")] {
     use tower::ServiceExt;
     use tower_http::services::ServeDir;
     use std::sync::Arc;
-    use leptos::{LeptosOptions, Errors, view};
-    use crate::landing::{App, AppProps};
+    use leptos::{LeptosOptions, view};
+    use crate::landing::App;
 
     pub async fn file_and_error_handler(uri: Uri, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<Body>) -> AxumResponse {
         let options = &*options;

--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -24,7 +24,7 @@ cfg_if! {
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
 
-            let addr = conf.leptos_options.site_addr.clone();
+            let addr = conf.leptos_options.site_addr;
             // Generate the list of routes in your Leptos App
             let routes = generate_route_list(|cx| view! { cx, <App/> });
 
@@ -37,7 +37,7 @@ cfg_if! {
                     .service(favicon)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
                     .leptos_routes(leptos_options.to_owned(), routes.to_owned(), |cx| view! { cx, <App/> })
-                    .service(Files::new("/", &site_root))
+                    .service(Files::new("/", site_root))
                 //.wrap(middleware::Compress::default())
             })
             .bind(&addr)?

--- a/examples/hackernews_axum/src/api.rs
+++ b/examples/hackernews_axum/src/api.rs
@@ -1,4 +1,4 @@
-use leptos::{on_cleanup, Scope, Serializable};
+use leptos::{Scope, Serializable};
 use serde::{Deserialize, Serialize};
 
 pub fn story(path: &str) -> String {
@@ -29,7 +29,7 @@ where
 
     // abort in-flight requests if the Scope is disposed
     // i.e., if we've navigated away from this page
-    on_cleanup(cx, move || {
+    leptos::on_cleanup(cx, move || {
         if let Some(abort_controller) = abort_controller {
             abort_controller.abort()
         }
@@ -38,7 +38,7 @@ where
 }
 
 #[cfg(feature = "ssr")]
-pub async fn fetch_api<T>(cx: Scope, path: &str) -> Option<T>
+pub async fn fetch_api<T>(_cx: Scope, path: &str) -> Option<T>
 where
     T: Serializable,
 {

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -19,7 +19,7 @@ if #[cfg(feature = "ssr")] {
 
         let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
         let leptos_options = conf.leptos_options;
-        let addr = leptos_options.site_addr.clone();
+        let addr = leptos_options.site_addr;
         let routes = generate_route_list(|cx| view! { cx, <App/> }).await;
 
         simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");

--- a/examples/session_auth_axum/src/fallback.rs
+++ b/examples/session_auth_axum/src/fallback.rs
@@ -13,7 +13,7 @@ if #[cfg(feature = "ssr")] {
     use tower_http::services::ServeDir;
     use std::sync::Arc;
     use leptos::{LeptosOptions, Errors, view};
-    use crate::error_template::{ErrorTemplate, ErrorTemplateProps};
+    use crate::error_template::ErrorTemplate;
     use crate::errors::TodoAppError;
 
     pub async fn file_and_error_handler(uri: Uri, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<Body>) -> AxumResponse {

--- a/examples/session_auth_axum/src/main.rs
+++ b/examples/session_auth_axum/src/main.rs
@@ -5,7 +5,7 @@ cfg_if! {
 if #[cfg(feature = "ssr")] {
     use axum::{
         response::{Response, IntoResponse},
-        routing::{post, get},
+        routing::get,
         extract::{Path, Extension, RawQuery},
         http::{Request, header::HeaderMap},
         body::Body as AxumBody,
@@ -16,7 +16,7 @@ if #[cfg(feature = "ssr")] {
     use session_auth_axum::*;
     use session_auth_axum::fallback::file_and_error_handler;
     use leptos_axum::{generate_route_list, LeptosRoutes, handle_server_fns_with_context};
-    use leptos::{log, view, provide_context, LeptosOptions, get_configuration, ServerFnError};
+    use leptos::{log, view, provide_context, LeptosOptions, get_configuration};
     use std::sync::Arc;
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use axum_database_sessions::{SessionConfig, SessionLayer, SessionStore};

--- a/examples/session_auth_axum/src/todo.rs
+++ b/examples/session_auth_axum/src/todo.rs
@@ -20,15 +20,15 @@ if #[cfg(feature = "ssr")] {
     use sqlx::SqlitePool;
 
     pub fn pool(cx: Scope) -> Result<SqlitePool, ServerFnError> {
-        Ok(use_context::<SqlitePool>(cx)
+       use_context::<SqlitePool>(cx)
             .ok_or("Pool missing.")
-            .map_err(|e| ServerFnError::ServerError(e.to_string()))?)
+            .map_err(|e| ServerFnError::ServerError(e.to_string()))
     }
 
     pub fn auth(cx: Scope) -> Result<AuthSession, ServerFnError> {
-        Ok(use_context::<AuthSession>(cx)
+        use_context::<AuthSession>(cx)
             .ok_or("Auth session missing.")
-            .map_err(|e| ServerFnError::ServerError(e.to_string()))?)
+            .map_err(|e| ServerFnError::ServerError(e.to_string()))
     }
 
     pub fn register_server_functions() {

--- a/examples/ssr_modes/Makefile.toml
+++ b/examples/ssr_modes/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/ssr_modes/src/main.rs
+++ b/examples/ssr_modes/src/main.rs
@@ -12,8 +12,8 @@ async fn main() -> std::io::Result<()> {
     // Generate the list of routes in your Leptos App
     let routes = generate_route_list(|cx| view! { cx, <App/> });
 
-    GetPost::register();
-    ListPostMetadata::register();
+    let _ = GetPost::register();
+    let _ = ListPostMetadata::register();
 
     HttpServer::new(move || {
         let leptos_options = &conf.leptos_options;

--- a/examples/ssr_modes_axum/Makefile.toml
+++ b/examples/ssr_modes_axum/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/ssr_modes_axum/src/fallback.rs
+++ b/examples/ssr_modes_axum/src/fallback.rs
@@ -11,8 +11,8 @@ cfg_if! { if #[cfg(feature = "ssr")] {
     use tower::ServiceExt;
     use tower_http::services::ServeDir;
     use std::sync::Arc;
-    use leptos::{LeptosOptions, Errors, view};
-    use crate::app::{App, AppProps};
+    use leptos::{LeptosOptions, view};
+    use crate::app::App;
 
     pub async fn file_and_error_handler(uri: Uri, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<Body>) -> AxumResponse {
         let options = &*options;

--- a/examples/ssr_modes_axum/src/main.rs
+++ b/examples/ssr_modes_axum/src/main.rs
@@ -1,11 +1,7 @@
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() {
-    use axum::{
-        extract::{Extension, Path},
-        routing::{get, post},
-        Router,
-    };
+    use axum::{extract::Extension, routing::post, Router};
     use leptos::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
     use ssr_modes_axum::{app::*, fallback::file_and_error_handler};
@@ -17,8 +13,8 @@ async fn main() {
     // Generate the list of routes in your Leptos App
     let routes = generate_route_list(|cx| view! { cx, <App/> }).await;
 
-    GetPost::register();
-    ListPostMetadata::register();
+    let _ = GetPost::register();
+    let _ = ListPostMetadata::register();
 
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))

--- a/examples/tailwind/Makefile.toml
+++ b/examples/tailwind/Makefile.toml
@@ -1,3 +1,5 @@
+extend = [{ path = "../cargo-make/common.toml" }]
+
 [tasks.build]
 command = "cargo"
 args = ["+nightly", "build-all-features"]

--- a/examples/tailwind/src/main.rs
+++ b/examples/tailwind/src/main.rs
@@ -20,7 +20,7 @@ cfg_if! {
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
 
-            let addr = conf.leptos_options.site_addr.clone();
+            let addr = conf.leptos_options.site_addr;
 
             // Generate the list of routes in your Leptos App
             let routes = generate_route_list(|cx| view! { cx, <App/> });
@@ -32,7 +32,7 @@ cfg_if! {
                 App::new()
                     .service(css)
                     .leptos_routes(leptos_options.to_owned(), routes.to_owned(), |cx| view! { cx, <App/> })
-                    .service(Files::new("/", &site_root))
+                    .service(Files::new("/", site_root))
                     .wrap(middleware::Compress::default())
             })
             .bind(&addr)?

--- a/examples/todo_app_sqlite_axum/src/fallback.rs
+++ b/examples/todo_app_sqlite_axum/src/fallback.rs
@@ -13,7 +13,7 @@ if #[cfg(feature = "ssr")] {
     use tower_http::services::ServeDir;
     use std::sync::Arc;
     use leptos::{LeptosOptions, Errors, view};
-    use crate::error_template::{ErrorTemplate, ErrorTemplateProps};
+    use crate::error_template::ErrorTemplate;
     use crate::errors::TodoAppError;
 
     pub async fn file_and_error_handler(uri: Uri, Extension(options): Extension<Arc<LeptosOptions>>, req: Request<Body>) -> AxumResponse {

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -32,7 +32,7 @@ cfg_if! {
     async fn main() {
         simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
-        let conn = db().await.expect("couldn't connect to DB");
+        let _conn = db().await.expect("couldn't connect to DB");
         /* sqlx::migrate!()
             .run(&mut conn)
             .await

--- a/examples/todo_app_sqlite_viz/src/fallback.rs
+++ b/examples/todo_app_sqlite_viz/src/fallback.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 cfg_if! {
 if #[cfg(feature = "ssr")] {
     use crate::{
-        error_template::{ErrorTemplate, ErrorTemplateProps},
+        error_template::ErrorTemplate,
         errors::TodoAppError,
     };
     use http::Uri;
@@ -22,7 +22,7 @@ if #[cfg(feature = "ssr")] {
             Error::Responder(Response::text("missing state type LeptosOptions")),
         )?;
         let root = &options.site_root;
-        let resp = get_static_file(uri, &root, headers, route_info).await?;
+        let resp = get_static_file(uri, root, headers, route_info).await?;
         let status = resp.status();
 
         if status.is_success() || status.is_redirection() {

--- a/examples/todo_app_sqlite_viz/src/main.rs
+++ b/examples/todo_app_sqlite_viz/src/main.rs
@@ -35,7 +35,7 @@ cfg_if! {
         simple_logger::init_with_level(log::Level::Debug)
             .expect("couldn't initialize logging");
 
-        let conn = db().await.expect("couldn't connect to DB");
+        let _conn = db().await.expect("couldn't connect to DB");
         /* sqlx::migrate!()
         .run(&mut conn)
         .await


### PR DESCRIPTION
This improves linting and cleans up related issues. The recent switch from compile errors to runtime warnings for incompatible feature flags made it possible to use the --all-features with clippy.

Verification:

- Run `cargo make verify-examples` from **leptos** root directory
- Manually test web applications
  - `counter_isomorphic`
  - `errors_axum`
  - `hackernews`
  - `hackernews_axum`
  - `session_auth_axum`
  - `ssr_modes`
  - `ssr_modes_axum`
  - `tailwind`
  - `todo_app_sqlite_axum`
  - `todo_app_sqlite_viz`