### PR TITLE
fix: clear `<title>` correctly when navigating between pages

### DIFF
--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -125,6 +125,7 @@ pub fn Title(
                     match document().query_selector("title") {
                         Ok(Some(title)) => title.unchecked_into(),
                         _ => {
+                            let el_ref = meta.title.el.clone();
                             let el = document().create_element("title").unwrap_throw();
                             let head = document().head().unwrap_throw();
                             head.append_child(el.unchecked_ref())
@@ -134,6 +135,7 @@ pub fn Title(
                                 let el = el.clone();
                                 move || {
                                     _ = head.remove_child(&el);
+                                    *el_ref.borrow_mut() = None;
                                 }
                             });
 


### PR DESCRIPTION
This should close #1369, by not only removing the `<title>` tag but removing it from the meta context when navigating away from a page that introduces a `<Title/>`, if there was not previously a `<title>` tag found. This leads to the correct branch if you then load another page.