### PR TITLE
Removed clippy warnings - merged "if"s

### DIFF
--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -20,10 +20,9 @@ pub fn block_to_primitive_expression(block: &syn::Block) -> Option<&syn::Expr> {
         return None;
     }
     match &block.stmts[0] {
-        syn::Stmt::Expr(e, None) => return Some(e),
-        _ => {}
+        syn::Stmt::Expr(e, None) => Some(e),
+        _ => None,
     }
-    None
 }
 
 /// Converts simple literals to its string representation.

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -10,7 +10,7 @@ use rstml::node::{
     KeyedAttribute, Node, NodeAttribute, NodeBlock, NodeElement, NodeName,
 };
 use std::collections::HashMap;
-use syn::{spanned::Spanned, Expr, ExprLit, ExprPath, Lit};
+use syn::{spanned::Spanned, Expr, Expr::Tuple, ExprLit, ExprPath, Lit};
 
 #[derive(Clone, Copy)]
 enum TagType {
@@ -1964,41 +1964,39 @@ fn fancy_class_name<'a>(
     // special case for complex class names:
     // e.g., Tailwind `class=("mt-[calc(100vh_-_3rem)]", true)`
     if name == "class" {
-        if let Some(expr) = node.value() {
-            if let syn::Expr::Tuple(tuple) = expr {
-                if tuple.elems.len() == 2 {
-                    let span = node.key.span();
-                    let class = quote_spanned! {
-                        span => .class
-                    };
-                    let class_name = &tuple.elems[0];
-                    let class_name = if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(s),
-                        ..
-                    }) = class_name
-                    {
-                        s.value()
-                    } else {
-                        proc_macro_error::emit_error!(
-                            class_name.span(),
-                            "class name must be a string literal"
-                        );
-                        Default::default()
-                    };
-                    let value = &tuple.elems[1];
-                    return Some((
-                        quote! {
-                            #class(#class_name, (#cx, #value))
-                        },
-                        class_name,
-                        value,
-                    ));
+        if let Some(Tuple(tuple)) = node.value() {
+            if tuple.elems.len() == 2 {
+                let span = node.key.span();
+                let class = quote_spanned! {
+                    span => .class
+                };
+                let class_name = &tuple.elems[0];
+                let class_name = if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s),
+                    ..
+                }) = class_name
+                {
+                    s.value()
                 } else {
                     proc_macro_error::emit_error!(
-                        tuple.span(),
-                        "class tuples must have two elements."
-                    )
-                }
+                        class_name.span(),
+                        "class name must be a string literal"
+                    );
+                    Default::default()
+                };
+                let value = &tuple.elems[1];
+                return Some((
+                    quote! {
+                        #class(#class_name, (#cx, #value))
+                    },
+                    class_name,
+                    value,
+                ));
+            } else {
+                proc_macro_error::emit_error!(
+                    tuple.span(),
+                    "class tuples must have two elements."
+                )
             }
         }
     }
@@ -2012,41 +2010,39 @@ fn fancy_style_name<'a>(
 ) -> Option<(TokenStream, String, &'a Expr)> {
     // special case for complex dynamic style names:
     if name == "style" {
-        if let Some(expr) = node.value() {
-            if let syn::Expr::Tuple(tuple) = expr {
-                if tuple.elems.len() == 2 {
-                    let span = node.key.span();
-                    let style = quote_spanned! {
-                        span => .style
-                    };
-                    let style_name = &tuple.elems[0];
-                    let style_name = if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(s),
-                        ..
-                    }) = style_name
-                    {
-                        s.value()
-                    } else {
-                        proc_macro_error::emit_error!(
-                            style_name.span(),
-                            "style name must be a string literal"
-                        );
-                        Default::default()
-                    };
-                    let value = &tuple.elems[1];
-                    return Some((
-                        quote! {
-                            #style(#style_name, (#cx, #value))
-                        },
-                        style_name,
-                        value,
-                    ));
+        if let Some(Tuple(tuple)) = node.value() {
+            if tuple.elems.len() == 2 {
+                let span = node.key.span();
+                let style = quote_spanned! {
+                    span => .style
+                };
+                let style_name = &tuple.elems[0];
+                let style_name = if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s),
+                    ..
+                }) = style_name
+                {
+                    s.value()
                 } else {
                     proc_macro_error::emit_error!(
-                        tuple.span(),
-                        "style tuples must have two elements."
-                    )
-                }
+                        style_name.span(),
+                        "style name must be a string literal"
+                    );
+                    Default::default()
+                };
+                let value = &tuple.elems[1];
+                return Some((
+                    quote! {
+                        #style(#style_name, (#cx, #value))
+                    },
+                    style_name,
+                    value,
+                ));
+            } else {
+                proc_macro_error::emit_error!(
+                    tuple.span(),
+                    "style tuples must have two elements."
+                )
             }
         }
     }

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -161,7 +161,7 @@ impl ServerFnTraitObj {
     }
 }
 
-#[cfg(any(feature = "ssr"))]
+#[cfg(feature = "ssr")]
 inventory::collect!(ServerFnTraitObj);
 
 #[allow(unused)]

--- a/server_fn/src/default.rs
+++ b/server_fn/src/default.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
     };
 }
 
-#[cfg(any(feature = "ssr"))]
+#[cfg(feature = "ssr")]
 inventory::collect!(DefaultServerFnTraitObj);
 
 /// Attempts to find a server function registered at the given path.

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -80,7 +80,7 @@
 #[doc(hidden)]
 pub use const_format;
 // used by the macro
-#[cfg(any(feature = "ssr"))]
+#[cfg(feature = "ssr")]
 #[doc(hidden)]
 pub use inventory;
 #[cfg(any(feature = "ssr", doc))]


### PR DESCRIPTION
The change in indentation makes the PR hard to review

so I will discuss the change in conversational language

Two "if"'s checks were merged into one "if"

this

-        if let Some(expr) = node.value() {
-            if let syn::Expr::Tuple(tuple) = expr {

becomes

+        if let Some(Tuple(tuple)) = node.value() {