### PR TITLE
Since rust 1.70 - the warnings about have gotten more particular.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver="2"
 members = [
   # core
   "leptos",


### PR DESCRIPTION
This patch just clears the warnings listed below and ensures we get the benefits of a better package manger function.

```console

warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest

```