### PR TITLE
fix: don't re-mount identical child in `DynChild`

### DIFF
--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -273,7 +273,8 @@ where
                             // I can imagine some edge case that the child changes while
                             // hydration is ongoing
                             if !HydrationCtx::is_hydrating() {
-                                if !was_child_moved && child != new_child {
+                                let same_child = child == new_child;
+                                if !was_child_moved && !same_child {
                                     // Remove the child
                                     let start = child.get_opening_node();
                                     let end = &closing;
@@ -308,10 +309,13 @@ where
                                 }
 
                                 // Mount the new child
-                                mount_child(
-                                    MountKind::Before(&closing),
-                                    &new_child,
-                                );
+                                // If it's the same child, don't re-mount
+                                if !same_child {
+                                    mount_child(
+                                        MountKind::Before(&closing),
+                                        &new_child,
+                                    );
+                                }
                             }
 
                             // We want to reuse text nodes, so hold onto it if


### PR DESCRIPTION
`leptos_dom::DynChild` seems to have been re-mounting the child on the second run, no matter what, even if the child was identical. This causes no visible issues, unless you're using animations, in which case they restart. This was discovered in the `leptos_router::Outlet` component, where the first navigation would cause a re-mount, restarting animations.

I'm not sure this solution is correct, but I can't imagine how it could be incorrect—all it does is check whether the current child and the new child are the same, in which case I can't imagine why it would need to be mounted again. 