### PR TITLE
fix queue_microtask

### DIFF
--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -9,15 +9,21 @@ cfg_if! {
             microtask(wasm_bindgen::closure::Closure::once_into_js(task));
         }
 
-        #[cfg(any(feature = "csr", feature = "hydrate"))]
-        fn microtask(task: wasm_bindgen::JsValue) {
-            use js_sys::{Reflect, Function};
-            use wasm_bindgen::prelude::*;
-            let window = web_sys::window().expect("window not available");
-            let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
-            let queue_microtask = queue_microtask.unchecked_into::<Function>();
-            let _ = queue_microtask.call0(&task);
+        #[wasm_bindgen::prelude::wasm_bindgen(
+            inline_js = "export function microtask(f) { queueMicrotask(f); }"
+        )]
+        extern "C" {
+            fn microtask(task: wasm_bindgen::JsValue);
         }
+        // #[cfg(any(feature = "csr", feature = "hydrate"))]
+        // fn microtask(task: wasm_bindgen::JsValue) {
+        //     use js_sys::{Reflect, Function};
+        //     use wasm_bindgen::prelude::*;
+        //     let window = web_sys::window().expect("window not available");
+        //     let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
+        //     let queue_microtask = queue_microtask.unchecked_into::<Function>();
+        //     let _ = queue_microtask.call0(&task);
+        // }
     } else {
         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
         /// in the browser, and simply runs the given function when on the server.

--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -1,42 +1,11 @@
 #![forbid(unsafe_code)]
-use cfg_if::cfg_if;
-use wasm_bindgen::JsValue;
-
-// cfg_if! {
-//     if #[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))] {
-//         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
-//         /// in the browser, and simply runs the given function when on the server.
-//         pub fn queue_microtask(task: impl FnOnce() + 'static) {
-//             microtask(wasm_bindgen::closure::Closure::once_into_js(task));
-//         }
-//
-//         #[wasm_bindgen::prelude::wasm_bindgen(
-//             inline_js = "export function microtask(f) { queueMicrotask(f); }"
-//         )]
-//         extern "C" {
-//             fn microtask(task: wasm_bindgen::JsValue);
-//         }
-//         // #[cfg(any(feature = "csr", feature = "hydrate"))]
-//         // fn microtask(task: wasm_bindgen::JsValue) {
-//         //     use js_sys::{Reflect, Function};
-//         //     use wasm_bindgen::prelude::*;
-//         //     let window = web_sys::window().expect("window not available");
-//         //     let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
-//         //     let queue_microtask = queue_microtask.unchecked_into::<Function>();
-//         //     let _ = queue_microtask.call0(&task);
-//         // }
-//     } else {
-//         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
-//         /// in the browser, and simply runs the given function when on the server.
-//         pub fn queue_microtask(task: impl FnOnce() + 'static) {
-//             task();
-//         }
-//     }
-// }
 
 pub fn queue_microtask(task: impl FnOnce() + 'static) {
     #[cfg(not(any(feature = "hydrate", feature = "csr")))]
-    task();
+    {
+        task();
+    }
+
     #[cfg(any(feature = "hydrate", feature = "csr"))]
     {
         use js_sys::{Function, Reflect};

--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -1,5 +1,13 @@
 #![forbid(unsafe_code)]
 
+/// The microtask is a short function which will run after the current task has
+/// completed its work and when there is no other code waiting to be run before
+/// control of the execution context is returned to the browser's event loop.
+///
+/// Microtasks are especially useful for libraries and frameworks that need
+/// to perform final cleanup or other just-before-rendering tasks.
+///
+/// [MDN queueMicrotask](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
 pub fn queue_microtask(task: impl FnOnce() + 'static) {
     #[cfg(not(any(feature = "hydrate", feature = "csr")))]
     {

--- a/leptos_reactive/src/spawn_microtask.rs
+++ b/leptos_reactive/src/spawn_microtask.rs
@@ -2,37 +2,37 @@
 use cfg_if::cfg_if;
 use wasm_bindgen::JsValue;
 
-cfg_if! {
-    if #[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))] {
-        /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
-        /// in the browser, and simply runs the given function when on the server.
-        pub fn queue_microtask(task: impl FnOnce() + 'static) {
-            microtask(wasm_bindgen::closure::Closure::once_into_js(task));
-        }
-
-        #[wasm_bindgen::prelude::wasm_bindgen(
-            inline_js = "export function microtask(f) { queueMicrotask(f); }"
-        )]
-        extern "C" {
-            fn microtask(task: wasm_bindgen::JsValue);
-        }
-        // #[cfg(any(feature = "csr", feature = "hydrate"))]
-        // fn microtask(task: wasm_bindgen::JsValue) {
-        //     use js_sys::{Reflect, Function};
-        //     use wasm_bindgen::prelude::*;
-        //     let window = web_sys::window().expect("window not available");
-        //     let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
-        //     let queue_microtask = queue_microtask.unchecked_into::<Function>();
-        //     let _ = queue_microtask.call0(&task);
-        // }
-    } else {
-        /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
-        /// in the browser, and simply runs the given function when on the server.
-        pub fn queue_microtask(task: impl FnOnce() + 'static) {
-            task();
-        }
-    }
-}
+// cfg_if! {
+//     if #[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))] {
+//         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
+//         /// in the browser, and simply runs the given function when on the server.
+//         pub fn queue_microtask(task: impl FnOnce() + 'static) {
+//             microtask(wasm_bindgen::closure::Closure::once_into_js(task));
+//         }
+//
+//         #[wasm_bindgen::prelude::wasm_bindgen(
+//             inline_js = "export function microtask(f) { queueMicrotask(f); }"
+//         )]
+//         extern "C" {
+//             fn microtask(task: wasm_bindgen::JsValue);
+//         }
+//         // #[cfg(any(feature = "csr", feature = "hydrate"))]
+//         // fn microtask(task: wasm_bindgen::JsValue) {
+//         //     use js_sys::{Reflect, Function};
+//         //     use wasm_bindgen::prelude::*;
+//         //     let window = web_sys::window().expect("window not available");
+//         //     let queue_microtask = Reflect::get(&window, &JsValue::from_str("queueMicrotask")).expect("queueMicrotask not available");
+//         //     let queue_microtask = queue_microtask.unchecked_into::<Function>();
+//         //     let _ = queue_microtask.call0(&task);
+//         // }
+//     } else {
+//         /// Exposes the [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) method
+//         /// in the browser, and simply runs the given function when on the server.
+//         pub fn queue_microtask(task: impl FnOnce() + 'static) {
+//             task();
+//         }
+//     }
+// }
 
 pub fn queue_microtask(task: impl FnOnce() + 'static) {
     #[cfg(not(any(feature = "hydrate", feature = "csr")))]


### PR DESCRIPTION
In Function::call0 in js_sys is the same as calling a function without arguments, the only accept argument is a context object used to capture/pass "ambient" data. The method that we want to use to replace the inline javascript is Function::call1.