### PR TITLE
fix: event delegation issue with `<input name="host">`

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -49,6 +49,7 @@ features = [
   "Range",
   "Text",
   "HtmlCollection",
+  "ShadowRoot",
   "TreeWalker",
 
   # Events we cast to in leptos_macro -- added here so we don't force users to import them

--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -158,20 +158,22 @@ pub(crate) fn add_delegated_event_listener(
                     }
 
                     // navigate up tree
-                    let host =
-                        js_sys::Reflect::get(&node, &JsValue::from_str("host"))
-                            .unwrap_throw();
-                    if host.is_truthy()
-                        && host != node
-                        && host.dyn_ref::<web_sys::Node>().is_some()
-                    {
-                        node = host;
-                    } else if let Some(parent) =
-                        node.unchecked_into::<web_sys::Node>().parent_node()
+                    if let Some(parent) =
+                        node.unchecked_ref::<web_sys::Node>().parent_node()
                     {
                         node = parent.into()
                     } else {
-                        node = JsValue::null()
+                        let host =
+                        js_sys::Reflect::get(&node, &JsValue::from_str("host"))
+                            .unwrap_throw();
+                        if host.is_truthy()
+                            && host != node
+                            && host.dyn_ref::<web_sys::Node>().is_some()
+                        {
+                            node = host;
+                        } else  {
+                            node = JsValue::null()
+                        }
                     }
                 }
             };

--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -162,18 +162,10 @@ pub(crate) fn add_delegated_event_listener(
                         node.unchecked_ref::<web_sys::Node>().parent_node()
                     {
                         node = parent.into()
-                    } else {
-                        let host =
-                        js_sys::Reflect::get(&node, &JsValue::from_str("host"))
-                            .unwrap_throw();
-                        if host.is_truthy()
-                            && host != node
-                            && host.dyn_ref::<web_sys::Node>().is_some()
-                        {
-                            node = host;
-                        } else  {
-                            node = JsValue::null()
-                        }
+                    } else if let Some(root) = node.dyn_ref::<web_sys::ShadowRoot>() {
+                        node = root.host().unchecked_into();
+                    } else  {
+                        node = JsValue::null()
                     }
                 }
             };


### PR DESCRIPTION
The current event delegation code causes an infinite loop if you have an input with the name `host`. This is because forms are given properties for their inputs, such that `form.host` now refers to the input, not to a theoretical `host` property that existed on the form previously.

```rust
#[component]
fn App(cx: Scope) -> impl IntoView {
    let on_submit = |ev: SubmitEvent| {
        ev.prevent_default();
        log!("submit");
    };

    view! { cx,
        <form on:submit=on_submit>
            <input name="host"/>
            <button>"Submit"</button>
        </form>
    }
}
```

Checking `host` is necessary to handle event delegation across shadow DOM roots. However, the order of these checks was also reversed so that this (less common) case was listed rather than the more common `parentNode` case. 