### PR TITLE
feat: pass components with no props directly into the view as a function that takes only `Scope`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Examples
+
+The examples in this directory are all built and tested against the current `main` branch.
+
+To the extent that new features have been released or breaking changes have been made since the previous release, the examples are compatible with the `main` branch and not the current release.
+
+To see the examples as they were at the time of the `0.3.0` release, [click here](https://github.com/leptos-rs/leptos/tree/v0.3.0/examples).

--- a/examples/hackernews/src/lib.rs
+++ b/examples/hackernews/src/lib.rs
@@ -22,9 +22,9 @@ pub fn App(cx: Scope) -> impl IntoView {
             <Nav />
             <main>
                 <Routes>
-                    <Route path="users/:id" view=|cx| view! { cx,  <User/> }/>
-                    <Route path="stories/:id" view=|cx| view! { cx,  <Story/> }/>
-                    <Route path=":stories?" view=|cx| view! { cx,  <Stories/> }/>
+                    <Route path="users/:id" view=User/>
+                    <Route path="stories/:id" view=Story/>
+                    <Route path=":stories?" view=Stories/>
                 </Routes>
             </main>
         </Router>

--- a/examples/hackernews_axum/src/lib.rs
+++ b/examples/hackernews_axum/src/lib.rs
@@ -22,9 +22,9 @@ pub fn App(cx: Scope) -> impl IntoView {
                 <Nav />
                 <main>
                     <Routes>
-                        <Route path="users/:id" view=|cx| view! { cx,  <User/> }/>
-                        <Route path="stories/:id" view=|cx| view! { cx,  <Story/> }/>
-                        <Route path=":stories?" view=|cx| view! { cx,  <Stories/> }/>
+                        <Route path="users/:id" view=User/>
+                        <Route path="stories/:id" view=Story/>
+                        <Route path=":stories?" view=Stories/>
                     </Routes>
                 </main>
             </Router>

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -36,15 +36,15 @@ pub fn RouterExample(cx: Scope) -> impl IntoView {
                     <ContactRoutes/>
                     <Route
                         path="about"
-                        view=move |cx| view! { cx,  <About/> }
+                        view=About
                     />
                     <Route
                         path="settings"
-                        view=move |cx| view! { cx,  <Settings/> }
+                        view=Settings
                     />
                     <Route
                         path="redirect-home"
-                        view=move |cx| view! { cx, <Redirect path="/"/> }
+                        view=|cx| view! { cx, <Redirect path="/"/>
                     />
                 </AnimatedRoutes>
             </main>
@@ -59,11 +59,11 @@ pub fn ContactRoutes(cx: Scope) -> impl IntoView {
     view! { cx,
         <Route
             path=""
-            view=move |cx| view! { cx,  <ContactList/> }
+            view=ContactList
         >
             <Route
                 path=":id"
-                view=move |cx| view! { cx,  <Contact/> }
+                view=Contact
             />
             <Route
                 path="/"

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -44,7 +44,7 @@ pub fn RouterExample(cx: Scope) -> impl IntoView {
                     />
                     <Route
                         path="redirect-home"
-                        view=|cx| view! { cx, <Redirect path="/"/>
+                        view=|cx| view! { cx, <Redirect path="/"/> }
                     />
                 </AnimatedRoutes>
             </main>

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -67,7 +67,7 @@ pub fn ContactRoutes(cx: Scope) -> impl IntoView {
             />
             <Route
                 path="/"
-                view=move |_| view! { cx,  <p>"Select a contact."</p> }
+                view=|cx| view! { cx,  <p>"Select a contact."</p> }
             />
         </Route>
     }

--- a/examples/ssr_modes/src/app.rs
+++ b/examples/ssr_modes/src/app.rs
@@ -18,13 +18,13 @@ pub fn App(cx: Scope) -> impl IntoView {
             <main>
                 <Routes>
                     // We’ll load the home page with out-of-order streaming and <Suspense/>
-                    <Route path="" view=|cx| view! { cx, <HomePage/> }/>
+                    <Route path="" view=HomePage/>
 
                     // We'll load the posts with async rendering, so they can set
                     // the title and metadata *after* loading the data
                     <Route
                         path="/post/:id"
-                        view=|cx| view! { cx, <Post/> }
+                        view=Post
                         ssr=SsrMode::Async
                     />
                 </Routes>

--- a/examples/ssr_modes_axum/src/app.rs
+++ b/examples/ssr_modes_axum/src/app.rs
@@ -18,18 +18,18 @@ pub fn App(cx: Scope) -> impl IntoView {
             <main>
                 <Routes>
                     // We’ll load the home page with out-of-order streaming and <Suspense/>
-                    <Route path="" view=|cx| view! { cx, <HomePage/> }/>
+                    <Route path="" view=HomePage/>
 
                     // We'll load the posts with async rendering, so they can set
                     // the title and metadata *after* loading the data
                     <Route
                         path="/post/:id"
-                        view=|cx| view! { cx, <Post/> }
+                        view=Post
                         ssr=SsrMode::Async
                     />
                     <Route
                         path="/post_in_order/:id"
-                        view=|cx| view! { cx, <Post/> }
+                        view=Post
                         ssr=SsrMode::InOrder
                     />
                 </Routes>

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -60,7 +60,7 @@ rkyv = ["leptos_reactive/rkyv"]
 tracing = ["leptos_macro/tracing"]
 
 [package.metadata.cargo-all-features]
-denylist = ["stable", "tracing", "template_macro"]
+denylist = ["stable", "tracing", "template_macro", "rustls", "default-tls"]
 skip_feature_sets = [
   [
     "csr",

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -60,7 +60,7 @@ rkyv = ["leptos_reactive/rkyv"]
 tracing = ["leptos_macro/tracing"]
 
 [package.metadata.cargo-all-features]
-denylist = ["stable", "tracing", "template_macro", "rustls", "default-tls"]
+denylist = ["stable", "tracing", "template_macro", "rustls", "default-tls", "web-sys", "wasm-bindgen"]
 skip_feature_sets = [
   [
     "csr",

--- a/leptos/src/await_.rs
+++ b/leptos/src/await_.rs
@@ -58,9 +58,9 @@ where
         create_resource(cx, || (), move |_| future(cx))
     };
     let view = store_value(cx, view);
-    view! { cx,
+    /* view! { cx,
         <Suspense fallback=|| ()>
             {move || res.with(cx, |data| view.with_value(|view| view(cx, data)))}
         </Suspense>
-    }
+    } */
 }

--- a/leptos/src/await_.rs
+++ b/leptos/src/await_.rs
@@ -58,9 +58,9 @@ where
         create_resource(cx, || (), move |_| future(cx))
     };
     let view = store_value(cx, view);
-    /* view! { cx,
+    view! { cx,
         <Suspense fallback=|| ()>
             {move || res.with(cx, |data| view.with_value(|view| view(cx, data)))}
         </Suspense>
-    } */
+    }
 }

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -251,9 +251,8 @@ pub trait PropsOrNoPropsBuilder {
 pub struct EmptyPropsBuilder {}
 
 impl EmptyPropsBuilder {
-    pub fn build(self) { }
+    pub fn build(self) {}
 }
-
 
 impl<P: Props> PropsOrNoPropsBuilder for P {
     type Builder = <P as Props>::Builder;
@@ -269,9 +268,17 @@ impl PropsOrNoPropsBuilder for EmptyPropsBuilder {
     }
 }
 
-impl<F, R> Component<EmptyPropsBuilder> for F where F: FnOnce(::leptos::Scope) -> R {}
+impl<F, R> Component<EmptyPropsBuilder> for F where
+    F: FnOnce(::leptos::Scope) -> R
+{
+}
 
-impl<P, F, R> Component<P> for F where F: FnOnce(::leptos::Scope, P) -> R, P: Props {}
+impl<P, F, R> Component<P> for F
+where
+    F: FnOnce(::leptos::Scope, P) -> R,
+    P: Props,
+{
+}
 
 #[doc(hidden)]
 pub fn component_props_builder<P: PropsOrNoPropsBuilder>(
@@ -284,7 +291,7 @@ pub fn component_props_builder<P: PropsOrNoPropsBuilder>(
 pub fn component_view<P>(
     f: impl ComponentConstructor<P>,
     cx: Scope,
-    props: P
+    props: P,
 ) -> View {
     f.construct(cx, props)
 }
@@ -308,7 +315,7 @@ impl<Func, V, P> ComponentConstructor<P> for Func
 where
     Func: FnOnce(Scope, P) -> V,
     V: IntoView,
-    P: PropsOrNoPropsBuilder
+    P: PropsOrNoPropsBuilder,
 {
     fn construct(self, cx: Scope, props: P) -> View {
         (self)(cx, props).into_view(cx)

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -250,26 +250,11 @@ pub fn component_props_builder<P: Props>(
 }
 
 #[doc(hidden)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct EmptyPropsBuilder {}
 
 impl EmptyPropsBuilder {
     pub fn build(self) { }
-}
-
-impl Props for () {
-    type Builder = EmptyPropsBuilder;
-
-    fn builder() -> Self::Builder {
-        EmptyPropsBuilder {}
-    }
-}
-
-impl<P: Props> Props for (P,) {
-    type Builder = P::Builder;
-
-    fn builder() -> Self::Builder {
-        P::builder()
-    }
 }
 
 #[doc(hidden)]
@@ -296,13 +281,13 @@ where
     }
 }
 
-impl<Func, V, A> ComponentConstructor<(A,)> for Func
+impl<Func, V, P> ComponentConstructor<P> for Func
 where
-    Func: FnOnce(Scope, A) -> V,
+    Func: FnOnce(Scope, P) -> V,
     V: IntoView,
-    A: Props
+    P: Props
 {
-    fn construct(self, cx: Scope, (props,): (A,)) -> View {
+    fn construct(self, cx: Scope, props: P) -> View {
         (self)(cx, props).into_view(cx)
     }
 }

--- a/leptos_macro/example/src/lib.rs
+++ b/leptos_macro/example/src/lib.rs
@@ -36,6 +36,5 @@ pub fn TestComponent(
     and_another: usize,
 ) -> impl IntoView {
     _ = (key, another, and_another);
-    todo!()
 }
 

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -216,7 +216,7 @@ impl ToTokens for Model {
         };
 
         let props_arg = if no_props {
-            quote! { }
+            quote! {}
         } else {
             quote! {
                 props: #props_name #generics
@@ -224,7 +224,7 @@ impl ToTokens for Model {
         };
 
         let destructure_props = if no_props {
-            quote! { }
+            quote! {}
         } else {
             quote! {
                 let #props_name {

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -251,25 +251,46 @@ impl ToTokens for Model {
             }
         };
 
-        let output = quote! {
-            #[doc = #builder_name_doc]
-            #[doc = ""]
-            #docs
-            #component_fn_prop_docs
-            #[derive(::leptos::typed_builder::TypedBuilder)]
-            #[builder(doc)]
-            #vis struct #props_name #generics #where_clause {
-                #prop_builder_fields
-            }
+        let props_code = if no_props {
+            quote! {
+                #[doc = #builder_name_doc]
+                #[doc = ""]
+                #docs
+                #component_fn_prop_docs
+                #[builder(doc)]
+                #vis struct #props_name #generics #where_clause { }
 
-            impl #generics ::leptos::Props for #props_name #generics #where_clause {
-                type Builder = #props_builder_name #generics;
-                fn builder() -> Self::Builder {
-                    #props_name::builder()
+                impl #generics #props_name #generics #where_clause {
+                    fn builder() -> ::leptos::EmptyPropsBuilder {
+                        Default::default()
+                    }
                 }
             }
+        } else {
+            quote! { 
+                #[doc = #builder_name_doc]
+                #[doc = ""]
+                #docs
+                #component_fn_prop_docs
+                #[derive(::leptos::typed_builder::TypedBuilder)]
+                #[builder(doc)]
+                #vis struct #props_name #generics #where_clause {
+                    #prop_builder_fields
+                }
 
-            #into_view
+                impl #generics ::leptos::Props for #props_name #generics #where_clause {
+                    type Builder = #props_builder_name #generics;
+                    fn builder() -> Self::Builder {
+                        #props_name::builder()
+                    }
+                }
+
+                #into_view
+            }
+        };
+
+        let output = quote! {
+            #props_code
 
             #docs
             #component_fn_prop_docs

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -131,6 +131,8 @@ impl ToTokens for Model {
             ret,
         } = self;
 
+        let no_props = props.len() == 1;
+
         let mut body = body.to_owned();
 
         // check for components that end ;
@@ -213,6 +215,42 @@ impl ToTokens for Model {
             }
         };
 
+        let props_arg = if no_props {
+            quote! { }
+        } else {
+            quote! {
+                props: #props_name #generics
+            }
+        };
+
+        let destructure_props = if no_props {
+            quote! { }
+        } else {
+            quote! {
+                let #props_name {
+                    #prop_names
+                } = props;
+            }
+        };
+
+        let into_view = if no_props {
+            quote! {
+                impl #generics ::leptos::IntoView for #props_name #generics #where_clause {
+                    fn into_view(self, cx: ::leptos::Scope) -> ::leptos::View {
+                        #name(cx).into_view(cx)
+                    }
+                }
+            }
+        } else {
+            quote! {
+                impl #generics ::leptos::IntoView for #props_name #generics #where_clause {
+                    fn into_view(self, cx: ::leptos::Scope) -> ::leptos::View {
+                        #name(cx, self).into_view(cx)
+                    }
+                }
+            }
+        };
+
         let output = quote! {
             #[doc = #builder_name_doc]
             #[doc = ""]
@@ -231,11 +269,7 @@ impl ToTokens for Model {
                 }
             }
 
-            impl #generics ::leptos::IntoView for #props_name #generics #where_clause {
-                fn into_view(self, cx: ::leptos::Scope) -> ::leptos::View {
-                    #name(cx, self).into_view(cx)
-                }
-            }
+            #into_view
 
             #docs
             #component_fn_prop_docs
@@ -244,15 +278,13 @@ impl ToTokens for Model {
             #vis fn #name #generics (
                 #[allow(unused_variables)]
                 #scope_name: ::leptos::Scope,
-                props: #props_name #generics
+                #props_arg
             ) #ret #(+ #lifetimes)*
             #where_clause
             {
                 #body
 
-                let #props_name {
-                    #prop_names
-                } = props;
+                #destructure_props
 
                 #tracing_span_expr
 

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -251,46 +251,25 @@ impl ToTokens for Model {
             }
         };
 
-        let props_code = if no_props {
-            quote! {
-                #[doc = #builder_name_doc]
-                #[doc = ""]
-                #docs
-                #component_fn_prop_docs
-                #[builder(doc)]
-                #vis struct #props_name #generics #where_clause { }
-
-                impl #generics #props_name #generics #where_clause {
-                    fn builder() -> ::leptos::EmptyPropsBuilder {
-                        Default::default()
-                    }
-                }
-            }
-        } else {
-            quote! { 
-                #[doc = #builder_name_doc]
-                #[doc = ""]
-                #docs
-                #component_fn_prop_docs
-                #[derive(::leptos::typed_builder::TypedBuilder)]
-                #[builder(doc)]
-                #vis struct #props_name #generics #where_clause {
-                    #prop_builder_fields
-                }
-
-                impl #generics ::leptos::Props for #props_name #generics #where_clause {
-                    type Builder = #props_builder_name #generics;
-                    fn builder() -> Self::Builder {
-                        #props_name::builder()
-                    }
-                }
-
-                #into_view
-            }
-        };
-
         let output = quote! {
-            #props_code
+            #[doc = #builder_name_doc]
+            #[doc = ""]
+            #docs
+            #component_fn_prop_docs
+            #[derive(::leptos::typed_builder::TypedBuilder)]
+            #[builder(doc)]
+            #vis struct #props_name #generics #where_clause {
+                #prop_builder_fields
+            }
+
+            impl #generics ::leptos::Props for #props_name #generics #where_clause {
+                type Builder = #props_builder_name #generics;
+                fn builder() -> Self::Builder {
+                    #props_name::builder()
+                }
+            }
+
+            #into_view
 
             #docs
             #component_fn_prop_docs

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -503,13 +503,11 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 /// // PascalCase: Generated component will be called MyComponent
 /// #[component]
 /// fn MyComponent(cx: Scope) -> impl IntoView {
-///     todo!()
 /// }
 ///
 /// // snake_case: Generated component will be called MySnakeCaseComponent
 /// #[component]
 /// fn my_snake_case_component(cx: Scope) -> impl IntoView {
-///     todo!()
 /// }
 /// ```
 ///
@@ -527,7 +525,6 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///
 ///     #[component]
 ///     pub fn MyComponent(cx: Scope) -> impl IntoView {
-///         todo!()
 ///     }
 /// }
 /// ```
@@ -543,7 +540,6 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///
 ///     #[component]
 ///     pub fn my_snake_case_component(cx: Scope) -> impl IntoView {
-///         todo!()
 ///     }
 /// }
 /// ```
@@ -557,7 +553,6 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///
 /// #[component]
 /// fn MyComponent<T: Fn() -> HtmlElement<Div>>(cx: Scope, render_prop: T) -> impl IntoView {
-///   todo!()
 /// }
 /// ```
 ///
@@ -571,7 +566,6 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 /// where
 ///     T: Fn() -> HtmlElement<Div>,
 /// {
-///     todo!()
 /// }
 /// ```
 ///

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -502,13 +502,11 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///
 /// // PascalCase: Generated component will be called MyComponent
 /// #[component]
-/// fn MyComponent(cx: Scope) -> impl IntoView {
-/// }
+/// fn MyComponent(cx: Scope) -> impl IntoView {}
 ///
 /// // snake_case: Generated component will be called MySnakeCaseComponent
 /// #[component]
-/// fn my_snake_case_component(cx: Scope) -> impl IntoView {
-/// }
+/// fn my_snake_case_component(cx: Scope) -> impl IntoView {}
 /// ```
 ///
 /// 3. The macro generates a type `ComponentProps` for every `Component` (so, `HomePage` generates `HomePageProps`,
@@ -524,8 +522,7 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///     use leptos::*;
 ///
 ///     #[component]
-///     pub fn MyComponent(cx: Scope) -> impl IntoView {
-///     }
+///     pub fn MyComponent(cx: Scope) -> impl IntoView {}
 /// }
 /// ```
 /// ```
@@ -539,8 +536,7 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///     use leptos::*;
 ///
 ///     #[component]
-///     pub fn my_snake_case_component(cx: Scope) -> impl IntoView {
-///     }
+///     pub fn my_snake_case_component(cx: Scope) -> impl IntoView {}
 /// }
 /// ```
 ///

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -436,6 +436,7 @@ fn element_to_tokens_ssr(
         template.push('<');
         template.push_str(&tag_name);
 
+        #[cfg(debug_assertions)]
         stmts_for_ide.save_element_completion(node);
 
         let mut inner_html = None;
@@ -1672,7 +1673,7 @@ pub(crate) fn component_to_tokens(
 
     let mut component = quote! {
         ::leptos::component_view(
-            #name,
+            &#name,
             #cx,
             ::leptos::component_props_builder(&#name)
                 #(#props)*
@@ -1682,7 +1683,8 @@ pub(crate) fn component_to_tokens(
         )
     };
 
-    IdeTagHelper::add_component_completion(&mut component, cx, node);
+    #[cfg(debug_assertions)]
+    IdeTagHelper::add_component_completion(&mut component, node);
 
     if events.is_empty() {
         component
@@ -2094,13 +2096,12 @@ impl IdeTagHelper {
         }
     }
 
-    ///
-    /// Add completion to close tag of the component definition.
-    ///
-    /// we can emit full copy of open_tag builder (close_tag.props().slots().children().build()),
-    /// but i choose to replace props with unreachable! call,
-    /// so expansion output will be shorter.
-    /// The output is looking like:
+    /// Add completion to the closing tag of the component.
+    /// 
+    /// In order to ensure that generics are passed through correctly in the 
+    /// current builder pattern, this clones the whole component constructor,
+    /// but it will never be used.
+    /// 
     /// ```no_build
     /// if false {
     ///     close_tag(cx, unreachable!())
@@ -2109,24 +2110,17 @@ impl IdeTagHelper {
     ///     open_tag(open_tag.props().slots().children().build())
     /// }
     /// ```
-    ///
-    /// Because element type can have generics, we cant construct simple statement like
-    /// let _ = #name; or (let _: #name = unreachable!()) both syntax require to know generics params.
     pub fn add_component_completion(
         component: &mut TokenStream,
-        cx: &Ident,
         node: &NodeElement,
     ) {
         // emit ide helper info
-        if let Some(close_tag) = node.close_tag.as_ref().map(|c| &c.name) {
-            let name = close_tag;
+        if node.close_tag.is_some() {
+            let constructor = component.clone();
             *component = quote! {
                 if false {
                     #[allow(unreachable_code)]
-                    #name(
-                        #cx,
-                        unreachable!()
-                    )
+                    #constructor
                 } else {
                     #component
                 }

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -2097,11 +2097,11 @@ impl IdeTagHelper {
     }
 
     /// Add completion to the closing tag of the component.
-    /// 
-    /// In order to ensure that generics are passed through correctly in the 
+    ///
+    /// In order to ensure that generics are passed through correctly in the
     /// current builder pattern, this clones the whole component constructor,
     /// but it will never be used.
-    /// 
+    ///
     /// ```no_build
     /// if false {
     ///     close_tag(cx, unreachable!())

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1674,11 +1674,11 @@ pub(crate) fn component_to_tokens(
         ::leptos::component_view(
             #name,
             #cx,
-            (::leptos::component_props_builder(&#name)
+            ::leptos::component_props_builder(&#name)
                 #(#props)*
                 #(#slots)*
                 #children
-                .build(),)
+                .build()
         )
     };
 

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1671,13 +1671,14 @@ pub(crate) fn component_to_tokens(
     });
 
     let mut component = quote! {
-        #name(
+        ::leptos::component_view(
+            #name,
             #cx,
-            ::leptos::component_props_builder(&#name)
+            (::leptos::component_props_builder(&#name)
                 #(#props)*
                 #(#slots)*
                 #children
-                .build()
+                .build(),)
         )
     };
 

--- a/leptos_reactive/src/context.rs
+++ b/leptos_reactive/src/context.rs
@@ -43,8 +43,6 @@ use std::any::{Any, TypeId};
 ///     // consume the provided context of type `ValueSetter` using `use_context`
 ///     // this traverses up the tree of `Scope`s and gets the nearest provided `ValueSetter`
 ///     let set_value = use_context::<ValueSetter>(cx).unwrap().0;
-///
-///     todo!()
 /// }
 /// ```
 #[cfg_attr(
@@ -107,7 +105,6 @@ where
 ///     // this traverses up the tree of `Scope`s and gets the nearest provided `ValueSetter`
 ///     let set_value = use_context::<ValueSetter>(cx).unwrap().0;
 ///
-///     todo!()
 /// }
 /// ```
 #[cfg_attr(


### PR DESCRIPTION
Currently, all components are transformed into a function with two arguments: a `Scope` and a `Props` type. Constructing a `Props` type allows us to use named props in the `view` macro without support for named function arguments in Rust, which is great. However, it also means that components that take no props are still implemented as functions of two arguments (a `Scope` and an empty `Props` type).

This PR addresses a significant component of #766 by rewriting prop-less components into a function that only takes a `Scope`, while still allowing them to be used in the `view` macro. This enables a very useful shortcut for passing them into any component prop that takes something like `Fn(Scope) -> impl IntoView`.

For example, you can now create routes like this:
```rust
view! { cx,
    <Route
        path=""
        view=ContactList
    >
        <Route
            path=":id"
            view=Contact
        />
        <Route
            path="/"
            view=|cx| view! { cx,  <p>"Select a contact."</p> }
        />
    </Route>
}
``` 

rather than this
```rust
view! { cx,
    <Route
        path=""
        view=|cx| view! { cx, <ContactList/> }
    >
        <Route
            path=":id"
            view=|cx| view! { cx, <Contact/> }
        />
        <Route
            path="/"
            view=|cx| view! { cx,  <p>"Select a contact."</p> }
        />
    </Route>
}
``` 

This removes a significant amount of boilerplate!

EDIT: This took me a *significant* amount of screwing around to get the traits and helper functions right. It's possible some of this is now useless boilerplate.