### PR TITLE
build(examples): generate workspace members variable

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -37,11 +37,11 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
 workspace = false
 description = "Generate the list of workspace members"
 script = '''
-          examples=$(ls | 
-          grep -v README.md | 
-          grep -v Makefile.toml | 
-          grep -v cargo-make | 
-          grep -v gtk | 
-          jq -R -s -c 'split("\n")[:-1]')
-          echo $examples
+examples=$(ls | 
+grep -v README.md | 
+grep -v Makefile.toml | 
+grep -v cargo-make | 
+grep -v gtk | 
+jq -R -s -c 'split("\n")[:-1]')
+echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 '''

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -32,3 +32,16 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
     "todo_app_sqlite_viz",
     "todomvc",
 ]
+
+[tasks.gen-members]
+workspace = false
+description = "Generate the list of workspace members"
+script = '''
+          examples=$(ls | 
+          grep -v README.md | 
+          grep -v Makefile.toml | 
+          grep -v cargo-make | 
+          grep -v gtk | 
+          jq -R -s -c 'split("\n")[:-1]')
+          echo $examples
+'''


### PR DESCRIPTION
READY TO REVIEW

Make it easy to update the `CARGO_MAKE_CRATE_WORKSPACE_MEMBERS` variable.

**Verification**

- Run `cargo make gen-members` from the **examples** directory.