### PR TITLE
ci: lint with clippy

### DIFF
--- a/cargo-make/lint.toml
+++ b/cargo-make/lint.toml
@@ -1,9 +1,10 @@
-[tasks.pre-clippy]
-env = { CARGO_MAKE_CLIPPY_ARGS = "--all-targets --all-features -- -D warnings" }
-
 [tasks.check-style]
-dependencies = ["check-format-flow", "clippy-flow"]
+dependencies = ["check-format-flow", "clippy-each-feature"]
 
 [tasks.check-format]
 env = { LEPTOS_PROJECT_DIRECTORY = "../" }
 args = ["fmt", "--", "--check", "--config-path", "${LEPTOS_PROJECT_DIRECTORY}"]
+
+[tasks.clippy-each-feature]
+command = "cargo"
+args = ["hack", "clippy", "--all", "--each-feature", "--no-dev-deps"]

--- a/cargo-make/lint.toml
+++ b/cargo-make/lint.toml
@@ -1,4 +1,4 @@
-[tasks.check-style]
+[tasks.lint]
 dependencies = ["check-format-flow", "clippy-each-feature"]
 
 [tasks.check-format]

--- a/cargo-make/lint.toml
+++ b/cargo-make/lint.toml
@@ -6,5 +6,6 @@ env = { LEPTOS_PROJECT_DIRECTORY = "../" }
 args = ["fmt", "--", "--check", "--config-path", "${LEPTOS_PROJECT_DIRECTORY}"]
 
 [tasks.clippy-each-feature]
+dependencies = ["install-clippy"]
 command = "cargo"
 args = ["hack", "clippy", "--all", "--each-feature", "--no-dev-deps"]

--- a/cargo-make/main.toml
+++ b/cargo-make/main.toml
@@ -13,6 +13,3 @@ RUSTFLAGS = "-D warnings"
 
 [tasks.ci]
 dependencies = ["lint", "test"]
-
-[tasks.lint]
-dependencies = ["check-format-flow"]

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -60,7 +60,7 @@ pub fn html_parts(
         wasm_output_name.push_str("_bg");
     }
 
-    let leptos_autoreload = autoreload("".into(), options);
+    let leptos_autoreload = autoreload("", options);
 
     let html_metadata =
         meta.and_then(|mc| mc.html.as_string()).unwrap_or_default();

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_raw_string_hashes)]
 #![forbid(unsafe_code)]
 
 pub mod errors;
@@ -180,9 +179,9 @@ impl TryFrom<String> for Env {
 /// Loads [LeptosOptions] from a Cargo.toml text content with layered overrides.
 /// If an env var is specified, like `LEPTOS_ENV`, it will override a setting in the file.
 pub fn get_config_from_str(text: &str) -> Result<ConfFile, LeptosConfigError> {
-    let re: Regex = Regex::new(r#"(?m)^\[package.metadata.leptos\]"#).unwrap();
+    let re: Regex = Regex::new(r"(?m)^\[package.metadata.leptos\]").unwrap();
     let re_workspace: Regex =
-        Regex::new(r#"(?m)^\[\[workspace.metadata.leptos\]\]"#).unwrap();
+        Regex::new(r"(?m)^\[\[workspace.metadata.leptos\]\]").unwrap();
 
     let metadata_name;
     let start;

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_raw_string_hashes)]
 #![forbid(unsafe_code)]
 
 pub mod errors;

--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -196,7 +196,7 @@ impl TimeoutHandle {
 /// Executes the given function after the given duration of time has passed.
 /// [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout).
 #[cfg_attr(
-  any(debug_assertions, features = "ssr"),
+  any(debug_assertions, feature = "ssr"),
   instrument(level = "trace", skip_all, fields(duration = ?duration))
 )]
 pub fn set_timeout(cb: impl FnOnce() + 'static, duration: Duration) {
@@ -206,7 +206,7 @@ pub fn set_timeout(cb: impl FnOnce() + 'static, duration: Duration) {
 /// Executes the given function after the given duration of time has passed, returning a cancelable handle.
 /// [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout).
 #[cfg_attr(
-  any(debug_assertions, features = "ssr"),
+  any(debug_assertions, feature = "ssr"),
   instrument(level = "trace", skip_all, fields(duration = ?duration))
 )]
 #[inline(always)]
@@ -329,7 +329,7 @@ impl IntervalHandle {
 /// returning a cancelable handle.
 /// See [`setInterval()`](https://developer.mozilla.org/en-US/docs/Web/API/setInterval).
 #[cfg_attr(
-  any(debug_assertions, features = "ssr"),
+  any(debug_assertions, feature = "ssr"),
   instrument(level = "trace", skip_all, fields(duration = ?duration))
 )]
 pub fn set_interval(cb: impl Fn() + 'static, duration: Duration) {
@@ -340,7 +340,7 @@ pub fn set_interval(cb: impl Fn() + 'static, duration: Duration) {
 /// returning a cancelable handle.
 /// See [`setInterval()`](https://developer.mozilla.org/en-US/docs/Web/API/setInterval).
 #[cfg_attr(
-  any(debug_assertions, features = "ssr"),
+  any(debug_assertions, feature = "ssr"),
   instrument(level = "trace", skip_all, fields(duration = ?duration))
 )]
 #[inline(always)]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(feature = "nightly", feature(fn_traits))]

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(fn_traits))]
 #![cfg_attr(feature = "nightly", feature(unboxed_closures))]

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -237,7 +237,7 @@ where
         id,
         source_ty: PhantomData,
         out_ty: PhantomData,
-        #[cfg(any(debug_assertions, features = "ssr"))]
+        #[cfg(any(debug_assertions, feature = "ssr"))]
         defined_at: std::panic::Location::caller(),
     }
 }
@@ -373,7 +373,7 @@ where
         id,
         source_ty: PhantomData,
         out_ty: PhantomData,
-        #[cfg(any(debug_assertions, features = "ssr"))]
+        #[cfg(any(debug_assertions, feature = "ssr"))]
         defined_at: std::panic::Location::caller(),
     }
 }
@@ -719,7 +719,7 @@ where
     pub(crate) id: ResourceId,
     pub(crate) source_ty: PhantomData<S>,
     pub(crate) out_ty: PhantomData<T>,
-    #[cfg(any(debug_assertions, features = "ssr"))]
+    #[cfg(any(debug_assertions, feature = "ssr"))]
     pub(crate) defined_at: &'static std::panic::Location<'static>,
 }
 
@@ -744,7 +744,7 @@ where
             id: self.id,
             source_ty: PhantomData,
             out_ty: PhantomData,
-            #[cfg(any(debug_assertions, features = "ssr"))]
+            #[cfg(any(debug_assertions, feature = "ssr"))]
             defined_at: self.defined_at,
         }
     }

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -475,7 +475,7 @@ impl RuntimeId {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[inline(always)]

--- a/leptos_reactive/src/scope.rs
+++ b/leptos_reactive/src/scope.rs
@@ -37,7 +37,7 @@ pub fn create_scope(
 ///
 /// You usually don't need to call this manually.
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 pub fn raw_scope_and_disposer(runtime: RuntimeId) -> (Scope, ScopeDisposer) {
@@ -52,7 +52,7 @@ pub fn raw_scope_and_disposer(runtime: RuntimeId) -> (Scope, ScopeDisposer) {
 ///
 /// You usually don't need to call this manually.
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 pub fn run_scope<T>(
@@ -69,7 +69,7 @@ pub fn run_scope<T>(
 ///
 /// You usually don't need to call this manually.
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 pub fn run_scope_undisposed<T>(
@@ -128,7 +128,7 @@ impl Scope {
     /// dispose of them when they are no longer needed (e.g., a list item has been destroyed or the user
     /// has navigated away from the route.)
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[inline(always)]
@@ -147,7 +147,7 @@ impl Scope {
     /// dispose of them when they are no longer needed (e.g., a list item has been destroyed or the user
     /// has navigated away from the route.)
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[inline(always)]
@@ -203,7 +203,7 @@ impl Scope {
     /// # });
     /// ```
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[inline(always)]
@@ -229,7 +229,7 @@ impl Scope {
     /// 2. run all cleanup functions defined for this scope by [`on_cleanup`](crate::on_cleanup).
     /// 3. dispose of all signals, effects, and resources owned by this `Scope`.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn dispose(self) {
@@ -306,7 +306,7 @@ impl Scope {
         })
     }
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub(crate) fn push_scope_property(&self, prop: ScopeProperty) {
@@ -322,7 +322,7 @@ impl Scope {
         })
     }
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub(crate) fn remove_scope_property(&self, prop: ScopeProperty) {
@@ -343,7 +343,7 @@ impl Scope {
         })
     }
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     /// Returns the the parent Scope, if any.
@@ -361,7 +361,7 @@ impl Scope {
 }
 
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 fn push_cleanup(cx: Scope, cleanup_fn: Box<dyn FnOnce()>) {
@@ -424,7 +424,7 @@ impl ScopeDisposer {
 impl Scope {
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn all_resources(&self) -> Vec<ResourceId> {
@@ -435,7 +435,7 @@ impl Scope {
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope that are
     /// pending from the server.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn pending_resources(&self) -> Vec<ResourceId> {
@@ -445,7 +445,7 @@ impl Scope {
 
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn serialization_resolvers(
@@ -460,7 +460,7 @@ impl Scope {
     /// Registers the given [`SuspenseContext`](crate::SuspenseContext) with the current scope,
     /// calling the `resolver` when its resources are all resolved.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn register_suspense(
@@ -517,7 +517,7 @@ impl Scope {
     /// The keys are hydration IDs. Values are tuples of two pinned
     /// `Future`s that return content for out-of-order and in-order streaming, respectively.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn pending_fragments(&self) -> HashMap<String, FragmentData> {
@@ -530,7 +530,7 @@ impl Scope {
 
     /// A future that will resolve when all blocking fragments are ready.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn blocking_fragments_ready(self) -> PinnedFuture<()> {
@@ -557,7 +557,7 @@ impl Scope {
     /// Returns a tuple of two pinned `Future`s that return content for out-of-order
     /// and in-order streaming, respectively.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn take_pending_fragment(&self, id: &str) -> Option<FragmentData> {
@@ -576,7 +576,7 @@ impl Scope {
     /// # Panics
     /// Panics if the runtime this scope belongs to has already been disposed.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[inline(always)]

--- a/leptos_reactive/src/serialization.rs
+++ b/leptos_reactive/src/serialization.rs
@@ -95,7 +95,7 @@ cfg_if! {
 
             fn de(json: &str) -> Result<Self, SerializationError> {
                 let intermediate =
-                    serde_json::from_str(&json).map_err(|e| SerializationError::Deserialize(Rc::new(e)))?;
+                    serde_json::from_str(json).map_err(|e| SerializationError::Deserialize(Rc::new(e)))?;
                 Self::deserialize(&intermediate).map_err(|e| SerializationError::Deserialize(Rc::new(e)))
             }
         }

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -95,7 +95,7 @@ where
 {
     /// Calls the `async` function with a reference to the input type as its argument.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn dispatch(&self, input: I) {
@@ -104,7 +104,7 @@ where
 
     /// The set of all submissions to this multi-action.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn submissions(&self) -> ReadSignal<Vec<Submission<I, O>>> {
@@ -119,7 +119,7 @@ where
 
     /// How many times an action has successfully resolved.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn version(&self) -> RwSignal<usize> {
@@ -129,7 +129,7 @@ where
     /// Associates the URL of the given server function with this action.
     /// This enables integration with the `MultiActionForm` component in `leptos_router`.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn using_server_fn<T: ServerFn>(self) -> Self {
@@ -212,7 +212,7 @@ where
 {
     /// Calls the `async` function with a reference to the input type as its argument.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         tracing::instrument(level = "trace", skip_all,)
     )]
     pub fn dispatch(&self, input: I) {
@@ -304,7 +304,7 @@ where
 /// # });
 /// ```
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     tracing::instrument(level = "trace", skip_all,)
 )]
 pub fn create_multi_action<I, O, F, Fu>(
@@ -351,7 +351,7 @@ where
 /// # });
 /// ```
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     tracing::instrument(level = "trace", skip_all,)
 )]
 pub fn create_server_multi_action<S>(

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::needless_raw_string_hashes)]
 #![forbid(unsafe_code)]
 
 //! # Leptos Router

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_raw_string_hashes)]
 #![forbid(unsafe_code)]
 
 //! # Leptos Router

--- a/router/src/matching/expand_optionals.rs
+++ b/router/src/matching/expand_optionals.rs
@@ -101,5 +101,5 @@ pub fn expand_optionals(pattern: &str) -> Vec<Cow<str>> {
     }
 }
 
-const OPTIONAL: &str = r#"(/?:[^/]+)\?"#;
-const OPTIONAL_2: &str = r#"^(/:[^/]+)\?"#;
+const OPTIONAL: &str = r"(/?:[^/]+)\?";
+const OPTIONAL_2: &str = r"^(/:[^/]+)\?";


### PR DESCRIPTION
READY FOR REVIEW

Add clippy to the `lint` task.

### Changes

- Support conditional compilation with `cargo hack`
- Fix most violations
- Defer resolution of [incorrect clone implementation](https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_) errors
- Add clippy to `ci` flow

### No errors on warnings

- I did not find a way to pass clippy options with `cargo hack`

_See [Clippy Lints](https://rust-lang.github.io/rust-clippy/master/index.html) for rule details._