### PR TITLE
docs: add examples for manual server integration

### DIFF
--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -135,14 +135,14 @@ impl History for BrowserIntegration {
 
 /// The wrapper type that the [Router](crate::Router) uses to interact with a [History].
 /// This is automatically provided in the browser. For the server, it should be provided
-/// as a context.
+/// as a context. Be sure that it can survive conversion to a URL in the browser.
 ///
 /// ```
 /// # use leptos_router::*;
 /// # use leptos::*;
 /// # run_scope(create_runtime(), |cx| {
 /// let integration = ServerIntegration {
-///     path: "insert/current/path/here".to_string(),
+///     path: "http://leptos.rs/".to_string(),
 /// };
 /// provide_context(cx, RouterIntegrationContext::new(integration));
 /// # });
@@ -167,7 +167,24 @@ impl History for RouterIntegrationContext {
     }
 }
 
-/// A generic router integration for the server side. All its need is the current path.
+/// A generic router integration for the server side.
+///
+/// This should match what the browser history will show.
+///
+/// Generally, this will already be provided if your are using the leptos
+/// server integrations.
+///
+/// ```
+/// # use leptos_router::*;
+/// # use leptos::*;
+/// # run_scope(create_runtime(), |cx| {
+/// let integration = ServerIntegration {
+///     // Swap out with your URL if integrating manually.
+///     path: "http://leptos.rs/".to_string(),
+/// };
+/// provide_context(cx, RouterIntegrationContext::new(integration));
+/// # });
+/// ```
 #[derive(Clone, Debug)]
 pub struct ServerIntegration {
     pub path: String,

--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -171,7 +171,7 @@ impl History for RouterIntegrationContext {
 ///
 /// This should match what the browser history will show.
 ///
-/// Generally, this will already be provided if your are using the leptos
+/// Generally, this will already be provided if you are using the leptos
 /// server integrations.
 ///
 /// ```


### PR DESCRIPTION
This could be a bit more verbose for people wanting to write their own integration with the router.

I copied the examples from how `ServerIntegration` is used [here](https://github.com/leptos-rs/leptos/blob/72414b7945dee81c37833b44b54285a36393dfc8/router/src/extract_routes.rs#LL61C51-L61C51).

probably should have opened an issue first before opening this, but alas. Likely an obvious thing for someone familiar with web, but more docs on finer details can be appreciated by newer people.