### PR TITLE
build(examples): auto install playwright browsers (#1112)

### DIFF
--- a/examples/cargo-make/cargo-leptos-web-test.toml
+++ b/examples/cargo-make/cargo-leptos-web-test.toml
@@ -1,5 +1,5 @@
 [tasks.web-test]
-dependencies = ["auto-setup", "cargo-leptos-e2e"]
+dependencies = ["auto-playwright-setup", "cargo-leptos-e2e"]
 
 [tasks.clean-all]
 dependencies = ["clean-cargo", "clean-node_modules", "clean-playwright"]

--- a/examples/cargo-make/common.toml
+++ b/examples/cargo-make/common.toml
@@ -60,9 +60,10 @@ description = "Runs end to end tests with cargo leptos"
 command = "cargo"
 args = ["leptos", "end-to-end"]
 
-[tasks.setup]
-description = "Setup e2e dependencies"
+[tasks.setup-playwright]
+description = "Setup playwright and install browsers"
 cwd = "${END2END_DIR}"
+env = { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1" }
 script = '''
     BOLD="\e[1m"
     GREEN="\e[0;32m"
@@ -71,17 +72,19 @@ script = '''
 
     if command -v pnpm; then
         pnpm install
+        pnpm playwright install
     elif command -v npm; then
         npm install
+        npx playwright install
     else
         echo "${RED}${BOLD}ERROR${RESET} - pnpm or npm is required by this task"
         exit 1
     fi
 '''
 
-[tasks.auto-setup]
+[tasks.auto-playwright-setup]
 script = '''
   if [ ! -d "${END2END_DIR}/node_modules" ]; then
-    cargo make setup
+    cargo make setup-playwright
   fi
 '''


### PR DESCRIPTION
This **PR** addresses #1112, in order to support `ci` testing of examples.

_Verification:_

- [Remove playwright browsers](https://playwright.dev/docs/browsers#managing-browser-binaries)
- From the **examples/tailwind** directory
  - Run `cargo make clean-node_modules`
  - Run `cargo make web-test`