### PR TITLE
fix: duplicate headers (like Set-Cookie) on the actix integration

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -254,17 +254,11 @@ pub fn handle_server_fns_with_context(
                             }
 
                             // Use provided ResponseParts headers if they exist
-                            let mut last_key = None;
                             let _count = res_parts
                                 .headers
-                                .drain()
+                                .into_iter()
                                 .map(|(k, v)| {
-                                    if let Some(k) = k {
-                                        last_key = Some(k.clone());
-                                        res.append_header((k, v));
-                                    } else if let Some(k) = last_key.clone() {
-                                        res.append_header((k, v));
-                                    }
+                                    res.append_header((k, v));
                                 })
                                 .count();
 
@@ -823,14 +817,8 @@ async fn build_stream_response(
         .streaming(complete_stream);
 
     // Add headers manipulated in the response
-    let mut last_key = None;
-    for (key, value) in headers.drain() {
-        if let Some(key) = key {
-            last_key = Some(key.clone());
-            res.headers_mut().append(key, value);
-        } else if let Some(key) = last_key.clone() {
-            res.headers_mut().append(key, value);
-        }
+    for (key, value) in headers.into_iter() {
+        res.headers_mut().append(key, value);
     }
 
     // Set status to what is returned in the function
@@ -864,14 +852,8 @@ async fn render_app_async_helper(
     let mut res = HttpResponse::Ok().content_type("text/html").body(html);
 
     // Add headers manipulated in the response
-    let mut last_key = None;
-    for (key, value) in headers.drain() {
-        if let Some(key) = key {
-            last_key = Some(key.clone());
-            res.headers_mut().append(key, value);
-        } else if let Some(key) = last_key.clone() {
-            res.headers_mut().append(key, value);
-        }
+    for (key, value) in headers.into_iter() {
+        res.headers_mut().append(key, value);
     }
 
     // Set status to what is returned in the function

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -228,7 +228,7 @@ pub fn handle_server_fns_with_context(
                                 use_context::<ResponseOptions>(cx).unwrap();
 
                             let mut res: HttpResponseBuilder;
-                            let mut res_parts = res_options.0.write();
+                            let res_parts = res_options.0.write();
 
                             if accept_header == Some("application/json")
                                 || accept_header
@@ -256,6 +256,7 @@ pub fn handle_server_fns_with_context(
                             // Use provided ResponseParts headers if they exist
                             let _count = res_parts
                                 .headers
+                                .clone()
                                 .into_iter()
                                 .map(|(k, v)| {
                                     res.append_header((k, v));
@@ -805,8 +806,7 @@ async fn build_stream_response(
 
     let res_options = res_options.0.read();
 
-    let (status, mut headers) =
-        (res_options.status, res_options.headers.clone());
+    let (status, headers) = (res_options.status, res_options.headers.clone());
     let status = status.unwrap_or_default();
 
     let complete_stream =
@@ -845,8 +845,7 @@ async fn render_app_async_helper(
 
     let res_options = res_options.0.read();
 
-    let (status, mut headers) =
-        (res_options.status, res_options.headers.clone());
+    let (status, headers) = (res_options.status, res_options.headers.clone());
     let status = status.unwrap_or_default();
 
     let mut res = HttpResponse::Ok().content_type("text/html").body(html);

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -254,11 +254,15 @@ pub fn handle_server_fns_with_context(
                             }
 
                             // Use provided ResponseParts headers if they exist
+                            let mut last_key = None;
                             let _count = res_parts
                                 .headers
                                 .drain()
                                 .map(|(k, v)| {
                                     if let Some(k) = k {
+                                        last_key = Some(k.clone());
+                                        res.append_header((k, v));
+                                    } else if let Some(k) = last_key.clone() {
                                         res.append_header((k, v));
                                     }
                                 })
@@ -817,12 +821,18 @@ async fn build_stream_response(
     let mut res = HttpResponse::Ok()
         .content_type("text/html")
         .streaming(complete_stream);
+
     // Add headers manipulated in the response
+    let mut last_key = None;
     for (key, value) in headers.drain() {
         if let Some(key) = key {
+            last_key = Some(key.clone());
+            res.headers_mut().append(key, value);
+        } else if let Some(key) = last_key.clone() {
             res.headers_mut().append(key, value);
         }
     }
+
     // Set status to what is returned in the function
     let res_status = res.status_mut();
     *res_status = status;
@@ -854,11 +864,16 @@ async fn render_app_async_helper(
     let mut res = HttpResponse::Ok().content_type("text/html").body(html);
 
     // Add headers manipulated in the response
+    let mut last_key = None;
     for (key, value) in headers.drain() {
         if let Some(key) = key {
+            last_key = Some(key.clone());
+            res.headers_mut().append(key, value);
+        } else if let Some(key) = last_key.clone() {
             res.headers_mut().append(key, value);
         }
     }
+
     // Set status to what is returned in the function
     let res_status = res.status_mut();
     *res_status = status;


### PR DESCRIPTION
Ignoring any header with a `None` key means that we can't set multiple cookies (for example).
The correct behaviour seems to be reusing the last non-None key from what I saw in the docs.