### PR TITLE
build(examples): make it easy to see which examples do what kind of testing

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -45,3 +45,71 @@ grep -v gtk |
 jq -R -s -c 'split("\n")[:-1]')
 echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 '''
+
+[tasks.test-info]
+workspace = false
+description = "List example projects with CI tests runners"
+script = '''
+BOLD="\e[1m"
+GREEN="\e[0;32m"
+ITALIC="\e[3m"
+YELLOW="\e[0;33m"
+RESET="\e[0m"
+
+echo
+echo "${YELLOW}CI test runners by example...${RESET}"
+echo
+
+examples=$(ls | 
+grep -v README.md | 
+grep -v Makefile.toml | 
+grep -v cargo-make | 
+grep -v gtk |
+sort -u | 
+awk '{print $0 ", "}')
+
+example_root_dir=$(pwd)
+
+for example_dir in $examples
+do
+  clean_name=$(echo $example_dir | sed 's%,%%')
+  cd $clean_name
+
+  c_tests=$(grep -rl --fixed-strings "#[test]" | wc -l)
+  rs_tests=$(grep -rl --fixed-strings "#[rstest]" | wc -l)
+  w_configs=$(grep -rl "\/wasm-test.toml\"" | wc -l)
+  pw_configs=$(grep -rl "\/playwright-test.toml\"" | wc -l)
+  cl_configs=$(grep -rl "\/cargo-leptos-test.toml\"" | wc -l)
+
+  test_runner=
+
+  if [ $c_tests -gt 0 ]; then
+    test_runner="-C"
+  fi
+
+  if [ $rs_tests -gt 0 ]; then
+    test_runner=$test_runner"-R"
+  fi
+
+  if [ $w_configs -gt 0 ]; then
+    test_runner=$test_runner"-W"
+  fi
+
+  if [ $pw_configs -gt 0 ]; then
+    test_runner=$test_runner"-P"
+  fi
+
+  if [ $cl_configs -gt 0 ]; then
+    test_runner=$test_runner"-L"
+  fi
+  
+  if [ ! -z $test_runner ]; then
+    echo "$clean_name ${BOLD}${test_runner}${RESET}"
+  fi
+
+  cd $example_root_dir
+done
+echo
+echo "${ITALIC}Test Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, R = RS Test, W = WASM Test${RESET}"
+echo
+'''

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -48,7 +48,7 @@ echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 
 [tasks.test-info]
 workspace = false
-description = "List example projects with CI tests runners"
+description = "report ci test runners for each example - Option [all]"
 script = '''
 BOLD="\e[1m"
 GREEN="\e[0;32m"
@@ -103,7 +103,11 @@ do
     test_runner=$test_runner"-L"
   fi
   
-  if [ ! -z $test_runner ]; then
+  if [ ! -z "$1" ]; then
+    # Show all examples
+    echo "$clean_name ${BOLD}${test_runner}${RESET}"
+  elif [ ! -z $test_runner ]; then
+    # Filter out examples that do not run tests in `ci`
     echo "$clean_name ${BOLD}${test_runner}${RESET}"
   fi
 


### PR DESCRIPTION
READY

Add the `test-info` task to report the test runners for each example that run during `ci`.

### Motivation

Make it easy to find out:

- Which examples have `ci` tests?
- How many types of tests do examples use?
- Where can I find an example of a specific test runner?

### Verification

The `test-info` task has two modes. The default only includes examples that run tests during `ci`. You can also pass any argument to include all examples in the report.

#### 1. Filter out examples that do not run tests in `ci`
- Run `cargo make test-info` from the **examples** directory
- See a report similar to the following...

```console
[cargo-make] INFO - Running Task: test-info

CI test runners by example...

counter -C-W
counters -W
counters_stable -W-P
counter_without_macros -R-W
js-framework-benchmark -W
router -P
tailwind -L

Test Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, R = RS Test, W = WASM Test
```

#### 2. Show all examples
- Run `cargo make test-info all` from the **examples** directory
- See a report similar to the following...
```console
[cargo-make] INFO - Running Task: test-info

CI test runners by example...

counter -C-W
counter_isomorphic 
counters -W
counters_stable -W-P
counter_without_macros -R-W
error_boundary 
errors_axum 
fetch 
hackernews 
hackernews_axum 
js-framework-benchmark -W
leptos-tailwind-axum 
login_with_token_csr_only 
parent_child 
router -P
session_auth_axum 
slots 
ssr_modes 
ssr_modes_axum 
tailwind -L
tailwind_csr_trunk 
timer 
todo_app_sqlite 
todo_app_sqlite_axum 
todo_app_sqlite_viz 
todomvc 

Test Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, R = RS Test, W = WASM Test
```

