### PR TITLE
fix(examples/js-framework-benchmark): error: cannot find macro template in this scope (#1182)

### DIFF
--- a/examples/cargo-make/wasm-test.toml
+++ b/examples/cargo-make/wasm-test.toml
@@ -1,3 +1,7 @@
+[tasks.test]
+env = { RUN_CARGO_TEST = false }
+condition = { env_true = ["RUN_CARGO_TEST"] }
+
 [tasks.post-test]
 dependencies = ["test-wasm"]
 

--- a/examples/js-framework-benchmark/Makefile.toml
+++ b/examples/js-framework-benchmark/Makefile.toml
@@ -5,10 +5,13 @@ extend = [
 
 [tasks.build]
 command = "cargo"
-args = ["+nightly", "build-all-features"]
+args = ["+nightly", "build-all-features", "--target", "wasm32-unknown-unknown"]
 install_crate = "cargo-all-features"
 
 [tasks.check]
 command = "cargo"
-args = ["+nightly", "check-all-features"]
+args = ["+nightly", "check-all-features", "--target", "wasm32-unknown-unknown"]
 install_crate = "cargo-all-features"
+
+[tasks.pre-clippy]
+env = { CARGO_MAKE_CLIPPY_ARGS = "--all-targets --all-features --target wasm32-unknown-unknown -- -D warnings" }


### PR DESCRIPTION
Fix #1182

This resolves the **Check** and **Verify** workflow issues for the **js-framework-benchmark** example.

## Verification

From the **examples/js-framework-benchmark** directory

- Run `build`
- Run `check`
- Run `verify-flow` 
