### PR TITLE
work around for remove inline0.js

### DIFF
--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -1,8 +1,4 @@
-// `queue_microtask` needs to be in its own module, which is the only thing
-// in this entire framework that requires "unsafe" code (because Rust seems to
-// that a `wasm_bindgen` imported function like this is unsafe)
-// this is stupid, and one day hopefully web_sys will add queue_microtask itself
-
+#![forbid(unsafe_code)]
 use cfg_if::cfg_if;
 
 cfg_if! {
@@ -19,7 +15,7 @@ cfg_if! {
             use wasm_bindgen::prelude::*;
             let window = web_sys::window().expect("window not available");
             let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
-            let queue_microtask = queue_microtask.dyn_into::<Function>().expect("queueMicrotask not a function");
+            let queue_microtask = queue_microtask.unchecked_into::<Function>();
             let _ = queue_microtask.call0(&task);
         }
     } else {

--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -14,11 +14,13 @@ cfg_if! {
         }
 
         #[cfg(any(feature = "csr", feature = "hydrate"))]
-        #[wasm_bindgen::prelude::wasm_bindgen(
-            inline_js = "export function microtask(f) { queueMicrotask(f); }"
-        )]
-        extern "C" {
-            fn microtask(task: wasm_bindgen::JsValue);
+        fn microtask(task: wasm_bindgen::JsValue) {
+            use js_sys::{Reflect, Function};
+            use wasm_bindgen::prelude::*;
+            let window = web_sys::window().expect("window not available");
+            let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
+            let queue_microtask = queue_microtask.dyn_into::<Function>().expect("queueMicrotask not a function");
+            let _ = queue_microtask.call0(&task);
         }
     } else {
         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method


### PR DESCRIPTION
this pr use js_sys Reflect to remove snippets/inline0.js file, which can simplify the deployment of leptos apps.