### PR TITLE
feat: allow feature-name flexibility when using server functions

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -46,6 +46,7 @@ ssr = [
   "leptos_macro/ssr",
   "leptos_reactive/ssr",
   "leptos_server/ssr",
+  "server_fn/ssr",
 ]
 nightly = [
   "leptos_dom/nightly",

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -35,10 +35,10 @@ trybuild = "1"
 leptos = { path = "../leptos" }
 
 [features]
-default = ["ssr"]
+default = []
 csr = []
 hydrate = []
-ssr = []
+ssr = ["server_fn_macro/ssr"]
 nightly = ["server_fn_macro/nightly"]
 tracing = []
 

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -35,7 +35,6 @@ trybuild = "1"
 leptos = { path = "../leptos" }
 
 [features]
-default = []
 csr = []
 hydrate = []
 ssr = ["server_fn_macro/ssr"]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -25,7 +25,7 @@ csr = ["leptos_reactive/csr"]
 default-tls = ["server_fn/default-tls"]
 hydrate = ["leptos_reactive/hydrate"]
 rustls = ["server_fn/rustls"]
-ssr = ["leptos_reactive/ssr", "server_fn/ssr"]
+ssr = ["leptos_reactive/ssr", "server_fn/ssr", "leptos/ssr"]
 nightly = ["leptos_reactive/nightly", "server_fn/nightly"]
 
 [package.metadata.cargo-all-features]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 
 [dependencies]
 leptos_reactive = { workspace = true }
+leptos_macro = { workspace = true }
 server_fn = { workspace = true }
 lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
@@ -21,11 +22,11 @@ inventory = "0.3"
 leptos = { path = "../leptos" }
 
 [features]
-csr = ["leptos_reactive/csr"]
+csr = ["leptos_reactive/csr", "leptos_macro/csr"]
 default-tls = ["server_fn/default-tls"]
-hydrate = ["leptos_reactive/hydrate"]
+hydrate = ["leptos_reactive/hydrate", "leptos_macro/hydrate"]
 rustls = ["server_fn/rustls"]
-ssr = ["leptos_reactive/ssr", "server_fn/ssr", "leptos/ssr"]
+ssr = ["leptos_reactive/ssr", "server_fn/ssr", "leptos_macro/ssr"]
 nightly = ["leptos_reactive/nightly", "server_fn/nightly"]
 
 [package.metadata.cargo-all-features]

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -19,3 +19,4 @@ const_format = "0.2.30"
 
 [features]
 nightly = []
+ssr = []


### PR DESCRIPTION
The current server-function implementation includes `#[cfg(feature = "ssr")]` in its codegen, which means that it actually checks an `ssr` feature in your application code, not whether an `ssr` feature is enabled for `server_fn_macro` itself. This means that your application is forced to use `ssr` as a feature name and not, for example, `server`. 

This PR instead checks the feature when the proc-macro runs, rather than emitting it into the generated code, which means that it will check which features are enabled on `server_fn_macro`, not in your application. This means you can name your features whatever you want — say `server` and `client` instead of Leptos's go-to `ssr` and `hydrate` — and it will work.

I've tested this by running the `todo_app_sqlite` example as is against the new code, and by replacing the `ssr` and `hydrate` features with `server` and `client`, and it compiles and runs identically in both cases.

@Demonthos tagging you both FYI, in case it requires anything on Dioxus's end, and in case you can see any issues with this.