### PR TITLE
chore: remove unused variable warnings with ssr props

### DIFF
--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -582,6 +582,13 @@ fn attribute_to_tokens_ssr<'a>(
     {
         // ignore props for SSR
         // ignore classes and styles: we'll handle these separately
+        if name.starts_with("prop:") {
+            let value = attr.value();
+            exprs_for_compiler.push(quote! {
+                #[allow(unused_braces)]
+                { _ = #value; }
+            });
+        }
     } else if name == "inner_html" {
         return attr.value();
     } else {


### PR DESCRIPTION
As mentioned in [Discord](https://discord.com/channels/1031524867910148188/1031524868883218474/1123256306384502784), attributes prefixed with `prop:` are ignored with SSR in the `view` macro, though this can cause unused variable warnings. This was already fixed with event listeners, but props was never handled to remove warnings.

This PR simply adds `_ = #expr` to remove any unused variable warnings.