### PR TITLE
ci(ci): only run on source change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,45 @@ on:
       - main
 
 jobs:
+  setup:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      source_changed: ${{ steps.set-source-changed.outputs.source_changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get source files that changed
+        id: changed-source
+        uses: tj-actions/changed-files@v36
+        with:
+          files: |
+            integrations
+            leptos
+            leptos_config
+            leptos_dom
+            leptos_hot_reload
+            leptos_macro
+            leptos_reactive
+            leptos_server
+            meta
+            router
+            server_fn
+            server_fn_macro
+
+      - name: List source files that changed
+        run: echo '${{ steps.changed-source.outputs.all_changed_files }}'
+
+      - name: Set source_changed
+        id: set-source-changed
+        run: |
+          echo "source_changed=${{ steps.changed-source.outputs.any_changed }}" >> "$GITHUB_OUTPUT"
+
   matrix-job:
     name: CI
+    needs: [setup]
+    if: needs.setup.outputs.source_changed == 'true'
     strategy:
       matrix:
         directory:

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -1,5 +1,7 @@
 extend = { path = "../cargo-make/main.toml" }
 
+# TODO: Remove simulated source change
+
 [tasks.check]
 clear = true
 dependencies = [

--- a/leptos/Makefile.toml
+++ b/leptos/Makefile.toml
@@ -1,7 +1,5 @@
 extend = { path = "../cargo-make/main.toml" }
 
-# TODO: Remove simulated source change
-
 [tasks.check]
 clear = true
 dependencies = [


### PR DESCRIPTION
READY FOR REVIEW

Only run the **CI** workflow when a file in a workspace member directory changes.

This will speed up checks for non-source changes.