### PR TITLE
Reorder `<For />` `apply_diff` steps

### DIFF
--- a/leptos_dom/examples/test-bench/src/main.rs
+++ b/leptos_dom/examples/test-bench/src/main.rs
@@ -30,37 +30,42 @@ fn view_fn(cx: Scope) -> impl IntoView {
     view! { cx,
         <h2>"Passing Tests"</h2>
         <ul>
-          /* These work! */
-          <Test from=[1] to=[] />
-          <Test from=[1, 2] to=[] />
-          <Test from=[1, 2, 3] to=[] />
-          <hr/>
-          <Test from=[] to=[1] />
-          <Test from=[1, 2] to=[1] />
-          <Test from=[2, 1] to=[1] />
-          <hr/>
-          <Test from=[1, 2, 3] to=[1, 2] />
-          <Test from=[2] to=[1, 2] />
-          <Test from=[1] to=[1, 2] />
-          <Test from=[] to=[1, 2, 3] />
-          <Test from=[2] to=[1, 2, 3] />
-          <Test from=[1] to=[1, 2, 3] />
-          <Test from=[1, 3, 2] to=[1, 2, 3] />
-          <Test from=[2, 1, 3] to=[1, 2, 3] />
-          <Test from=[3] to=[1, 2, 3] />
-          <Test from=[3, 1] to=[1, 2, 3] />
-          <Test from=[3, 2, 1] to=[1, 2, 3] />
-         <hr/>
-          <Test from=[1, 4, 2, 3] to=[1, 2, 3, 4] />
-          <hr/>
-          <Test from=[1, 4, 3, 2, 5] to=[1, 2, 3, 4, 5] />
-          <Test from=[4, 5, 3, 1, 2] to=[1, 2, 3, 4, 5] />
+            <Test from=[1] to=[]/>
+            <Test from=[1, 2] to=[3, 2] then=vec![2]/>
+            <Test from=[1, 2] to=[]/>
+            <Test from=[1, 2, 3] to=[]/>
+            <hr/>
+            <Test from=[] to=[1]/>
+            <Test from=[1, 2] to=[1]/>
+            <Test from=[2, 1] to=[1]/>
+            <hr/>
+            <Test from=[1, 2, 3] to=[1, 2]/>
+            <Test from=[2] to=[1, 2]/>
+            <Test from=[1] to=[1, 2]/>
+            <Test from=[] to=[1, 2, 3]/>
+            <Test from=[2] to=[1, 2, 3]/>
+            <Test from=[1] to=[1, 2, 3]/>
+            <Test from=[1, 3, 2] to=[1, 2, 3]/>
+            <Test from=[2, 1, 3] to=[1, 2, 3]/>
+            <Test from=[3] to=[1, 2, 3]/>
+            <Test from=[3, 1] to=[1, 2, 3]/>
+            <Test from=[3, 2, 1] to=[1, 2, 3]/>
+            <hr/>
+            <Test from=[1, 4, 2, 3] to=[1, 2, 3, 4]/>
+            <hr/>
+            <Test from=[1, 4, 3, 2, 5] to=[1, 2, 3, 4, 5]/>
+            <Test from=[4, 5, 3, 1, 2] to=[1, 2, 3, 4, 5]/>
         </ul>
     }
 }
 
 #[component]
-fn Test<From, To>(cx: Scope, from: From, to: To) -> impl IntoView
+fn Test<From, To>(
+    cx: Scope,
+    from: From,
+    to: To,
+    #[prop(optional)] then: Option<Vec<usize>>,
+) -> impl IntoView
 where
     From: IntoIterator<Item = usize>,
     To: IntoIterator<Item = usize>,
@@ -71,49 +76,48 @@ where
     let (list, set_list) = create_signal(cx, from.clone());
     request_animation_frame({
         let to = to.clone();
+        let then = then.clone();
         move || {
             set_list(to);
+
+            if let Some(then) = then {
+                request_animation_frame({
+                    move || {
+                        set_list(then);
+                    }
+                });
+            }
         }
     });
 
     view! { cx,
-      <li>
-          "from: [" {move ||
-            from
-              .iter()
-              .map(ToString::to_string)
-              .intersperse(", ".to_string())
-              .collect::<String>()
-          } "]"
-          <br />
-          "to: [" {move ||
-            to
-              .iter()
-              .map(ToString::to_string)
-              .intersperse(", ".to_string())
-              .collect::<String>()
-          } "]"
-          <br />
-          "result: ["
-          <For
-              each=list
-              key=|i| *i
-              view=|cx, i| {
-                  view! { cx, <span>{i} ", "</span> }
-              }
-          /> "]"
-        /* <p>
-          "Pre | "
-          <For
-              each=list
-              key=|i| *i
-              view=|cx, i| {
-                  view! { cx, <span>{i}</span> }
-              }
-          />
-          " | Post"
-        </p> */
-      </li>
+        <li>
+            "from: [" {move || {
+                from
+                    .iter()
+                    .map(ToString::to_string)
+                    .intersperse(", ".to_string())
+                    .collect::<String>()
+            }} "]" <br/> "to: [" {
+                let then = then.clone();
+                move || {
+                    then
+                        .clone()
+                        .unwrap_or(to.iter().copied().collect())
+                        .iter()
+                        .map(ToString::to_string)
+                        .intersperse(", ".to_string())
+                        .collect::<String>()
+                }
+            } "]" <br/> "result: ["
+            <For
+                each=list
+                key=|i| *i
+                view=|cx, i| {
+                    view! { cx, <span>{i} ", "</span> }
+                }
+            /> "]"
+        </li>
     }
 }
 

--- a/leptos_dom/examples/test-bench/src/main.rs
+++ b/leptos_dom/examples/test-bench/src/main.rs
@@ -26,117 +26,114 @@ fn main() {
     mount_to_body(view_fn);
 }
 
-// fn view_fn(cx: Scope) -> impl IntoView {
-//     view! { cx,
-//         <h2>"Passing Tests"</h2>
-//         <ul>
-//           /* These work! */
-//           <Test from=[1] to=[] />
-//           <Test from=[1, 2] to=[] />
-//           <Test from=[1, 2, 3] to=[] />
-//           <hr/>
-//           <Test from=[] to=[1] />
-//           <Test from=[1, 2] to=[1] />
-//           <Test from=[2, 1] to=[1] />
-//           <hr/>
-//           <Test from=[1, 2, 3] to=[1, 2] />
-//           <Test from=[2] to=[1, 2] />
-//           <Test from=[1] to=[1, 2] />
-//           <Test from=[] to=[1, 2, 3] />
-//           <Test from=[2] to=[1, 2, 3] />
-//           <Test from=[1] to=[1, 2, 3] />
-//           <Test from=[1, 3, 2] to=[1, 2, 3] />
-//           <Test from=[2, 1, 3] to=[1, 2, 3] />
-//         </ul>
-//         <h2>"Broken Tests"</h2>
-//         <ul>
-//           <Test from=[3] to=[1, 2, 3] />
-//           <Test from=[3, 1] to=[1, 2, 3] />
-//           <Test from=[3, 2, 1] to=[1, 2, 3] />
-//          <hr/>
-//           <Test from=[1, 4, 2, 3] to=[1, 2, 3, 4] />
-//           <hr/>
-//           <Test from=[1, 4, 3, 2, 5] to=[1, 2, 3, 4, 5] />
-//           <Test from=[4, 5, 3, 1, 2] to=[1, 2, 3, 4, 5] />
-//         </ul>
-//     }
-// }
-
-// #[component]
-// fn Test<From, To>(cx: Scope, from: From, to: To) -> impl IntoView
-// where
-//     From: IntoIterator<Item = usize>,
-//     To: IntoIterator<Item = usize>,
-// {
-//     let from = from.into_iter().collect::<Vec<_>>();
-//     let to = to.into_iter().collect::<Vec<_>>();
-
-//     let (list, set_list) = create_signal(cx, from.clone());
-//     request_animation_frame({
-//         let to = to.clone();
-//         move || {
-//             set_list(to);
-//         }
-//     });
-
-//     view! { cx,
-//       <li>
-//           "from: [" {move ||
-//             from
-//               .iter()
-//               .map(ToString::to_string)
-//               .intersperse(", ".to_string())
-//               .collect::<String>()
-//           } "]"
-//           <br />
-//           "to: [" {move ||
-//             to
-//               .iter()
-//               .map(ToString::to_string)
-//               .intersperse(", ".to_string())
-//               .collect::<String>()
-//           } "]"
-//           <br />
-//           "result: ["
-//           <For
-//               each=list
-//               key=|i| *i
-//               view=|cx, i| {
-//                   view! { cx, <span>{i} ", "</span> }
-//               }
-//           /> "]"
-//         /* <p>
-//           "Pre | "
-//           <For
-//               each=list
-//               key=|i| *i
-//               view=|cx, i| {
-//                   view! { cx, <span>{i}</span> }
-//               }
-//           />
-//           " | Post"
-//         </p> */
-//       </li>
-//     }
-// }
-
 fn view_fn(cx: Scope) -> impl IntoView {
-    let (should_show_a, sett_should_show_a) = create_signal(cx, true);
-
-    let a = vec![1, 2, 3, 4];
-    let b = vec![1, 2, 3];
-
     view! { cx,
-      <button on:click=move |_| sett_should_show_a.update(|show| *show = !*show)>"Toggle"</button>
-
-      <For
-        each={move || if should_show_a.get() {
-          a.clone()
-        } else {
-          b.clone()
-        }}
-        key=|i| *i
-        view=|cx, i| view! { cx, <h1>{i}</h1> }
-      />
+        <h2>"Passing Tests"</h2>
+        <ul>
+          /* These work! */
+          <Test from=[1] to=[] />
+          <Test from=[1, 2] to=[] />
+          <Test from=[1, 2, 3] to=[] />
+          <hr/>
+          <Test from=[] to=[1] />
+          <Test from=[1, 2] to=[1] />
+          <Test from=[2, 1] to=[1] />
+          <hr/>
+          <Test from=[1, 2, 3] to=[1, 2] />
+          <Test from=[2] to=[1, 2] />
+          <Test from=[1] to=[1, 2] />
+          <Test from=[] to=[1, 2, 3] />
+          <Test from=[2] to=[1, 2, 3] />
+          <Test from=[1] to=[1, 2, 3] />
+          <Test from=[1, 3, 2] to=[1, 2, 3] />
+          <Test from=[2, 1, 3] to=[1, 2, 3] />
+          <Test from=[3] to=[1, 2, 3] />
+          <Test from=[3, 1] to=[1, 2, 3] />
+          <Test from=[3, 2, 1] to=[1, 2, 3] />
+         <hr/>
+          <Test from=[1, 4, 2, 3] to=[1, 2, 3, 4] />
+          <hr/>
+          <Test from=[1, 4, 3, 2, 5] to=[1, 2, 3, 4, 5] />
+          <Test from=[4, 5, 3, 1, 2] to=[1, 2, 3, 4, 5] />
+        </ul>
     }
 }
+
+#[component]
+fn Test<From, To>(cx: Scope, from: From, to: To) -> impl IntoView
+where
+    From: IntoIterator<Item = usize>,
+    To: IntoIterator<Item = usize>,
+{
+    let from = from.into_iter().collect::<Vec<_>>();
+    let to = to.into_iter().collect::<Vec<_>>();
+
+    let (list, set_list) = create_signal(cx, from.clone());
+    request_animation_frame({
+        let to = to.clone();
+        move || {
+            set_list(to);
+        }
+    });
+
+    view! { cx,
+      <li>
+          "from: [" {move ||
+            from
+              .iter()
+              .map(ToString::to_string)
+              .intersperse(", ".to_string())
+              .collect::<String>()
+          } "]"
+          <br />
+          "to: [" {move ||
+            to
+              .iter()
+              .map(ToString::to_string)
+              .intersperse(", ".to_string())
+              .collect::<String>()
+          } "]"
+          <br />
+          "result: ["
+          <For
+              each=list
+              key=|i| *i
+              view=|cx, i| {
+                  view! { cx, <span>{i} ", "</span> }
+              }
+          /> "]"
+        /* <p>
+          "Pre | "
+          <For
+              each=list
+              key=|i| *i
+              view=|cx, i| {
+                  view! { cx, <span>{i}</span> }
+              }
+          />
+          " | Post"
+        </p> */
+      </li>
+    }
+}
+
+// fn view_fn(cx: Scope) -> impl IntoView {
+//     let (should_show_a, sett_should_show_a) = create_signal(cx, true);
+
+//     let a = vec![2];
+//     let b = vec![1, 2, 3];
+
+//     view! { cx,
+//       <button on:click=move |_| sett_should_show_a.update(|show| *show = !*show)>"Toggle"</button>
+
+//       <For
+//         each={move || if should_show_a.get() {
+//           a.clone()
+//         } else {
+//           b.clone()
+//         }}
+//         key=|i| *i
+//         view=|cx, i| view! { cx, <h1>{i}</h1> }
+//       />
+//     }
+// }

--- a/leptos_dom/src/components/each.rs
+++ b/leptos_dom/src/components/each.rs
@@ -795,8 +795,6 @@ fn apply_diff<T, EF, V>(
     EF: Fn(Scope, T) -> V,
     V: IntoView,
 {
-    debug!("starting children:\n{children:#?}");
-
     let range = RANGE.with(|range| (*range).clone());
 
     // The order of cmds needs to be:
@@ -843,9 +841,6 @@ fn apply_diff<T, EF, V>(
     }
 
     let (move_cmds, add_cmds) = unpack_moves(&diff);
-
-    debug!("\n{diff:#?}");
-    debug!("\n{move_cmds:#?}\n{add_cmds:#?}");
 
     let mut moved_children = move_cmds
         .iter()
@@ -909,8 +904,6 @@ fn apply_diff<T, EF, V>(
 
         children[at] = Some(each_item);
     }
-
-    debug!("ending children:\n{children:#?}");
 
     #[allow(unstable_name_collisions)]
     children.drain_filter(|c| c.is_none());


### PR DESCRIPTION
This PR fixes more edge cases with `apply_diff` by reordering steps and simplifying `unpack_moves`.