### PR TITLE
feat: improved error handling and version tracking for pending actions/`<ActionForm/>` (closes #1205)

### DIFF
--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -106,13 +106,31 @@ where
         self.0.with_value(|a| a.pending.read_only())
     }
 
-    /// Updates whether the action is currently pending.
+    /// Updates whether the action is currently pending. If the action has been dispatched 
+    /// multiple times, and some of them are still pending, it will *not* update the `pending`
+    /// signal.
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn set_pending(&self, pending: bool) {
-        self.0.try_with_value(|a| a.pending.set(pending));
+        self.0.try_with_value(|a| {
+            let pending_dispatches = a.pending_dispatches;
+            let still_pending = pending_dispatches.try_update(|n| {
+                if pending {
+                    *n += 1;
+                } else {
+                    *n -= 1;
+                }
+                *n
+            })
+            .unwrap_or(0);
+            if still_pending == 0 {
+                a.pending.set(false);
+            } else {
+                a.pending.set(true);
+            }
+        });
     }
 
     /// The URL associated with the action (typically as part of a server function.)
@@ -142,6 +160,11 @@ where
     /// How many times the action has successfully resolved.
     pub fn version(&self) -> RwSignal<usize> {
         self.0.with_value(|a| a.version)
+    }
+
+    /// How many dispatches are still pending.
+    pub fn pending_dispatches(&self) -> Signal<usize> {
+        self.0.with_value(|a| a.pending_dispatches).read_only().into()
     }
 
     /// The current argument that was dispatched to the `async` function.
@@ -186,6 +209,7 @@ where
     I: 'static,
     O: 'static,
 {
+    cx: Scope,
     /// How many times the action has successfully resolved.
     pub version: RwSignal<usize>,
     /// The current argument that was dispatched to the `async` function.
@@ -195,6 +219,8 @@ where
     pub value: RwSignal<Option<O>>,
     pending: RwSignal<bool>,
     url: Option<String>,
+    /// How many dispatched actions are still pending.
+    pending_dispatches: RwSignal<usize>,
     #[allow(clippy::complexity)]
     action_fn: Rc<dyn Fn(&I) -> Pin<Box<dyn Future<Output = O>>>>,
 }
@@ -215,14 +241,25 @@ where
         let input = self.input;
         let version = self.version;
         let pending = self.pending;
+        let pending_dispatches = self.pending_dispatches;
         let value = self.value;
+        let cx = self.cx;
         pending.set(true);
+        pending_dispatches.update(|n| *n += 1);
         spawn_local(async move {
             let new_value = fut.await;
-            value.set(Some(new_value));
-            input.set(None);
-            pending.set(false);
-            version.update(|n| *n += 1);
+            cx.batch(move || {
+                value.set(Some(new_value));
+                input.set(None);
+                version.update(|n| *n += 1);
+                let still_pending = pending_dispatches.try_update(|n| {
+                    *n -= 1;
+                    *n
+                }).unwrap_or(0);
+                if still_pending == 0 {
+                    pending.set(false);
+                }
+            });
         })
     }
 }
@@ -316,6 +353,7 @@ where
     let input = create_rw_signal(cx, None);
     let value = create_rw_signal(cx, None);
     let pending = create_rw_signal(cx, false);
+    let pending_dispatches = create_rw_signal(cx, 0);
     let action_fn = Rc::new(move |input: &I| {
         let fut = action_fn(input);
         Box::pin(fut) as Pin<Box<dyn Future<Output = O>>>
@@ -324,11 +362,13 @@ where
     Action(store_value(
         cx,
         ActionState {
+            cx,
             version,
             url: None,
             input,
             value,
             pending,
+            pending_dispatches,
             action_fn,
         },
     ))


### PR DESCRIPTION
This adds an internal version counter to ensure that actions do not resolve to `pending: false` if there are multiple dispatches still in flight. It also properly translates errors encountered during `<ActionForm/>` POST requests into `ServerFnError::Request`.

Closes #1205.