### PR TITLE
fix: `todomvc` example style errors

### DIFF
--- a/examples/cargo-make/common.toml
+++ b/examples/cargo-make/common.toml
@@ -5,6 +5,9 @@ env = { CARGO_MAKE_CLIPPY_ARGS = "--all-targets --all-features -- -D warnings" }
 description = "Check for style violations"
 dependencies = ["check-format-flow", "clippy-flow"]
 
+[tasks.check-format]
+args = ["fmt", "--", "--check", "--config-path", "../../"]
+
 [tasks.verify-local]
 description = "Run all quality checks and tests from an example directory"
 dependencies = ["check-style", "test-local"]

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -83,9 +83,9 @@ impl Todos {
         self.0.retain(|todo| {
             let retain = f(todo);
             // because these signals are created at the top level,
-            // they are owned by the <TodoMVC/> component and not 
-            // by the individual <Todo/> components. This means 
-            // that if they are not manually disposed when removed, they 
+            // they are owned by the <TodoMVC/> component and not
+            // by the individual <Todo/> components. This means
+            // that if they are not manually disposed when removed, they
             // will be held onto until the <TodoMVC/> is unmounted.
             if !retain {
                 todo.title.dispose();


### PR DESCRIPTION
This resolves style errors in the `todomvc` example. It also ensures all examples respect the project format standards.

Verification:

- Run `cargo make check-style` from the **examples/todomvc** directory.
- Run `cargo make verify-examples` from the **leptos** root directory.

