### PR TITLE
fixed typo in parent-child doc

### DIFF
--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -117,7 +117,7 @@ pub fn App(cx: Scope) -> impl IntoView {
 
 
 #[component]
-pub fn ButtonC<F>(cx: Scope) -> impl IntoView {
+pub fn ButtonC(cx: Scope) -> impl IntoView {
     view! { cx,
         <button>"Toggle"</button>
     }


### PR DESCRIPTION
Removed extra `<F>` from 
```
#[component]
pub fn ButtonC<F>(cx: Scope) -> impl IntoView {
    view! { cx,
        <button>"Toggle"</button>
    }
}
```