### PR TITLE
test: setup e2e automatically for tailwind example

### DIFF
--- a/examples/cargo-make/cargo-leptos-web-test.toml
+++ b/examples/cargo-make/cargo-leptos-web-test.toml
@@ -1,5 +1,5 @@
 [tasks.web-test]
-dependencies = ["cargo-leptos-e2e"]
+dependencies = ["auto-setup", "cargo-leptos-e2e"]
 
 [tasks.clean-all]
 dependencies = ["clean-cargo", "clean-node_modules", "clean-playwright"]

--- a/examples/cargo-make/common.toml
+++ b/examples/cargo-make/common.toml
@@ -78,3 +78,10 @@ script = '''
         exit 1
     fi
 '''
+
+[tasks.auto-setup]
+script = '''
+  if [ ! -d "${END2END_DIR}/node_modules" ]; then
+    cargo make setup
+  fi
+'''


### PR DESCRIPTION
This automates e2e setup for `cargo-leptos-web-test`s.

Verification:

From the **examples/tailwind** directory...
- Run `cargo make clean-all`
- Run `cargo make web-test` 