### PR TITLE
fix: correctly show fallback for Transition on first load even if not hydrating

### DIFF
--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -130,9 +130,16 @@ impl HydrationCtx {
         })
     }
 
-    #[cfg(all(target_arch = "wasm32", feature = "web"))]
-    pub(crate) fn is_hydrating() -> bool {
-        IS_HYDRATING.with(|is_hydrating| **is_hydrating.borrow())
+    /// Whether the UI is currently in the process of hydrating from the server-sent HTML.
+    pub fn is_hydrating() -> bool {
+        #[cfg(all(target_arch = "wasm32", feature = "web"))]
+        {
+            IS_HYDRATING.with(|is_hydrating| **is_hydrating.borrow())
+        }
+        #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
+        {
+            false
+        }
     }
 
     pub(crate) fn to_string(id: &HydrationKey, closing: bool) -> String {


### PR DESCRIPTION
Currently there's a bug with `<Transition/>`: if you are in hydrate mode, on first page load it correctly shows the fallback, then subsequently whatever the previous children were. However, on subsequent navigations it never shows the fallback, because it incorrectly assumes that the children have been streamed down from the server as if it were first page load. This should fix that issue.