### PR TITLE
Rsx parser with recovery after errors, and unquoted text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,3 @@ opt-level = 'z'
 
 [workspace.metadata.cargo-all-features]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
-
-[patch.crates-io]
-syn-rsx = { path = '../syn-rsx' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ opt-level = 'z'
 
 [workspace.metadata.cargo-all-features]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
+
+[patch.crates-io]
+syn-rsx = { path = '../syn-rsx' }

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -19,7 +19,7 @@ syn = { version = "2", features = [
 	"printing",
 ] }
 quote = "1"
-syn-rsx = "0.9"
+syn-rsx = {git = "https://github.com/vldm/syn-rsx"}
 proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -19,7 +19,7 @@ syn = { version = "2", features = [
 	"printing",
 ] }
 quote = "1"
-syn-rsx = {git = "https://github.com/vldm/syn-rsx"}
+rstml = "0.10.6"
 proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
-syn = { version = "1", features = [
+syn = { version = "2", features = [
 	"full",
 	"parsing",
 	"extra-traits",

--- a/leptos_hot_reload/src/lib.rs
+++ b/leptos_hot_reload/src/lib.rs
@@ -76,7 +76,7 @@ impl ViewMacros {
             tokens.next(); // ,
                            // TODO handle class = ...
             let rsx =
-                syn_rsx::parse2(tokens.collect::<proc_macro2::TokenStream>())?;
+                rstml::parse2(tokens.collect::<proc_macro2::TokenStream>())?;
             let template = LNode::parse_view(rsx)?;
             views.push(MacroInvocation { id, template })
         }

--- a/leptos_hot_reload/src/node.rs
+++ b/leptos_hot_reload/src/node.rs
@@ -2,7 +2,7 @@ use crate::parsing::is_component_node;
 use anyhow::Result;
 use quote::ToTokens;
 use serde::{Deserialize, Serialize};
-use syn_rsx::{Node, NodeAttribute};
+use rstml::node::{Node, NodeAttribute};
 
 // A lightweight virtual DOM structure we can use to hold
 // the state of a Leptos view macro template. This is because

--- a/leptos_hot_reload/src/node.rs
+++ b/leptos_hot_reload/src/node.rs
@@ -1,8 +1,8 @@
 use crate::parsing::is_component_node;
 use anyhow::Result;
 use quote::ToTokens;
-use serde::{Deserialize, Serialize};
 use rstml::node::{Node, NodeAttribute};
+use serde::{Deserialize, Serialize};
 
 // A lightweight virtual DOM structure we can use to hold
 // the state of a Leptos view macro template. This is because
@@ -92,14 +92,10 @@ impl LNode {
                     let name = el.name().to_string();
                     let mut attrs = Vec::new();
 
-                    for attr in el
-                            .open_tag
-                            .attributes {
+                    for attr in el.open_tag.attributes {
                         if let NodeAttribute::Attribute(attr) = attr {
                             let name = attr.key.to_string();
-                            if let Some(value) =
-                                attr.value_literal_string()
-                            {
+                            if let Some(value) = attr.value_literal_string() {
                                 attrs.push((
                                     name,
                                     LAttributeValue::Static(value),

--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -1,7 +1,7 @@
-use syn_rsx::{NodeElement, NodeValueExpr};
+use syn_rsx::NodeElement;
 
-pub fn value_to_string(value: &NodeValueExpr) -> Option<String> {
-    match &value.as_ref() {
+pub fn value_to_string(value: &syn::Expr) -> Option<String> {
+    match &value {
         syn::Expr::Lit(lit) => match &lit.lit {
             syn::Lit::Str(s) => Some(s.value()),
             syn::Lit::Char(c) => Some(c.value().to_string()),
@@ -14,7 +14,7 @@ pub fn value_to_string(value: &NodeValueExpr) -> Option<String> {
 }
 
 pub fn is_component_node(node: &NodeElement) -> bool {
-    node.name
+    node.name()
         .to_string()
         .starts_with(|c: char| c.is_ascii_uppercase())
 }

--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -1,4 +1,4 @@
-use syn_rsx::NodeElement;
+use rstml::node::NodeElement;
 
 pub fn value_to_string(value: &syn::Expr) -> Option<String> {
     match &value {

--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -1,5 +1,35 @@
 use rstml::node::NodeElement;
 
+///
+/// Converts `syn::Block` to simple expression
+///
+/// For example:
+/// ```no_build
+/// // "string literal" in
+/// {"string literal"}
+/// // number literal
+/// {0x12}
+/// // boolean literal
+/// {true}
+/// // variable
+/// {path::x}
+/// ```
+pub fn block_to_primitive_expression(block: &syn::Block) -> Option<&syn::Expr> {
+    // its empty block, or block with multi lines
+    if block.stmts.len() != 1 {
+        return None;
+    }
+    match &block.stmts[0] {
+        syn::Stmt::Expr(e, None) => return Some(&e),
+        _ => {}
+    }
+    None
+}
+
+/// Converts simple literals to its string representation.
+///
+/// This function doesn't convert literal wrapped inside block
+/// like: `{"string"}`.
 pub fn value_to_string(value: &syn::Expr) -> Option<String> {
     match &value {
         syn::Expr::Lit(lit) => match &lit.lit {

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
-syn-rsx = {git = "https://github.com/vldm/syn-rsx"}
+rstml = "0.10.6"
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
-syn-rsx = "0.9"
+syn-rsx = {git = "https://github.com/vldm/syn-rsx"}
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -12,15 +12,15 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-attribute-derive = { version = "0.5", features = ["syn-full"] }
+attribute-derive = { version = "0.6", features = ["syn-full"] }
 cfg-if = "1"
 html-escape = "0.2"
 itertools = "0.10"
-prettyplease = "0.1"
+prettyplease = "0.2.4"
 proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 syn-rsx = "0.9"
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -9,11 +9,11 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote_spanned, ToTokens, TokenStreamExt};
 use syn::{
     parse::Parse, parse_quote, spanned::Spanned,
-    AngleBracketedGenericArguments, Attribute, FnArg, GenericArgument, Item,
-    ItemFn, LitStr, Meta, Pat, PatIdent, Path,
-    PathArguments, ReturnType, Stmt, Type, TypePath, Visibility,
+    AngleBracketedGenericArguments, Attribute, FnArg, GenericArgument,
+    LitStr, Meta, Pat, PatIdent, Path,
+    PathArguments, ReturnType, Type, TypePath, Visibility,
+    ItemFn, Stmt, Item,
 };
-
 pub struct Model {
     is_transparent: bool,
     docs: Docs,

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -9,10 +9,9 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote_spanned, ToTokens, TokenStreamExt};
 use syn::{
     parse::Parse, parse_quote, spanned::Spanned,
-    AngleBracketedGenericArguments, Attribute, FnArg, GenericArgument,
-    LitStr, Meta, Pat, PatIdent, Path,
-    PathArguments, ReturnType, Type, TypePath, Visibility,
-    ItemFn, Stmt, Item,
+    AngleBracketedGenericArguments, Attribute, FnArg, GenericArgument, Item,
+    ItemFn, LitStr, Meta, Pat, PatIdent, Path, PathArguments, ReturnType, Stmt,
+    Type, TypePath, Visibility,
 };
 pub struct Model {
     is_transparent: bool,
@@ -57,22 +56,17 @@ impl Parse for Model {
 
         // We need to remove the `#[doc = ""]` and `#[builder(_)]`
         // attrs from the function signature
-        drain_filter(&mut item.attrs, |attr| {
-            
-            match &attr.meta {
-                Meta::NameValue(attr) => attr.path == parse_quote!(doc),
-                Meta::List(attr ) => attr.path == parse_quote!(prop),
-                _ => false
-            }
+        drain_filter(&mut item.attrs, |attr| match &attr.meta {
+            Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+            Meta::List(attr) => attr.path == parse_quote!(prop),
+            _ => false,
         });
         item.sig.inputs.iter_mut().for_each(|arg| {
             if let FnArg::Typed(ty) = arg {
-                drain_filter(&mut ty.attrs, |attr| {
-                    match &attr.meta {
-                        Meta::NameValue(attr) => attr.path == parse_quote!(doc),
-                        Meta::List(attr ) => attr.path == parse_quote!(prop),
-                        _ => false
-                    }
+                drain_filter(&mut ty.attrs, |attr| match &attr.meta {
+                    Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+                    Meta::List(attr) => attr.path == parse_quote!(prop),
+                    _ => false,
                 });
             }
         });
@@ -410,11 +404,9 @@ impl Docs {
         let mut attrs = attrs
             .iter()
             .filter_map(|attr| {
-                
                 let Meta::NameValue(attr ) = &attr.meta else {
                     return None
                 };
-                
                 if !attr.path.is_ident("doc") {
                     return None
                 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -9,7 +9,7 @@ use proc_macro2::{Span, TokenTree};
 use quote::ToTokens;
 use server_fn_macro::{server_macro_impl, ServerContext};
 use syn::parse_macro_input;
-use syn_rsx::{parse, NodeAttribute};
+use syn_rsx::{parse, KeyedAttribute};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Mode {
@@ -874,9 +874,9 @@ pub fn params_derive(
     }
 }
 
-pub(crate) fn attribute_value(attr: &NodeAttribute) -> &syn::Expr {
-    match &attr.value {
-        Some(value) => value.as_ref(),
+pub(crate) fn attribute_value(attr: &KeyedAttribute) -> &syn::Expr {
+    match &attr.possible_value {
+        Some(value) => &value.value,
         None => abort!(attr.key, "attribute should have value"),
     }
 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -9,7 +9,7 @@ use proc_macro2::{Span, TokenTree};
 use quote::ToTokens;
 use server_fn_macro::{server_macro_impl, ServerContext};
 use syn::parse_macro_input;
-use syn_rsx::{parse, KeyedAttribute};
+use rstml::{parse, node::KeyedAttribute};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Mode {
@@ -351,8 +351,8 @@ pub fn view(tokens: TokenStream) -> TokenStream {
                     .chain(tokens)
                     .collect()
             };
-            let config = syn_rsx::ParserConfig::default().recover_block(true);
-            let parser = syn_rsx::Parser::new(config);
+            let config = rstml::ParserConfig::default().recover_block(true);
+            let parser = rstml::Parser::new(config);
             let (nodes, errors)  = parser.parse_recoverable(tokens).split_vec();
             let errors = errors.into_iter().map(|e| e.emit_as_expr_tokens());
             let nodes_output = render_view(

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -7,9 +7,9 @@ extern crate proc_macro_error;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenTree};
 use quote::ToTokens;
+use rstml::{node::KeyedAttribute, parse};
 use server_fn_macro::{server_macro_impl, ServerContext};
 use syn::parse_macro_input;
-use rstml::{parse, node::KeyedAttribute};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Mode {
@@ -353,21 +353,22 @@ pub fn view(tokens: TokenStream) -> TokenStream {
             };
             let config = rstml::ParserConfig::default().recover_block(true);
             let parser = rstml::Parser::new(config);
-            let (nodes, errors)  = parser.parse_recoverable(tokens).split_vec();
+            let (nodes, errors) = parser.parse_recoverable(tokens).split_vec();
             let errors = errors.into_iter().map(|e| e.emit_as_expr_tokens());
             let nodes_output = render_view(
-                    &cx,
-                    &nodes,
-                    Mode::default(),
-                    global_class.as_ref(),
-                    normalized_call_site(proc_macro::Span::call_site()),
-                );
-            quote!{
+                &cx,
+                &nodes,
+                Mode::default(),
+                global_class.as_ref(),
+                normalized_call_site(proc_macro::Span::call_site()),
+            );
+            quote! {
                 {
                     #(#errors;)*
                     #nodes_output
                 }
-            }.into()
+            }
+            .into()
         }
         _ => {
             abort_call_site!(

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -5,7 +5,7 @@ use attribute_derive::Attribute as AttributeDerive;
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn::{
-    parse::Parse, parse_quote, Field, ItemStruct, LitStr, Type, Visibility,
+    parse::Parse, parse_quote, Field, ItemStruct, LitStr, Type, Visibility, Meta,
 };
 
 pub struct Model {
@@ -32,12 +32,20 @@ impl Parse for Model {
         // We need to remove the `#[doc = ""]` and `#[builder(_)]`
         // attrs from the function signature
         drain_filter(&mut item.attrs, |attr| {
-            attr.path == parse_quote!(doc) || attr.path == parse_quote!(prop)
+            match &attr.meta {
+                Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+                Meta::List(attr ) => attr.path == parse_quote!(prop),
+                _ => false
+            }
         });
         item.fields.iter_mut().for_each(|arg| {
             drain_filter(&mut arg.attrs, |attr| {
-                attr.path == parse_quote!(doc)
-                    || attr.path == parse_quote!(prop)
+                 
+                match &attr.meta {
+                    Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+                    Meta::List(attr ) => attr.path == parse_quote!(prop),
+                    _ => false
+                }
             });
         });
 

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -5,7 +5,8 @@ use attribute_derive::Attribute as AttributeDerive;
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn::{
-    parse::Parse, parse_quote, Field, ItemStruct, LitStr, Type, Visibility, Meta,
+    parse::Parse, parse_quote, Field, ItemStruct, LitStr, Meta, Type,
+    Visibility,
 };
 
 pub struct Model {
@@ -31,21 +32,16 @@ impl Parse for Model {
 
         // We need to remove the `#[doc = ""]` and `#[builder(_)]`
         // attrs from the function signature
-        drain_filter(&mut item.attrs, |attr| {
-            match &attr.meta {
-                Meta::NameValue(attr) => attr.path == parse_quote!(doc),
-                Meta::List(attr ) => attr.path == parse_quote!(prop),
-                _ => false
-            }
+        drain_filter(&mut item.attrs, |attr| match &attr.meta {
+            Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+            Meta::List(attr) => attr.path == parse_quote!(prop),
+            _ => false,
         });
         item.fields.iter_mut().for_each(|arg| {
-            drain_filter(&mut arg.attrs, |attr| {
-                 
-                match &attr.meta {
-                    Meta::NameValue(attr) => attr.path == parse_quote!(doc),
-                    Meta::List(attr ) => attr.path == parse_quote!(prop),
-                    _ => false
-                }
+            drain_filter(&mut arg.attrs, |attr| match &attr.meta {
+                Meta::NameValue(attr) => attr.path == parse_quote!(doc),
+                Meta::List(attr) => attr.path == parse_quote!(prop),
+                _ => false,
             });
         });
 

--- a/leptos_macro/src/template.rs
+++ b/leptos_macro/src/template.rs
@@ -3,7 +3,7 @@ use leptos_hot_reload::parsing::is_component_node;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{spanned::Spanned, ExprBlock};
-use syn_rsx::{Node, NodeAttribute, NodeElement, KeyedAttribute, NodeBlock};
+use rstml::node::{Node, NodeAttribute, NodeElement, KeyedAttribute, NodeBlock};
 use uuid::Uuid;
 
 pub(crate) fn render_template(cx: &Ident, nodes: &[Node]) -> TokenStream {

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
 use std::collections::HashMap;
 use syn::{spanned::Spanned, Expr, ExprLit, ExprPath, Lit};
-use syn_rsx::{Node, NodeAttribute, NodeElement, NodeName, NodeValueExpr};
+use syn_rsx::{Node, NodeAttribute, NodeElement, NodeName, KeyedAttribute};
 
 #[derive(Clone, Copy)]
 enum TagType {
@@ -213,18 +213,22 @@ fn root_node_to_tokens_ssr(
             global_class,
             view_marker,
         ),
-        Node::Comment(_) | Node::Doctype(_) | Node::Attribute(_) => quote! {},
+        Node::Comment(_) | Node::Doctype(_) => quote! {},
         Node::Text(node) => {
-            let value = node.value.as_ref();
             quote! {
-                leptos::leptos_dom::html::text(#value)
+                leptos::leptos_dom::html::text(#node)
+            }
+        }
+        Node::RawText(r) => {
+            let text = r.to_string_best();
+            quote! {
+                leptos::leptos_dom::html::text(#text)
             }
         }
         Node::Block(node) => {
-            let value = node.value.as_ref();
             quote! {
                 #[allow(unused_braces)]
-                #value
+                #node
             }
         }
         Node::Element(node) => {
@@ -329,15 +333,15 @@ fn root_element_to_tokens_ssr(
             },
         });
 
-        let tag_name = node.name.to_string();
+        let tag_name = node.name().to_string();
         let is_custom_element = is_custom_element(&tag_name);
         let typed_element_name = if is_custom_element {
-            Ident::new("Custom", node.name.span())
+            Ident::new("Custom", node.name().span())
         } else {
             let camel_cased = camel_case_tag_name(
                 &tag_name.replace("svg::", "").replace("math::", ""),
             );
-            Ident::new(&camel_cased, node.name.span())
+            Ident::new(&camel_cased, node.name().span())
         };
         let typed_element_name = if is_svg_element(&tag_name) {
             quote! { svg::#typed_element_name }
@@ -409,7 +413,7 @@ fn element_to_tokens_ssr(
         }));
     } else {
         let tag_name = node
-            .name
+            .name()
             .to_string()
             .replace("svg::", "")
             .replace("math::", "");
@@ -419,8 +423,8 @@ fn element_to_tokens_ssr(
 
         let mut inner_html = None;
 
-        for attr in &node.attributes {
-            if let Node::Attribute(attr) = attr {
+        for attr in node.attributes() {
+            if let NodeAttribute::Attribute(attr) = attr {
                 inner_html = attribute_to_tokens_ssr(
                     cx,
                     attr,
@@ -439,9 +443,9 @@ fn element_to_tokens_ssr(
             quote! { leptos::leptos_dom::HydrationCtx::id() }
         };
         match node
-            .attributes
+            .attributes()
             .iter()
-            .find(|node| matches!(node, Node::Attribute(attr) if attr.key.to_string() == "id"))
+            .find(|node| matches!(node, NodeAttribute::Attribute(attr) if attr.key.to_string() == "id"))
         {
             Some(_) => {
                 template.push_str(" leptos-hk=\"_{}\"");
@@ -462,7 +466,7 @@ fn element_to_tokens_ssr(
 
             if let Some(inner_html) = inner_html {
                 template.push_str("{}");
-                let value = inner_html.as_ref();
+                let value = inner_html;
 
                 holes.push(quote! {
                   (#value).into_attribute(#cx).as_nameless_value_string().unwrap_or_default()
@@ -484,42 +488,35 @@ fn element_to_tokens_ssr(
                             );
                         }
                         Node::Text(text) => {
-                            if let Some(value) = value_to_string(&text.value) {
-                                let value = if is_script_or_style {
-                                    value.into()
-                                } else {
-                                    html_escape::encode_safe(&value)
-                                };
-                                template.push_str(
-                                    &value
-                                        .replace('{', "\\{")
-                                        .replace('}', "\\}"),
-                                );
+                            let value = text.value_string() ;
+                            let value = if is_script_or_style {
+                                value.into()
                             } else {
-                                template.push_str("{}");
-                                let value = text.value.as_ref();
-
-                                holes.push(quote! {
-                                  #value.into_view(#cx).render_to_string(#cx)
-                                })
-                            }
+                                html_escape::encode_safe(&value)
+                            };
+                            template.push_str(
+                                &value
+                                    .replace('{', "\\{")
+                                    .replace('}', "\\}"),
+                            );
                         }
                         Node::Block(block) => {
-                            if let Some(value) = value_to_string(&block.value) {
-                                template.push_str(&value);
-                            } else {
-                                let value = block.value.as_ref();
+                            // TODO: Is it was string? Original syn-rsx parse block with braces,
+                            // but value_to_string expect it without braces.
+                            // if let Some(value) = value_to_string(&block.value) {
+                            //     template.push_str(&value);
+                            // } else {
 
-                                if !template.is_empty() {
-                                    chunks.push(SsrElementChunks::String {
-                                        template: std::mem::take(template),
-                                        holes: std::mem::take(holes),
-                                    })
-                                }
-                                chunks.push(SsrElementChunks::View(quote! {
-                                  {#value}.into_view(#cx)
-                                }));
+                            if !template.is_empty() {
+                                chunks.push(SsrElementChunks::String {
+                                    template: std::mem::take(template),
+                                    holes: std::mem::take(holes),
+                                })
                             }
+                            chunks.push(SsrElementChunks::View(quote! {
+                                {#block}.into_view(#cx)
+                            }));
+                            
                         }
                         Node::Fragment(_) => abort!(
                             Span::call_site(),
@@ -531,7 +528,7 @@ fn element_to_tokens_ssr(
             }
 
             template.push_str("</");
-            template.push_str(&node.name.to_string());
+            template.push_str(&node.name().to_string());
             template.push('>');
         }
     }
@@ -540,17 +537,17 @@ fn element_to_tokens_ssr(
 // returns `inner_html`
 fn attribute_to_tokens_ssr<'a>(
     cx: &Ident,
-    node: &'a NodeAttribute,
+    attr: &'a KeyedAttribute,
     template: &mut String,
     holes: &mut Vec<TokenStream>,
     exprs_for_compiler: &mut Vec<TokenStream>,
     global_class: Option<&TokenTree>,
-) -> Option<&'a NodeValueExpr> {
-    let name = node.key.to_string();
+) -> Option<&'a syn::Expr> {
+    let name = attr.key.to_string();
     if name == "ref" || name == "_ref" || name == "ref_" || name == "node_ref" {
         // ignore refs on SSR
     } else if let Some(name) = name.strip_prefix("on:") {
-        let handler = attribute_value(node);
+        let handler = attribute_value(attr);
         let (event_type, _, _) = parse_event_name(name);
 
         exprs_for_compiler.push(quote! {
@@ -563,16 +560,16 @@ fn attribute_to_tokens_ssr<'a>(
         // ignore props for SSR
         // ignore classes and sdtyles: we'll handle these separately
     } else if name == "inner_html" {
-        return node.value.as_ref();
+        return attr.value();
     } else {
         let name = name.replacen("attr:", "", 1);
 
         // special case of global_class and class attribute
         if name == "class"
             && global_class.is_some()
-            && node.value.as_ref().and_then(value_to_string).is_none()
+            && attr.value().and_then(value_to_string).is_none()
         {
-            let span = node.key.span();
+            let span = attr.key.span();
             proc_macro_error::emit_error!(span, "Combining a global class (view! { cx, class = ... }) \
             and a dynamic `class=` attribute on an element causes runtime inconsistencies. You can \
             toggle individual classes dynamically with the `class:name=value` syntax. \n\nSee this issue \
@@ -582,7 +579,7 @@ fn attribute_to_tokens_ssr<'a>(
         if name != "class" && name != "style" {
             template.push(' ');
 
-            if let Some(value) = node.value.as_ref() {
+            if let Some(value) = attr.value() {
                 if let Some(value) = value_to_string(value) {
                     template.push_str(&name);
                     template.push_str("=\"");
@@ -590,7 +587,6 @@ fn attribute_to_tokens_ssr<'a>(
                     template.push('"');
                 } else {
                     template.push_str("{}");
-                    let value = value.as_ref();
                     holes.push(quote! {
                         &{#value}.into_attribute(#cx)
                             .as_nameless_value_string()
@@ -630,11 +626,11 @@ fn set_class_attribute_ssr(
         Some(val) => (String::new(), Some(val)),
     };
     let static_class_attr = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|a| match a {
-            Node::Attribute(attr) if attr.key.to_string() == "class" => {
-                attr.value.as_ref().and_then(value_to_string)
+            NodeAttribute::Attribute(attr) if attr.key.to_string() == "class" => {
+                attr.value().and_then(value_to_string)
             }
             _ => None,
         })
@@ -644,17 +640,17 @@ fn set_class_attribute_ssr(
         .join(" ");
 
     let dyn_class_attr = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|a| {
-            if let Node::Attribute(a) = a {
+            if let NodeAttribute::Attribute(a) = a {
                 if a.key.to_string() == "class" {
-                    if a.value.as_ref().and_then(value_to_string).is_some()
+                    if a.value().and_then(value_to_string).is_some()
                         || fancy_class_name(&a.key.to_string(), cx, a).is_some()
                     {
                         None
                     } else {
-                        Some((a.key.span(), &a.value))
+                        Some((a.key.span(), a.value()))
                     }
                 } else {
                     None
@@ -666,10 +662,10 @@ fn set_class_attribute_ssr(
         .collect::<Vec<_>>();
 
     let class_attrs = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|node| {
-            if let Node::Attribute(node) = node {
+            if let NodeAttribute::Attribute(node) = node {
                 let name = node.key.to_string();
                 if name == "class" {
                     return if let Some((_, name, value)) =
@@ -713,7 +709,6 @@ fn set_class_attribute_ssr(
         for (_span, value) in dyn_class_attr {
             if let Some(value) = value {
                 template.push_str(" {}");
-                let value = value.as_ref();
                 holes.push(quote! {
                   &(#cx, #value).into_attribute(#cx).as_nameless_value_string()
                     .map(|a| leptos::leptos_dom::ssr::escape_attr(&a).to_string())
@@ -745,11 +740,11 @@ fn set_style_attribute_ssr(
     holes: &mut Vec<TokenStream>,
 ) {
     let static_style_attr = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|a| match a {
-            Node::Attribute(attr) if attr.key.to_string() == "style" => {
-                attr.value.as_ref().and_then(value_to_string)
+            NodeAttribute::Attribute(attr) if attr.key.to_string() == "style" => {
+                attr.value().and_then(value_to_string)
             }
             _ => None,
         })
@@ -757,17 +752,17 @@ fn set_style_attribute_ssr(
         .map(|style| format!("{style};"));
 
     let dyn_style_attr = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|a| {
-            if let Node::Attribute(a) = a {
+            if let NodeAttribute::Attribute(a) = a {
                 if a.key.to_string() == "style" {
-                    if a.value.as_ref().and_then(value_to_string).is_some()
+                    if a.value().and_then(value_to_string).is_some()
                         || fancy_style_name(&a.key.to_string(), cx, a).is_some()
                     {
                         None
                     } else {
-                        Some((a.key.span(), &a.value))
+                        Some((a.key.span(), a.value()))
                     }
                 } else {
                     None
@@ -779,10 +774,10 @@ fn set_style_attribute_ssr(
         .collect::<Vec<_>>();
 
     let style_attrs = node
-        .attributes
+        .attributes()
         .iter()
         .filter_map(|node| {
-            if let Node::Attribute(node) = node {
+            if let NodeAttribute::Attribute(node) = node {
                 let name = node.key.to_string();
                 if name == "style" {
                     return if let Some((_, name, value)) =
@@ -825,7 +820,6 @@ fn set_style_attribute_ssr(
         for (_span, value) in dyn_style_attr {
             if let Some(value) = value {
                 template.push_str(" {};");
-                let value = value.as_ref();
                 holes.push(quote! {
                   &(#cx, #value).into_attribute(#cx).as_nameless_value_string()
                     .map(|a| leptos::leptos_dom::ssr::escape_attr(&a).to_string())
@@ -949,17 +943,15 @@ fn node_to_tokens(
         ),
         Node::Comment(_) | Node::Doctype(_) => Some(quote! {}),
         Node::Text(node) => {
-            let value = node.value.as_ref();
             Some(quote! {
-                leptos::leptos_dom::html::text(#value)
+                leptos::leptos_dom::html::text(#node)
             })
         }
         Node::Block(node) => {
-            let value = node.value.as_ref();
-            Some(quote! { #value })
+            Some(quote! { #node })
         }
-        Node::Attribute(node) => {
-            Some(attribute_to_tokens(cx, node, global_class))
+        Node::RawText(r) => {
+            Some(quote! { #r })
         }
         Node::Element(node) => element_to_tokens(
             cx,
@@ -980,6 +972,8 @@ fn element_to_tokens(
     global_class: Option<&TokenTree>,
     view_marker: Option<String>,
 ) -> Option<TokenStream> {
+
+    let name = node.name();
     if is_component_node(node) {
         if let Some(slot) = get_slot(node) {
             slot_to_tokens(cx, node, slot, parent_slots, global_class);
@@ -988,20 +982,17 @@ fn element_to_tokens(
             Some(component_to_tokens(cx, node, global_class))
         }
     } else {
-        let tag = node.name.to_string();
+        let tag = name.to_string();
         let name = if is_custom_element(&tag) {
-            let name = node.name.to_string();
+            let name = node.name().to_string();
             quote! { leptos::leptos_dom::html::custom(#cx, leptos::leptos_dom::html::Custom::new(#name)) }
         } else if is_svg_element(&tag) {
-            let name = &node.name;
             parent_type = TagType::Svg;
             quote! { leptos::leptos_dom::svg::#name(#cx) }
         } else if is_math_ml_element(&tag) {
-            let name = &node.name;
             parent_type = TagType::Math;
             quote! { leptos::leptos_dom::math::#name(#cx) }
         } else if is_ambiguous_element(&tag) {
-            let name = &node.name;
             match parent_type {
                 TagType::Unknown => {
                     // We decided this warning was too aggressive, but I'll leave it here in case we want it later
@@ -1020,12 +1011,11 @@ fn element_to_tokens(
                 }
             }
         } else {
-            let name = &node.name;
             parent_type = TagType::Html;
             quote! { leptos::leptos_dom::html::#name(#cx) }
         };
-        let attrs = node.attributes.iter().filter_map(|node| {
-            if let Node::Attribute(node) = node {
+        let attrs = node.attributes().iter().filter_map(|node| {
+            if let NodeAttribute::Attribute(node) = node {
                 let name = node.key.to_string();
                 let name = name.trim();
                 if name.starts_with("class:")
@@ -1041,8 +1031,8 @@ fn element_to_tokens(
                 None
             }
         });
-        let class_attrs = node.attributes.iter().filter_map(|node| {
-            if let Node::Attribute(node) = node {
+        let class_attrs = node.attributes().iter().filter_map(|node| {
+            if let NodeAttribute::Attribute(node) = node {
                 let name = node.key.to_string();
                 if let Some((fancy, _, _)) = fancy_class_name(&name, cx, node) {
                     Some(fancy)
@@ -1055,8 +1045,8 @@ fn element_to_tokens(
                 None
             }
         });
-        let style_attrs = node.attributes.iter().filter_map(|node| {
-            if let Node::Attribute(node) = node {
+        let style_attrs = node.attributes().iter().filter_map(|node| {
+            if let NodeAttribute::Attribute(node) = node {
                 let name = node.key.to_string();
                 if let Some((fancy, _, _)) = fancy_style_name(&name, cx, node) {
                     Some(fancy)
@@ -1102,30 +1092,25 @@ fn element_to_tokens(
                     false,
                 ),
                 Node::Text(node) => {
-                    if let Some(primitive) = value_to_string(&node.value) {
-                        (quote! { #primitive }, true)
-                    } else {
-                        let value = node.value.as_ref();
-                        (
-                            quote! {
-                                #[allow(unused_braces)] #value
-                            },
-                            false,
-                        )
-                    }
+                    (quote! { #node }, true)
+                }
+                // TODO: Implement html  escaping?
+                Node::RawText(node) => {
+                    (quote! { #node }, true)
                 }
                 Node::Block(node) => {
-                    if let Some(primitive) = value_to_string(&node.value) {
-                        (quote! { #primitive }, true)
-                    } else {
-                        let value = node.value.as_ref();
+                    // TODO: Is there any static string possible in block?
+                    // if let Some(primitive) = value_to_string(&node.) {
+                    //     (quote! { #primitive }, true)
+                    // } 
+                    // else {
                         (
                             quote! {
-                                #[allow(unused_braces)] #value
+                                #[allow(unused_braces)] #node
                             },
                             false,
                         )
-                    }
+                    // }
                 }
                 Node::Element(node) => (
                     element_to_tokens(
@@ -1139,7 +1124,7 @@ fn element_to_tokens(
                     .unwrap_or_default(),
                     false,
                 ),
-                Node::Comment(_) | Node::Doctype(_) | Node::Attribute(_) => {
+                Node::Comment(_) | Node::Doctype(_)  => {
                     (quote! {}, false)
                 }
             };
@@ -1172,7 +1157,7 @@ fn element_to_tokens(
 
 fn attribute_to_tokens(
     cx: &Ident,
-    node: &NodeAttribute,
+    node: &KeyedAttribute,
     global_class: Option<&TokenTree>,
 ) -> TokenStream {
     let span = node.key.span();
@@ -1303,7 +1288,7 @@ fn attribute_to_tokens(
         // special case of global_class and class attribute
         if name == "class"
             && global_class.is_some()
-            && node.value.as_ref().and_then(value_to_string).is_none()
+            && node.value().and_then(value_to_string).is_none()
         {
             let span = node.key.span();
             proc_macro_error::emit_error!(span, "Combining a global class (view! { cx, class = ... }) \
@@ -1313,9 +1298,9 @@ fn attribute_to_tokens(
         };
 
         // all other attributes
-        let value = match node.value.as_ref() {
+        let value = match node.value() {
             Some(value) => {
-                let value = value.as_ref();
+                let value = value;
 
                 quote! { #value }
             }
@@ -1367,7 +1352,7 @@ pub(crate) fn parse_event_name(name: &str) -> (TokenStream, bool, bool) {
 pub(crate) fn slot_to_tokens(
     cx: &Ident,
     node: &NodeElement,
-    slot: &NodeAttribute,
+    slot: &KeyedAttribute,
     parent_slots: Option<&mut HashMap<String, Vec<TokenStream>>>,
     global_class: Option<&TokenTree>,
 ) {
@@ -1376,19 +1361,19 @@ pub(crate) fn slot_to_tokens(
     let name = convert_to_snake_case(if name.starts_with("slot:") {
         name.replacen("slot:", "", 1)
     } else {
-        node.name.to_string()
+        node.name().to_string()
     });
 
-    let component_name = ident_from_tag_name(&node.name);
-    let span = node.name.span();
+    let component_name = ident_from_tag_name(node.name());
+    let span = node.name().span();
 
     let Some(parent_slots) = parent_slots else {
         proc_macro_error::emit_error!(span, "slots cannot be used inside HTML elements");
         return;
     };
 
-    let attrs = node.attributes.iter().filter_map(|node| {
-        if let Node::Attribute(node) = node {
+    let attrs = node.attributes().iter().filter_map(|node| {
+        if let NodeAttribute::Attribute(node) = node {
             if is_slot(node) {
                 None
             } else {
@@ -1406,10 +1391,8 @@ pub(crate) fn slot_to_tokens(
             let name = &attr.key;
 
             let value = attr
-                .value
-                .as_ref()
+                .value()
                 .map(|v| {
-                    let v = v.as_ref();
                     quote! { #v }
                 })
                 .unwrap_or_else(|| quote! { #name });
@@ -1504,12 +1487,12 @@ pub(crate) fn component_to_tokens(
     node: &NodeElement,
     global_class: Option<&TokenTree>,
 ) -> TokenStream {
-    let name = &node.name;
-    let component_name = ident_from_tag_name(&node.name);
-    let span = node.name.span();
+    let name = node.name();
+    let component_name = ident_from_tag_name(node.name());
+    let span = node.name().span();
 
-    let attrs = node.attributes.iter().filter_map(|node| {
-        if let Node::Attribute(node) = node {
+    let attrs = node.attributes().iter().filter_map(|node| {
+        if let NodeAttribute::Attribute(node) = node {
             Some(node)
         } else {
             None
@@ -1526,10 +1509,8 @@ pub(crate) fn component_to_tokens(
             let name = &attr.key;
 
             let value = attr
-                .value
-                .as_ref()
+                .value()
                 .map(|v| {
-                    let v = v.as_ref();
                     quote! { #v }
                 })
                 .unwrap_or_else(|| quote! { #name });
@@ -1637,7 +1618,7 @@ pub(crate) fn component_to_tokens(
 }
 
 pub(crate) fn event_from_attribute_node(
-    attr: &NodeAttribute,
+    attr: &KeyedAttribute,
     force_undelegated: bool,
 ) -> (TokenStream, &Expr) {
     let event_name = attr
@@ -1697,7 +1678,7 @@ fn ident_from_tag_name(tag_name: &NodeName) -> Ident {
 fn expr_to_ident(expr: &syn::Expr) -> Option<&ExprPath> {
     match expr {
         syn::Expr::Block(block) => block.block.stmts.last().and_then(|stmt| {
-            if let syn::Stmt::Expr(expr) = stmt {
+            if let syn::Stmt::Expr(expr, ..) = stmt {
                 expr_to_ident(expr)
             } else {
                 None
@@ -1708,15 +1689,15 @@ fn expr_to_ident(expr: &syn::Expr) -> Option<&ExprPath> {
     }
 }
 
-fn is_slot(node: &NodeAttribute) -> bool {
+fn is_slot(node: &KeyedAttribute) -> bool {
     let key = node.key.to_string();
     let key = key.trim();
     key == "slot" || key.starts_with("slot:")
 }
 
-fn get_slot(node: &NodeElement) -> Option<&NodeAttribute> {
-    node.attributes.iter().find_map(|node| {
-        if let Node::Attribute(node) = node {
+fn get_slot(node: &NodeElement) -> Option<&KeyedAttribute> {
+    node.attributes().iter().find_map(|node| {
+        if let NodeAttribute::Attribute(node) = node {
             if is_slot(node) {
                 Some(node)
             } else {
@@ -1744,7 +1725,7 @@ fn is_self_closing(node: &NodeElement) -> bool {
     // self-closing tags
     // https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
     matches!(
-        node.name.to_string().as_str(),
+        node.name().to_string().as_str(),
         "area"
             | "base"
             | "br"
@@ -1899,13 +1880,13 @@ fn parse_event(event_name: &str) -> (&str, bool) {
 fn fancy_class_name<'a>(
     name: &str,
     cx: &Ident,
-    node: &'a NodeAttribute,
+    node: &'a KeyedAttribute,
 ) -> Option<(TokenStream, String, &'a Expr)> {
     // special case for complex class names:
     // e.g., Tailwind `class=("mt-[calc(100vh_-_3rem)]", true)`
     if name == "class" {
-        if let Some(expr) = node.value.as_ref() {
-            if let syn::Expr::Tuple(tuple) = expr.as_ref() {
+        if let Some(expr) = node.value() {
+            if let syn::Expr::Tuple(tuple) = expr {
                 if tuple.elems.len() == 2 {
                     let span = node.key.span();
                     let class = quote_spanned! {
@@ -1948,12 +1929,12 @@ fn fancy_class_name<'a>(
 fn fancy_style_name<'a>(
     name: &str,
     cx: &Ident,
-    node: &'a NodeAttribute,
+    node: &'a KeyedAttribute,
 ) -> Option<(TokenStream, String, &'a Expr)> {
     // special case for complex dynamic style names:
     if name == "style" {
-        if let Some(expr) = node.value.as_ref() {
-            if let syn::Expr::Tuple(tuple) = expr.as_ref() {
+        if let Some(expr) = node.value() {
+            if let syn::Expr::Tuple(tuple) = expr {
                 if tuple.elems.len() == 2 {
                     let span = node.key.span();
                     let style = quote_spanned! {

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
 use std::collections::HashMap;
 use syn::{spanned::Spanned, Expr, ExprLit, ExprPath, Lit};
-use syn_rsx::{Node, NodeAttribute, NodeElement, NodeName, KeyedAttribute};
+use rstml::node::{Node, NodeAttribute, NodeElement, NodeName, KeyedAttribute};
 
 #[derive(Clone, Copy)]
 enum TagType {

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -44,7 +44,7 @@ error: unexpected end of input, expected assignment `=`
 47 |     #[prop(default)] default: bool,
    |                   ^
 
-error: unexpected end of input, expected one of: `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+error: unexpected end of input, expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
 
        = help: try `#[prop(default=5 * 10)]`
   --> tests/ui/component.rs:56:22

--- a/leptos_macro/tests/ui/component_absolute.stderr
+++ b/leptos_macro/tests/ui/component_absolute.stderr
@@ -44,7 +44,7 @@ error: unexpected end of input, expected assignment `=`
 45 |     #[prop(default)] default: bool,
    |                   ^
 
-error: unexpected end of input, expected one of: `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+error: unexpected end of input, expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
 
        = help: try `#[prop(default=5 * 10)]`
   --> tests/ui/component_absolute.rs:54:22

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -90,10 +90,10 @@ where
         children: Children,
     ) -> HtmlElement<leptos::html::A> {
         #[cfg(not(any(feature = "hydrate", feature = "csr")))]
-        _ = state;
+        {_ = state;}
 
         #[cfg(not(any(feature = "hydrate", feature = "csr")))]
-        _ = replace;
+        {_ = replace;}
 
         let location = use_location(cx);
         let is_active = create_memo(cx, move |_| match href.get() {

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -90,10 +90,14 @@ where
         children: Children,
     ) -> HtmlElement<leptos::html::A> {
         #[cfg(not(any(feature = "hydrate", feature = "csr")))]
-        {_ = state;}
+        {
+            _ = state;
+        }
 
         #[cfg(not(any(feature = "hydrate", feature = "csr")))]
-        {_ = replace;}
+        {
+            _ = replace;
+        }
 
         let location = use_location(cx);
         let is_active = create_memo(cx, move |_| match href.get() {

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -15,7 +15,7 @@ serde_qs = "0.12"
 thiserror = "1"
 serde_json = "1"
 quote = "1"
-syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
+syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
 proc-macro2 = "1"
 ciborium = "0.2"
 xxhash-rust = { version = "0.8", features = ["const_xxh64"] }

--- a/server_fn/server_fn_macro_default/Cargo.toml
+++ b/server_fn/server_fn_macro_default/Cargo.toml
@@ -11,7 +11,7 @@ description = "The default implementation of the server_fn macro without a conte
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 server_fn_macro = { workspace = true }
 
 [dev-dependencies]

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 quote = "1"
-syn = { version = "1", features = ["full", "parsing", "extra-traits"] }
+syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
 proc-macro2 = "1"
 proc-macro-error = "1"
 xxhash-rust = { version = "0.8.6", features = ["const_xxh64"] }


### PR DESCRIPTION
Hi.
Original author of syn-rsx is absent for a while.
I tried to reach him through the e-mail but have no luck with that.

I have created a fork of https://github.com/rs-tml/rstml 
With aim to better IDE support.
Fork contain few refactors which breaks the API, but during refactor all types became to be self-describing (every type contain all tokens that was parsed), which, i hope, will reduce future breaking changes.

In this PR i move from syn-rsx to rstml fork.
Which also bump minimum syn version to 2.0 (it was already in dependencies before)

## In summary, this pr introduce or changes :
1. Add support of unquoted text support.
2. Introduce recovery of parser after invalid closing tags, unclosed tags or invalid expression ( can be checked by semantic syntax highlight)
3. Simplified Node::Text ( no expressions, or other literals except string)
4. Attribute refactoring - not a node anymore, seperated Block and key=value attributes.
5. As part of 2. `NodeBlock::Invalid` was introduced, which represent block with invalid `syn::Block` syntax.


## To discuss:
- Component macro refactor.
 Currently if inside fn body any invalid expression was found, then macro will fail to expand. 
 To fix this, we can omit parsing of fn body.
 
- `#[allow(unused_braces)]`, `vec![]` and other macro usage inside expansion.
I have removed this macro usage, because with them `rust-analyzer` failed to give completion for invalid expression inside braces `<div> {v.<COMPLETION>} </div>`. Probably i can return it for `NodeBlock::Valid`, and keep it removed only for `InvalidBlock`.


