### PR TITLE
feat(config): implement common traits for Env

### DIFF
--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -95,7 +95,7 @@ fn env_w_default(
 /// An enum that can be used to define the environment Leptos is running in.
 /// Setting this to the `PROD` variant will not include the WebSocket code for `cargo-leptos` watch mode.
 /// Defaults to `DEV`.
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum Env {
     PROD,
     DEV,


### PR DESCRIPTION
In order to facilitate its usage in other structs, which might derive various traits, such as `serde::Serialize` or `PartialEq`, implement them for the `leptos_config::Env` enum.