### PR TITLE
perf: reduce overhead of hydration keys

### DIFF
--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -80,7 +80,7 @@ where
     E: Error + Send + Sync + 'static,
 {
     fn into_view(self, cx: leptos_reactive::Scope) -> crate::View {
-        let id = ErrorKey(HydrationCtx::peek().previous.into());
+        let id = ErrorKey(HydrationCtx::peek().id.to_string().into());
         let errors = use_context::<RwSignal<Errors>>(cx);
         match self {
             Ok(stuff) => {

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -50,13 +50,13 @@ cfg_if! {
 
       static IS_HYDRATING: RefCell<LazyCell<bool>> = RefCell::new(LazyCell::new(|| {
         #[cfg(debug_assertions)]
-        return crate::document().get_element_by_id("_0-0-0").is_some()
-          || crate::document().get_element_by_id("_0-0-0o").is_some()
-          || HYDRATION_COMMENTS.with(|comments| comments.get("_0-0-0o").is_some());
+        return crate::document().get_element_by_id("_1").is_some()
+          || crate::document().get_element_by_id("_1o").is_some()
+          || HYDRATION_COMMENTS.with(|comments| comments.get("_1o").is_some());
 
         #[cfg(not(debug_assertions))]
-        return crate::document().get_element_by_id("_0-0-0").is_some()
-          || HYDRATION_COMMENTS.with(|comments| comments.get("_0-0-0").is_some());
+        return crate::document().get_element_by_id("_1").is_some()
+          || HYDRATION_COMMENTS.with(|comments| comments.get("_1").is_some());
       }));
     }
 
@@ -69,23 +69,20 @@ cfg_if! {
 /// A stable identifier within the server-rendering or hydration process.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct HydrationKey {
-    /// The key of the previous component.
-    pub previous: String,
-    /// The element offset within the current component.
-    pub offset: usize,
+    /// ID of the current key.
+    pub id: usize,
 }
 
 impl Display for HydrationKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}", self.previous, self.offset)
+        write!(f, "{}", self.id)
     }
 }
 
 impl Default for HydrationKey {
     fn default() -> Self {
         Self {
-            previous: "0-".to_string(),
-            offset: 0,
+            id: 0
         }
     }
 }
@@ -105,7 +102,7 @@ impl HydrationCtx {
     pub fn id() -> HydrationKey {
         ID.with(|id| {
             let mut id = id.borrow_mut();
-            id.offset = id.offset.wrapping_add(1);
+            id.id = id.id.wrapping_add(1);
             id.clone()
         })
     }
@@ -114,10 +111,7 @@ impl HydrationCtx {
     pub fn next_component() -> HydrationKey {
         ID.with(|id| {
             let mut id = id.borrow_mut();
-            let offset = id.offset;
-            id.previous.push_str(&offset.to_string());
-            id.previous.push('-');
-            id.offset = 0;
+            id.id = id.id.wrapping_add(1);
             id.clone()
         })
     }


### PR DESCRIPTION
The current hydration-key system mirrors the one in SolidJS, with keys growing over time so you end up with things like `0-1-1-1-1-1-1-2-1-3-1-3-10-3` as the component tree is nested. Originally this was for the correct handling of suspense. However, as our renderer has grown apart from Solid's the way we actually render things has changed.

This way of generating hydration keys was also creating massively long chains, that actually grew linearly as the number of components used grew, which meant larger pages were built slower and slower (because you were generating longer and longer keys per component.)

I've done a bit of an experiment and this turns out to be almost entirely unnecessary, I think. Because the renderer is now built to run completely top-down, we can just use a single-number key, which should really help with SSR performance.

This is a draft for now because I ran out of time, but wanted to share it so people can do some early testing.

To dos
- [ ] Clippy/cleanup
- [ ] Test against more examples and real apps