### PR TITLE
chore: criterion was outdated version 0.4.0 becomes 0.5.1.

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -45,7 +45,7 @@ indexmap = "1"
 self_cell = "1.0.0"
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 reactive-signals = { version = "0.1.0-alpha.4", features = ["profile"] }
 l021 = { package = "leptos", version = "0.2.1" }
 sycamore = { version = "0.8", features = ["ssr"] }


### PR DESCRIPTION
Sorry for mirco PR's 

There are lots of packages marked as outdated.

I want to deal with them individually - So when problems occurs we can run git blame / git revert and know exactly what being changed.

This maybe the first of many PRs