### PR TITLE
fix: routing logic to scroll to top was broken

### DIFF
--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -126,11 +126,15 @@ impl History for BrowserIntegration {
                     .unwrap_or(hash);
                 let el = leptos_dom::document().get_element_by_id(&hash);
                 if let Some(el) = el {
-                    el.scroll_into_view()
-                } else if loc.scroll {
-                    leptos_dom::window().scroll_to_with_x_and_y(0.0, 0.0);
+                    el.scroll_into_view();
+                    return;
                 }
             }
+        }
+
+        // scroll to top
+        if loc.scroll {
+            leptos_dom::window().scroll_to_with_x_and_y(0.0, 0.0);
         }
     }
 }


### PR DESCRIPTION
The router is intended to scroll to the top of the page on navigation unless `NavigateOptions.scroll` is set to `false`, or the `noscroll` attribute is set on an `<a>` element. Unfortunately the logic for checking this was slightly messed up, so it was not actually being done. This PR should fix that. 

It will appear as if it's a breaking change in the router's behavior but this is what sometimes happens when you fix a long-standing bug. If you have any questions about the changed behavior, feel free to let me know, but it should behave as above: the default behavior should be to scroll to the top of the window on navigation, and you must opt in to maintain the current scroll position.