### PR TITLE
fix: incorrect opening node for `<Each/>` in debug mode (closes #1168)

### DIFF
--- a/leptos_dom/src/components/each.rs
+++ b/leptos_dom/src/components/each.rs
@@ -377,6 +377,9 @@ where
 
         let component = EachRepr::default();
 
+        #[cfg(all(debug_assertions, target_arch = "wasm32", feature = "web"))]
+        let opening = component.opening.node.clone().unchecked_into();
+
         #[cfg(all(target_arch = "wasm32", feature = "web"))]
         let (children, closing) =
             (component.children.clone(), component.closing.node.clone());
@@ -387,7 +390,11 @@ where
             move |prev_hash_run: Option<HashRun<FxIndexSet<K>>>| {
                 let mut children_borrow = children.borrow_mut();
 
-                #[cfg(all(target_arch = "wasm32", feature = "web"))]
+                #[cfg(all(
+                    not(debug_assertions),
+                    target_arch = "wasm32",
+                    feature = "web"
+                ))]
                 let opening = if let Some(Some(child)) = children_borrow.get(0)
                 {
                     // correctly remove opening <!--<EachItem/>-->
@@ -693,6 +700,7 @@ fn apply_diff<T, EF, V>(
         if opening.previous_sibling().is_none()
             && closing.next_sibling().is_none()
         {
+            crate::log!("clearing");
             let parent = closing
                 .parent_node()
                 .expect("could not get closing node")

--- a/leptos_dom/src/components/each.rs
+++ b/leptos_dom/src/components/each.rs
@@ -700,7 +700,6 @@ fn apply_diff<T, EF, V>(
         if opening.previous_sibling().is_none()
             && closing.next_sibling().is_none()
         {
-            crate::log!("clearing");
             let parent = closing
                 .parent_node()
                 .expect("could not get closing node")


### PR DESCRIPTION
The calculation being used at line 398 was correct for release mode, and both unnecessary and incorrect for debug mode, where we have an explicit opening marker.

This should re-close #1168.