### PR TITLE
Clean up examples after verification

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,7 +69,11 @@ dependencies = [
 
 [tasks.test]
 clear = true
-dependencies = ["test-all", "test-leptos_macro-example", "doc-leptos_macro-example"]
+dependencies = [
+	"test-all",
+	"test-leptos_macro-example",
+	"doc-leptos_macro-example",
+]
 
 [tasks.test-all]
 command = "cargo"
@@ -102,9 +106,15 @@ cwd = "examples"
 command = "cargo"
 args = ["make", "verify-flow"]
 
+[tasks.clean-examples]
+description = "Clean all example projects"
+cwd = "examples"
+command = "cargo"
+args = ["make", "clean-all"]
+
 [env]
 RUSTFLAGS = ""
-LEPTOS_OUTPUT_NAME="ci" # allows examples to check/build without cargo-leptos
+LEPTOS_OUTPUT_NAME = "ci" # allows examples to check/build without cargo-leptos
 
 [env.github-actions]
 RUSTFLAGS = "-D warnings"

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -44,6 +44,7 @@ dependencies = ["test-flow", "web-test-flow"]
 [tasks.pre-verify]
 
 [tasks.post-verify]
+dependencies = ["clean-all"]
 
 [tasks.web-test-flow]
 description = "Provides pre and post hooks for web-test"

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -31,7 +31,7 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 
 [tasks.verify-flow]
 description = "Provides pre and post hooks for verify"
-dependencies = ["pre-verify-flow", "verify", "post-verify-flow"]
+dependencies = ["pre-verify", "verify", "post-verify"]
 
 [tasks.verify]
 description = "Run all quality checks and tests"
@@ -41,16 +41,16 @@ dependencies = ["check-style", "test-unit-and-web"]
 description = "Run all unit and web tests"
 dependencies = ["test-flow", "web-test-flow"]
 
-[tasks.pre-verify-flow]
+[tasks.pre-verify]
 
-[tasks.post-verify-flow]
+[tasks.post-verify]
 
 [tasks.web-test-flow]
 description = "Provides pre and post hooks for web-test"
-dependencies = ["pre-web-test-flow", "web-test", "post-web-test-flow"]
+dependencies = ["pre-web-test", "web-test", "post-web-test"]
 
-[tasks.pre-web-test-flow]
+[tasks.pre-web-test]
 
 [tasks.web-test]
 
-[tasks.post-web-test-flow]
+[tasks.post-web-test]

--- a/examples/cargo-make/common.toml
+++ b/examples/cargo-make/common.toml
@@ -12,3 +12,12 @@ dependencies = ["check-style", "test-local"]
 [tasks.test-local]
 description = "Run all tests from an example directory"
 dependencies = ["test", "web-test"]
+
+[tasks.clean-trunk]
+description = "Runs the trunk clean command."
+category = "Cleanup"
+command = "trunk"
+args = ["clean"]
+
+[tasks.clean-all]
+dependencies = ["clean", "clean-trunk"]


### PR DESCRIPTION
This reduces the storage space costs of running `cargo make verify-examples`.

`verify-examples` will now clean up cargo and trunk files as it goes along.

Verification:

- Run `cargo make verify-examples` and see target and dist folders are not present in examples.