### PR TITLE
fix: multipart forms on server fns

### DIFF
--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/leptos-rs/leptos"
 description = "Actix integrations for the Leptos web framework."
 
 [dependencies]
+actix-http = "3"
 actix-web = "4"
 futures = "0.3"
 leptos = { workspace = true, features = ["ssr"] }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1079,7 +1079,7 @@ where
         .expect("HttpRequest should have been provided via context");
     let body = use_context::<Bytes>(cx)
         .expect("web::Bytes should have been provided via context");
-    
+
     let (_, mut payload) = actix_http::h1::Payload::create(false);
     payload.unread_data(body);
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -185,7 +185,7 @@ pub fn handle_server_fns_with_context(
                     .and_then(|value| value.to_str().ok());
 
                 if let Some(server_fn) = server_fn_by_path(path.as_str()) {
-                    let body: &[u8] = &body;
+                    let body_ref: &[u8] = &body;
 
                     let runtime = create_runtime();
                     let (cx, disposer) = raw_scope_and_disposer(runtime);
@@ -198,10 +198,15 @@ pub fn handle_server_fns_with_context(
                     provide_context(cx, req.clone());
                     provide_context(cx, res_options.clone());
 
+                    // provide a clone of the original payload
+                    // we consume it here (using the web::Bytes extractor),
+                    // but it is required for things like MultipartForm
+                    provide_context(cx, body.clone());
+
                     let query = req.query_string().as_bytes();
 
                     let data = match &server_fn.encoding {
-                        Encoding::Url | Encoding::Cbor => body,
+                        Encoding::Url | Encoding::Cbor => body_ref,
                         Encoding::GetJSON | Encoding::GetCBOR => query,
                     };
                     let res = match (server_fn.trait_obj)(cx, data).await {
@@ -1072,9 +1077,16 @@ where
 {
     let req = use_context::<actix_web::HttpRequest>(cx)
         .expect("HttpRequest should have been provided via context");
-    let input = E::extract(&req)
+    let body = use_context::<Bytes>(cx)
+        .expect("web::Bytes should have been provided via context");
+    
+    let (_, mut payload) = actix_http::h1::Payload::create(false);
+    payload.unread_data(body);
+
+    let input = E::from_request(&req, &mut dev::Payload::from(payload))
         .await
         .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
+
     Ok(f.call(input).await)
 }
 

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -2,7 +2,7 @@ use crate::{use_navigate, use_resolved_path, ToHref, Url};
 use leptos::{html::form, *};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, rc::Rc};
-use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use wasm_bindgen_futures::JsFuture;
 use web_sys::RequestRedirect;
 


### PR DESCRIPTION
As a consequence, any extractor that needs to consume the Payload (like MultipartForm) should now work on server fns.