### PR TITLE
change: remove APIs that had been marked deprecated

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -130,23 +130,6 @@ pub fn redirect(cx: leptos::Scope, path: &str) {
 }
 
 /// Decomposes an HTTP request into its parts, allowing you to read its headers
-/// and other data without consuming the body.
-#[deprecated(note = "Replaced with generate_request_and_parts() to allow for \
-                     putting LeptosRequest in the Context")]
-pub async fn generate_request_parts(req: Request<Body>) -> RequestParts {
-    // provide request headers as context in server scope
-    let (parts, body) = req.into_parts();
-    let body = body::to_bytes(body).await.unwrap_or_default();
-    RequestParts {
-        method: parts.method,
-        uri: parts.uri,
-        headers: parts.headers,
-        version: parts.version,
-        body,
-    }
-}
-
-/// Decomposes an HTTP request into its parts, allowing you to read its headers
 /// and other data without consuming the body. Creates a new Request from the
 /// original parts for further processing
 pub async fn generate_request_and_parts(

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -152,7 +152,6 @@ pub use leptos_config::{self, get_configuration, LeptosOptions};
 pub mod ssr {
     pub use leptos_dom::{ssr::*, ssr_in_order::*};
 }
-#[allow(deprecated)]
 pub use leptos_dom::{
     self, create_node_ref, debug_warn, document, error, ev,
     helpers::{
@@ -161,7 +160,6 @@ pub use leptos_dom::{
         request_idle_callback, request_idle_callback_with_handle, set_interval,
         set_interval_with_handle, set_timeout, set_timeout_with_handle,
         window_event_listener, window_event_listener_untyped,
-        window_event_listener_with_precast,
     },
     html, log, math, mount_to, mount_to_body, svg, warn, window, Attribute,
     Class, CollectView, Errors, Fragment, HtmlElement, IntoAttribute,

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -384,26 +384,6 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
 
     #[doc(hidden)]
     #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
-    #[deprecated = "Use HtmlElement::from_chunks() instead."]
-    pub fn from_html(
-        cx: Scope,
-        element: El,
-        html: impl Into<Cow<'static, str>>,
-    ) -> Self {
-        Self {
-            cx,
-            attrs: smallvec![],
-            children: ElementChildren::Chunks(vec![StringOrView::String(
-                html.into(),
-            )]),
-            element,
-            #[cfg(debug_assertions)]
-            view_marker: None,
-        }
-    }
-
-    #[doc(hidden)]
-    #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
     pub fn from_chunks(
         cx: Scope,
         element: El,

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -79,12 +79,6 @@ pub fn create_node_ref<T: ElementDescriptor + 'static>(
 }
 
 impl<T: ElementDescriptor + 'static> NodeRef<T> {
-    /// Creates an empty reference.
-    #[deprecated = "Use `create_node_ref` instead of `NodeRef::new()`."]
-    pub fn new(cx: Scope) -> Self {
-        Self(create_rw_signal(cx, None))
-    }
-
     /// Gets the element that is currently stored in the reference.
     ///
     /// This tracks reactively, so that node references can be used in effects.

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -173,18 +173,6 @@ pub trait SignalUpdate<T> {
     ///
     /// **Note:** `update()` does not auto-memoize, i.e., it will notify subscribers
     /// even if the value has not actually changed.
-    #[deprecated = "Please use `try_update` instead. This method will be \
-                    removed in a future version of this crate"]
-    fn update_returning<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O> {
-        self.try_update(f)
-    }
-
-    /// Applies a function to the current value to mutate it in place
-    /// and notifies subscribers that the signal has changed. Returns
-    /// [`Some(O)`] if the signal is still valid, [`None`] otherwise.
-    ///
-    /// **Note:** `update()` does not auto-memoize, i.e., it will notify subscribers
-    /// even if the value has not actually changed.
     fn try_update<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O>;
 }
 
@@ -248,19 +236,6 @@ pub trait SignalUpdateUntracked<T> {
     /// value without notifying dependents.
     #[track_caller]
     fn update_untracked(&self, f: impl FnOnce(&mut T));
-
-    /// Runs the provided closure with a mutable reference to the current
-    /// value without notifying dependents and returns
-    /// the value the closure returned.
-    #[deprecated = "Please use `try_update_untracked` instead. This method \
-                    will be removed in a future version of `leptos`"]
-    #[inline(always)]
-    fn update_returning_untracked<U>(
-        &self,
-        f: impl FnOnce(&mut T) -> U,
-    ) -> Option<U> {
-        self.try_update_untracked(f)
-    }
 
     /// Runs the provided closure with a mutable reference to the current
     /// value without notifying dependents and returns
@@ -930,27 +905,6 @@ impl<T> SignalUpdateUntracked<T> for WriteSignal<T> {
         self.id.update_with_no_effect(self.runtime, f);
     }
 
-    #[cfg_attr(
-        any(debug_assertions, feature = "ssr"),
-        instrument(
-            level = "trace",
-            name = "WriteSignal::update_returning_untracked()",
-            skip_all,
-            fields(
-                id = ?self.id,
-                defined_at = %self.defined_at,
-                ty = %std::any::type_name::<T>()
-            )
-        )
-    )]
-    #[inline(always)]
-    fn update_returning_untracked<U>(
-        &self,
-        f: impl FnOnce(&mut T) -> U,
-    ) -> Option<U> {
-        self.id.update_with_no_effect(self.runtime, f)
-    }
-
     #[inline(always)]
     fn try_update_untracked<O>(
         &self,
@@ -1343,27 +1297,6 @@ impl<T> SignalUpdateUntracked<T> for RwSignal<T> {
     #[inline(always)]
     fn update_untracked(&self, f: impl FnOnce(&mut T)) {
         self.id.update_with_no_effect(self.runtime, f);
-    }
-
-    #[cfg_attr(
- any(debug_assertions, features="ssr"),
-    instrument(
-        level = "trace",
-        name = "RwSignal::update_returning_untracked()",
-        skip_all,
-        fields(
-            id = ?self.id,
-            defined_at = %self.defined_at,
-            ty = %std::any::type_name::<T>()
-        )
-    )
-    )]
-    #[inline(always)]
-    fn update_returning_untracked<U>(
-        &self,
-        f: impl FnOnce(&mut T) -> U,
-    ) -> Option<U> {
-        self.id.update_with_no_effect(self.runtime, f)
     }
 
     #[cfg_attr(

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -161,7 +161,6 @@ impl<T> StoredValue<T> {
             .expect("could not set stored value");
     }
 
-
     /// Same as [`Self::update`], but returns [`Some(O)`] if the
     /// signal is still valid, [`None`] otherwise.
     pub fn try_update_value<O>(self, f: impl FnOnce(&mut T) -> O) -> Option<O> {

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -63,40 +63,6 @@ impl<T> StoredValue<T> {
     /// # });
     /// ```
     #[track_caller]
-    #[deprecated = "Please use `get_value` instead, as this method does not \
-                    track the stored value. This method will also be removed \
-                    in a future version of `leptos`"]
-    pub fn get(&self) -> T
-    where
-        T: Clone,
-    {
-        self.get_value()
-    }
-
-    /// Returns a clone of the signals current value, subscribing the effect
-    /// to this signal.
-    ///
-    /// # Panics
-    /// Panics if you try to access a value stored in a [`Scope`] that has been disposed.
-    ///
-    /// # Examples
-    /// ```
-    /// # use leptos_reactive::*;
-    /// # create_scope(create_runtime(), |cx| {
-    ///
-    /// #[derive(Clone)]
-    /// pub struct MyCloneableData {
-    ///     pub value: String,
-    /// }
-    /// let data = store_value(cx, MyCloneableData { value: "a".into() });
-    ///
-    /// // calling .get() clones and returns the value
-    /// assert_eq!(data.get().value, "a");
-    /// // there's a short-hand getter form
-    /// assert_eq!(data().value, "a");
-    /// # });
-    /// ```
-    #[track_caller]
     pub fn get_value(&self) -> T
     where
         T: Clone,
@@ -106,50 +72,11 @@ impl<T> StoredValue<T> {
 
     /// Same as [`StoredValue::get`] but will not panic by default.
     #[track_caller]
-    #[deprecated = "Please use `try_get_value` instead, as this method does \
-                    not track the stored value. This method will also be \
-                    removed in a future version of `leptos`"]
-    pub fn try_get(&self) -> Option<T>
-    where
-        T: Clone,
-    {
-        self.try_get_value()
-    }
-
-    /// Same as [`StoredValue::get`] but will not panic by default.
-    #[track_caller]
     pub fn try_get_value(&self) -> Option<T>
     where
         T: Clone,
     {
         self.try_with_value(T::clone)
-    }
-
-    /// Applies a function to the current stored value.
-    ///
-    /// # Panics
-    /// Panics if you try to access a value stored in a [`Scope`] that has been disposed.
-    ///
-    /// # Examples
-    /// ```
-    /// # use leptos_reactive::*;
-    /// # create_scope(create_runtime(), |cx| {
-    ///
-    /// pub struct MyUncloneableData {
-    ///   pub value: String
-    /// }
-    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    ///
-    /// // calling .with() to extract the value
-    /// assert_eq!(data.with(|data| data.value.clone()), "a");
-    /// });
-    /// ```
-    #[track_caller]
-    #[deprecated = "Please use `with_value` instead, as this method does not \
-                    track the stored value. This method will also be removed \
-                    in a future version of `leptos`"]
-    pub fn with<U>(&self, f: impl FnOnce(&T) -> U) -> U {
-        self.with_value(f)
     }
 
     /// Applies a function to the current stored value.
@@ -176,15 +103,6 @@ impl<T> StoredValue<T> {
     //               a future version of `leptos`"]
     pub fn with_value<U>(&self, f: impl FnOnce(&T) -> U) -> U {
         self.try_with_value(f).expect("could not get stored value")
-    }
-
-    /// Same as [`StoredValue::with`] but returns [`Some(O)]` only if
-    /// the signal is still valid. [`None`] otherwise.
-    #[deprecated = "Please use `try_with_value` instead, as this method does \
-                    not track the stored value. This method will also be \
-                    removed in a future version of `leptos`"]
-    pub fn try_with<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
-        self.try_with_value(f)
     }
 
     /// Same as [`StoredValue::with`] but returns [`Some(O)]` only if
@@ -238,63 +156,9 @@ impl<T> StoredValue<T> {
     /// # });
     /// ```
     #[track_caller]
-    #[deprecated = "Please use `update_value` instead, as this method does not \
-                    track the stored value. This method will also be removed \
-                    in a future version of `leptos`"]
-    pub fn update(&self, f: impl FnOnce(&mut T)) {
-        self.update_value(f);
-    }
-
-    /// Updates the stored value.
-    ///
-    /// # Examples
-    /// ```
-    /// # use leptos_reactive::*;
-    /// # create_scope(create_runtime(), |cx| {
-    ///
-    /// pub struct MyUncloneableData {
-    ///   pub value: String
-    /// }
-    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// data.update(|data| data.value = "b".into());
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
-    /// });
-    /// ```
-    ///
-    /// ```
-    /// use leptos_reactive::*;
-    /// # create_scope(create_runtime(), |cx| {
-    ///
-    /// pub struct MyUncloneableData {
-    ///     pub value: String,
-    /// }
-    ///
-    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// let updated = data.update_returning(|data| {
-    ///     data.value = "b".into();
-    ///     data.value.clone()
-    /// });
-    ///
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
-    /// assert_eq!(updated, Some(String::from("b")));
-    /// # });
-    /// ```
-    #[track_caller]
     pub fn update_value(&self, f: impl FnOnce(&mut T)) {
         self.try_update_value(f)
             .expect("could not set stored value");
-    }
-
-    /// Updates the stored value.
-    #[track_caller]
-    #[deprecated = "Please use `try_update_value` instead, as this method does \
-                    not track the stored value. This method will also be \
-                    removed in a future version of `leptos`"]
-    pub fn update_returning<U>(
-        &self,
-        f: impl FnOnce(&mut T) -> U,
-    ) -> Option<U> {
-        self.try_update_value(f)
     }
 
     /// Same as [`Self::update`], but returns [`Some(O)`] if the
@@ -309,29 +173,6 @@ impl<T> StoredValue<T> {
         })
         .ok()
         .flatten()
-    }
-
-    /// Sets the stored value.
-    ///
-    /// # Examples
-    /// ```
-    /// # use leptos_reactive::*;
-    /// # create_scope(create_runtime(), |cx| {
-    ///
-    /// pub struct MyUncloneableData {
-    ///   pub value: String
-    /// }
-    /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// data.set(MyUncloneableData { value: "b".into() });
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
-    /// });
-    /// ```
-    #[track_caller]
-    #[deprecated = "Please use `set_value` instead, as this method does not \
-                    track the stored value. This method will also be removed \
-                    in a future version of `leptos`"]
-    pub fn set(&self, value: T) {
-        self.set_value(value);
     }
 
     /// Sets the stored value.

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -146,7 +146,7 @@ impl<T> StoredValue<T> {
     /// }
     ///
     /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// let updated = data.try_update(|data| {
+    /// let updated = data.try_update_value(|data| {
     ///     data.value = "b".into();
     ///     data.value.clone()
     /// });

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -146,7 +146,7 @@ impl<T> StoredValue<T> {
     /// }
     ///
     /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// let updated = data.update_returning(|data| {
+    /// let updated = data.try_update(|data| {
     ///     data.value = "b".into();
     ///     data.value.clone()
     /// });

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -56,8 +56,8 @@ impl<T> StoredValue<T> {
     /// }
     /// let data = store_value(cx, MyCloneableData { value: "a".into() });
     ///
-    /// // calling .get() clones and returns the value
-    /// assert_eq!(data.get().value, "a");
+    /// // calling .get_value() clones and returns the value
+    /// assert_eq!(data.get_value().value, "a");
     /// // there's a short-hand getter form
     /// assert_eq!(data().value, "a");
     /// # });
@@ -94,8 +94,8 @@ impl<T> StoredValue<T> {
     /// }
     /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
     ///
-    /// // calling .with() to extract the value
-    /// assert_eq!(data.with(|data| data.value.clone()), "a");
+    /// // calling .with_value() to extract the value
+    /// assert_eq!(data.with_value(|data| data.value.clone()), "a");
     /// # });
     /// ```
     #[track_caller]
@@ -132,8 +132,8 @@ impl<T> StoredValue<T> {
     ///   pub value: String
     /// }
     /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// data.update(|data| data.value = "b".into());
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
+    /// data.update_value(|data| data.value = "b".into());
+    /// assert_eq!(data.with_value(|data| data.value.clone()), "b");
     /// });
     /// ```
     ///
@@ -151,7 +151,7 @@ impl<T> StoredValue<T> {
     ///     data.value.clone()
     /// });
     ///
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
+    /// assert_eq!(data.with_value(|data| data.value.clone()), "b");
     /// assert_eq!(updated, Some(String::from("b")));
     /// # });
     /// ```
@@ -160,6 +160,7 @@ impl<T> StoredValue<T> {
         self.try_update_value(f)
             .expect("could not set stored value");
     }
+
 
     /// Same as [`Self::update`], but returns [`Some(O)`] if the
     /// signal is still valid, [`None`] otherwise.
@@ -186,8 +187,8 @@ impl<T> StoredValue<T> {
     ///     pub value: String,
     /// }
     /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-    /// data.set(MyUncloneableData { value: "b".into() });
-    /// assert_eq!(data.with(|data| data.value.clone()), "b");
+    /// data.set_value(MyUncloneableData { value: "b".into() });
+    /// assert_eq!(data.with_value(|data| data.value.clone()), "b");
     /// # });
     /// ```
     #[track_caller]
@@ -244,10 +245,10 @@ impl<T> StoredValue<T> {
 ///     pub value: String,
 /// }
 ///
-/// // ✅ you can move the `StoredValue` and access it with .with()
+/// // ✅ you can move the `StoredValue` and access it with .with_value()
 /// let data = store_value(cx, MyUncloneableData { value: "a".into() });
-/// let callback_a = move || data.with(|data| data.value == "a");
-/// let callback_b = move || data.with(|data| data.value == "b");
+/// let callback_a = move || data.with_value(|data| data.value == "a");
+/// let callback_b = move || data.with_value(|data| data.value == "b");
 /// # }).dispose();
 /// ```
 #[track_caller]


### PR DESCRIPTION
This removes the following deprecated APIs:
- Actix: `render_preloaded_data_app` and `.leptos_preloaded_data_routes()` (use `SsrMode::Async` with `<Suspense/>` instead)
- Axum: `generate_request_parts` (use `generate_request_and_parts` instead)
- `window_event_listener` is now the typed version (briefly `window_event_listener_with_precast`), and `window_event_listener_untyped` is the old `window_event_listener`
- `set_interval` no longer returns a handle (use `set_interval_with_handle` instead)
- `HtmlElement::from_html()` (mostly internal and related to SSR optimizations; if you were using this for some weird reason, use `HtmlElement::from_chunks()`) 
- `NodeRef::new(cx)` (use `create_node_ref(cx)`)
- `update_returning` etc. (use `try_update`)
- `StoredValue::get()`, `with()`, `set()`, and `update()` (use `get_value()`, `with_value()`, `set_value()`, `update_value()`)