### PR TITLE
build: run tasks from workpace or member directory

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,35 +34,6 @@ install_crate = "cargo-all-features"
 clear = true
 dependencies = [{ name = "check-wasm-release", path = "leptos" }]
 
-[tasks.check-examples]
-clear = true
-dependencies = [
-	{ name = "check", path = "examples/counter" },
-	{ name = "check", path = "examples/counter_isomorphic" },
-	{ name = "check", path = "examples/counters" },
-	{ name = "check", path = "examples/error_boundary" },
-	{ name = "check", path = "examples/errors_axum" },
-	{ name = "check", path = "examples/fetch" },
-	{ name = "check", path = "examples/hackernews" },
-	{ name = "check", path = "examples/hackernews_axum" },
-	{ name = "check", path = "examples/js-framework-benchmark" },
-	{ name = "check", path = "examples/leptos-tailwind-axum" },
-	{ name = "check", path = "examples/login_with_token_csr_only" },
-	{ name = "check", path = "examples/parent_child" },
-	{ name = "check", path = "examples/router" },
-	{ name = "check", path = "examples/session_auth_axum" },
-	{ name = "check", path = "examples/slots" },
-	{ name = "check", path = "examples/ssr_modes" },
-	{ name = "check", path = "examples/ssr_modes_axum" },
-	{ name = "check", path = "examples/tailwind" },
-	{ name = "check", path = "examples/tailwind_csr_trunk" },
-	{ name = "check", path = "examples/timer" },
-	{ name = "check", path = "examples/todo_app_sqlite" },
-	{ name = "check", path = "examples/todo_app_sqlite_axum" },
-	{ name = "check", path = "examples/todo_app_sqlite_viz" },
-	{ name = "check", path = "examples/todomvc" },
-]
-
 [tasks.check-stable]
 clear = true
 dependencies = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,84 +3,25 @@
 #     cargo install --force cargo-make
 ############
 
-[config]
-# make tasks run at the workspace root
-default_to_workspace = false
-
-[tasks.check]
-clear = true
-dependencies = [
-	"check-all",
-	"check-wasm",
-	"check-all-release",
-	"check-wasm-release",
-]
-
-[tasks.check-all]
-command = "cargo"
-args = ["+nightly", "check-all-features"]
-install_crate = "cargo-all-features"
-
-[tasks.check-wasm]
-clear = true
-dependencies = [{ name = "check-wasm", path = "leptos" }]
-
-[tasks.check-all-release]
-command = "cargo"
-args = ["+nightly", "check-all-features"]
-install_crate = "cargo-all-features"
-
-[tasks.check-wasm-release]
-clear = true
-dependencies = [{ name = "check-wasm-release", path = "leptos" }]
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 
 [tasks.check-stable]
+workspace = false
 clear = true
 dependencies = [
 	{ name = "check", path = "examples/counter_without_macros" },
 	{ name = "check", path = "examples/counters_stable" },
 ]
 
-[tasks.test]
-clear = true
-dependencies = [
-	"test-all",
-	"test-leptos_macro-example",
-	"doc-leptos_macro-example",
-]
-
-[tasks.test-all]
-command = "cargo"
-args = ["+nightly", "test-all-features"]
-install_crate = "cargo-all-features"
-
-[tasks.test-leptos_macro-example]
-description = "Tests the leptos_macro/example to check if macro handles doc comments correctly"
-command = "cargo"
-args = ["+nightly", "test", "--doc"]
-cwd = "leptos_macro/example"
-install_crate = false
-
-[tasks.doc-leptos_macro-example]
-description = "Docs the leptos_macro/example to check if macro handles doc comments correctly"
-command = "cargo"
-args = ["+nightly", "doc"]
-cwd = "leptos_macro/example"
-install_crate = false
-
 [tasks.ci-examples]
+workspace = false
 cwd = "examples"
 command = "cargo"
 args = ["make", "ci-clean"]
 
 [tasks.clean-examples]
+workspace = false
 cwd = "examples"
 command = "cargo"
 args = ["make", "clean"]
-
-[env]
-RUSTFLAGS = ""
-LEPTOS_OUTPUT_NAME = "ci" # allows examples to check/build without cargo-leptos
-
-[env.github-actions]
-RUSTFLAGS = "-D warnings"

--- a/cargo-make/main.toml
+++ b/cargo-make/main.toml
@@ -13,12 +13,6 @@ command = "cargo"
 args = ["+nightly", "check-all-features"]
 install_crate = "cargo-all-features"
 
-# FIXME: Should this duplicate of check-all be removed?
-[tasks.check-all-release]
-command = "cargo"
-args = ["+nightly", "check-all-features"]
-install_crate = "cargo-all-features"
-
 [tasks.test]
 alias = "test-all"
 

--- a/cargo-make/main.toml
+++ b/cargo-make/main.toml
@@ -1,0 +1,28 @@
+[env]
+RUSTFLAGS = ""
+LEPTOS_OUTPUT_NAME = "ci" # allows examples to check/build without cargo-leptos
+
+[env.github-actions]
+RUSTFLAGS = "-D warnings"
+
+[tasks.check]
+alias = "check-all"
+
+[tasks.check-all]
+command = "cargo"
+args = ["+nightly", "check-all-features"]
+install_crate = "cargo-all-features"
+
+# FIXME: Should this duplicate of check-all be removed?
+[tasks.check-all-release]
+command = "cargo"
+args = ["+nightly", "check-all-features"]
+install_crate = "cargo-all-features"
+
+[tasks.test]
+alias = "test-all"
+
+[tasks.test-all]
+command = "cargo"
+args = ["+nightly", "test-all-features"]
+install_crate = "cargo-all-features"

--- a/integrations/actix/Makefile.toml
+++ b/integrations/actix/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/main.toml" }

--- a/integrations/axum/Makefile.toml
+++ b/integrations/axum/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/main.toml" }

--- a/integrations/utils/Makefile.toml
+++ b/integrations/utils/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/main.toml" }

--- a/integrations/viz/Makefile.toml
+++ b/integrations/viz/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/main.toml" }

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -5,7 +5,7 @@ clear = true
 dependencies = [
 	"check-all",
 	"check-wasm",
-	# "check-all-release",	Skip because it is a duplicate of check-all
+	"check-release",
 	"check-wasm-release",
 ]
 
@@ -54,3 +54,7 @@ args = [
 	"--features=csr",
 	"--target=wasm32-unknown-unknown",
 ]
+
+[tasks.check-release]
+command = "cargo"
+args = ["check", "--release"]

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -1,3 +1,14 @@
+extend = { path = "../cargo-make/main.toml" }
+
+[tasks.check]
+clear = true
+dependencies = [
+	"check-all",
+	"check-wasm",
+	# "check-all-release",	Skip because it is a duplicate of check-all
+	"check-wasm-release",
+]
+
 [tasks.check-wasm]
 clear = true
 dependencies = ["check-hydrate", "check-csr"]

--- a/leptos_config/Makefile.toml
+++ b/leptos_config/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/leptos_dom/Makefile.toml
+++ b/leptos_dom/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/leptos_hot_reload/Makefile.toml
+++ b/leptos_hot_reload/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/leptos_macro/Makefile.toml
+++ b/leptos_macro/Makefile.toml
@@ -1,0 +1,23 @@
+extend = { path = "../cargo-make/main.toml" }
+
+[tasks.test]
+clear = true
+dependencies = [
+    "test-all",
+    "test-leptos_macro-example",
+    "doc-leptos_macro-example",
+]
+
+[tasks.test-leptos_macro-example]
+description = "Tests the leptos_macro/example to check if macro handles doc comments correctly"
+command = "cargo"
+args = ["+nightly", "test", "--doc"]
+cwd = "example"
+install_crate = false
+
+[tasks.doc-leptos_macro-example]
+description = "Docs the leptos_macro/example to check if macro handles doc comments correctly"
+command = "cargo"
+args = ["+nightly", "doc"]
+cwd = "example"
+install_crate = false

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1686,7 +1686,7 @@ pub(crate) fn component_to_tokens(
         }
     });
 
-    #[allow(unused-mut)] // used in debug
+    #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         ::leptos::component_view(
             &#name,

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1553,6 +1553,7 @@ pub(crate) fn component_to_tokens(
     global_class: Option<&TokenTree>,
 ) -> TokenStream {
     let name = node.name();
+    #[cfg(debug_assertions)]
     let component_name = ident_from_tag_name(node.name());
     let span = node.name().span();
 
@@ -1685,6 +1686,7 @@ pub(crate) fn component_to_tokens(
         }
     });
 
+    #[allow(unused-mut)] // used in debug
     let mut component = quote! {
         ::leptos::component_view(
             &#name,
@@ -2120,6 +2122,7 @@ impl IdeTagHelper {
     ///     open_tag(open_tag.props().slots().children().build())
     /// }
     /// ```
+    #[cfg(debug_assertions)]
     pub fn add_component_completion(
         component: &mut TokenStream,
         node: &NodeElement,

--- a/leptos_reactive/Makefile.toml
+++ b/leptos_reactive/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/leptos_server/Makefile.toml
+++ b/leptos_server/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/meta/Makefile.toml
+++ b/meta/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/router/Makefile.toml
+++ b/router/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/server_fn/Makefile.toml
+++ b/server_fn/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }

--- a/server_fn/server_fn_macro_default/Makefile.toml
+++ b/server_fn/server_fn_macro_default/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../../cargo-make/main.toml" }

--- a/server_fn_macro/Makefile.toml
+++ b/server_fn_macro/Makefile.toml
@@ -1,0 +1,1 @@
+extend = { path = "../cargo-make/main.toml" }


### PR DESCRIPTION
READY FOR REVIEW

Add the ability to run `ci` checks and tests from either the workspace root or a member directory.

## Benefits

- Support test driven development workflow
- Enable crate level `ci` workflows

## Changes 

- Move common tasks to the `cargo-make/main.toml`
- Extend all workspace members from `cargo-make/main.toml`
- Move project specific tasks to `leptos`
- Move project specific tasks to `leptos_macro`
- Replace `check-all-release` with `check-release` 



