### PR TITLE
feat: add an `anyhow`-like `Result` type for easier error handling

### DIFF
--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,4 +1,5 @@
 use leptos::*;
+use leptos::error::Result;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -8,30 +9,24 @@ pub struct Cat {
 }
 
 #[derive(Error, Clone, Debug)]
-pub enum FetchError {
+pub enum CatError {
     #[error("Please request more than zero cats.")]
     NonZeroCats,
-    #[error("Error loading data from serving.")]
-    Request,
-    #[error("Error deserializaing cat data from request.")]
-    Json,
 }
 
 type CatCount = usize;
 
-async fn fetch_cats(count: CatCount) -> Result<Vec<String>, FetchError> {
+async fn fetch_cats(count: CatCount) -> Result<Vec<String>> {
     if count > 0 {
         // make the request
         let res = reqwasm::http::Request::get(&format!(
             "https://api.thecatapi.com/v1/images/search?limit={count}",
         ))
         .send()
-        .await
-        .map_err(|_| FetchError::Request)?
+        .await?
         // convert it to JSON
         .json::<Vec<Cat>>()
-        .await
-        .map_err(|_| FetchError::Json)?
+        .await?
         // extract the URL field for each cat
         .into_iter()
         .take(count)
@@ -39,7 +34,7 @@ async fn fetch_cats(count: CatCount) -> Result<Vec<String>, FetchError> {
         .collect::<Vec<_>>();
         Ok(res)
     } else {
-        Err(FetchError::NonZeroCats)
+        Err(CatError::NonZeroCats.into())
     }
 }
 

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,5 +1,4 @@
-use leptos::*;
-use leptos::error::Result;
+use leptos::{error::Result, *};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -43,10 +43,7 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     let mut todos = Vec::new();
     let mut rows =
         sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
-    while let Some(row) = rows
-        .try_next()
-        .await?
-    {
+    while let Some(row) = rows.try_next().await? {
         todos.push(row);
     }
 

--- a/examples/todo_app_sqlite/src/todo.rs
+++ b/examples/todo_app_sqlite/src/todo.rs
@@ -9,7 +9,7 @@ cfg_if! {
         use sqlx::{Connection, SqliteConnection};
 
         pub async fn db() -> Result<SqliteConnection, ServerFnError> {
-            SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
+            Ok(SqliteConnection::connect("sqlite:Todos.db").await?)
         }
 
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
@@ -45,8 +45,7 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
         sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
     while let Some(row) = rows
         .try_next()
-        .await
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
+        .await?
     {
         todos.push(row);
     }
@@ -76,12 +75,11 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
 pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
     let mut conn = db().await?;
 
-    sqlx::query("DELETE FROM todos WHERE id = $1")
+    Ok(sqlx::query("DELETE FROM todos WHERE id = $1")
         .bind(id)
         .execute(&mut conn)
         .await
-        .map(|_| ())
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))
+        .map(|_| ())?)
 }
 
 #[component]

--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -11,7 +11,7 @@ cfg_if! {
         // use http::{header::SET_COOKIE, HeaderMap, HeaderValue, StatusCode};
 
         pub async fn db() -> Result<SqliteConnection, ServerFnError> {
-            SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
+            Ok(SqliteConnection::connect("sqlite:Todos.db").await?)
         }
 
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
@@ -47,11 +47,7 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     let mut todos = Vec::new();
     let mut rows =
         sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
-    while let Some(row) = rows
-        .try_next()
-        .await
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
-    {
+    while let Some(row) = rows.try_next().await? {
         todos.push(row);
     }
 
@@ -93,12 +89,11 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
 pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
     let mut conn = db().await?;
 
-    sqlx::query("DELETE FROM todos WHERE id = $1")
+    Ok(sqlx::query("DELETE FROM todos WHERE id = $1")
         .bind(id)
         .execute(&mut conn)
         .await
-        .map(|_| ())
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))
+        .map(|_| ())?)
 }
 
 #[component]

--- a/examples/todo_app_sqlite_viz/src/todo.rs
+++ b/examples/todo_app_sqlite_viz/src/todo.rs
@@ -11,7 +11,7 @@ cfg_if! {
         // use http::{header::SET_COOKIE, HeaderMap, HeaderValue, StatusCode};
 
         pub async fn db() -> Result<SqliteConnection, ServerFnError> {
-            SqliteConnection::connect("sqlite:Todos.db").await.map_err(|e| ServerFnError::ServerError(e.to_string()))
+            Ok(SqliteConnection::connect("sqlite:Todos.db").await?)
         }
 
         #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, sqlx::FromRow)]
@@ -47,11 +47,7 @@ pub async fn get_todos(cx: Scope) -> Result<Vec<Todo>, ServerFnError> {
     let mut todos = Vec::new();
     let mut rows =
         sqlx::query_as::<_, Todo>("SELECT * FROM todos").fetch(&mut conn);
-    while let Some(row) = rows
-        .try_next()
-        .await
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))?
-    {
+    while let Some(row) = rows.try_next().await? {
         todos.push(row);
     }
 
@@ -93,12 +89,11 @@ pub async fn add_todo(title: String) -> Result<(), ServerFnError> {
 pub async fn delete_todo(id: u16) -> Result<(), ServerFnError> {
     let mut conn = db().await?;
 
-    sqlx::query("DELETE FROM todos WHERE id = $1")
+    Ok(sqlx::query("DELETE FROM todos WHERE id = $1")
         .bind(id)
         .execute(&mut conn)
         .await
-        .map(|_| ())
-        .map_err(|e| ServerFnError::ServerError(e.to_string()))
+        .map(|_| ())?)
 }
 
 #[component]

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -182,7 +182,8 @@ pub use leptos_macro::{component, server, slot, view, Params};
 pub use leptos_reactive::*;
 pub use leptos_server::{
     self, create_action, create_multi_action, create_server_action,
-    create_server_multi_action, Action, MultiAction, ServerFn, ServerFnError, ServerFnErrorErr
+    create_server_multi_action, Action, MultiAction, ServerFn, ServerFnError,
+    ServerFnErrorErr,
 };
 pub use server_fn::{self, ServerFn as _};
 pub use typed_builder;

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -171,6 +171,11 @@ pub use leptos_dom::{
     Class, CollectView, Errors, Fragment, HtmlElement, IntoAttribute,
     IntoClass, IntoProperty, IntoStyle, IntoView, NodeRef, Property, View,
 };
+
+/// Types to make it easier to handle errors in your application.
+pub mod error {
+    pub use leptos_dom::{Error, Result};
+}
 #[cfg(not(any(target_arch = "wasm32", feature = "template_macro")))]
 pub use leptos_macro::view as template;
 pub use leptos_macro::{component, server, slot, view, Params};

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -174,7 +174,7 @@ pub use leptos_dom::{
 
 /// Types to make it easier to handle errors in your application.
 pub mod error {
-    pub use leptos_dom::{Error, Result};
+    pub use server_fn::error::{Error, Result};
 }
 #[cfg(not(any(target_arch = "wasm32", feature = "template_macro")))]
 pub use leptos_macro::view as template;

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -182,7 +182,7 @@ pub use leptos_macro::{component, server, slot, view, Params};
 pub use leptos_reactive::*;
 pub use leptos_server::{
     self, create_action, create_multi_action, create_server_action,
-    create_server_multi_action, Action, MultiAction, ServerFn, ServerFnError,
+    create_server_multi_action, Action, MultiAction, ServerFn, ServerFnError, ServerFnErrorErr
 };
 pub use server_fn::{self, ServerFn as _};
 pub use typed_builder;

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -18,6 +18,7 @@ indexmap = "1.9"
 itertools = "0.10"
 js-sys = "0.3"
 leptos_reactive = { workspace = true }
+server_fn = { workspace = true }
 once_cell = "1"
 pad-adapter = "0.1"
 paste = "1"

--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -1,7 +1,7 @@
 use crate::{HydrationCtx, IntoView};
 use cfg_if::cfg_if;
 use leptos_reactive::{signal_prelude::*, use_context, RwSignal};
-use server_fn::error::{Error};
+use server_fn::error::Error;
 use std::{borrow::Cow, collections::HashMap};
 
 /// A struct to hold all the possible errors that could be provided by child Views

--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -1,55 +1,8 @@
 use crate::{HydrationCtx, IntoView};
 use cfg_if::cfg_if;
 use leptos_reactive::{signal_prelude::*, use_context, RwSignal};
-use server_fn::{ServerFnError, ServerFnErrorErr};
-use std::{borrow::Cow, collections::HashMap, error, fmt, ops, sync::Arc};
-
-/// This is a result type into which any error can be converted,
-/// and which can be used directly in your `view`.
-///
-/// All errors will be stored as [`Error`].
-pub type Result<T, E = Error> = core::result::Result<T, E>;
-
-/// A generic wrapper for any error.
-#[derive(Debug, Clone)]
-#[repr(transparent)]
-pub struct Error(Arc<dyn error::Error + Send + Sync>);
-
-impl Error {
-    /// Converts the wrapper into the inner reference-counted error.
-    pub fn into_inner(self) -> Arc<dyn error::Error + Send + Sync> {
-        Arc::clone(&self.0)
-    }
-}
-
-impl ops::Deref for Error {
-    type Target = Arc<dyn error::Error + Send + Sync>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl<T> From<T> for Error
-where
-    T: std::error::Error + Send + Sync + 'static,
-{
-    fn from(value: T) -> Self {
-        Error(Arc::new(value))
-    }
-}
-
-impl From<ServerFnError> for Error {
-    fn from(e: ServerFnError) -> Self {
-        Error(Arc::new(ServerFnErrorErr::from(e)))
-    }
-}
+use server_fn::error::{Error};
+use std::{borrow::Cow, collections::HashMap};
 
 /// A struct to hold all the possible errors that could be provided by child Views
 #[derive(Debug, Clone, Default)]

--- a/leptos_dom/src/components/errors.rs
+++ b/leptos_dom/src/components/errors.rs
@@ -1,6 +1,7 @@
 use crate::{HydrationCtx, IntoView};
 use cfg_if::cfg_if;
 use leptos_reactive::{signal_prelude::*, use_context, RwSignal};
+use server_fn::{ServerFnError, ServerFnErrorErr};
 use std::{borrow::Cow, collections::HashMap, error, fmt, ops, sync::Arc};
 
 /// This is a result type into which any error can be converted,
@@ -41,6 +42,12 @@ where
 {
     fn from(value: T) -> Self {
         Error(Arc::new(value))
+    }
+}
+
+impl From<ServerFnError> for Error {
+    fn from(e: ServerFnError) -> Self {
+        Error(Arc::new(ServerFnErrorErr::from(e)))
     }
 }
 
@@ -164,6 +171,7 @@ where
         }
     }
 }
+
 impl Errors {
     /// Returns `true` if there are no errors.
     #[inline(always)]

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -116,7 +116,9 @@
 //! your app is not available.
 
 use leptos_reactive::*;
-pub use server_fn::{Encoding, Payload, ServerFnError, error::ServerFnErrorErr};
+pub use server_fn::{
+    error::ServerFnErrorErr, Encoding, Payload, ServerFnError,
+};
 
 mod action;
 mod multi_action;

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -116,7 +116,7 @@
 //! your app is not available.
 
 use leptos_reactive::*;
-pub use server_fn::{Encoding, Payload, ServerFnError, ServerFnErrorErr};
+pub use server_fn::{Encoding, Payload, ServerFnError, error::ServerFnErrorErr};
 
 mod action;
 mod multi_action;

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -116,7 +116,7 @@
 //! your app is not available.
 
 use leptos_reactive::*;
-pub use server_fn::{Encoding, Payload, ServerFnError};
+pub use server_fn::{Encoding, Payload, ServerFnError, ServerFnErrorErr};
 
 mod action;
 mod multi_action;

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -406,7 +406,8 @@ where
                 cx.batch(move || {
                     value.try_set(Some(Err(e.clone())));
                     if let Some(error) = error {
-                        error.try_set(Some(Box::new(ServerFnErrorErr::from(e))));
+                        error
+                            .try_set(Some(Box::new(ServerFnErrorErr::from(e))));
                     }
                 });
             }

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -386,7 +386,7 @@ where
             let e = ServerFnError::Request(e.to_string());
             value.try_set(Some(Err(e.clone())));
             if let Some(error) = error {
-                error.try_set(Some(Box::new(e)));
+                error.try_set(Some(Box::new(ServerFnErrorErr::from(e))));
             }
         });
     });
@@ -406,7 +406,7 @@ where
                 cx.batch(move || {
                     value.try_set(Some(Err(e.clone())));
                     if let Some(error) = error {
-                        error.try_set(Some(Box::new(e)));
+                        error.try_set(Some(Box::new(ServerFnErrorErr::from(e))));
                     }
                 });
             }
@@ -472,7 +472,7 @@ where
                         error!("{e:?}");
                         if let Some(error) = error {
                             error.try_set(Some(Box::new(
-                                ServerFnError::Request(
+                                ServerFnErrorErr::Request(
                                     e.as_string().unwrap_or_default(),
                                 ),
                             )));

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -1,0 +1,167 @@
+use serde::{Deserialize, Serialize};
+use std::{error, fmt, ops, sync::Arc};
+use thiserror::Error;
+
+/// This is a result type into which any error can be converted,
+/// and which can be used directly in your `view`.
+///
+/// All errors will be stored as [`Error`].
+pub type Result<T, E = Error> = core::result::Result<T, E>;
+
+/// A generic wrapper for any error.
+#[derive(Debug, Clone)]
+#[repr(transparent)]
+pub struct Error(Arc<dyn error::Error + Send + Sync>);
+
+impl Error {
+    /// Converts the wrapper into the inner reference-counted error.
+    pub fn into_inner(self) -> Arc<dyn error::Error + Send + Sync> {
+        Arc::clone(&self.0)
+    }
+}
+
+impl ops::Deref for Error {
+    type Target = Arc<dyn error::Error + Send + Sync>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<T> From<T> for Error
+where
+    T: std::error::Error + Send + Sync + 'static,
+{
+    fn from(value: T) -> Self {
+        Error(Arc::new(value))
+    }
+}
+
+impl From<ServerFnError> for Error {
+    fn from(e: ServerFnError) -> Self {
+        Error(Arc::new(ServerFnErrorErr::from(e)))
+    }
+}
+
+/// Type for errors that can occur when using server functions.
+///
+/// Unlike [`ServerFnErrorErr`], this does not implement [`std::error::Error`].
+/// This means that other error types can easily be converted into it using the
+/// `?` operator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ServerFnError {
+    /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
+    Registration(String),
+    /// Occurs on the client if there is a network error while trying to run function on server.
+    Request(String),
+    /// Occurs when there is an error while actually running the function on the server.
+    ServerError(String),
+    /// Occurs on the client if there is an error deserializing the server's response.
+    Deserialization(String),
+    /// Occurs on the client if there is an error serializing the server function arguments.
+    Serialization(String),
+    /// Occurs on the server if there is an error deserializing one of the arguments that's been sent.
+    Args(String),
+    /// Occurs on the server if there's a missing argument.
+    MissingArg(String),
+}
+
+impl std::fmt::Display for ServerFnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ServerFnError::Registration(s) => format!(
+                    "error while trying to register the server function: {s}"
+                ),
+                ServerFnError::Request(s) => format!(
+                    "error reaching server to call server function: {s}"
+                ),
+                ServerFnError::ServerError(s) =>
+                    format!("error running server function: {s}"),
+                ServerFnError::Deserialization(s) =>
+                    format!("error deserializing server function results: {s}"),
+                ServerFnError::Serialization(s) =>
+                    format!("error serializing server function arguments: {s}"),
+                ServerFnError::Args(s) => format!(
+                    "error deserializing server function arguments: {s}"
+                ),
+                ServerFnError::MissingArg(s) => format!("missing argument {s}"),
+            }
+        )
+    }
+}
+
+impl<E> From<E> for ServerFnError
+where
+    E: std::error::Error,
+{
+    fn from(e: E) -> Self {
+        ServerFnError::ServerError(e.to_string())
+    }
+}
+
+/// Type for errors that can occur when using server functions.
+///
+/// Unlike [`ServerFnErrorErr`], this implements [`std::error::Error`]. This means
+/// it can be used in situations in which the `Error` trait is required, but it’s
+/// not possible to create a blanket implementation that converts other errors into
+/// this type.
+///
+/// [`ServerFnError`] and [`ServerFnErrorErr`] mutually implement [`From`], so
+/// it is easy to convert between the two types.
+#[derive(Error, Debug, Clone, Serialize, Deserialize)]
+pub enum ServerFnErrorErr {
+    /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
+    #[error("error while trying to register the server function: {0}")]
+    Registration(String),
+    /// Occurs on the client if there is a network error while trying to run function on server.
+    #[error("error reaching server to call server function: {0}")]
+    Request(String),
+    /// Occurs when there is an error while actually running the function on the server.
+    #[error("error running server function: {0}")]
+    ServerError(String),
+    /// Occurs on the client if there is an error deserializing the server's response.
+    #[error("error deserializing server function results: {0}")]
+    Deserialization(String),
+    /// Occurs on the client if there is an error serializing the server function arguments.
+    #[error("error serializing server function arguments: {0}")]
+    Serialization(String),
+    /// Occurs on the server if there is an error deserializing one of the arguments that's been sent.
+    #[error("error deserializing server function arguments: {0}")]
+    Args(String),
+    /// Occurs on the server if there's a missing argument.
+    #[error("missing argument {0}")]
+    MissingArg(String),
+}
+
+impl From<ServerFnError> for ServerFnErrorErr {
+    fn from(value: ServerFnError) -> Self {
+        match value {
+            ServerFnError::Registration(value) => {
+                ServerFnErrorErr::Registration(value)
+            }
+            ServerFnError::Request(value) => ServerFnErrorErr::Request(value),
+            ServerFnError::ServerError(value) => {
+                ServerFnErrorErr::ServerError(value)
+            }
+            ServerFnError::Deserialization(value) => {
+                ServerFnErrorErr::Deserialization(value)
+            }
+            ServerFnError::Serialization(value) => {
+                ServerFnErrorErr::Serialization(value)
+            }
+            ServerFnError::Args(value) => ServerFnErrorErr::Args(value),
+            ServerFnError::MissingArg(value) => {
+                ServerFnErrorErr::MissingArg(value)
+            }
+        }
+    }
+}

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -90,15 +90,17 @@ use quote::TokenStreamExt;
 // used by the macro
 #[doc(hidden)]
 pub use serde;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 pub use server_fn_macro_default::server;
 use std::{future::Future, pin::Pin, str::FromStr};
 #[cfg(any(feature = "ssr", doc))]
 use syn::parse_quote;
-use thiserror::Error;
 // used by the macro
 #[doc(hidden)]
 pub use xxhash_rust;
+/// Error types used in server functions.
+pub mod error;
+pub use error::ServerFnError;
 
 /// Default server function registry
 pub mod default;
@@ -451,83 +453,6 @@ where
     }
 }
 
-/// Type for errors that can occur when using server functions.
-/// 
-/// Unlike [`ServerFnErrorErr`], this does not implement [`std::error::Error`].
-/// This means that other error types can easily be converted into it using the 
-/// `?` operator.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ServerFnError {
-    /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
-    Registration(String),
-    /// Occurs on the client if there is a network error while trying to run function on server.
-    Request(String),
-    /// Occurs when there is an error while actually running the function on the server.
-    ServerError(String),
-    /// Occurs on the client if there is an error deserializing the server's response.
-    Deserialization(String),
-    /// Occurs on the client if there is an error serializing the server function arguments.
-    Serialization(String),
-    /// Occurs on the server if there is an error deserializing one of the arguments that's been sent.
-    Args(String),
-    /// Occurs on the server if there's a missing argument.
-    MissingArg(String),
-}
-
-impl<E> From<E> for ServerFnError where E: std::error::Error {
-    fn from(e: E) -> Self {
-        ServerFnError::ServerError(e.to_string())
-    }
-}
-
-/// Type for errors that can occur when using server functions.
-/// 
-/// Unlike [`ServerFnErrorErr`], this implements [`std::error::Error`]. This means 
-/// it can be used in situations in which the `Error` trait is required, but it’s 
-/// not possible to create a blanket implementation that converts other errors into 
-/// this type.
-/// 
-/// [`ServerFnError`] and [`ServerFnErrorErr`] mutually implement [`From`], so 
-/// it is easy to convert between the two types.
-#[derive(Error, Debug, Clone, Serialize, Deserialize)]
-pub enum ServerFnErrorErr {
-    /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
-    #[error("error while trying to register the server function: {0}")]
-    Registration(String),
-    /// Occurs on the client if there is a network error while trying to run function on server.
-    #[error("error reaching server to call server function: {0}")]
-    Request(String),
-    /// Occurs when there is an error while actually running the function on the server.
-    #[error("error running server function: {0}")]
-    ServerError(String),
-    /// Occurs on the client if there is an error deserializing the server's response.
-    #[error("error deserializing server function results {0}")]
-    Deserialization(String),
-    /// Occurs on the client if there is an error serializing the server function arguments.
-    #[error("error serializing server function arguments {0}")]
-    Serialization(String),
-    /// Occurs on the server if there is an error deserializing one of the arguments that's been sent.
-    #[error("error deserializing server function arguments {0}")]
-    Args(String),
-    /// Occurs on the server if there's a missing argument.
-    #[error("missing argument {0}")]
-    MissingArg(String),
-}
-
-impl From<ServerFnError> for ServerFnErrorErr {
-    fn from(value: ServerFnError) -> Self {
-        match value {
-            ServerFnError::Registration(value) => ServerFnErrorErr::Registration(value),
-            ServerFnError::Request(value) => ServerFnErrorErr::Request(value),
-            ServerFnError::ServerError(value) => ServerFnErrorErr::ServerError(value),
-            ServerFnError::Deserialization(value) => ServerFnErrorErr::Deserialization(value),
-            ServerFnError::Serialization(value) => ServerFnErrorErr::Serialization(value),
-            ServerFnError::Args(value) => ServerFnErrorErr::Args(value),
-            ServerFnError::MissingArg(value) => ServerFnErrorErr::MissingArg(value),
-        }
-    }
-}
-
 /// Executes the HTTP call to call a server function from the client, given its URL and argument type.
 #[cfg(not(feature = "ssr"))]
 pub async fn call_server_fn<T, C: 'static>(
@@ -700,7 +625,7 @@ where
 // Lazily initialize the client to be reused for all server function calls.
 #[cfg(any(all(not(feature = "ssr"), not(target_arch = "wasm32")), doc))]
 static CLIENT: once_cell::sync::Lazy<reqwest::Client> =
-    once_cell::sync::Lazy::new(|| reqwest::Client::new());
+    once_cell::sync::Lazy::new(reqwest::Client::new);
 
 #[cfg(any(all(not(feature = "ssr"), not(target_arch = "wasm32")), doc))]
 static ROOT_URL: once_cell::sync::OnceCell<&'static str> =

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -452,8 +452,45 @@ where
 }
 
 /// Type for errors that can occur when using server functions.
-#[derive(Error, Debug, Clone, Serialize, Deserialize)]
+/// 
+/// Unlike [`ServerFnErrorErr`], this does not implement [`std::error::Error`].
+/// This means that other error types can easily be converted into it using the 
+/// `?` operator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ServerFnError {
+    /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
+    Registration(String),
+    /// Occurs on the client if there is a network error while trying to run function on server.
+    Request(String),
+    /// Occurs when there is an error while actually running the function on the server.
+    ServerError(String),
+    /// Occurs on the client if there is an error deserializing the server's response.
+    Deserialization(String),
+    /// Occurs on the client if there is an error serializing the server function arguments.
+    Serialization(String),
+    /// Occurs on the server if there is an error deserializing one of the arguments that's been sent.
+    Args(String),
+    /// Occurs on the server if there's a missing argument.
+    MissingArg(String),
+}
+
+impl<E> From<E> for ServerFnError where E: std::error::Error {
+    fn from(e: E) -> Self {
+        ServerFnError::ServerError(e.to_string())
+    }
+}
+
+/// Type for errors that can occur when using server functions.
+/// 
+/// Unlike [`ServerFnErrorErr`], this implements [`std::error::Error`]. This means 
+/// it can be used in situations in which the `Error` trait is required, but it’s 
+/// not possible to create a blanket implementation that converts other errors into 
+/// this type.
+/// 
+/// [`ServerFnError`] and [`ServerFnErrorErr`] mutually implement [`From`], so 
+/// it is easy to convert between the two types.
+#[derive(Error, Debug, Clone, Serialize, Deserialize)]
+pub enum ServerFnErrorErr {
     /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
     #[error("error while trying to register the server function: {0}")]
     Registration(String),
@@ -475,6 +512,20 @@ pub enum ServerFnError {
     /// Occurs on the server if there's a missing argument.
     #[error("missing argument {0}")]
     MissingArg(String),
+}
+
+impl From<ServerFnError> for ServerFnErrorErr {
+    fn from(value: ServerFnError) -> Self {
+        match value {
+            ServerFnError::Registration(value) => ServerFnErrorErr::Registration(value),
+            ServerFnError::Request(value) => ServerFnErrorErr::Request(value),
+            ServerFnError::ServerError(value) => ServerFnErrorErr::ServerError(value),
+            ServerFnError::Deserialization(value) => ServerFnErrorErr::Deserialization(value),
+            ServerFnError::Serialization(value) => ServerFnErrorErr::Serialization(value),
+            ServerFnError::Args(value) => ServerFnErrorErr::Args(value),
+            ServerFnError::MissingArg(value) => ServerFnErrorErr::MissingArg(value),
+        }
+    }
 }
 
 /// Executes the HTTP call to call a server function from the client, given its URL and argument type.


### PR DESCRIPTION
The `Result<T>` type provided by a library like `anyhow` is extremely useful for converting errors of different types into a single type using the `?` operator:

```rust
async fn fetch_cats(count: CatCount) -> Result<Vec<String>> {
    if count > 0 {
        // make the request
        let res = reqwasm::http::Request::get(&format!(
            "https://api.thecatapi.com/v1/images/search?limit={count}",
        ))
        .send()
        .await?
        // convert it to JSON
        .json::<Vec<Cat>>()
        .await?
        // extract the URL field for each cat
        .into_iter()
        .take(count)
        .map(|cat| cat.url)
        .collect::<Vec<_>>();
        Ok(res)
    } else {
        Err(CatError::NonZeroCats.into())
    }
}
```

However, `anyhow::Result` can't be directly rendered into the `view` of a Leptos component, because `anyhow::Error` doesn't implement `std::error::Error`. (In fact, it can't, because it `impl<T> From<T> for anyhow::Error where T: std::errror::Error // etc.` would mean that an `Error` implementation for `Error` conflicts with the default `From<T> for T`...)

I initially tried using `anyhow::Result` internally, but this caused issues because `anyhow::Error` is not `Clone`, causing lifetime troubles where trying to simply render something like a `Resource<(), Result<T>>` into the DOM. (Because this forces `Resource::with` rather than `Resource::read`, which means a reference, which means a lifetime that's not `'static`...)

However, we can get around this by doing something very similar to what `anyhow` does: providing a `leptos::error::Error` type that simply wraps an `Arc<dyn Error + Send + Sync>`. Now, `leptos_dom` can render anything that it could render before (any `Result<T, E> where E: Error + Send + Sync`), because those are all `Into<Error>`), but it can also do the "convert any kind of error into a single type" trick which makes `anyhow::Result` so convenient.