### PR TITLE
fix: adjust hydration key generation

### DIFF
--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -58,14 +58,13 @@ where
     F: Fn(Scope, RwSignal<Errors>) -> IV + 'static,
     IV: IntoView,
 {
-    let before_children = HydrationCtx::next_component();
+    let before_children = HydrationCtx::next_component("e");
 
     let errors: RwSignal<Errors> = create_rw_signal(cx, Errors::default());
 
     provide_context(cx, errors);
 
     // Run children so that they render and execute resources
-    _ = HydrationCtx::next_component();
     let children = children(cx);
     HydrationCtx::continue_from(before_children);
 

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -69,7 +69,9 @@ where
     // provide this SuspenseContext to any resources below it
     provide_context(cx, context);
 
-    let current_id = HydrationCtx::next_component();
+    let before = HydrationCtx::peek();
+    let current_id = HydrationCtx::next_component("s");
+    leptos::log!("<Suspense/> next_component {current_id}");
 
     let child = DynChild::new({
         #[cfg(not(any(feature = "csr", feature = "hydrate")))]
@@ -161,8 +163,8 @@ where
         _ => unreachable!(),
     };
 
-    HydrationCtx::continue_from(current_id.clone());
-    HydrationCtx::next_component();
+    HydrationCtx::continue_from(before.clone());
+    _ = HydrationCtx::id();
 
     leptos_dom::View::Suspense(current_id, core_component)
 }

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -73,7 +73,7 @@ where
 
     let child = DynChild::new({
         #[cfg(not(any(feature = "csr", feature = "hydrate")))]
-        let current_id = current_id;
+        let current_id = current_id.clone();
 
         let children = Rc::new(orig_children(cx).into_view(cx));
         #[cfg(not(any(feature = "csr", feature = "hydrate")))]
@@ -97,7 +97,7 @@ where
                 {
                     // no resources were read under this, so just return the child
                     if context.pending_resources.get() == 0 {
-                        HydrationCtx::continue_from(current_id);
+                        HydrationCtx::continue_from(current_id.clone());
                         DynChild::new({
                             let children = Rc::clone(&children);
                             move || (*children).clone()
@@ -106,7 +106,7 @@ where
                     }
                     // show the fallback, but also prepare to stream HTML
                     else {
-                        HydrationCtx::continue_from(current_id);
+                        HydrationCtx::continue_from(current_id.clone());
 
                         cx.register_suspense(
                             context,
@@ -114,8 +114,11 @@ where
                             // out-of-order streaming
                             {
                                 let orig_children = Rc::clone(&orig_children);
+                                let current_id = current_id.clone();
                                 move || {
-                                    HydrationCtx::continue_from(current_id);
+                                    HydrationCtx::continue_from(
+                                        current_id.clone(),
+                                    );
                                     DynChild::new({
                                         let orig_children =
                                             orig_children(cx).into_view(cx);
@@ -129,8 +132,11 @@ where
                             // in-order streaming
                             {
                                 let orig_children = Rc::clone(&orig_children);
+                                let current_id = current_id.clone();
                                 move || {
-                                    HydrationCtx::continue_from(current_id);
+                                    HydrationCtx::continue_from(
+                                        current_id.clone(),
+                                    );
                                     DynChild::new({
                                         let orig_children =
                                             orig_children(cx).into_view(cx);
@@ -155,7 +161,7 @@ where
         _ => unreachable!(),
     };
 
-    HydrationCtx::continue_from(current_id);
+    HydrationCtx::continue_from(current_id.clone());
     HydrationCtx::next_component();
 
     leptos_dom::View::Suspense(current_id, core_component)

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -445,7 +445,7 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
               element: AnyElement {
                 name: element.name(),
                 is_void: element.is_void(),
-                id: *element.hydration_id()
+                id: element.hydration_id().clone()
               },
               #[cfg(debug_assertions)]
               view_marker
@@ -1070,7 +1070,7 @@ impl<El: ElementDescriptor> IntoView for HtmlElement<El> {
                 ..
             } = self;
 
-            let id = *element.hydration_id();
+            let id = element.hydration_id().clone();
 
             let mut element = Element::new(element);
             let children = children;
@@ -1114,7 +1114,7 @@ pub fn custom<El: ElementDescriptor>(cx: Scope, el: El) -> HtmlElement<Custom> {
             #[cfg(all(target_arch = "wasm32", feature = "web"))]
             element: el.as_ref().clone(),
             #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
-            id: *el.hydration_id(),
+            id: el.hydration_id().clone(),
         },
     )
 }

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -102,10 +102,10 @@ impl HydrationCtx {
     }
 
     /// Resets the hydration `id` for the next component, and returns it
-    pub fn next_component() -> HydrationKey {
+    pub fn next_component(tag: &'static str) -> HydrationKey {
         ID.with(|id| {
             let mut id = id.borrow_mut();
-            id.fragment = format!("{}{}", id.fragment, id.id);
+            id.fragment = format!("{}-{}{}", id.fragment, id.id, tag);
             id.id = 0;
             id.clone()
         })

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -50,13 +50,13 @@ cfg_if! {
 
       static IS_HYDRATING: RefCell<LazyCell<bool>> = RefCell::new(LazyCell::new(|| {
         #[cfg(debug_assertions)]
-        return crate::document().get_element_by_id("_0-1").is_some()
-          || crate::document().get_element_by_id("_0-1o").is_some()
-          || HYDRATION_COMMENTS.with(|comments| comments.get("_0-1o").is_some());
+        return crate::document().get_element_by_id("_-1").is_some()
+          || crate::document().get_element_by_id("_-1o").is_some()
+          || HYDRATION_COMMENTS.with(|comments| comments.get("_-1o").is_some());
 
         #[cfg(not(debug_assertions))]
-        return crate::document().get_element_by_id("_0-1").is_some()
-          || HYDRATION_COMMENTS.with(|comments| comments.get("_0-1").is_some());
+        return crate::document().get_element_by_id("_-1").is_some()
+          || HYDRATION_COMMENTS.with(|comments| comments.get("_-1").is_some());
       }));
     }
 
@@ -72,7 +72,7 @@ pub struct HydrationKey {
     /// ID of the current key.
     pub id: usize,
     /// ID of the current fragment.
-    pub fragment: usize,
+    pub fragment: String,
 }
 
 impl Display for HydrationKey {
@@ -105,7 +105,7 @@ impl HydrationCtx {
     pub fn next_component() -> HydrationKey {
         ID.with(|id| {
             let mut id = id.borrow_mut();
-            id.fragment = id.fragment.wrapping_add(1);
+            id.fragment = format!("{}{}", id.fragment, id.id);
             id.id = 0;
             id.clone()
         })

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -67,7 +67,7 @@ cfg_if! {
 }
 
 /// A stable identifier within the server-rendering or hydration process.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct HydrationKey {
     /// ID of the current key.
     pub id: usize,
@@ -89,7 +89,7 @@ pub struct HydrationCtx;
 impl HydrationCtx {
     /// Get the next `id` without incrementing it.
     pub fn peek() -> HydrationKey {
-        ID.with(|id| *id.borrow())
+        ID.with(|id| id.borrow().clone())
     }
 
     /// Increments the current hydration `id` and returns it
@@ -97,7 +97,7 @@ impl HydrationCtx {
         ID.with(|id| {
             let mut id = id.borrow_mut();
             id.id = id.id.wrapping_add(1);
-            *id
+            id.clone()
         })
     }
 
@@ -107,7 +107,7 @@ impl HydrationCtx {
             let mut id = id.borrow_mut();
             id.fragment = id.fragment.wrapping_add(1);
             id.id = 0;
-            *id
+            id.clone()
         })
     }
 

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -378,7 +378,7 @@ impl Element {
               is_void: el.is_void(),
               attrs: Default::default(),
               children: Default::default(),
-              id: *el.hydration_id(),
+              id: el.hydration_id().clone(),
               #[cfg(debug_assertions)]
               view_marker: None
             }

--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -453,7 +453,7 @@ impl View {
             View::CoreComponent(node) => {
                 let (id, name, wrap, content) = match node {
                     CoreComponent::Unit(u) => (
-                        u.id,
+                        u.id.clone(),
                         "",
                         false,
                         Box::new(move || {

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -381,7 +381,7 @@ impl View {
             View::CoreComponent(node) => {
                 let (id, name, wrap, content) = match node {
                     CoreComponent::Unit(u) => (
-                        u.id,
+                        u.id.clone(),
                         "",
                         false,
                         Box::new(move |chunks: &mut VecDeque<StreamChunk>| {


### PR DESCRIPTION
The current hydration key generation increments `fragment` by 1 for each `<Suspense/>`/`<Transition/>` and for each `<ErrorBoundary/>`. This can lead to overlapping IDs in some circumstances. This strategy for generating keys should ensure that they remain unique, at the cost of slightly longer keys at some points.