### PR TITLE
Fix #1199 - Docs: Add note on how to fix failing builds which rebuild-std

### DIFF
--- a/docs/book/src/appendix_binary_size.md
+++ b/docs/book/src/appendix_binary_size.md
@@ -47,6 +47,12 @@ Note that if you're using this with SSR too, the same Cargo profile will be appl
 target = "x86_64-unknown-linux-gnu" # or whatever
 ```
 
+Also note that in some cases, the cfg feature `has_std` will not be set, which may cause build errors with some dependencies which check for `has_std`. You may fix any build errors due to this by adding:
+```toml
+[build]
+rustflags = ["--cfg=has_std"]
+```
+
 And you'll need to add `panic = "abort"` to `[profile.release]` in `Cargo.toml`. Note that this applies the same `build-std` and panic settings to your server binary, which may not be desirable. Some further exploration is probably needed here.
 
 5. One of the sources of binary size in WASM binaries can be `serde` serialization/deserialization code. Leptos uses `serde` by default to serialize and deserialize resources created with `create_resource`. You might try experimenting with the `miniserde` and `serde-lite` features, which allow you to use those crates for serialization and deserialization instead; each only implements a subset of `serde`’s functionality, but typically optimizes for size over speed.


### PR DESCRIPTION
Fixes #1199 

`leptos_meta` fails to build under the following conditions:
1, using nightly
2, having `leptos_meta` as a dependency
3, using `rust-toolchain.toml` set to a nightly channel
4, following the advice on rebuilding std to remove panic info in section [Appendix: Optimizing WASM Binary Size](https://leptos-rs.github.io/leptos/appendix_binary_size.html#appendix-optimizing-wasm-binary-size)

This addition to docs aims to make it clear on how to fix this build error, should it arise.

If you'd like edits/changes/clarifications in the doc, let me know.

Thanks!