### PR TITLE
`v0.4.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver="2"
+resolver = "2"
 members = [
   # core
   "leptos",
@@ -26,22 +26,22 @@ members = [
 exclude = ["benchmarks", "examples"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 
 [workspace.dependencies]
-leptos = { path = "./leptos", version = "0.3.0" }
-leptos_dom = { path = "./leptos_dom", version = "0.3.0" }
-leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.3.0" }
-leptos_macro = { path = "./leptos_macro", version = "0.3.0" }
-leptos_reactive = { path = "./leptos_reactive", version = "0.3.0" }
-leptos_server = { path = "./leptos_server", version = "0.3.0" }
-server_fn = { path = "./server_fn", version = "0.3.0" }
-server_fn_macro = { path = "./server_fn_macro", version = "0.3.0" }
-server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.3.0" }
-leptos_config = { path = "./leptos_config", version = "0.3.0" }
-leptos_router = { path = "./router", version = "0.3.0" }
-leptos_meta = { path = "./meta", version = "0.3.0" }
-leptos_integration_utils = { path = "./integrations/utils", version = "0.3.0" }
+leptos = { path = "./leptos", version = "0.4.0" }
+leptos_dom = { path = "./leptos_dom", version = "0.4.0" }
+leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.4.0" }
+leptos_macro = { path = "./leptos_macro", version = "0.4.0" }
+leptos_reactive = { path = "./leptos_reactive", version = "0.4.0" }
+leptos_server = { path = "./leptos_server", version = "0.4.0" }
+server_fn = { path = "./server_fn", version = "0.4.0" }
+server_fn_macro = { path = "./server_fn_macro", version = "0.4.0" }
+server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.4.0" }
+leptos_config = { path = "./leptos_config", version = "0.4.0" }
+leptos_router = { path = "./router", version = "0.4.0" }
+leptos_meta = { path = "./meta", version = "0.4.0" }
+leptos_integration_utils = { path = "./integrations/utils", version = "0.4.0" }
 
 [profile.release]
 codegen-units = 1

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_meta"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"


### PR DESCRIPTION
Enough bugfixes and features have accumulated in the main branch that it's time for a new release. However, a very early change meant this needs to be a semver bump. Rather than continuing the confusion of the feature/bug gap between 0.3.1 and main, this releases the current state of the main branch.

This does *not* include the reactive ownership rewrite (#918), which I'd guess will be 0.5.

Full release notes can be found separately.