### PR TITLE
chore: resolve clippy `incorrect_clone_impl_on_copy_type` (closes #1401)

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 #![cfg_attr(feature = "nightly", feature(fn_traits))]

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -147,7 +147,7 @@ impl<T: ElementDescriptor + 'static> NodeRef<T> {
 
 impl<T: ElementDescriptor> Clone for NodeRef<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(fn_traits))]
 #![cfg_attr(feature = "nightly", feature(unboxed_closures))]

--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -179,13 +179,7 @@ where
     T: 'static,
 {
     fn clone(&self) -> Self {
-        Self {
-            runtime: self.runtime,
-            id: self.id,
-            ty: PhantomData,
-            #[cfg(any(debug_assertions, feature = "ssr"))]
-            defined_at: self.defined_at,
-        }
+        *self
     }
 }
 

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -734,19 +734,8 @@ where
     S: 'static,
     T: 'static,
 {
-    #[cfg_attr(
-        any(debug_assertions, feature = "ssr"),
-        instrument(level = "trace", skip_all,)
-    )]
     fn clone(&self) -> Self {
-        Self {
-            runtime: self.runtime,
-            id: self.id,
-            source_ty: PhantomData,
-            out_ty: PhantomData,
-            #[cfg(any(debug_assertions, feature = "ssr"))]
-            defined_at: self.defined_at,
-        }
+        *self
     }
 }
 

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -71,11 +71,7 @@ where
 
 impl<T> Clone for Signal<T> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner,
-            #[cfg(any(debug_assertions, feature = "ssr"))]
-            defined_at: self.defined_at,
-        }
+        *self
     }
 }
 
@@ -436,13 +432,7 @@ where
 
 impl<T> Clone for SignalTypes<T> {
     fn clone(&self) -> Self {
-        match self {
-            Self::ReadSignal(arg0) => Self::ReadSignal(*arg0),
-            Self::Memo(arg0) => Self::Memo(*arg0),
-            Self::DerivedSignal(arg0, arg1) => {
-                Self::DerivedSignal(*arg0, *arg1)
-            }
-        }
+        *self
     }
 }
 

--- a/leptos_reactive/src/signal_wrappers_write.rs
+++ b/leptos_reactive/src/signal_wrappers_write.rs
@@ -63,11 +63,7 @@ where
 
 impl<T> Clone for SignalSetter<T> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner,
-            #[cfg(any(debug_assertions, feature = "ssr"))]
-            defined_at: self.defined_at,
-        }
+        *self
     }
 }
 
@@ -231,11 +227,7 @@ where
 
 impl<T> Clone for SignalSetterTypes<T> {
     fn clone(&self) -> Self {
-        match self {
-            Self::Write(arg0) => Self::Write(*arg0),
-            Self::Mapped(cx, f) => Self::Mapped(*cx, *f),
-            Self::Default => Self::Default,
-        }
+        *self
     }
 }
 

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -33,11 +33,7 @@ where
 
 impl<T> Clone for StoredValue<T> {
     fn clone(&self) -> Self {
-        Self {
-            runtime: self.runtime,
-            id: self.id,
-            ty: self.ty,
-        }
+        *self
     }
 }
 

--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -187,7 +187,7 @@ where
     O: 'static,
 {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::incorrect_clone_impl_on_copy_type)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -77,7 +77,7 @@ where
     O: 'static,
 {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 
@@ -178,12 +178,7 @@ where
 
 impl<I, O> Clone for Submission<I, O> {
     fn clone(&self) -> Self {
-        Self {
-            input: self.input,
-            value: self.value,
-            pending: self.pending,
-            canceled: self.canceled,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
This is a good lint! Ensures correctness, catches one issue (the `tracing` instrumentation can't be added to a `Clone` that is also `Copy`), and encourages removing a bunch of redundant lines of code in a way I hadn't thought of previously.

Closes #1401.