### PR TITLE
Chore: router -- cached is outdated was 0.43.0 is now 0.44.0.

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -10,7 +10,7 @@ description = "Router for the Leptos web framework."
 
 [dependencies]
 leptos = { workspace = true }
-cached = { version = "0.43.0", optional = true }
+cached = { version = "0.44.0", optional = true }
 cfg-if = "1"
 common_macros = "0.1"
 gloo-net = { version = "0.2", features = ["http"] }


### PR DESCRIPTION
A small issue, but I find clearing these imperfections periodically is preferable, Otherwise splurging and fixing many before issuing a release is a headache ...  really subtle errors can creep in if one say fixes 10 in one go.

These things really need time to breathe.

