### PR TITLE
fix: remove unwrap when removing previous sibling

### DIFF
--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -345,10 +345,10 @@ where
                             // for more details on why we need to do this for
                             // release
                             if !cfg!(debug_assertions) {
-                                t.previous_sibling()
-                                    .unwrap()
-                                    .unchecked_into::<web_sys::Element>()
-                                    .remove();
+                                if let Some(el) = t.previous_sibling() {
+                                    el.unchecked_into::<web_sys::Element>()
+                                        .remove();
+                                }
                             }
 
                             t.remove();


### PR DESCRIPTION
I don't understand really any of the code here, but in case the fix is as simple as adding a `if let Some` check to avoid the panic, then this PR does that. If not, then feel free to close this PR.

Fixes https://github.com/leptos-rs/leptos/issues/1382