### PR TITLE
fix: corrects error-deserialization behavior of `ActionForm` (closes #1024)

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -28,6 +28,7 @@ js-sys = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
 lru = { version = "0.10", optional = true }
+serde_json = "1.0.96"
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
fix #1024