### PR TITLE
fix: `<use_/>` as typed top-level element in view

### DIFF
--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -351,7 +351,10 @@ fn root_element_to_tokens_ssr(
             Ident::new("Custom", Span::call_site())
         } else {
             let camel_cased = camel_case_tag_name(
-                &tag_name.replace("svg::", "").replace("math::", ""),
+                tag_name
+                    .trim_start_matches("svg::")
+                    .trim_start_matches("math::")
+                    .trim_end_matches('_'),
             );
             Ident::new(&camel_cased, Span::call_site())
         };
@@ -1852,11 +1855,7 @@ fn is_self_closing(node: &NodeElement) -> bool {
 fn camel_case_tag_name(tag_name: &str) -> String {
     let mut chars = tag_name.chars();
     let first = chars.next();
-    let underscore = if tag_name == "option" || tag_name == "use" {
-        "_"
-    } else {
-        ""
-    };
+    let underscore = if tag_name == "option" { "_" } else { "" };
     first
         .map(|f| f.to_ascii_uppercase())
         .into_iter()


### PR DESCRIPTION
Closes #1408.