### PR TITLE
examples: fix trunk config to run tailwind at the right time

### DIFF
--- a/examples/tailwind_csr_trunk/Trunk.toml
+++ b/examples/tailwind_csr_trunk/Trunk.toml
@@ -1,4 +1,4 @@
 [[hooks]]
-stage = "build"
+stage = "pre_build"
 command = "sh"
 command_arguments = ["-c", "npx tailwindcss -i input.css -o style/output.css"]


### PR DESCRIPTION
The current example only works if there is already a created CSS file but on the first run it fails.
This patch should fix is.