### PR TITLE
fix: nested Suspense/Transition with cascading resources

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -114,9 +114,6 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
-                                    leptos::log!(
-                                        "continuing from {current_id:?}"
-                                    );
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );
@@ -134,9 +131,6 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
-                                    leptos::log!(
-                                        "continuing from {current_id:?}"
-                                    );
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -97,6 +97,7 @@ where
                 let initial = {
                     // no resources were read under this, so just return the child
                     if context.pending_resources.get() == 0 {
+                        HydrationCtx::continue_from(current_id.clone());
                         DynChild::new({
                             let children = Rc::clone(&children);
                             move || (*children).clone()

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -97,7 +97,6 @@ where
                 let initial = {
                     // no resources were read under this, so just return the child
                     if context.pending_resources.get() == 0 {
-                        HydrationCtx::continue_from(current_id.clone());
                         DynChild::new({
                             let children = Rc::clone(&children);
                             move || (*children).clone()
@@ -115,6 +114,7 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
+                                    leptos::log!("continuing from {current_id:?}");
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );
@@ -132,6 +132,7 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
+                                    leptos::log!("continuing from {current_id:?}");
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -114,7 +114,9 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
-                                    leptos::log!("continuing from {current_id:?}");
+                                    leptos::log!(
+                                        "continuing from {current_id:?}"
+                                    );
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );
@@ -132,7 +134,9 @@ where
                             {
                                 let orig_children = Rc::clone(&orig_children);
                                 move || {
-                                    leptos::log!("continuing from {current_id:?}");
+                                    leptos::log!(
+                                        "continuing from {current_id:?}"
+                                    );
                                     HydrationCtx::continue_from(
                                         current_id.clone(),
                                     );

--- a/leptos/tests/test_examples/suspense-tests/Cargo.toml
+++ b/leptos/tests/test_examples/suspense-tests/Cargo.toml
@@ -17,7 +17,7 @@ leptos_actix = { path = "../../../../integrations/actix", optional = true }
 leptos_router = { path = "../../../../router", default-features = false }
 log = "0.4"
 simple_logger = "4"
-wasm-bindgen = "0.2.85"
+wasm-bindgen = "0.2.87"
 serde = "1.0.159"
 tokio = { version = "1.27.0", features = ["time"], optional = true }
 

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -8,7 +8,7 @@ cfg_if! {
     use wasm_bindgen::JsCast;
 
     // We can tell if we start in hydration mode by checking to see if the
-    // id "_0-0-0" is present in the DOM. If it is, we know we are hydrating from
+    // id "_0-1" is present in the DOM. If it is, we know we are hydrating from
     // the server, if not, we are starting off in CSR
     thread_local! {
       static HYDRATION_COMMENTS: LazyCell<HashMap<String, web_sys::Comment>> = LazyCell::new(|| {

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -222,12 +222,7 @@ pub fn render_to_stream_with_prefix_undisposed_with_context_and_block_replacemen
                 .push(async move { (fragment_id, data.out_of_order.await) });
         } else {
             fragments.push(Box::pin(async move {
-                (fragment_id.clone(), {
-                    println!("waiting for {fragment_id:?}");
-                    let data = data.out_of_order.await;
-                    println!("{fragment_id:?} resolved w/ {data:?}");
-                    data
-                })
+                (fragment_id.clone(), data.out_of_order.await)
             })
                 as Pin<Box<dyn Future<Output = (String, String)>>>);
         }

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -221,66 +221,110 @@ pub fn render_to_stream_with_prefix_undisposed_with_context_and_block_replacemen
             blocking_fragments
                 .push(async move { (fragment_id, data.out_of_order.await) });
         } else {
-            fragments
-                .push(async move { (fragment_id, data.out_of_order.await) });
+            fragments.push(Box::pin(async move {
+                (fragment_id.clone(), {
+                    println!("waiting for {fragment_id:?}");
+                    let data = data.out_of_order.await;
+                    println!("{fragment_id:?} resolved w/ {data:?}");
+                    data
+                })
+            })
+                as Pin<Box<dyn Future<Output = (String, String)>>>);
         }
     }
 
+    let stream = futures::stream::once(
+        // HTML for the view function and script to store resources
+        async move {
+            let resolvers = format!(
+                "<script>__LEPTOS_PENDING_RESOURCES = \
+                 {pending_resources};__LEPTOS_RESOLVED_RESOURCES = new \
+                 Map();__LEPTOS_RESOURCE_RESOLVERS = new Map();</script>"
+            );
+
+            if replace_blocks {
+                let mut blocks = Vec::with_capacity(blocking_fragments.len());
+                while let Some((blocked_id, blocked_fragment)) =
+                    blocking_fragments.next().await
+                {
+                    blocks.push((blocked_id, blocked_fragment));
+                }
+
+                let prefix = prefix(cx);
+
+                let mut shell = shell;
+
+                for (blocked_id, blocked_fragment) in blocks {
+                    let open = format!("<!--suspense-open-{blocked_id}-->");
+                    let close = format!("<!--suspense-close-{blocked_id}-->");
+                    let (first, rest) =
+                        shell.split_once(&open).unwrap_or_default();
+                    let (_fallback, rest) =
+                        rest.split_once(&close).unwrap_or_default();
+
+                    shell = format!("{first}{blocked_fragment}{rest}").into();
+                }
+
+                format!("{prefix}{shell}{resolvers}")
+            } else {
+                let mut blocking = String::new();
+                let mut blocking_fragments =
+                    fragments_to_chunks(blocking_fragments);
+
+                while let Some(fragment) = blocking_fragments.next().await {
+                    blocking.push_str(&fragment);
+                }
+                let prefix = prefix(cx);
+                format!("{prefix}{shell}{resolvers}{blocking}")
+            }
+        },
+    )
+    .chain(ooo_body_stream_recurse(cx, fragments, serializers));
+
+    (stream, runtime, scope)
+}
+
+fn ooo_body_stream_recurse(
+    cx: Scope,
+    fragments: FuturesUnordered<PinnedFuture<(String, String)>>,
+    serializers: FuturesUnordered<PinnedFuture<(ResourceId, String)>>,
+) -> Pin<Box<dyn Stream<Item = String>>> {
     // resources and fragments
     // stream HTML for each <Suspense/> as it resolves
     let fragments = fragments_to_chunks(fragments);
     // stream data for each Resource as it resolves
     let resources = render_serializers(serializers);
 
-    // HTML for the view function and script to store resources
-    let stream = futures::stream::once(async move {
-        let resolvers = format!(
-            "<script>__LEPTOS_PENDING_RESOURCES = \
-             {pending_resources};__LEPTOS_RESOLVED_RESOURCES = new \
-             Map();__LEPTOS_RESOURCE_RESOLVERS = new Map();</script>"
-        );
-
-        if replace_blocks {
-            let mut blocks = Vec::with_capacity(blocking_fragments.len());
-            while let Some((blocked_id, blocked_fragment)) =
-                blocking_fragments.next().await
-            {
-                blocks.push((blocked_id, blocked_fragment));
-            }
-
-            let prefix = prefix(cx);
-
-            let mut shell = shell;
-
-            for (blocked_id, blocked_fragment) in blocks {
-                let open = format!("<!--suspense-open-{blocked_id}-->");
-                let close = format!("<!--suspense-close-{blocked_id}-->");
-                let (first, rest) = shell.split_once(&open).unwrap_or_default();
-                let (_fallback, rest) =
-                    rest.split_once(&close).unwrap_or_default();
-
-                shell = format!("{first}{blocked_fragment}{rest}").into();
-            }
-
-            format!("{prefix}{shell}{resolvers}")
-        } else {
-            let mut blocking = String::new();
-            let mut blocking_fragments =
-                fragments_to_chunks(blocking_fragments);
-
-            while let Some(fragment) = blocking_fragments.next().await {
-                blocking.push_str(&fragment);
-            }
-            let prefix = prefix(cx);
-            format!("{prefix}{shell}{resolvers}{blocking}")
-        }
-    })
-    // TODO these should be combined again in a way that chains them appropriately
-    // such that individual resources can resolve before all fragments are done
-    .chain(fragments)
-    .chain(resources);
-
-    (stream, runtime, scope)
+    Box::pin(
+        // TODO these should be combined again in a way that chains them appropriately
+        // such that individual resources can resolve before all fragments are done
+        fragments.chain(resources).chain(
+            futures::stream::once(async move {
+                let pending = cx.pending_fragments();
+                if pending.len() > 0 {
+                    let fragments = FuturesUnordered::new();
+                    let serializers = cx.serialization_resolvers();
+                    for (fragment_id, data) in pending {
+                        fragments.push(Box::pin(async move {
+                            (fragment_id.clone(), data.out_of_order.await)
+                        })
+                            as Pin<Box<dyn Future<Output = (String, String)>>>);
+                    }
+                    Box::pin(ooo_body_stream_recurse(
+                        cx,
+                        fragments,
+                        serializers,
+                    ))
+                        as Pin<Box<dyn Stream<Item = String>>>
+                } else {
+                    Box::pin(futures::stream::once(async move {
+                        Default::default()
+                    }))
+                }
+            })
+            .flatten(),
+        ),
+    )
 }
 
 #[cfg_attr(

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -94,12 +94,7 @@ pub fn render_to_stream_in_order_with_prefix_undisposed_with_context(
     let runtime = create_runtime();
 
     let (
-        (
-            blocking_fragments_ready,
-            chunks,
-            prefix,
-            pending_resources,
-        ),
+        (blocking_fragments_ready, chunks, prefix, pending_resources),
         scope_id,
         _,
     ) = run_scope_undisposed(runtime, |cx| {
@@ -145,10 +140,13 @@ pub fn render_to_stream_in_order_with_prefix_undisposed_with_context(
         )
     })
     .chain(rx)
-    .chain(futures::stream::once(async move {
-        let serializers = cx.serialization_resolvers();
-        render_serializers(serializers)
-    }).flatten());
+    .chain(
+        futures::stream::once(async move {
+            let serializers = cx.serialization_resolvers();
+            render_serializers(serializers)
+        })
+        .flatten(),
+    );
 
     (stream, runtime, scope_id)
 }

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -96,6 +96,7 @@ mod trigger;
 pub use context::*;
 pub use diagnostics::SpecialNonReactiveZone;
 pub use effect::*;
+pub use hydration::FragmentData;
 pub use memo::*;
 pub use resource::*;
 use runtime::*;


### PR DESCRIPTION
Currently, nested `<Suspense/>` (or `<Transition/>`) components that read from resources created at the top level are fine. However, creating a new resource inside the body rendered by the `<Suspense/>` causes issues (see #1156) because the stream does not wait for the newly-pending fragment to resolve. 

This PR should resolve that, allowing for nested data loading. While this is an antipattern (all resources should be hoisted out to a higher level instead to allow them to load in parallel) it's sometimes necessary—some resources just really do depend on the previous resource—and in any case it's a bug it to be broken without warning, I think.