### PR TITLE
test(counters_stable/wasm): enter count

### DIFF
--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -18,6 +18,7 @@ pretty_assertions = "1.3.0"
 [dev-dependencies.web-sys]
 features = [
     "Event",
+    "EventInit",
     "EventTarget",
     "HtmlElement",
     "HtmlInputElement",

--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -16,5 +16,11 @@ wasm-bindgen-test = "0.3.37"
 pretty_assertions = "1.3.0"
 
 [dev-dependencies.web-sys]
-features = ["Element", "HtmlElement", "XPathResult"]
+features = [
+    "Event",
+    "EventTarget",
+    "HtmlElement",
+    "HtmlInputElement",
+    "XPathResult",
+]
 version = "0.3.64"

--- a/examples/counters_stable/e2e/tests/add_1k_counters.spec.ts
+++ b/examples/counters_stable/e2e/tests/add_1k_counters.spec.ts
@@ -14,7 +14,6 @@ test.describe("Add 1000 Counters", () => {
     await ui.addOneThousandCounters();
     await ui.addOneThousandCounters();
 
-    await expect(ui.total).toHaveText("0");
     await expect(ui.counters).toHaveText("3000");
   });
 });

--- a/examples/counters_stable/e2e/tests/add_counter.spec.ts
+++ b/examples/counters_stable/e2e/tests/add_counter.spec.ts
@@ -10,7 +10,6 @@ test.describe("Add Counter", () => {
     await ui.addCounter();
     await ui.addCounter();
 
-    await expect(ui.total).toHaveText("0");
     await expect(ui.counters).toHaveText("3");
   });
 });

--- a/examples/counters_stable/e2e/tests/decrement_count.spec.ts
+++ b/examples/counters_stable/e2e/tests/decrement_count.spec.ts
@@ -12,6 +12,5 @@ test.describe("Decrement Count", () => {
     await ui.decrementCount();
 
     await expect(ui.total).toHaveText("-3");
-    await expect(ui.counters).toHaveText("1");
   });
 });

--- a/examples/counters_stable/e2e/tests/enter_count.spec.ts
+++ b/examples/counters_stable/e2e/tests/enter_count.spec.ts
@@ -26,6 +26,5 @@ test.describe("Enter Count", () => {
     await ui.enterCount("50", 1);
 
     await expect(ui.total).toHaveText("250");
-    await expect(ui.counters).toHaveText("3");
   });
 });

--- a/examples/counters_stable/e2e/tests/increment_count.spec.ts
+++ b/examples/counters_stable/e2e/tests/increment_count.spec.ts
@@ -12,6 +12,5 @@ test.describe("Increment Count", () => {
     await ui.incrementCount();
 
     await expect(ui.total).toHaveText("3");
-    await expect(ui.counters).toHaveText("1");
   });
 });

--- a/examples/counters_stable/e2e/tests/remove_counter.spec.ts
+++ b/examples/counters_stable/e2e/tests/remove_counter.spec.ts
@@ -12,7 +12,6 @@ test.describe("Remove Counter", () => {
 
     await ui.removeCounter(1);
 
-    await expect(ui.total).toHaveText("0");
     await expect(ui.counters).toHaveText("2");
   });
 });

--- a/examples/counters_stable/src/lib.rs
+++ b/examples/counters_stable/src/lib.rs
@@ -97,9 +97,9 @@ fn Counter(
     view! { cx,
         <li>
             <button data-testid="decrement_count" on:click=move |_| set_value.update(move |value| *value -= 1)>"-1"</button>
-            <input type="text"
+            <input data-testid="counter_input" type="text"
                 prop:value={move || value.get().to_string()}
-                on:input=input
+                on:input:undelegated=input
             />
             <span>{value}</span>
             <button data-testid="increment_count" on:click=move |_| set_value.update(move |value| *value += 1)>"+1"</button>

--- a/examples/counters_stable/src/lib.rs
+++ b/examples/counters_stable/src/lib.rs
@@ -99,7 +99,7 @@ fn Counter(
             <button data-testid="decrement_count" on:click=move |_| set_value.update(move |value| *value -= 1)>"-1"</button>
             <input data-testid="counter_input" type="text"
                 prop:value={move || value.get().to_string()}
-                on:input:undelegated=input
+                on:input=input
             />
             <span>{value}</span>
             <button data-testid="increment_count" on:click=move |_| set_value.update(move |value| *value += 1)>"+1"</button>

--- a/examples/counters_stable/tests/web/add_1k_counters.rs
+++ b/examples/counters_stable/tests/web/add_1k_counters.rs
@@ -13,6 +13,5 @@ fn should_increase_the_number_of_counters() {
     ui::add_1k_counters();
 
     // Then
-    assert_eq!(ui::total(), 0);
     assert_eq!(ui::counters(), 3000);
 }

--- a/examples/counters_stable/tests/web/add_counter.rs
+++ b/examples/counters_stable/tests/web/add_counter.rs
@@ -13,6 +13,5 @@ fn should_increase_the_number_of_counters() {
     ui::add_counter();
 
     // Then
-    assert_eq!(ui::total(), 0);
     assert_eq!(ui::counters(), 3);
 }

--- a/examples/counters_stable/tests/web/decrement_counter.rs
+++ b/examples/counters_stable/tests/web/decrement_counter.rs
@@ -15,5 +15,4 @@ fn should_decrease_the_total_count() {
 
     // Then
     assert_eq!(ui::total(), -3);
-    assert_eq!(ui::counters(), 1);
 }

--- a/examples/counters_stable/tests/web/enter_count.rs
+++ b/examples/counters_stable/tests/web/enter_count.rs
@@ -1,0 +1,34 @@
+use super::*;
+use crate::counters_page as ui;
+use pretty_assertions::assert_eq;
+
+#[wasm_bindgen_test]
+fn should_increase_the_total_count() {
+    // Given
+    ui::view_counters();
+    ui::add_counter();
+
+    // When
+    ui::enter_count(1, 5);
+
+    // Then
+    assert_eq!(ui::total(), 5);
+}
+
+#[wasm_bindgen_test]
+fn should_decrease_the_total_count() {
+    // Given
+    ui::view_counters();
+    ui::add_counter();
+    ui::add_counter();
+    ui::add_counter();
+
+    // When
+    ui::enter_count(1, 100);
+    ui::enter_count(2, 100);
+    ui::enter_count(3, 100);
+    ui::enter_count(1, 50);
+
+    // Then
+    assert_eq!(ui::total(), 250);
+}

--- a/examples/counters_stable/tests/web/fixtures/counters_page.rs
+++ b/examples/counters_stable/tests/web/fixtures/counters_page.rs
@@ -1,7 +1,7 @@
 use counters_stable::Counters;
 use leptos::*;
 use wasm_bindgen::JsCast;
-use web_sys::{Element, Event, HtmlElement, HtmlInputElement};
+use web_sys::{Element, Event, EventInit, HtmlElement, HtmlInputElement};
 
 // Actions
 
@@ -24,7 +24,9 @@ pub fn decrement_counter(index: u32) {
 pub fn enter_count(index: u32, count: i32) {
     let input = counter_input_element(index, "counter_input");
     input.set_value(count.to_string().as_str());
-    let event = Event::new("input").unwrap();
+    let mut event_init = EventInit::new();
+    event_init.bubbles(true);
+    let event = Event::new_with_event_init_dict("input", &event_init).unwrap();
     input.dispatch_event(&event).unwrap();
 }
 

--- a/examples/counters_stable/tests/web/fixtures/counters_page.rs
+++ b/examples/counters_stable/tests/web/fixtures/counters_page.rs
@@ -1,7 +1,7 @@
 use counters_stable::Counters;
 use leptos::*;
 use wasm_bindgen::JsCast;
-use web_sys::{Element, HtmlElement};
+use web_sys::{Element, Event, HtmlElement, HtmlInputElement};
 
 // Actions
 
@@ -19,6 +19,13 @@ pub fn clear_counters() {
 
 pub fn decrement_counter(index: u32) {
     counter_html_element(index, "decrement_count").click();
+}
+
+pub fn enter_count(index: u32, count: i32) {
+    let input = counter_input_element(index, "counter_input");
+    input.set_value(count.to_string().as_str());
+    let event = Event::new("input").unwrap();
+    input.dispatch_event(&event).unwrap();
 }
 
 pub fn increment_counter(index: u32) {
@@ -62,6 +69,12 @@ fn counter_element(index: u32, text: &str) -> Element {
 fn counter_html_element(index: u32, text: &str) -> HtmlElement {
     counter_element(index, text)
         .dyn_into::<HtmlElement>()
+        .unwrap()
+}
+
+fn counter_input_element(index: u32, text: &str) -> HtmlInputElement {
+    counter_element(index, text)
+        .dyn_into::<HtmlInputElement>()
         .unwrap()
 }
 

--- a/examples/counters_stable/tests/web/increment_counter.rs
+++ b/examples/counters_stable/tests/web/increment_counter.rs
@@ -15,5 +15,4 @@ fn should_increase_the_total_count() {
 
     // Then
     assert_eq!(ui::total(), 3);
-    assert_eq!(ui::counters(), 1);
 }

--- a/examples/counters_stable/tests/web/main.rs
+++ b/examples/counters_stable/tests/web/main.rs
@@ -5,6 +5,7 @@ pub mod add_1k_counters;
 pub mod add_counter;
 pub mod clear_counters;
 pub mod decrement_counter;
+pub mod enter_count;
 pub mod increment_counter;
 pub mod remove_counter;
 pub mod view_counters;

--- a/examples/counters_stable/tests/web/remove_counter.rs
+++ b/examples/counters_stable/tests/web/remove_counter.rs
@@ -14,6 +14,5 @@ fn should_decrement_the_number_of_counters() {
     ui::remove_counter(2);
 
     // Then
-    assert_eq!(ui::total(), 0);
     assert_eq!(ui::counters(), 2);
 }


### PR DESCRIPTION
READY FOR REVIEW

Supports #210

Add wasm tests for Enter Count feature.

This PR covers 100% of e2e test scenarios.

### E2E Scenarios

- [x] Add 1000 Counters › should increase the number of counters
- [x] Add Counter › should increase the number of counters
- [x] Clear Counters › should reset the counts
- [x] Decrement Counter › should decrease the total count
- [x] Enter Count › should increase the total count
- [x] Enter Count › should decrease the total count
- [x] Increment Counter › should increase the total count
- [x] Remove Counter › should decrement the number of counters
- [x] View Counters › should see the title
- [x] View Counters › should see the initial counts

_Thank you @gbj. The handler change from `on:input` to `on:input:undelegated` enabled the input to work as expected._