### PR TITLE
Ran cargo clippy --fix.

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -203,9 +203,10 @@ pub fn handle_server_fns_with_context(
                     if req
                         .headers()
                         .get("Content-Type")
-                        .and_then(|value| value.to_str().ok()).map(|value| value.starts_with(
-                                    "multipart/form-data; boundary=",
-                                ))
+                        .and_then(|value| value.to_str().ok())
+                        .map(|value| {
+                            value.starts_with("multipart/form-data; boundary=")
+                        })
                         == Some(true)
                     {
                         provide_context(cx, body.clone());

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -203,14 +203,9 @@ pub fn handle_server_fns_with_context(
                     if req
                         .headers()
                         .get("Content-Type")
-                        .and_then(|value| value.to_str().ok())
-                        .and_then(|value| {
-                            Some(
-                                value.starts_with(
+                        .and_then(|value| value.to_str().ok()).map(|value| value.starts_with(
                                     "multipart/form-data; boundary=",
-                                ),
-                            )
-                        })
+                                ))
                         == Some(true)
                     {
                         provide_context(cx, body.clone());

--- a/leptos_hot_reload/src/node.rs
+++ b/leptos_hot_reload/src/node.rs
@@ -73,7 +73,7 @@ impl LNode {
                         LNode::parse_node(child, &mut children)?;
                     }
                     views.push(LNode::Component {
-                        name: name,
+                        name,
                         props: el
                             .open_tag
                             .attributes

--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -20,7 +20,7 @@ pub fn block_to_primitive_expression(block: &syn::Block) -> Option<&syn::Expr> {
         return None;
     }
     match &block.stmts[0] {
-        syn::Stmt::Expr(e, None) => return Some(&e),
+        syn::Stmt::Expr(e, None) => return Some(e),
         _ => {}
     }
     None

--- a/leptos_reactive/benches/fan_out.rs
+++ b/leptos_reactive/benches/fan_out.rs
@@ -1,9 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn rs_fan_out(c: &mut Criterion) {
-    use reactive_signals::{
-        runtimes::ClientRuntime, signal,
-    };
+    use reactive_signals::{runtimes::ClientRuntime, signal};
 
     c.bench_function("rs_fan_out", |b| {
         b.iter(|| {

--- a/leptos_reactive/benches/fan_out.rs
+++ b/leptos_reactive/benches/fan_out.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 fn rs_fan_out(c: &mut Criterion) {
     use reactive_signals::{
-        runtimes::ClientRuntime, signal, types::Func, Signal,
+        runtimes::ClientRuntime, signal,
     };
 
     c.bench_function("rs_fan_out", |b| {

--- a/leptos_reactive/benches/narrow_down.rs
+++ b/leptos_reactive/benches/narrow_down.rs
@@ -2,14 +2,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use std::{cell::Cell, rc::Rc};
 
 fn rs_narrow_down(c: &mut Criterion) {
-    use reactive_signals::{
-        runtimes::ClientRuntime, signal, types::Func, Signal,
-    };
+    use reactive_signals::{runtimes::ClientRuntime, signal};
 
     c.bench_function("rs_narrow_down", |b| {
         b.iter(|| {
             let cx = ClientRuntime::bench_root_scope();
-            let acc = Rc::new(Cell::new(0));
             let sigs =
                 Rc::new((0..1000).map(|n| signal!(cx, n)).collect::<Vec<_>>());
             let memo = signal!(cx, {
@@ -28,11 +25,9 @@ fn l021_narrow_down(c: &mut Criterion) {
         let runtime = create_runtime();
         b.iter(|| {
             create_scope(runtime, |cx| {
-                let acc = Rc::new(Cell::new(0));
                 let sigs =
                     (0..1000).map(|n| create_signal(cx, n)).collect::<Vec<_>>();
                 let reads = sigs.iter().map(|(r, _)| *r).collect::<Vec<_>>();
-                let writes = sigs.iter().map(|(_, w)| *w).collect::<Vec<_>>();
                 let memo = create_memo(cx, move |_| {
                     reads.iter().map(|r| r.get()).sum::<i32>()
                 });
@@ -50,7 +45,6 @@ fn sycamore_narrow_down(c: &mut Criterion) {
     c.bench_function("sycamore_narrow_down", |b| {
         b.iter(|| {
             let d = create_scope(|cx| {
-                let acc = Rc::new(Cell::new(0));
                 let sigs = Rc::new(
                     (0..1000).map(|n| create_signal(cx, n)).collect::<Vec<_>>(),
                 );
@@ -72,11 +66,9 @@ fn leptos_narrow_down(c: &mut Criterion) {
     c.bench_function("leptos_narrow_down", |b| {
         b.iter(|| {
             create_scope(runtime, |cx| {
-                let acc = Rc::new(Cell::new(0));
                 let sigs =
                     (0..1000).map(|n| create_signal(cx, n)).collect::<Vec<_>>();
                 let reads = sigs.iter().map(|(r, _)| *r).collect::<Vec<_>>();
-                let writes = sigs.iter().map(|(_, w)| *w).collect::<Vec<_>>();
                 let memo = create_memo(cx, move |_| {
                     reads.iter().map(|r| r.get()).sum::<i32>()
                 });

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -37,7 +37,7 @@ impl GlobalSuspenseContext {
 
     /// Runs a function with a reference to the underlying suspense context.
     pub fn with_inner<T>(&self, f: impl FnOnce(&SuspenseContext) -> T) -> T {
-        f(&*self.0.borrow())
+        f(&self.0.borrow())
     }
 
     /// Runs a function with a reference to the underlying suspense context.

--- a/router/src/components/outlet.rs
+++ b/router/src/components/outlet.rs
@@ -54,7 +54,6 @@ pub fn Outlet(cx: Scope) -> impl IntoView {
             let (current_view, set_current_view) = create_signal(cx, None);
 
             create_effect(cx, {
-                let global_suspense = global_suspense.clone();
                 move |prev| {
                     let outlet = outlet.get();
                     let is_fallback =


### PR DESCRIPTION
Lots of minor changes 

Only one thing worth talking about is the removal of a .clone() call.

As with the recent release of  rust 1.7 : cargo clippy has added a few new rules.
