### PR TITLE
ci(check-examples): only run on source change

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -63,7 +63,7 @@ jobs:
   matrix-job:
     name: Check
     needs: [setup]
-    if: "${{ needs.setup.outputs.source_changed == 'true' }}"
+    if: ${{ needs.setup.outputs.source_changed == 'true' }}
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -63,7 +63,7 @@ jobs:
   matrix-job:
     name: Check
     needs: [setup]
-    if: ${{ needs.setup.outputs.source_changed == 'true' }}
+    if: ${{ fromJSON(needs.setup.outputs.source_changed) }}
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -35,12 +35,10 @@ jobs:
           echo "Example Directories: $examples"
           echo "matrix={\"directory\":$examples}" >> "$GITHUB_OUTPUT"
 
-      - name: Get source directories that changed
+      - name: Get source files that changed
         id: changed-source
         uses: tj-actions/changed-files@v36
         with:
-          dir_names: true
-          dir_names_max_depth: "1"
           files: |
             integrations
             leptos
@@ -55,7 +53,7 @@ jobs:
             server_fn
             server_fn_macro
 
-      - name: List source directories that changed
+      - name: List source files that changed
         run: echo '${{ steps.changed-source.outputs.all_changed_files }}'
 
       - name: Set source_changed

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      source_changed: ${{ steps.set-source-changed.outputs.any_changed }}
+      source_changed: ${{ steps.set-source-changed.outputs.source_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,12 +58,13 @@ jobs:
 
       - name: Set source_changed
         id: set-source-changed
-        run: echo "source_changed=${{ steps.changed-source.outputs.any_changed }}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "source_changed=${{ steps.changed-source.outputs.any_changed }}" >> "$GITHUB_OUTPUT"
 
   matrix-job:
     name: Check
     needs: [setup]
-    if: ${{ fromJSON(needs.setup.outputs.source_changed) }}
+    if: needs.setup.outputs.source_changed == 'true'
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -65,7 +65,7 @@ jobs:
   matrix-job:
     name: Check
     needs: [setup]
-    if: "needs.setup.outputs.source_changed == 'true'"
+    if: needs.setup.outputs.source_changed == 'true'
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -63,7 +63,7 @@ jobs:
   matrix-job:
     name: Check
     needs: [setup]
-    if: needs.setup.outputs.source_changed == 'true'
+    if: "${{ needs.setup.outputs.source_changed == 'true' }}"
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      source_changed: ${{ steps.set-source-changed.outputs.any_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,9 +35,37 @@ jobs:
           echo "Example Directories: $examples"
           echo "matrix={\"directory\":$examples}" >> "$GITHUB_OUTPUT"
 
+      - name: Get source directories that changed
+        id: changed-source
+        uses: tj-actions/changed-files@v36
+        with:
+          dir_names: true
+          dir_names_max_depth: "1"
+          files: |
+            integrations
+            leptos
+            leptos_config
+            leptos_dom
+            leptos_hot_reload
+            leptos_macro
+            leptos_reactive
+            leptos_server
+            meta
+            router
+            server_fn
+            server_fn_macro
+
+      - name: List source directories that changed
+        run: echo '${{ steps.changed-source.outputs.all_changed_files }}'
+
+      - name: Set source_changed
+        id: set-source-changed
+        run: echo "source_changed=${{ steps.changed-source.outputs.any_changed }}" >> "$GITHUB_OUTPUT"
+
   matrix-job:
     name: Check
     needs: [setup]
+    if: "needs.setup.outputs.source_changed == 'true'"
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
       fail-fast: false

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -1,5 +1,7 @@
 extend = { path = "../cargo-make/main.toml" }
 
+# TODO: Remove simulated source change
+
 [tasks.check]
 clear = true
 dependencies = [

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -1,7 +1,5 @@
 extend = { path = "../cargo-make/main.toml" }
 
-# TODO: Remove simulated source change
-
 [tasks.check]
 clear = true
 dependencies = [


### PR DESCRIPTION
READY FOR REVIEW

Only run the **Check Examples** workflow when a file in a workspace member directory changes.

This will speed up checks for changes that do not affect the examples.