### PR TITLE
Bump indexmap to version 2

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -14,7 +14,7 @@ drain_filter_polyfill = "0.1"
 educe = "0.4"
 futures = "0.3"
 html-escape = "0.2"
-indexmap = "1.9"
+indexmap = "2"
 itertools = "0.10"
 js-sys = "0.3"
 leptos_reactive = { workspace = true }

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -24,4 +24,4 @@ proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"
 camino = "1.1.3"
-indexmap = "1.9.2"
+indexmap = "2"

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -41,7 +41,7 @@ web-sys = { version = "0.3", optional = true, features = [
   "Window",
 ] }
 cfg-if = "1"
-indexmap = "1"
+indexmap = "2"
 self_cell = "1.0.0"
 
 [dev-dependencies]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -12,7 +12,7 @@ cfg-if = "1"
 leptos = { workspace = true }
 tracing = "0.1"
 wasm-bindgen = "0.2"
-indexmap = "1"
+indexmap = "2"
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
Not sure if y'all are interested but indexmap had a major version release a couple weeks ago:
https://github.com/bluss/indexmap/blob/master/RELEASES.md

Notably it includes a version bump of its underlying hashmap library hashbrown:
https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md

Also notably it now requires rust 1.64 or later where as the previously specified highest version of 1.9.2 required rust 1.56.1 or later.

Just a little housekeeping PR, I'm not trying to advocate for anything. Feel free to delete this PR if it's not needed/wanted.