### PR TITLE
fix: flicking `<Transition/>` in release mode (closes #960)

### DIFF
--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -66,7 +66,7 @@ pub fn Suspense<F, E, V>(
 where
     F: Fn() -> E + 'static,
     E: IntoView,
-    V: IntoView + 'static
+    V: IntoView + 'static,
 {
     let context = SuspenseContext::new(cx);
 

--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -92,7 +92,7 @@ where
                         cx.run_child_scope(|cx| if context.ready() {
                         Fragment::lazy(Box::new(|| vec![orig_child(cx).into_view(cx)])).into_view(cx)
                     } else {
-                        Fragment::lazy(Box::new(|| vec![orig_child(cx).into_view(cx)])).into_view(cx)
+                        Fragment::lazy(Box::new(|| vec![fallback().into_view(cx)])).into_view(cx)
                     });
                     *prev_disposer.borrow_mut() = Some(disposer);
                     view

--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -1,7 +1,5 @@
 use cfg_if::cfg_if;
-use leptos_dom::{DynChild, HydrationCtx, IntoView};
-#[cfg(not(any(feature = "csr", feature = "hydrate")))]
-use leptos_dom::Fragment;
+use leptos_dom::{DynChild, Fragment, HydrationCtx, IntoView};
 use leptos_macro::component;
 #[cfg(any(feature = "csr", feature = "hydrate"))]
 use leptos_reactive::ScopeDisposer;

--- a/leptos/src/suspense.rs
+++ b/leptos/src/suspense.rs
@@ -1,6 +1,6 @@
 use cfg_if::cfg_if;
 use leptos_dom::{DynChild, HydrationCtx, IntoView};
-#[cfg(not(feature = "csr", feature = "hydrate"))]
+#[cfg(not(any(feature = "csr", feature = "hydrate")))]
 use leptos_dom::Fragment;
 use leptos_macro::component;
 #[cfg(any(feature = "csr", feature = "hydrate"))]

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -78,7 +78,7 @@ where
     F: Fn() -> E + 'static,
     E: IntoView,
 {
-    let prev_children = Rc::new(RefCell::new(None::<Vec<View>>));
+    let prev_children = Rc::new(RefCell::new(None::<View>));
 
     let first_run = Rc::new(std::cell::Cell::new(true));
     let child_runs = Cell::new(0);
@@ -112,13 +112,13 @@ where
                 }
             })
             .children(Box::new(move |cx| {
-                let frag = children(cx);
+                let frag = children(cx).into_view(cx);
 
                 let suspense_context = use_context::<SuspenseContext>(cx)
                     .expect("there to be a SuspenseContext");
 
                 if cfg!(feature = "hydrate") || !first_run.get() {
-                    *prev_children.borrow_mut() = Some(frag.nodes.clone());
+                    *prev_children.borrow_mut() = Some(frag.clone());
                 }
                 if is_first_run(&first_run, &suspense_context) {
                     let has_local_only = suspense_context.has_local_only()


### PR DESCRIPTION
I'm so happy about this, as it took me a lot of messing around and turned out to be quite simple! Nota bene: if you ever find yourself needing to clone a `Fragment` and use it somewhere else, know that it doesn't work very well to clone a `Fragment` before you turn it into a `View`, but it *does* work very well to clone a `Fragment` and move it after you turn it into a `View`.

We can probably improve that but for now, this fixes the issue.