### PR TITLE
Feat: Update rstml to v0.11.0

### DIFF
--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -19,7 +19,7 @@ syn = { version = "2", features = [
 	"printing",
 ] }
 quote = "1"
-rstml = "0.10.6"
+rstml = "0.11.0"
 proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro-error = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
-rstml = "0.10.6"
+rstml = "0.11.0"
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -169,14 +169,26 @@ mod template;
 /// # });
 /// ```
 ///
-/// Class names can include dashes, but cannot (at the moment) include a dash-separated segment of only numbers.
+/// Class names can include dashes, and since leptos v0.5.0 can include a dash-separated segment of only numbers.
+/// ```rust
+/// # use leptos::*;
+/// # run_scope(create_runtime(), |cx| {
+/// # if !cfg!(any(feature = "csr", feature = "hydrate")) {
+/// let (count, set_count) = create_signal(cx, 2);
+/// view! { cx, <div class:hidden-div-25={move || count.get() < 3}>"Now you see me, now you don’t."</div> }
+/// # ;
+/// # }
+/// # });
+/// ```
+///
+/// Class names cannot include special symbols.
 /// ```rust,compile_fail
 /// # use leptos::*;
 /// # run_scope(create_runtime(), |cx| {
 /// # if !cfg!(any(feature = "csr", feature = "hydrate")) {
 /// let (count, set_count) = create_signal(cx, 2);
-/// // `hidden-div-25` is invalid at the moment
-/// view! { cx, <div class:hidden-div-25={move || count.get() < 3}>"Now you see me, now you don’t."</div> }
+/// // class:hidden-[div]-25 is invalid attribute name
+/// view! { cx, <div class:hidden-[div]-25={move || count.get() < 3}>"Now you see me, now you don’t."</div> }
 /// # ;
 /// # }
 /// # });
@@ -921,8 +933,8 @@ pub fn params_derive(
 }
 
 pub(crate) fn attribute_value(attr: &KeyedAttribute) -> &syn::Expr {
-    match &attr.possible_value {
-        Some(value) => &value.value,
+    match attr.value() {
+        Some(value) => value,
         None => abort!(attr.key, "attribute should have value"),
     }
 }

--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1225,7 +1225,7 @@ fn attribute_to_tokens(
         };
         let undelegated_ident = match &node.key {
             NodeName::Punctuated(parts) => parts.last().and_then(|last| {
-                if last == "undelegated" {
+                if last.to_string() == "undelegated" {
                     Some(last)
                 } else {
                     None
@@ -1246,9 +1246,8 @@ fn attribute_to_tokens(
         let event_type = if is_custom {
             event_type
         } else if let Some(ev_name) = event_name_ident {
-            let span = ev_name.span();
-            quote_spanned! {
-                span => #ev_name
+            quote! {
+                #ev_name
             }
         } else {
             event_type
@@ -1256,9 +1255,8 @@ fn attribute_to_tokens(
 
         let event_type = if is_force_undelegated {
             let undelegated = if let Some(undelegated) = undelegated_ident {
-                let span = undelegated.span();
-                quote_spanned! {
-                    span => #undelegated
+                quote! {
+                    #undelegated
                 }
             } else {
                 quote! { undelegated }


### PR DESCRIPTION
It's marked as feature, since in rstml v0.11.0 i added support of numbers in dash seperated attributes


https://github.com/leptos-rs/leptos/issues/73
https://github.com/rs-tml/rstml/issues/9

Currently during parse it follows SGML rule:
ID and NAME tokens must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods (".").
https://www.w3.org/TR/html4/types.html#type-cdata

So special symbols are still forbidden in attribute names.