### PR TITLE
Relax Debug trait bounds

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -81,7 +81,7 @@ pub fn create_resource<S, T, Fu>(
     fetcher: impl Fn(S) -> Fu + 'static,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: Serializable + 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -119,7 +119,7 @@ pub fn create_resource_with_initial_value<S, T, Fu>(
     initial_value: Option<T>,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: Serializable + 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -165,7 +165,7 @@ pub fn create_blocking_resource<S, T, Fu>(
     fetcher: impl Fn(S) -> Fu + 'static,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: Serializable + 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -186,7 +186,7 @@ fn create_resource_helper<S, T, Fu>(
     serializable: ResourceSerialization,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: Serializable + 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -290,7 +290,7 @@ pub fn create_local_resource<S, T, Fu>(
     fetcher: impl Fn(S) -> Fu + 'static,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -324,7 +324,7 @@ pub fn create_local_resource_with_initial_value<S, T, Fu>(
     initial_value: Option<T>,
 ) -> Resource<S, T>
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: 'static,
     Fu: Future<Output = T> + 'static,
 {
@@ -380,7 +380,7 @@ where
 #[cfg(not(feature = "hydrate"))]
 fn load_resource<S, T>(_cx: Scope, _id: ResourceId, r: Rc<ResourceState<S, T>>)
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: 'static,
 {
     SUPPRESS_RESOURCE_LOAD.with(|s| {
@@ -393,7 +393,7 @@ where
 #[cfg(feature = "hydrate")]
 fn load_resource<S, T>(cx: Scope, id: ResourceId, r: Rc<ResourceState<S, T>>)
 where
-    S: PartialEq + Debug + Clone + 'static,
+    S: PartialEq + Clone + 'static,
     T: Serializable + 'static,
 {
     use wasm_bindgen::{JsCast, UnwrapThrowExt};

--- a/leptos_reactive/src/selector.rs
+++ b/leptos_reactive/src/selector.rs
@@ -3,9 +3,7 @@ use crate::{
     create_isomorphic_effect, create_signal, ReadSignal, Scope, SignalUpdate,
     WriteSignal,
 };
-use std::{
-    cell::RefCell, collections::HashMap, hash::Hash, rc::Rc,
-};
+use std::{cell::RefCell, collections::HashMap, hash::Hash, rc::Rc};
 
 /// Creates a conditional signal that only notifies subscribers when a change
 /// in the source signal’s value changes whether it is equal to the key value

--- a/leptos_reactive/src/selector.rs
+++ b/leptos_reactive/src/selector.rs
@@ -4,7 +4,7 @@ use crate::{
     WriteSignal,
 };
 use std::{
-    cell::RefCell, collections::HashMap, fmt::Debug, hash::Hash, rc::Rc,
+    cell::RefCell, collections::HashMap, hash::Hash, rc::Rc,
 };
 
 /// Creates a conditional signal that only notifies subscribers when a change
@@ -52,7 +52,7 @@ pub fn create_selector<T>(
     source: impl Fn() -> T + Clone + 'static,
 ) -> impl Fn(T) -> bool + Clone
 where
-    T: PartialEq + Eq + Debug + Clone + Hash + 'static,
+    T: PartialEq + Eq + Clone + Hash + 'static,
 {
     create_selector_with_fn(cx, source, PartialEq::eq)
 }
@@ -69,7 +69,7 @@ pub fn create_selector_with_fn<T>(
     f: impl Fn(&T, &T) -> bool + Clone + 'static,
 ) -> impl Fn(T) -> bool + Clone
 where
-    T: PartialEq + Eq + Debug + Clone + Hash + 'static,
+    T: PartialEq + Eq + Clone + Hash + 'static,
 {
     #[allow(clippy::type_complexity)]
     let subs: Rc<

--- a/router/src/hooks.rs
+++ b/router/src/hooks.rs
@@ -36,7 +36,7 @@ pub fn use_params_map(cx: Scope) -> Memo<ParamsMap> {
 /// Returns the current route params, parsed into the given type, or an error.
 pub fn use_params<T: Params>(cx: Scope) -> Memo<Result<T, ParamsError>>
 where
-    T: PartialEq + std::fmt::Debug,
+    T: PartialEq,
 {
     let route = use_route(cx);
     create_memo(cx, move |_| route.params().with(T::from_map))
@@ -50,7 +50,7 @@ pub fn use_query_map(cx: Scope) -> Memo<ParamsMap> {
 /// Returns the current URL search query, parsed into the given type, or an error.
 pub fn use_query<T: Params>(cx: Scope) -> Memo<Result<T, ParamsError>>
 where
-    T: PartialEq + std::fmt::Debug,
+    T: PartialEq,
 {
     let router = use_router(cx);
     create_memo(cx, move |_| {


### PR DESCRIPTION
Remove unneccesary `std::fmt::Debug` trait bounds on some functions.