### PR TITLE
perf: exclude hydration code in CSR mode

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -28,13 +28,13 @@ leptos = { path = "." }
 default = ["serde"]
 template_macro = ["leptos_dom/web", "web-sys", "wasm-bindgen"]
 csr = [
-  "leptos_dom/web",
+  "leptos_dom/csr",
   "leptos_macro/csr",
   "leptos_reactive/csr",
   "leptos_server/csr",
 ]
 hydrate = [
-  "leptos_dom/web",
+  "leptos_dom/hydrate",
   "leptos_macro/hydrate",
   "leptos_reactive/hydrate",
   "leptos_server/hydrate",

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -164,7 +164,9 @@ features = [
 
 [features]
 default = []
-web = ["leptos_reactive/csr"]
+web = []
+csr = ["leptos_reactive/csr", "web"]
+hydrate = ["leptos_reactive/hydrate", "web"]
 ssr = ["leptos_reactive/ssr"]
 nightly = ["leptos_reactive/nightly"]
 nonce = ["dep:base64", "dep:getrandom", "dep:rand"]

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -3,14 +3,14 @@ use std::{cell::RefCell, fmt::Display};
 #[cfg(all(target_arch = "wasm32", feature = "hydrate"))]
 mod hydration {
     use once_cell::unsync::Lazy as LazyCell;
-    use std::collections::HashMap;
+    use std::{cell::RefCell, collections::HashMap};
     use wasm_bindgen::JsCast;
 
     // We can tell if we start in hydration mode by checking to see if the
     // id "_0-1" is present in the DOM. If it is, we know we are hydrating from
     // the server, if not, we are starting off in CSR
     thread_local! {
-      static HYDRATION_COMMENTS: LazyCell<HashMap<String, web_sys::Comment>> = LazyCell::new(|| {
+      pub static HYDRATION_COMMENTS: LazyCell<HashMap<String, web_sys::Comment>> = LazyCell::new(|| {
         let document = crate::document();
         let body = document.body().unwrap();
         let walker = document
@@ -30,7 +30,7 @@ mod hydration {
       });
 
       #[cfg(debug_assertions)]
-      pub(crate) static VIEW_MARKERS: LazyCell<HashMap<String, web_sys::Comment>> = LazyCell::new(|| {
+      pub static VIEW_MARKERS: LazyCell<HashMap<String, web_sys::Comment>> = LazyCell::new(|| {
         let document = crate::document();
         let body = document.body().unwrap();
         let walker = document
@@ -47,7 +47,7 @@ mod hydration {
         map
       });
 
-      static IS_HYDRATING: RefCell<LazyCell<bool>> = RefCell::new(LazyCell::new(|| {
+      pub static IS_HYDRATING: RefCell<LazyCell<bool>> = RefCell::new(LazyCell::new(|| {
         #[cfg(debug_assertions)]
         return crate::document().get_element_by_id("_0-1").is_some()
           || crate::document().get_element_by_id("_0-1o").is_some()
@@ -59,13 +59,13 @@ mod hydration {
       }));
     }
 
-    pub(crate) fn get_marker(id: &str) -> Option<web_sys::Comment> {
+    pub fn get_marker(id: &str) -> Option<web_sys::Comment> {
         HYDRATION_COMMENTS.with(|comments| comments.get(id).cloned())
     }
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "hydrate"))]
-use hydration::*;
+pub(crate) use hydration::*;
 
 /// A stable identifier within the server-rendering or hydration process.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -416,11 +416,18 @@ impl Comment {
 
                 Self { content }
             } else {
+                #[cfg(not(feature = "hydrate"))]
+                {
+                    _ = id;
+                    _ = closing;
+                }
+
                 let node = COMMENT.with(|comment| comment.clone_node().unwrap());
 
                 #[cfg(debug_assertions)]
                 node.set_text_content(Some(&format!(" {content} ")));
 
+                #[cfg(feature = "hydrate")]
                 if HydrationCtx::is_hydrating() {
                     let id = HydrationCtx::to_string(id, closing);
 


### PR DESCRIPTION
`leptos_dom`, unlike the other packages, doesn't currently separate `csr` and `hydrate` but merges them into one `web` feature. This splits them apart, simply for the purpose of disabling some of the hydration code. This saves several kilobytes of WASM binary size in `csr` mode.