### PR TITLE
fix: closing element names wrong for `svg::`, `math::`, and `use_` (closes #1403)

### DIFF
--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -551,7 +551,7 @@ fn element_to_tokens_ssr(
             }
 
             template.push_str("</");
-            template.push_str(&node.name().to_string());
+            template.push_str(tag_name);
             template.push('>');
         }
     }


### PR DESCRIPTION
fix #1403