### PR TITLE
fix: hydration-key conflicts between `<ErrorBoundary/>` children and fallback

### DIFF
--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -58,13 +58,16 @@ where
     F: Fn(Scope, RwSignal<Errors>) -> IV + 'static,
     IV: IntoView,
 {
-    _ = HydrationCtx::next_component();
+    let before_children = HydrationCtx::next_component();
+
     let errors: RwSignal<Errors> = create_rw_signal(cx, Errors::default());
 
     provide_context(cx, errors);
 
     // Run children so that they render and execute resources
+    _ = HydrationCtx::next_component();
     let children = children(cx);
+    HydrationCtx::continue_from(before_children);
 
     #[cfg(all(debug_assertions, feature = "hydrate"))]
     {


### PR DESCRIPTION
Fixes issue #1345.