### PR TITLE
fix(counters_stable): intermittent closed target errors (#1240)

### DIFF
--- a/examples/counters_stable/e2e/playwright.config.ts
+++ b/examples/counters_stable/e2e/playwright.config.ts
@@ -14,11 +14,11 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: !process.env.DEV,
   /* Retry on CI only */
-  retries: process.env.CI ? 10 : 10,
+  retries: process.env.DEV ? 0 : 10,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 1,
+  workers: process.env.DEV ? 1 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "list",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/examples/counters_stable/e2e/playwright.config.ts
+++ b/examples/counters_stable/e2e/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.DEV ? 1 : 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "list",
+  reporter: [["html", { open: "never" }], ["list"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/examples/counters_stable/e2e/tests/add_1k_counters.spec.ts
+++ b/examples/counters_stable/e2e/tests/add_1k_counters.spec.ts
@@ -4,19 +4,16 @@ import { CountersPage } from "./counters_page";
 test.describe("Add 1000 Counters", () => {
   test("should increment the total count by 1K", async ({ page }) => {
     const ui = new CountersPage(page);
-    await ui.goto();
 
-    // FIXME: Uncomment to make the test fail consistently
-
-    await ui.addOneThousandCounters();
-    // await expect(ui.total).toHaveText("0");
-    // await expect(ui.counters).toHaveText("1000");
+    await Promise.all([
+      await ui.goto(),
+      await ui.addOneThousandCountersButton.waitFor(),
+    ]);
 
     await ui.addOneThousandCounters();
-    // await expect(ui.total).toHaveText("0");
-    // await expect(ui.counters).toHaveText("2000");
-
     await ui.addOneThousandCounters();
+    await ui.addOneThousandCounters();
+
     await expect(ui.total).toHaveText("0");
     await expect(ui.counters).toHaveText("3000");
   });

--- a/examples/counters_stable/e2e/tests/counters_page.ts
+++ b/examples/counters_stable/e2e/tests/counters_page.ts
@@ -42,7 +42,10 @@ export class CountersPage {
   }
 
   async addCounter() {
-    this.addCounterButton.click();
+    await Promise.all([
+      this.addCounterButton.waitFor(),
+      this.addCounterButton.click(),
+    ]);
   }
 
   async addOneThousandCounters() {
@@ -50,14 +53,23 @@ export class CountersPage {
   }
 
   async decrementCount() {
-    this.decrementCountButton.click();
+    await Promise.all([
+      this.decrementCountButton.waitFor(),
+      this.decrementCountButton.click(),
+    ]);
   }
 
   async incrementCount() {
-    this.incrementCountButton.click();
+    await Promise.all([
+      this.incrementCountButton.waitFor(),
+      this.incrementCountButton.click(),
+    ]);
   }
 
   async clearCounters() {
-    this.clearCountersButton.click();
+    await Promise.all([
+      this.clearCountersButton.waitFor(),
+      this.clearCountersButton.click(),
+    ]);
   }
 }


### PR DESCRIPTION
READY FOR REVIEW

Fix #1240

The solution is to wait before clicking a button.

**Two Strategies**

1. Wait before each click attempt (used by most buttons)
2. Synchronize navigation and the wait for a button (used only by Add 1000 Counters button)

All buttons except the **Add 1000 Counters** button use strategy **1**. It is not clear why this is a requirement. Switching strategies breaks the test!?