### PR TITLE
feat: add "async routing" feature

### DIFF
--- a/examples/hackernews/src/lib.rs
+++ b/examples/hackernews/src/lib.rs
@@ -1,5 +1,5 @@
 use cfg_if::cfg_if;
-use leptos::{component, view, IntoView, Scope};
+use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
 mod api;
@@ -9,23 +9,25 @@ use routes::{nav::*, stories::*, story::*, users::*};
 #[component]
 pub fn App(cx: Scope) -> impl IntoView {
     provide_meta_context(cx);
-    view! {
-        cx,
-        <>
-            <Stylesheet id="leptos" href="/pkg/hackernews.css"/>
-            <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
-            <Meta name="description" content="Leptos implementation of a HackerNews demo."/>
-            <Router>
-                <Nav />
-                <main>
-                    <Routes>
-                        <Route path="users/:id" view=|cx| view! { cx,  <User/> }/>
-                        <Route path="stories/:id" view=|cx| view! { cx,  <Story/> }/>
-                        <Route path=":stories?" view=|cx| view! { cx,  <Stories/> }/>
-                    </Routes>
-                </main>
-            </Router>
-        </>
+    let (is_routing, set_is_routing) = create_signal(cx, false);
+
+    view! { cx,
+        <Stylesheet id="leptos" href="/pkg/hackernews.css"/>
+        <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
+        <Meta name="description" content="Leptos implementation of a HackerNews demo."/>
+        // adding `set_is_routing` causes the router to wait for async data to load on new pages
+        <Router set_is_routing>
+            // shows a progress bar while async data are loading
+            <RoutingProgress is_routing max_time=std::time::Duration::from_millis(250)/>
+            <Nav />
+            <main>
+                <Routes>
+                    <Route path="users/:id" view=|cx| view! { cx,  <User/> }/>
+                    <Route path="stories/:id" view=|cx| view! { cx,  <Story/> }/>
+                    <Route path=":stories?" view=|cx| view! { cx,  <Stories/> }/>
+                </Routes>
+            </main>
+        </Router>
     }
 }
 

--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -278,7 +278,33 @@ where
                                     let start = child.get_opening_node();
                                     let end = &closing;
 
-                                    unmount_child(&start, end);
+                                    match child {
+                                        View::CoreComponent(
+                                            crate::CoreComponent::DynChild(
+                                                child,
+                                            ),
+                                        ) => {
+                                            let start =
+                                                child.get_opening_node();
+                                            let end = child.closing.node;
+                                            prepare_to_move(
+                                                &child.document_fragment,
+                                                &start,
+                                                &end,
+                                            );
+                                        }
+                                        View::Component(child) => {
+                                            let start =
+                                                child.get_opening_node();
+                                            let end = child.closing.node;
+                                            prepare_to_move(
+                                                &child.document_fragment,
+                                                &start,
+                                                &end,
+                                            );
+                                        }
+                                        _ => unmount_child(&start, end),
+                                    }
                                 }
 
                                 // Mount the new child

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -110,7 +110,7 @@ pub use slice::*;
 pub use spawn::*;
 pub use spawn_microtask::*;
 pub use stored_value::*;
-pub use suspense::SuspenseContext;
+pub use suspense::{GlobalSuspenseContext, SuspenseContext};
 pub use trigger::*;
 
 mod macros {

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -3,10 +3,11 @@ use crate::{
     create_effect, create_isomorphic_effect, create_memo, create_signal,
     queue_microtask,
     runtime::{with_runtime, RuntimeId},
-    serialization::Serializable, GlobalSuspenseContext,
+    serialization::Serializable,
     spawn::spawn_local,
-    use_context, Memo, ReadSignal, Scope, ScopeProperty, SignalGetUntracked,
-    SignalSet, SignalUpdate, SignalWith, SuspenseContext, WriteSignal,
+    use_context, GlobalSuspenseContext, Memo, ReadSignal, Scope, ScopeProperty,
+    SignalGetUntracked, SignalSet, SignalUpdate, SignalWith, SuspenseContext,
+    WriteSignal,
 };
 use std::{
     any::Any,

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -2,8 +2,9 @@
 
 #![forbid(unsafe_code)]
 use crate::{
-    create_rw_signal, create_signal, queue_microtask, store_value, ReadSignal,
-    RwSignal, Scope, SignalUpdate, StoredValue, WriteSignal, create_isomorphic_effect, signal::SignalGet, SignalSet
+    create_isomorphic_effect, create_rw_signal, create_signal, queue_microtask,
+    signal::SignalGet, store_value, ReadSignal, RwSignal, Scope, SignalSet,
+    SignalUpdate, StoredValue, WriteSignal,
 };
 use futures::Future;
 use std::{borrow::Cow, cell::RefCell, collections::VecDeque, pin::Pin};
@@ -20,8 +21,8 @@ pub struct SuspenseContext {
     pub(crate) should_block: StoredValue<bool>,
 }
 
-/// A single, global suspense context that will be checked when resources 
-/// are read. This won’t be “blocked” by lower suspense components. This is 
+/// A single, global suspense context that will be checked when resources
+/// are read. This won’t be “blocked” by lower suspense components. This is
 /// useful for e.g., holding route transitions.
 #[derive(Copy, Clone, Debug)]
 pub struct GlobalSuspenseContext(SuspenseContext);
@@ -36,8 +37,7 @@ impl GlobalSuspenseContext {
     pub fn as_inner(&self) -> &SuspenseContext {
         &self.0
     }
- }
-
+}
 
 impl SuspenseContext {
     /// Whether the suspense contains local resources at this moment,
@@ -54,7 +54,7 @@ impl SuspenseContext {
 
     /// Returns a `Future` that resolves when this suspense is resolved.
     pub fn to_future(&self, cx: Scope) -> impl Future<Output = ()> {
-        use futures::StreamExt; 
+        use futures::StreamExt;
 
         let pending_resources = self.pending_resources;
         let (tx, mut rx) = futures::channel::mpsc::channel(1);
@@ -66,7 +66,7 @@ impl SuspenseContext {
                 }
             })
         });
-        async move { 
+        async move {
             rx.next().await;
         }
     }

--- a/router/src/components/mod.rs
+++ b/router/src/components/mod.rs
@@ -1,6 +1,7 @@
 mod form;
 mod link;
 mod outlet;
+mod progress;
 mod redirect;
 mod route;
 mod router;
@@ -9,6 +10,7 @@ mod routes;
 pub use form::*;
 pub use link::*;
 pub use outlet::*;
+pub use progress::*;
 pub use redirect::*;
 pub use route::*;
 pub use router::*;

--- a/router/src/components/progress.rs
+++ b/router/src/components/progress.rs
@@ -1,0 +1,66 @@
+use leptos::{leptos_dom::helpers::IntervalHandle, *};
+
+/// A visible indicator that the router is in the process of navigating
+/// to another route.
+///
+/// This is used when `<Router set_is_routing>` has been provided, to
+/// provide some visual indicator that the page is currently loading
+/// async data, so that it is does not appear to have frozen. It can be
+/// styled independently.
+#[component]
+pub fn RoutingProgress(
+    cx: Scope,
+    /// Whether the router is currently loading the new page.
+    #[prop(into)]
+    is_routing: Signal<bool>,
+    /// The maximum expected time for loading, which is used to
+    /// calibrate the animation process.
+    #[prop(optional, into)]
+    max_time: std::time::Duration,
+    /// The time to show the full progress bar after page has loaded, before hiding it. (Defaults to 100ms.)
+    #[prop(default = std::time::Duration::from_millis(250))]
+    before_hiding: std::time::Duration,
+    /// CSS classes to be applied to the `<progress>`.
+    #[prop(optional, into)]
+    class: String,
+) -> impl IntoView {
+    const INCREMENT_EVERY_MS: f32 = 5.0;
+    let expected_increments =
+        max_time.as_secs_f32() / (INCREMENT_EVERY_MS / 1000.0);
+    let percent_per_increment = 100.0 / expected_increments;
+
+    let (is_showing, set_is_showing) = create_signal(cx, false);
+    let (progress, set_progress) = create_signal(cx, 0.0);
+
+    create_effect(cx, move |prev: Option<Option<IntervalHandle>>| {
+        if is_routing.get() {
+            set_is_showing.set(true);
+            set_interval_with_handle(
+                move || {
+                    set_progress.update(|n| *n += percent_per_increment);
+                },
+                std::time::Duration::from_millis(INCREMENT_EVERY_MS as u64),
+            )
+            .ok()
+        } else {
+            set_progress.set(100.0);
+            set_timeout(
+                move || {
+                    set_progress.set(0.0);
+                    set_is_showing.set(false);
+                },
+                before_hiding,
+            );
+            if let Some(Some(interval)) = prev {
+                interval.clear();
+            }
+            None
+        }
+    });
+
+    view! { cx,
+        <Show when=move || is_showing.get() fallback=|_| ()>
+            <progress class=class.clone() min="0" max="100" value=move || progress.get()/>
+        </Show>
+    }
+}

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -25,7 +25,8 @@ pub fn Router(
     #[prop(optional)]
     fallback: Option<fn(Scope) -> View>,
     /// A signal that will be set while the navigation process is underway.
-    #[prop(optional, into)] set_is_routing: Option<SignalSetter<bool>>,
+    #[prop(optional, into)]
+    set_is_routing: Option<SignalSetter<bool>>,
     /// The `<Router/>` should usually wrap your whole page. It can contain
     /// any elements, and should include a [Routes](crate::Routes) component somewhere
     /// to define and display [Route](crate::Route)s.
@@ -238,7 +239,9 @@ impl RouterContextInner {
             };
 
             // reset count of pending resources at global level
-            expect_context::<GlobalSuspenseContext>(cx).as_inner().clear();
+            expect_context::<GlobalSuspenseContext>(cx)
+                .as_inner()
+                .clear();
 
             match resolved_to {
                 None => Err(NavigationError::NotRoutable(to.to_string())),
@@ -274,11 +277,12 @@ impl RouterContextInner {
                             move |state| *state = next_state
                         });
 
-                        let global_suspense = expect_context::<GlobalSuspenseContext>(cx);
+                        let global_suspense =
+                            expect_context::<GlobalSuspenseContext>(cx);
                         let path_stack = self.path_stack;
-                            path_stack.update_value(|stack| {
-                                stack.push(resolved_to.clone())
-                            });
+                        path_stack.update_value(|stack| {
+                            stack.push(resolved_to.clone())
+                        });
 
                         let set_is_routing = use_context::<SetIsRouting>(cx);
                         if let Some(set_is_routing) = set_is_routing {

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -24,6 +24,8 @@ pub fn Router(
     /// A fallback that should be shown if no route is matched.
     #[prop(optional)]
     fallback: Option<fn(Scope) -> View>,
+    /// A signal that will be set while the navigation process is underway.
+    #[prop(optional, into)] set_is_routing: Option<SignalSetter<bool>>,
     /// The `<Router/>` should usually wrap your whole page. It can contain
     /// any elements, and should include a [Routes](crate::Routes) component somewhere
     /// to define and display [Route](crate::Route)s.
@@ -32,9 +34,16 @@ pub fn Router(
     // create a new RouterContext and provide it to every component beneath the router
     let router = RouterContext::new(cx, base, fallback);
     provide_context(cx, router);
+    provide_context(cx, GlobalSuspenseContext::new(cx));
+    if let Some(set_is_routing) = set_is_routing {
+        provide_context(cx, SetIsRouting(set_is_routing));
+    }
 
     children(cx)
 }
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SetIsRouting(pub SignalSetter<bool>);
 
 /// Context type that contains information about the current router state.
 #[derive(Debug, Clone)]
@@ -228,6 +237,9 @@ impl RouterContextInner {
                 resolve_path("", to, None).map(String::from)
             };
 
+            // reset count of pending resources at global level
+            expect_context::<GlobalSuspenseContext>(cx).as_inner().clear();
+
             match resolved_to {
                 None => Err(NavigationError::NotRoutable(to.to_string())),
                 Some(resolved_to) => {
@@ -262,18 +274,31 @@ impl RouterContextInner {
                             move |state| *state = next_state
                         });
 
-                        self.path_stack.update_value(|stack| {
-                            stack.push(resolved_to.clone())
-                        });
+                        let global_suspense = expect_context::<GlobalSuspenseContext>(cx);
+                        let path_stack = self.path_stack;
+                            path_stack.update_value(|stack| {
+                                stack.push(resolved_to.clone())
+                            });
 
-                        if referrers.borrow().len() == len {
-                            this.navigate_end(LocationChange {
-                                value: resolved_to,
-                                replace: false,
-                                scroll: true,
-                                state,
-                            })
+                        let set_is_routing = use_context::<SetIsRouting>(cx);
+                        if let Some(set_is_routing) = set_is_routing {
+                            set_is_routing.0.set(true);
                         }
+                        spawn_local(async move {
+                            if let Some(set_is_routing) = set_is_routing {
+                                global_suspense.as_inner().to_future(cx).await;
+                                set_is_routing.0.set(false);
+                            }
+
+                            if referrers.borrow().len() == len {
+                                this.navigate_end(LocationChange {
+                                    value: resolved_to,
+                                    replace: false,
+                                    scroll: true,
+                                    state,
+                                });
+                            }
+                        });
                     }
 
                     Ok(())


### PR DESCRIPTION
#994 describes the behavior used by many (but not all) frameworks: if you navigate to a new page in the client (after hydration or with client-side rendering) and async resources must be loaded to render it, rather than navigating immediately and showing a "Loading..." fallback, hold the current page until the resources have loaded.

I'm open to suggestions on how to opt into this. For the moment, I've done it by adding an optional `set_is_routing` prop to the `<Router/>` component that just takes a `WriteSignal<bool>` or similar.

```rust
#[component]
pub fn App(cx: Scope) -> impl IntoView {
    let (is_routing, set_is_routing) = create_signal(cx, false);

    view! { cx,
        <Router set_is_routing>
```

In my opinion this is kind of clever because it requires the user to provide some kind of indicator that will be set during the routing process (i.e., while the previous page is still being held), which is necessary for good UX. If you don't use this signal, it looks like the page is just not responding while loading data, as the browser's own page-load indicators don't fire (since it's a client-side navigation).

I think this is much more polished than the "fallback" default, so this may become default behavior in a future release.


https://github.com/leptos-rs/leptos/assets/286622/cecd9e8b-1305-4959-b5d9-3708571e8940

To-do
- [x] Support this in `<Outlet/>` for nested routes as well as `<Routes/>` for top-level routes
- ~~[ ] Test against animated routing~~ (this is hard, maybe I'll leave it for later...)
- [x] provide a default progress-bar kind of component as well, that makes it easy to use that pending notification?