### PR TITLE
feat: allow custom url for live reload

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -7,7 +7,6 @@ extern crate tracing;
 
 #[tracing::instrument(level = "trace", fields(error), skip_all)]
 fn autoreload(options: &LeptosOptions) -> String {
-    //let site_ip = &options.site_addr.ip().to_string();
     let reload_url = options.reload_url;
     match std::env::var("LEPTOS_WATCH").is_ok() {
         true => format!(

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -14,7 +14,6 @@ fn autoreload(options: &LeptosOptions) -> String {
             r#"
                 <script crossorigin="">(function () {{
                     {}
-                    //var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
                     var ws = new WebSocket('{reload_url}');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -14,7 +14,8 @@ fn autoreload(options: &LeptosOptions) -> String {
             r#"
                 <script crossorigin="">(function () {{
                     {}
-                    var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
+                    //var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
+                    var ws = new WebSocket('ws://timada.localhost/starter-reload/live_reload');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -7,15 +7,15 @@ extern crate tracing;
 
 #[tracing::instrument(level = "trace", fields(error), skip_all)]
 fn autoreload(options: &LeptosOptions) -> String {
-    let site_ip = &options.site_addr.ip().to_string();
-    let reload_port = options.reload_port;
+    //let site_ip = &options.site_addr.ip().to_string();
+    let reload_url = options.reload_url;
     match std::env::var("LEPTOS_WATCH").is_ok() {
         true => format!(
             r#"
                 <script crossorigin="">(function () {{
                     {}
                     //var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
-                    var ws = new WebSocket('wss://ws.timada.localhost/starter-reload/live_reload');
+                    var ws = new WebSocket('{reload_url}');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -15,7 +15,7 @@ fn autoreload(options: &LeptosOptions) -> String {
                 <script crossorigin="">(function () {{
                     {}
                     //var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
-                    var ws = new WebSocket('ws://timada.localhost/starter-reload/live_reload');
+                    var ws = new WebSocket('wss://timada.localhost/starter-reload/live_reload');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -15,7 +15,7 @@ fn autoreload(options: &LeptosOptions) -> String {
                 <script crossorigin="">(function () {{
                     {}
                     //var ws = new WebSocket('ws://{site_ip}:{reload_port}/live_reload');
-                    var ws = new WebSocket('wss://timada.localhost/starter-reload/live_reload');
+                    var ws = new WebSocket('wss://ws.timada.localhost/starter-reload/live_reload');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -7,7 +7,7 @@ extern crate tracing;
 
 #[tracing::instrument(level = "trace", fields(error), skip_all)]
 fn autoreload(options: &LeptosOptions) -> String {
-    let reload_url = options.reload_url;
+    let reload_url = options.reload_url.to_owned();
     match std::env::var("LEPTOS_WATCH").is_ok() {
         true => format!(
             r#"

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -49,6 +49,10 @@ pub struct LeptosOptions {
     /// Defaults to `3001`
     #[builder(default = 3001)]
     pub reload_port: u32,
+    /// The url the Websocket watcher listens on.
+    /// Defaults to `ws://127.0.0.1:3001`
+    #[builder(default = "ws://127.0.0.1:3001/live_reload".to_string())]
+    pub reload_url: String,
 }
 
 impl LeptosOptions {

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -81,6 +81,7 @@ impl LeptosOptions {
                 .parse()?,
             reload_port: env_w_default("LEPTOS_RELOAD_PORT", "3001")?
                 .parse()?,
+            reload_url: env_w_default("LEPTOS_RELOAD_URL", "ws://127.0.0.1:3001/live_reload")?,
         })
     }
 }


### PR DESCRIPTION
I try to make `cargo leptos watch` work under local reverse proxy with https but not possible to do live reload due to not able to set websocket url. 

Let's say i have `https://example.localhost/leptos-todo-app` reverse proxy `http://127.0.0.1:3000` . 

I should be able to  live reload on `wss://ws.example.localhost/leptos-todo-app/live_reload` revers proxy `ws://127.0.0.1:3001`