### PR TITLE
fix: wait for blocking fragments to resolve  before pulling metadata (closes #1118)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -797,7 +797,10 @@ async fn build_stream_response(
 
     let mut stream = Box::pin(
         futures::stream::once(async move { head.clone() })
-            .chain(futures::stream::once(async move { first_app_chunk }).chain(stream))
+            .chain(
+                futures::stream::once(async move { first_app_chunk })
+                    .chain(stream),
+            )
             .chain(futures::stream::once(async move {
                 runtime.dispose();
                 tail.to_string()

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -787,12 +787,17 @@ async fn build_stream_response(
     scope: ScopeId,
 ) -> HttpResponse {
     let cx = leptos::Scope { runtime, id: scope };
+    let mut stream = Box::pin(stream);
+
+    // wait for any blocking resources to load before pulling metadata
+    let first_app_chunk = stream.next().await.unwrap_or_default();
+
     let (head, tail) =
         html_parts_separated(options, use_context::<MetaContext>(cx).as_ref());
 
     let mut stream = Box::pin(
         futures::stream::once(async move { head.clone() })
-            .chain(stream)
+            .chain(futures::stream::once(async move { first_app_chunk }).chain(stream))
             .chain(futures::stream::once(async move {
                 runtime.dispose();
                 tail.to_string()

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -685,11 +685,14 @@ async fn forward_stream(
     mut tx: Sender<String>,
 ) {
     let cx = Scope { runtime, id: scope };
+    let mut shell = Box::pin(bundle);
+    let first_app_chunk = shell.next().await.unwrap_or_default();
+
     let (head, tail) =
         html_parts_separated(options, use_context::<MetaContext>(cx).as_ref());
 
     _ = tx.send(head).await;
-    let mut shell = Box::pin(bundle);
+    _ = tx.send(first_app_chunk).await;
     while let Some(fragment) = shell.next().await {
         _ = tx.send(fragment).await;
     }


### PR DESCRIPTION
This closes a secondary issue raised in #1118, during which I realized that `leptos_meta` tags were not interacting correctly with blocking resources, i.e., the metadata for the `<head>` was being extracted before the blocking resources had actually resolved.