### PR TITLE
Rework diff functionality for Each component

### DIFF
--- a/leptos_dom/examples/test-bench/src/main.rs
+++ b/leptos_dom/examples/test-bench/src/main.rs
@@ -55,6 +55,8 @@ fn view_fn(cx: Scope) -> impl IntoView {
             <hr/>
             <Test from=[1, 4, 3, 2, 5] to=[1, 2, 3, 4, 5]/>
             <Test from=[4, 5, 3, 1, 2] to=[1, 2, 3, 4, 5]/>
+            <Test from=[0, 1, 2, 3] to=[1, 3]/> // issue #1274
+            <Test from=[] to=[3, 9, 17] then=vec![3, 5, 7, 9, 17, 23]/> // issue #1297
         </ul>
     }
 }

--- a/leptos_dom/src/components/each.rs
+++ b/leptos_dom/src/components/each.rs
@@ -527,13 +527,15 @@ fn diff<K: Eq + Hash>(from: &FxIndexSet<K>, to: &FxIndexSet<K>) -> Diff {
         let mut adds = vec![];
         for (index, item) in from.iter().enumerate() {
             if let Some(to_item) = to.get_full(item) {
-                let op = DiffOpMove {
-                    from: index,
-                    len: 1,
-                    to: to_item.0,
-                    move_in_dom: true,
-                };
-                moves.push(op);
+                if index != to_item.0 {
+                    let op = DiffOpMove {
+                        from: index,
+                        len: 1,
+                        to: to_item.0,
+                        move_in_dom: true,
+                    };
+                    moves.push(op);
+                }
             } else {
                 let op = DiffOpRemove { at: index };
                 removes.push(op);

--- a/leptos_dom/src/components/each.rs
+++ b/leptos_dom/src/components/each.rs
@@ -17,6 +17,7 @@ mod web {
     pub use wasm_bindgen::JsCast;
 }
 
+#[allow(dead_code)] // not used in SSR
 type FxIndexSet<T> =
     indexmap::IndexSet<T, std::hash::BuildHasherDefault<rustc_hash::FxHasher>>;
 


### PR DESCRIPTION
Hi! While reading through the code behind this guy: https://github.com/leptos-rs/leptos/issues/1289 I noticed that the `diff` makes some assumptions / calculations that may not be correct. In the example provided, if you type `C` then `a` notice the bottom two items `Cocos` and `Christmas` are out of order. This is with `add`s and `remove`s alone, no `move`s necessary. If you check the console you can see the data in the correct order. This results in not only a visual inconsistency but a panic on what i think is trying to reach an incorrect index. I think this PR as it stands solves that issue, and potentially any others with panicing / proper arrangement, but is of course not optimized. I don't have the time to finish this right now but wanted to leave it up in case it helps anyone else working on it. I will have time to pick this back up tomorrow.

The approach this PR is taking is to build a canonical list of mutations from `from` to `to` that will result in the correct `to` and from there perhaps combine moves and remove no-ops. Those are my next steps personally.

Feel free to remove this or whatever if it's off base or if draft PRs aren't welcome / too much noise!!

