### PR TITLE
Adding instructions to add a tailwind plugin to examples.

### DIFF
--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -30,6 +30,25 @@ npm install -D tailwindcss
 
 If you'd rather not use `npm`, you can install the Tailwind binary [here](https://github.com/tailwindlabs/tailwindcss/releases).
 
+## Adding Tailwind plugins
+
+If you'd like to add [Tailwind plugins](https://tailwindcss.com/docs/plugins), such as [DaisyUI](https://daisyui.com/), you can do the following:
+
+`npm install -D daisyui@latest`
+
+Then add the plugin to your exports in `tailwind.config.js` :
+
+```javascript
+module.exports = {
+  //...
+  plugins: [require("daisyui")],
+};
+```
+
+And re-run the following to generate the css:
+
+`npx tailwindcss -i ./input.css -o ./style/output.css --watch`
+
 ## Setting up with VS Code and Additional Tools
 
 If you're using VS Code, add the following to your `settings.json`


### PR DESCRIPTION
This adds instructions for adding tailwind plugins such as DaisyUI to the tailwind example. Someone besides me may find it useful.