### PR TITLE
feat: add Axum `extract()` function

### DIFF
--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -18,7 +18,6 @@ cfg_if! {
             _ = GetTodos::register();
             _ = AddTodo::register();
             _ = DeleteTodo::register();
-            _ = FormDataHandler::register();
         }
 
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
@@ -108,30 +107,6 @@ pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
         .map_err(|e| ServerFnError::ServerError(e.to_string()))
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-pub struct FormData {
-    hi: String,
-}
-
-#[server(FormDataHandler, "/api")]
-pub async fn form_data(cx: Scope) -> Result<FormData, ServerFnError> {
-    use axum::extract::FromRequest;
-
-    let req = use_context::<leptos_axum::LeptosRequest<axum::body::Body>>(cx)
-        .and_then(|req| req.take_request())
-        .unwrap();
-    if req.method() == http::Method::POST {
-        let form = axum::Form::from_request(req, &())
-            .await
-            .map_err(|e| ServerFnError::ServerError(e.to_string()))?;
-        Ok(form.0)
-    } else {
-        Err(ServerFnError::ServerError(
-            "wrong form fields submitted".to_string(),
-        ))
-    }
-}
-
 #[component]
 pub fn TodoApp(cx: Scope) -> impl IntoView {
     //let id = use_context::<String>(cx);
@@ -148,24 +123,7 @@ pub fn TodoApp(cx: Scope) -> impl IntoView {
                 <Routes>
                     <Route path="" view=|cx| view! { cx,
                         <Todos/>
-                    }/> //Route
-                    <Route path="weird" methods=&[Method::Get, Method::Post]
-                        ssr=SsrMode::Async
-                        view=|cx| {
-                            let res = create_resource(cx, || (), move |_| async move {
-                                form_data(cx).await
-                            });
-                            view! { cx,
-                                <Suspense fallback=|| ()>
-                                    <pre>
-                                        {move || {
-                                            res.with(cx, |body| format!("{body:#?}"))
-                                        }}
-                                    </pre>
-                                </Suspense>
-                            }
-                        }
-                    />
+                    }/>
                 </Routes>
             </main>
         </Router>

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
-    extract::{FromRef, Path, RawQuery, FromRequestParts},
+    extract::{FromRef, FromRequestParts, Path, RawQuery},
     http::{
         header::{HeaderName, HeaderValue},
         HeaderMap, Request, StatusCode,
@@ -1284,7 +1284,7 @@ impl<B> From<Request<B>> for ExtractorHelper {
 /// pub async fn query_extract(cx: Scope) -> Result<String, ServerFnError> {
 ///     use axum::{extract::Query, http::Method};
 ///     use leptos_axum::extract;
-/// 
+///
 ///     extract(cx, |method: Method, res: Query<MyQuery>| async move {
 ///             format!("{method:?} and {}", res.q)
 ///         },
@@ -1332,7 +1332,6 @@ macro_rules! factory_tuple ({ $($param:ident)* } => {
         }
     }
 });
-
 
 factory_tuple! { A }
 factory_tuple! { A B }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
-    extract::{FromRef, Path, RawQuery},
+    extract::{FromRef, Path, RawQuery, FromRequestParts},
     http::{
         header::{HeaderName, HeaderValue},
         HeaderMap, Request, StatusCode,
@@ -150,69 +150,6 @@ pub async fn generate_request_and_parts(
     (request, request_parts)
 }
 
-/// A struct to hold the [`http::request::Request`] and allow users to take ownership of it
-/// Required by `Request` not being `Clone`. See
-/// [this issue](https://github.com/hyperium/http/pull/574) for eventual resolution:
-#[derive(Debug, Default)]
-pub struct LeptosRequest<B>(Arc<RwLock<Option<Request<B>>>>);
-
-impl<B> Clone for LeptosRequest<B> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-impl<B> LeptosRequest<B> {
-    /// Overwrite the contents of a LeptosRequest with a new `Request<B>`
-    pub fn overwrite(&self, req: Option<Request<B>>) {
-        let mut writable = self.0.write();
-        *writable = req
-    }
-    /// Consume the inner `Request<B>` inside the LeptosRequest and return it
-    ///```rust, ignore
-    /// use axum::{
-    /// RequestPartsExt,
-    /// headers::Host
-    /// };
-    /// #[server(GetHost, "/api")]
-    /// pub async fn get_host(cx: Scope) -> Result((), ServerFnError){
-    ///  let req = use_context::<leptos_axum::LeptosRequest<axum::body::Body>>(cx);
-    ///  if let Some(req) = req{
-    ///     let owned_req = req.take_request().unwrap();
-    ///     let (mut parts, _body) = owned_req.into_parts();
-    ///     let host: TypedHeader<Host> = parts.extract().await().unwrap();
-    ///     println!("Host: {host:#?}");
-    ///  }
-    /// }
-    /// ```
-    pub fn take_request(&self) -> Option<Request<B>> {
-        let mut writable = self.0.write();
-        writable.take()
-    }
-    /// Can be used to get immutable access to the interior fields of Request
-    /// and do something with them
-    pub fn with(&self, with_fn: impl Fn(Option<&Request<B>>)) {
-        let readable = self.0.read();
-        with_fn(readable.as_ref());
-    }
-
-    /// Can be used to mutate the fields of the Request
-    pub fn update(&self, update_fn: impl Fn(Option<&mut Request<B>>)) {
-        let mut writable = self.0.write();
-        update_fn(writable.as_mut());
-    }
-}
-/// Generate a wrapper for the http::Request::Request type that allows one to
-/// process it, access the body, and use axum Extractors on it.
-/// Required by Request not being Clone. See
-/// [this issue](https://github.com/hyperium/http/pull/574) for eventual resolution:
-pub async fn generate_leptos_request<B>(req: Request<B>) -> LeptosRequest<B>
-where
-    B: Default + std::fmt::Debug,
-{
-    let leptos_request = LeptosRequest::default();
-    leptos_request.overwrite(Some(req));
-    leptos_request
-}
 /// An Axum handlers to listens for a request with Leptos server function arguments in the body,
 /// run the server function if found, and return the resulting [Response].
 ///
@@ -310,9 +247,8 @@ async fn handle_server_fns_inner(
                 additional_context(cx);
 
                 let (req, req_parts) = generate_request_and_parts(req).await;
-                let leptos_req = generate_leptos_request(req).await; // Add this so we can get details about the Request
                 provide_context(cx, req_parts.clone());
-                provide_context(cx, leptos_req);
+                provide_context(cx, ExtractorHelper::from(req));
                 // Add this so that we can set headers and status of the response
                 provide_context(cx, ResponseOptions::default());
 
@@ -675,9 +611,8 @@ where
 
                     let full_path = format!("http://leptos.dev{path}");
                     let (req, req_parts) = generate_request_and_parts(req).await;
-                    let leptos_req = generate_leptos_request(req).await;
                     move |cx| {
-                        provide_contexts(cx, full_path, req_parts,leptos_req, default_res_options);
+                        provide_contexts(cx, full_path, req_parts, req.into(), default_res_options);
                         app_fn(cx).into_view(cx)
                     }
                 };
@@ -829,9 +764,8 @@ where
                     let app = {
                         let full_path = full_path.clone();
                         let (req, req_parts) = generate_request_and_parts(req).await;
-                        let leptos_req = generate_leptos_request(req).await;
                         move |cx| {
-                            provide_contexts(cx, full_path, req_parts,leptos_req, default_res_options);
+                            provide_contexts(cx, full_path, req_parts, req.into(), default_res_options);
                             app_fn(cx).into_view(cx)
                         }
                     };
@@ -851,19 +785,20 @@ where
         })
     }
 }
+
 #[tracing::instrument(level = "trace", fields(error), skip_all)]
-fn provide_contexts<B: 'static + std::fmt::Debug + std::default::Default>(
+fn provide_contexts(
     cx: Scope,
     path: String,
     req_parts: RequestParts,
-    leptos_req: LeptosRequest<B>,
+    extractor: ExtractorHelper,
     default_res_options: ResponseOptions,
 ) {
     let integration = ServerIntegration { path };
     provide_context(cx, RouterIntegrationContext::new(integration));
     provide_context(cx, MetaContext::new());
     provide_context(cx, req_parts);
-    provide_context(cx, leptos_req);
+    provide_context(cx, extractor);
     provide_context(cx, default_res_options);
     provide_server_redirect(cx, move |path| redirect(cx, path));
 }
@@ -999,9 +934,8 @@ where
                         let app = {
                             let full_path = full_path.clone();
                             let (req, req_parts) = generate_request_and_parts(req).await;
-                            let leptos_req = generate_leptos_request(req).await;
                             move |cx| {
-                                provide_contexts(cx, full_path, req_parts,leptos_req, default_res_options);
+                                provide_contexts(cx, full_path, req_parts, req.into(), default_res_options);
                                 app_fn(cx).into_view(cx)
                             }
                         };
@@ -1246,7 +1180,7 @@ where
                         }
                         SsrMode::Async => {
                             let s = render_app_async_with_context(
-                                LeptosOptions::from_ref(&options),
+                                LeptosOptions::from_ref(options),
                                 additional_context.clone(),
                                 app_fn.clone(),
                             );
@@ -1307,3 +1241,112 @@ fn get_leptos_pool() -> LocalPoolHandle {
         })
         .clone()
 }
+
+#[derive(Clone, Debug)]
+struct ExtractorHelper {
+    parts: Arc<tokio::sync::Mutex<Parts>>,
+}
+
+impl ExtractorHelper {
+    pub fn new(parts: Parts) -> Self {
+        Self {
+            parts: Arc::new(tokio::sync::Mutex::new(parts)),
+        }
+    }
+
+    pub async fn extract<F, T, U>(&self, f: F) -> Result<U, T::Rejection>
+    where
+        F: Extractor<T, U>,
+        T: std::fmt::Debug + Send + FromRequestParts<()> + 'static,
+        T::Rejection: std::fmt::Debug + Send + 'static,
+    {
+        let mut parts = self.parts.lock().await;
+        let data = T::from_request_parts(&mut parts, &()).await?;
+        Ok(f.call(data).await)
+    }
+}
+
+impl<B> From<Request<B>> for ExtractorHelper {
+    fn from(req: Request<B>) -> Self {
+        // TODO provide body for extractors there, too?
+        let (parts, _) = req.into_parts();
+        ExtractorHelper::new(parts)
+    }
+}
+
+/// A helper to make it easier to use Axum extractors in server functions. This takes
+/// a handler function as its argument. The handler rules similar to Axum
+/// [handlers](https://docs.rs/axum/latest/axum/extract/index.html#intro): it is an async function
+/// whose arguments are “extractors.”
+///
+/// ```rust,ignore
+/// #[server(QueryExtract, "/api")]
+/// pub async fn query_extract(cx: Scope) -> Result<String, ServerFnError> {
+///     use axum::{extract::Query, http::Method};
+///     use leptos_axum::extract;
+/// 
+///     extract(cx, |method: Method, res: Query<MyQuery>| async move {
+///             format!("{method:?} and {}", res.q)
+///         },
+///     )
+///     .await
+///     .map_err(|e| ServerFnError::ServerError("Could not extract method and query...".to_string()))
+/// }
+/// ```
+#[tracing::instrument(level = "trace", fields(error), skip_all)]
+pub async fn extract<T, U>(
+    cx: Scope,
+    f: impl Extractor<T, U>,
+) -> Result<U, T::Rejection>
+where
+    T: std::fmt::Debug + Send + FromRequestParts<()> + 'static,
+    T::Rejection: std::fmt::Debug + Send + 'static,
+{
+    use_context::<ExtractorHelper>(cx)
+        .expect(
+            "should have had ExtractorHelper provided by the leptos_axum \
+             integration",
+        )
+        .extract(f)
+        .await
+}
+
+pub trait Extractor<T, U>
+where
+    T: FromRequestParts<()>,
+{
+    fn call(&self, args: T) -> Pin<Box<dyn Future<Output = U>>>;
+}
+
+macro_rules! factory_tuple ({ $($param:ident)* } => {
+    impl<Func, Fut, U, $($param,)*> Extractor<($($param,)*), U> for Func
+    where
+        $($param: FromRequestParts<()> + Send,)*
+        Func: Fn($($param),*) -> Fut + 'static,
+        Fut: Future<Output = U> + 'static,
+    {
+        #[inline]
+        #[allow(non_snake_case)]
+        fn call(&self, ($($param,)*): ($($param,)*)) -> Pin<Box<dyn Future<Output = U>>> {
+            Box::pin((self)($($param,)*))
+        }
+    }
+});
+
+
+factory_tuple! { A }
+factory_tuple! { A B }
+factory_tuple! { A B C }
+factory_tuple! { A B C D }
+factory_tuple! { A B C D E }
+factory_tuple! { A B C D E F }
+factory_tuple! { A B C D E F G }
+factory_tuple! { A B C D E F G H }
+factory_tuple! { A B C D E F G H I }
+factory_tuple! { A B C D E F G H I J }
+factory_tuple! { A B C D E F G H I J K }
+factory_tuple! { A B C D E F G H I J K L }
+factory_tuple! { A B C D E F G H I J K L M }
+factory_tuple! { A B C D E F G H I J K L M N }
+factory_tuple! { A B C D E F G H I J K L M N O }
+factory_tuple! { A B C D E F G H I J K L M N O P }


### PR DESCRIPTION
Typically, Axum extractors are called in an "access phase" at the beginning of processing a request, conceptually at the "root" of the application tree, before any rendering begins. Leptos is built in the other direction, allowing you to fetch data granularly closer to the "leaves" of the application, in individual components calling individual server functions. Because the Axum request can't be cloned, this has been awkward to handle and has necessitated special handler functions that then pass data down the context tree.

This PR introduces an `extract` function that can be called instead directly in a server function. `extract` takes a `Scope` (...of course) and a handler function that is very similar to an Axum handler, i.e., an async function that takes some number of extractors.
```rust
#[server(QueryExtract, "/api")]
pub async fn query_extract(cx: Scope) -> Result<String, ServerFnError> {
    use axum::{extract::Query, http::Method};
    use leptos_axum::extract;

    extract(cx, |method: Method, res: Query<MyQuery>| async move {
            format!("{method:?} and {}", res.q)
        },
    )
    .await
    .map_err(|e| ServerFnError::ServerError("Could not extract method and query...".to_string()))
}
```

This is implemented by holding the request's `Parts` in an async mutex. This means, I think, that if multiple server functions are called during an initial server-rendering pass on a single page, the extractors will run serially. Based on my understanding of [the Axum implementation](https://docs.rs/axum-core/0.3.4/src/axum_core/extract/tuple.rs.html#33-43) all the extractors for a given handler are already run serially, though, so while there's obviously some overhead from the mutex the performance implications of my approach (which I'd assumed would be more convenient for Leptos but worse performance) are not clear. Benchmarking would be required to see if there's any effect, and of course the custom handler approach is still viable.

This only addresses extractors that work on request `Parts`, not on the request body. The body is consumed by `POST` server functions, of course, and a copy is already provided as `Bytes` via [`RequestParts`](https://docs.rs/leptos_axum/latest/leptos_axum/struct.RequestParts.html)

To be considered: Should we ditch `RequestParts` entirely? It does involve cloning the headers and body, so there would be some performance benefit.