### PR TITLE
update warnings to remove mention of csr as a default feature

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -841,9 +841,7 @@ where
     crate::console_warn(
         "You have both `csr` and `ssr` or `hydrate` and `ssr` enabled as \
          features, which may cause issues like <Suspense/>` failing to work \
-         silently. `csr` is enabled by default on `leptos`, and can be \
-         disabled by adding `default-features = false` to your `leptos` \
-         dependency.",
+         silently.",
     );
 
     cfg_if! {

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -368,9 +368,7 @@ impl View {
         crate::console_error(
             "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` \
              enabled as features, which may cause issues like <Suspense/>` \
-             failing to work silently. `csr` is enabled by default on \
-             `leptos`, and can be disabled by adding `default-features = \
-             false` to your `leptos` dependency.\n",
+             failing to work silently.\n",
         );
 
         self.render_to_string_helper(false)

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -59,9 +59,7 @@ pub fn render_to_stream_in_order_with_prefix(
     crate::console_error(
         "\n[DANGER] You have both `csr` and `ssr` or `hydrate` and `ssr` \
          enabled as features, which may cause issues like <Suspense/>` \
-         failing to work silently. `csr` is enabled by default on `leptos`, \
-         and can be disabled by adding `default-features = false` to your \
-         `leptos` dependency.\n",
+         failing to work silently.\n",
     );
 
     let (stream, runtime, _) =


### PR DESCRIPTION
Hi,
thanks for your work on Leptos.

I noticed these warnings while working on my project. Since `csr` is no longer a default feature as of 0.4.0, I figured the warnings should be updated.