### PR TITLE
feat: add `MaybeProp` type

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -37,7 +37,7 @@ pub use hydration::{HydrationCtx, HydrationKey};
 use leptos_reactive::Scope;
 #[cfg(not(feature = "nightly"))]
 use leptos_reactive::{
-    MaybeSignal, Memo, ReadSignal, RwSignal, Signal, SignalGet,
+    MaybeProp, MaybeSignal, Memo, ReadSignal, RwSignal, Signal, SignalGet,
 };
 pub use logging::*;
 pub use macro_helpers::*;
@@ -199,6 +199,20 @@ where
 }
 #[cfg(not(feature = "nightly"))]
 impl<T> IntoView for MaybeSignal<T>
+where
+    T: IntoView + Clone,
+{
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(level = "trace", name = "MaybeSignal<T>", skip_all)
+    )]
+    fn into_view(self, cx: Scope) -> View {
+        DynChild::new(move || self.get()).into_view(cx)
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+impl<T> IntoView for MaybeProp<T>
 where
     T: IntoView + Clone,
 {

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -875,7 +875,7 @@ pub struct MaybeProp<T: 'static>(Option<MaybeSignal<Option<T>>>);
 
 impl<T: Copy> Copy for MaybeProp<T> {}
 
-impl<T: Default> Default for MaybeProp<T> {
+impl<T> Default for MaybeProp<T> {
     fn default() -> Self {
         Self(None)
     }
@@ -1198,3 +1198,29 @@ impl From<&str> for MaybeProp<String> {
 }
 
 impl_get_fn_traits![Signal, MaybeSignal];
+
+#[cfg(feature = "nightly")]
+impl<T: Clone> FnOnce<()> for MaybeProp<T> {
+    type Output = Option<T>;
+
+    #[inline(always)]
+    extern "rust-call" fn call_once(self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<T: Clone> FnMut<()> for MaybeProp<T> {
+    #[inline(always)]
+    extern "rust-call" fn call_mut(&mut self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<T: Clone> Fn<()> for MaybeProp<T> {
+    #[inline(always)]
+    extern "rust-call" fn call(&self, _args: ()) -> Self::Output {
+        self.get()
+    }
+}

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -1110,12 +1110,12 @@ where
     /// ```rust
     /// # use leptos_reactive::*;
     /// # create_scope(create_runtime(), |cx| {
-    /// let (count, set_count) = create_signal(cx, 2);
-    /// let double_count = Signal::derive(cx, move || count.get() * 2);
+    /// let (count, set_count) = create_signal(cx, Some(2));
+    /// let double_count = Signal::derive(cx, move || count.get().map(|n| n * 2));
     ///
     /// // this function takes any kind of wrapped signal
-    /// fn above_3(arg: &MaybeSignal<i32>) -> bool {
-    ///     arg.get() > 3
+    /// fn above_3(arg: &MaybeProp<i32>) -> bool {
+    ///     arg.get().unwrap_or(0) > 3
     /// }
     ///
     /// assert_eq!(above_3(&count.into()), false);

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -556,6 +556,15 @@ impl<T: Default> Default for MaybeSignal<T> {
 /// # });
 /// ```
 impl<T: Clone> SignalGet<T> for MaybeSignal<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::get()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn get(&self) -> T {
         match self {
             Self::Static(t) => t.clone(),
@@ -563,6 +572,15 @@ impl<T: Clone> SignalGet<T> for MaybeSignal<T> {
         }
     }
 
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::try_get()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn try_get(&self) -> Option<T> {
         match self {
             Self::Static(t) => Some(t.clone()),
@@ -640,6 +658,15 @@ impl<T> SignalWith<T> for MaybeSignal<T> {
 }
 
 impl<T> SignalWithUntracked<T> for MaybeSignal<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::with_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O {
         match self {
             Self::Static(t) => f(t),
@@ -647,6 +674,15 @@ impl<T> SignalWithUntracked<T> for MaybeSignal<T> {
         }
     }
 
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::try_with_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn try_with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
         match self {
             Self::Static(t) => Some(f(t)),
@@ -656,6 +692,15 @@ impl<T> SignalWithUntracked<T> for MaybeSignal<T> {
 }
 
 impl<T: Clone> SignalGetUntracked<T> for MaybeSignal<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::get_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn get_untracked(&self) -> T {
         match self {
             Self::Static(t) => t.clone(),
@@ -663,6 +708,15 @@ impl<T: Clone> SignalGetUntracked<T> for MaybeSignal<T> {
         }
     }
 
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeSignal::try_get_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
     fn try_get_untracked(&self) -> Option<T> {
         match self {
             Self::Static(t) => Some(t.clone()),
@@ -672,6 +726,15 @@ impl<T: Clone> SignalGetUntracked<T> for MaybeSignal<T> {
 }
 
 impl<T: Clone> SignalStream<T> for MaybeSignal<T> {
+    #[cfg_attr(
+    any(debug_assertions, feature = "ssr"),
+    instrument(
+        level = "trace",
+        name = "MaybeSignal::to_stream()",
+        skip_all,
+        fields(ty = %std::any::type_name::<T>())
+    )
+)]
     fn to_stream(
         &self,
         cx: Scope,
@@ -761,6 +824,376 @@ impl<T> From<Signal<T>> for MaybeSignal<T> {
 impl From<&str> for MaybeSignal<String> {
     fn from(value: &str) -> Self {
         Self::Static(value.to_string())
+    }
+}
+
+/// A wrapping type for an optional component prop, which can either be a signal or a
+/// non-reactive value, and which may or may not have a value. In other words, this is
+/// an `Option<MaybeSignal<Option<T>>>` that automatically flattens its getters.
+///
+/// This creates an extremely flexible type for component libraries, etc.
+///
+/// ## Core Trait Implementations
+/// - [`.get()`](#impl-SignalGet<T>-for-MaybeProp<T>) (or calling the signal as a function) clones the current
+///   value of the signal. If you call it within an effect, it will cause that effect
+///   to subscribe to the signal, and to re-run whenever the value of the signal changes.
+///   - [`.get_untracked()`](#impl-SignalGetUntracked<T>-for-MaybeProp<T>) clones the value of the signal
+///   without reactively tracking it.
+/// - [`.with()`](#impl-SignalWith<T>-for-MaybeProp<T>) allows you to reactively access the signal’s value without
+///   cloning by applying a callback function.
+///   - [`.with_untracked()`](#impl-SignalWithUntracked<T>-for-MaybeProp<T>) allows you to access the signal’s
+///   value without reactively tracking it.
+/// - [`.to_stream()`](#impl-SignalStream<T>-for-MaybeProp<T>) converts the signal to an `async` stream of values.
+///
+/// ## Examples
+/// ```rust
+/// # use leptos_reactive::*;
+/// # create_scope(create_runtime(), |cx| {
+/// let (count, set_count) = create_signal(cx, Some(2));
+/// let double = |n| n * 2;
+/// let double_count = MaybeProp::derive(cx, move || count.get().map(double));
+/// let memoized_double_count =
+///     create_memo(cx, move |_| count.get().map(double));
+/// let static_value = 5;
+///
+/// // this function takes either a reactive or non-reactive value
+/// fn above_3(arg: &MaybeProp<i32>) -> bool {
+///     // ✅ calling the signal clones and returns the value
+///     //    it is a shorthand for arg.get()q
+///     arg.get().map(|arg| arg > 3).unwrap_or(false)
+/// }
+///
+/// assert_eq!(above_3(&None::<i32>.into()), false);
+/// assert_eq!(above_3(&static_value.into()), true);
+/// assert_eq!(above_3(&count.into()), false);
+/// assert_eq!(above_3(&double_count), true);
+/// assert_eq!(above_3(&memoized_double_count.into()), true);
+/// # });
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MaybeProp<T: 'static>(Option<MaybeSignal<Option<T>>>);
+
+impl<T: Copy> Copy for MaybeProp<T> {}
+
+impl<T: Default> Default for MaybeProp<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// # use leptos_reactive::*;
+/// # create_scope(create_runtime(), |cx| {
+/// let (count, set_count) = create_signal(cx, Some(2));
+/// let double = |n| n * 2;
+/// let double_count = MaybeProp::derive(cx, move || count.get().map(double));
+/// let memoized_double_count =
+///     create_memo(cx, move |_| count.get().map(double));
+/// let static_value = 5;
+///
+/// // this function takes either a reactive or non-reactive value
+/// fn above_3(arg: &MaybeProp<i32>) -> bool {
+///     // ✅ calling the signal clones and returns the value
+///     //    it is a shorthand for arg.get()q
+///     arg.get().map(|arg| arg > 3).unwrap_or(false)
+/// }
+///
+/// assert_eq!(above_3(&None::<i32>.into()), false);
+/// assert_eq!(above_3(&static_value.into()), true);
+/// assert_eq!(above_3(&count.into()), false);
+/// assert_eq!(above_3(&double_count), true);
+/// assert_eq!(above_3(&memoized_double_count.into()), true);
+/// # });
+/// ```
+impl<T: Clone> SignalGet<Option<T>> for MaybeProp<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::get()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    fn get(&self) -> Option<T> {
+        self.0.as_ref().and_then(|s| s.get())
+    }
+
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::try_get()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    fn try_get(&self) -> Option<Option<T>> {
+        self.0.as_ref().and_then(|s| s.try_get())
+    }
+}
+
+/// # Examples
+///
+/// ```
+/// # use leptos_reactive::*;
+/// # create_scope(create_runtime(), |cx| {
+/// let (name, set_name) = create_signal(cx, Some("Alice".to_string()));
+/// let name_upper = MaybeProp::derive(cx, move || {
+///     name.with(|n| n.as_ref().map(|n| n.to_uppercase()))
+/// });
+/// let memoized_lower = create_memo(cx, move |_| {
+///     name.with(|n| n.as_ref().map(|n| n.to_lowercase()))
+/// });
+/// let static_value: MaybeProp<String> = "Bob".to_string().into();
+///
+/// // this function takes any kind of wrapped signal
+/// fn current_len_inefficient(arg: &MaybeProp<String>) -> usize {
+///     // ❌ unnecessarily clones the string
+///     arg.get().map(|n| n.len()).unwrap_or(0)
+/// }
+///
+/// fn current_len(arg: &MaybeProp<String>) -> usize {
+///     // ✅ gets the length without cloning the `String`
+///     arg.with(|value| value.len()).unwrap_or(0)
+/// }
+///
+/// assert_eq!(current_len(&None::<String>.into()), 0);
+/// assert_eq!(current_len(&name_upper), 5);
+/// assert_eq!(current_len(&memoized_lower.into()), 5);
+/// assert_eq!(current_len(&static_value), 3);
+///
+/// assert_eq!(name.get(), Some("Alice".to_string()));
+/// assert_eq!(name_upper.get(), Some("ALICE".to_string()));
+/// assert_eq!(memoized_lower.get(), Some("alice".to_string()));
+/// assert_eq!(static_value.get(), Some("Bob".to_string()));
+/// # });
+/// ```
+impl<T> MaybeProp<T> {
+    /// Applies a function to the current value, returning the result.
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::with()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
+        self.0
+            .as_ref()
+            .and_then(|inner| inner.with(|value| value.as_ref().map(f)))
+    }
+
+    /// Applies a function to the current value, returning the result. Returns `None`
+    /// if the value has already been disposed.
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::try_with()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    pub fn try_with<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
+        self.0
+            .as_ref()
+            .and_then(|inner| inner.try_with(|value| value.as_ref().map(f)))
+            .flatten()
+    }
+
+    /// Applies a function to the current value, returning the result, without
+    /// causing the current reactive scope to track changes.
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::with_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
+        self.0.as_ref().and_then(|inner| {
+            inner.with_untracked(|value| value.as_ref().map(f))
+        })
+    }
+
+    /// Applies a function to the current value, returning the result, without
+    /// causing the current reactive scope to track changes. Returns `None` if
+    /// the value has already been disposed.
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::try_with_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    pub fn try_with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
+        self.0
+            .as_ref()
+            .and_then(|inner| {
+                inner.try_with_untracked(|value| value.as_ref().map(f))
+            })
+            .flatten()
+    }
+}
+
+impl<T: Clone> SignalGetUntracked<Option<T>> for MaybeProp<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::get_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    fn get_untracked(&self) -> Option<T> {
+        self.0.as_ref().and_then(|inner| inner.get_untracked())
+    }
+
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::try_get_untracked()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    fn try_get_untracked(&self) -> Option<Option<T>> {
+        self.0.as_ref().and_then(|inner| inner.try_get_untracked())
+    }
+}
+
+impl<T: Clone> SignalStream<Option<T>> for MaybeProp<T> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::to_stream()",
+            skip_all,
+            fields(ty = %std::any::type_name::<T>())
+        )
+    )]
+    fn to_stream(
+        &self,
+        cx: Scope,
+    ) -> std::pin::Pin<Box<dyn futures::Stream<Item = Option<T>>>> {
+        match &self.0 {
+            None => Box::pin(futures::stream::once(async move { None })),
+            Some(MaybeSignal::Static(t)) => {
+                let t = t.clone();
+
+                let stream = futures::stream::once(async move { t });
+
+                Box::pin(stream)
+            }
+            Some(MaybeSignal::Dynamic(s)) => s.to_stream(cx),
+        }
+    }
+}
+
+impl<T> MaybeProp<T>
+where
+    T: 'static,
+{
+    /// Wraps a derived signal, i.e., any computation that accesses one or more
+    /// reactive signals.
+    /// ```rust
+    /// # use leptos_reactive::*;
+    /// # create_scope(create_runtime(), |cx| {
+    /// let (count, set_count) = create_signal(cx, 2);
+    /// let double_count = Signal::derive(cx, move || count.get() * 2);
+    ///
+    /// // this function takes any kind of wrapped signal
+    /// fn above_3(arg: &MaybeSignal<i32>) -> bool {
+    ///     arg.get() > 3
+    /// }
+    ///
+    /// assert_eq!(above_3(&count.into()), false);
+    /// assert_eq!(above_3(&double_count.into()), true);
+    /// assert_eq!(above_3(&2.into()), false);
+    /// # });
+    /// ```
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(
+            level = "trace",
+            name = "MaybeProp::derive()",
+            skip_all,
+            fields(
+                cx = ?cx.id,
+                ty = %std::any::type_name::<T>()
+            )
+        )
+    )]
+    pub fn derive(
+        cx: Scope,
+        derived_signal: impl Fn() -> Option<T> + 'static,
+    ) -> Self {
+        Self(Some(MaybeSignal::derive(cx, derived_signal)))
+    }
+}
+
+impl<T> From<T> for MaybeProp<T> {
+    fn from(value: T) -> Self {
+        Self(Some(MaybeSignal::from(Some(value))))
+    }
+}
+
+impl<T> From<Option<T>> for MaybeProp<T> {
+    fn from(value: Option<T>) -> Self {
+        Self(Some(MaybeSignal::from(value)))
+    }
+}
+
+impl<T> From<MaybeSignal<Option<T>>> for MaybeProp<T> {
+    fn from(value: MaybeSignal<Option<T>>) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<T> From<Option<MaybeSignal<Option<T>>>> for MaybeProp<T> {
+    fn from(value: Option<MaybeSignal<Option<T>>>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> From<ReadSignal<Option<T>>> for MaybeProp<T> {
+    fn from(value: ReadSignal<Option<T>>) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl<T> From<RwSignal<Option<T>>> for MaybeProp<T> {
+    fn from(value: RwSignal<Option<T>>) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl<T> From<Memo<Option<T>>> for MaybeProp<T> {
+    fn from(value: Memo<Option<T>>) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl<T> From<Signal<Option<T>>> for MaybeProp<T> {
+    fn from(value: Signal<Option<T>>) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl From<&str> for MaybeProp<String> {
+    fn from(value: &str) -> Self {
+        Self(Some(MaybeSignal::from(Some(value.to_string()))))
     }
 }
 


### PR DESCRIPTION
This adds a `MaybeProp` type, which is essentially a wrapper for `Option<MaybeSignal<Option<T>>>` with a nicer API.

This allows you to define optional props that 
1) may or may not be provided
2) if provided, may be a plain value or a signal
3) if a signal type, may or may not have a value (i.e., are a `Signal<Option<T>>`)

> Implementing `From<_>` for a plain `Signal<T>` type here is possible, but depends on the changes in `0.5.0`, so I'll add it for that release.

```rust
#[component]
pub fn App(cx: Scope) -> impl IntoView {
    let (count, set_count) = create_signal(cx, 5);

    view! { cx,
        <TakesMaybeProp/>
        <TakesMaybeProp maybe=42/>
        <TakesMaybeProp maybe=Signal::derive(cx, move || Some(count.get()))/>
    }
}

#[component]
pub fn TakesMaybeProp(cx: Scope, #[prop(optional, into)] maybe: MaybeProp<i32>) -> impl IntoView {
    // .get() gives you `Option<T>`, replacing `self.as_ref().and_then(|n| n.get())`
    let value: Option<i32> = maybe.get();
    // .with() takes a plain `&T`; returns `None` if the prop isn't present or the inner value is None
    let plus_one = maybe.with(|n: &i32| n + 1);

    view! { cx,
        <p>{maybe}</p>
    }
}
```

Closes #1047.