### PR TITLE
examples: remove random `<form>`

### DIFF
--- a/examples/todo_app_sqlite_axum/src/todo.rs
+++ b/examples/todo_app_sqlite_axum/src/todo.rs
@@ -126,10 +126,6 @@ pub fn Todos(cx: Scope) -> impl IntoView {
 
     view! {
         cx,
-        <form method="POST" action="/weird">
-            <input type="text" name="hi" value="John"/>
-            <input type="submit"/>
-        </form>
         <div>
             <MultiActionForm action=add_todo>
                 <label>


### PR DESCRIPTION
This slipped in as a demo of the ability to handle `POST` requests during rendering, but I accidentally committed it. It has the potential to create confusion by doing an unenhanced full-reload. (See #1391) I'm just removing it to match the `todo_app_sqlite` example.