### PR TITLE
(WIP) fix: unmounting of nested fragments (closes #1223)

### DIFF
--- a/leptos_dom/src/components.rs
+++ b/leptos_dom/src/components.rs
@@ -67,6 +67,23 @@ pub struct ComponentRepr {
     pub(crate) view_marker: Option<String>,
 }
 
+#[cfg(all(target_arch = "wasm32", feature = "web"))]
+impl ComponentRepr {
+    pub(crate) fn prepare_to_move(&self) {
+        #[cfg(debug_assertions)]
+        let start = self.get_opening_node();
+        let end = &self.closing.node;
+
+        for child in &self.children {
+            child.prepare_to_move();
+        }
+
+        #[cfg(debug_assertions)]
+        self.document_fragment.append_child(&start).unwrap();
+        self.document_fragment.append_child(&end).unwrap();
+    }
+}
+
 impl fmt::Debug for ComponentRepr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use fmt::Write;

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -752,6 +752,26 @@ impl View {
 
         self
     }
+
+    #[cfg(all(target_arch = "wasm32", feature = "web"))]
+    fn prepare_to_move(&self) {
+        match self {
+            View::CoreComponent(crate::CoreComponent::DynChild(child)) => {
+                let start = child.get_opening_node();
+                let end = &child.closing.node;
+                prepare_to_move(&child.document_fragment, &start, &end);
+            }
+            View::Component(child) => {
+                child.prepare_to_move();
+            }
+            _ => {
+                let start = self.get_opening_node();
+                let end = self.get_closing_node();
+
+                unmount_child(&start, &end);
+            }
+        }
+    }
 }
 
 #[cfg_attr(debug_assertions, instrument)]


### PR DESCRIPTION
I think that this should accurately handle unmounting and remounting things like nested fragments in release mode, finally. It is not particularly urgent, as the only cases I've seen this happening can either be refactored or were rewritten (Suspense/Transition cloning). But it is definitely good for issues like #1223 which occur occasionally.

EDIT: Oops seems like I did in fact break some things here... Will have to fix later.