### PR TITLE
tailwind_csr_trunk has maintenance issues

### DIFF
--- a/examples/tailwind_csr_trunk/Cargo.toml
+++ b/examples/tailwind_csr_trunk/Cargo.toml
@@ -4,18 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-leptos = { version = "0.2", features = [
-  "serde",
-  "csr",
-] }
-leptos_meta = { version = "0.2", features = ["csr"] }
-leptos_router = { version = "0.2", features = ["csr"]  }
+leptos = { path = "../../leptos", features = ["serde", "csr"] }
+leptos_meta = { path = "../../meta", features = ["csr"] }
+leptos_router = { path = "../../router", features = ["csr"] }
 log = "0.4"
 gloo-net = { version = "0.2", features = ["http"] }
 
 
 # dependecies for client (enable when csr or hydrate set)
 wasm-bindgen = { version = "0.2" }
-console_log = { version = "1"}
-console_error_panic_hook = { version = "0.1"}
-
+console_log = { version = "1" }
+console_error_panic_hook = { version = "0.1" }


### PR DESCRIPTION
It will eventually fail and become buggy.

examples/hackernews_axum pulls in leptos submodules using this pattern

```
leptos_axum = { path = "../../integrations/axum", optional = true }
leptos_meta = { path = "../../meta", default-features = false }
leptos_router = { path = "../../router", default-features = false }
```

Happiness, as the leptos version transitions from 3, 4, 5 the examples track the current version..

This PR just updates tailwind_csr_trunk to follow that convention.

Previously tailwind_csr_trunk, was stuck at version 2, it has dropped behind already ( current  leptos is 3.0.1 ).