### PR TITLE
Use config for serde_qs deserialization

### DIFF
--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -692,6 +692,6 @@ where
             web_sys::UrlSearchParams::new_with_str_sequence_sequence(form_data)
                 .unwrap_throw();
         let data = data.to_string().as_string().unwrap_or_default();
-        serde_qs::from_str::<Self>(&data)
+        serde_qs::Config::default().deserialize_str::<Self>(&data)
     }
 }

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -692,6 +692,6 @@ where
             web_sys::UrlSearchParams::new_with_str_sequence_sequence(form_data)
                 .unwrap_throw();
         let data = data.to_string().as_string().unwrap_or_default();
-        serde_qs::Config::default().deserialize_str::<Self>(&data)
+        serde_qs::Config::new(5, false).deserialize_str::<Self>(&data)
     }
 }

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -375,7 +375,7 @@ where
         // decode the args
         let value = match Self::encoding() {
             Encoding::Url | Encoding::GetJSON | Encoding::GetCBOR => {
-                serde_qs::from_bytes(data)
+                serde_qs::Config::new(5, true).deserialize_bytes(data)
                     .map_err(|e| ServerFnError::Deserialization(e.to_string()))
             }
             Encoding::Cbor => ciborium::de::from_reader(data)


### PR DESCRIPTION
Currently `from_form_data` implementation tries to convert `UrlSearchparams` formatted query string to Type T using 'serde_qs::from_str' which couldn't convert encoded square brackets to nested types of T.

This PR fixes that by replacing `serde_qs::from_str`  with  `serde_qs::Config` as it provides the needed functionality.

Example
```
#[derive(Serialize, Deserialize)]
struct Address {
    door: String,
    street: Option<String>
}

#[derive(Serialize, Deserialize)]
struct Data {
    id: u32,
    address: Address
}

let formData = "id=5&address[door]=248"; // UrlSearchParams encoded

serde_qs::from_str<T>(formData); // throws error
serde_qs::Config::default()::deserialize_str<T>(formData) // this works
```