### PR TITLE
docs: must use `View`

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -483,6 +483,9 @@ impl Text {
 
 /// A leptos view which can be mounted to the DOM.
 #[derive(Clone, PartialEq, Eq)]
+#[must_use = "You are creating a View but not using it. An unused view can \
+              cause your view to be rendered as () unexpectedly, and it can \
+              also cause issues with client-side hydration."]
 pub enum View {
     /// HTML element node.
     Element(Element),


### PR DESCRIPTION
This addresses issues like #1248 by warning you if you create a `View` that is unused. This can create confusing issues, e.g., a stray semicolon causes you to return `()` instead of your intended `View` from a function, showing nothing. It can also cause hydration issues (the hydration system assumes that if something is created on the client, it exists in the HTML.)