### PR TITLE
Convenient event handling with slots

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -166,8 +166,8 @@ pub use leptos_dom::{
     },
     html, log, math, mount_to, mount_to_body, nonce, svg, warn, window,
     Attribute, Class, CollectView, Errors, Fragment, HtmlElement,
-    IntoAttribute, IntoClass, IntoEventHandler, IntoProperty, IntoStyle,
-    IntoView, NodeRef, Property, View,
+    IntoAttribute, IntoClass, IntoProperty, IntoStyle, IntoView, NodeRef,
+    Property, View,
 };
 
 /// Types to make it easier to handle errors in your application.

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -166,8 +166,8 @@ pub use leptos_dom::{
     },
     html, log, math, mount_to, mount_to_body, nonce, svg, warn, window,
     Attribute, Class, CollectView, Errors, Fragment, HtmlElement,
-    IntoAttribute, IntoClass, IntoProperty, IntoStyle, IntoView, NodeRef,
-    Property, View,
+    IntoAttribute, IntoClass, IntoEventHandler, IntoProperty, IntoStyle,
+    IntoView, NodeRef, Property, View,
 };
 
 /// Types to make it easier to handle errors in your application.

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -172,6 +172,84 @@ pub trait EventHandler {
     fn attach<T: DOMEventResponder>(self, target: T) -> T;
 }
 
+impl<T, const N: usize> EventHandler for [T; N]
+where
+    T: EventHandler,
+{
+    #[inline]
+    fn attach<R: DOMEventResponder>(self, target: R) -> R {
+        let mut target = target;
+        for item in self {
+            target = item.attach(target);
+        }
+        target
+    }
+}
+
+impl<T> EventHandler for Option<T>
+where
+    T: EventHandler,
+{
+    #[inline]
+    fn attach<R: DOMEventResponder>(self, target: R) -> R {
+        match self {
+            Some(event_handler) => event_handler.attach(target),
+            None => target,
+        }
+    }
+}
+
+macro_rules! tc {
+  ($($ty:ident),*) => {
+    impl<$($ty),*> EventHandler for ($($ty,)*)
+    where
+      $($ty: EventHandler),*
+    {
+      #[inline]
+      fn attach<RES: DOMEventResponder>(self, target: RES) -> RES {
+        ::paste::paste! {
+          let (
+          $(
+            [<$ty:lower>],)*
+          ) = self;
+          $(
+            let target = [<$ty:lower>].attach(target);
+          )*
+          target
+        }
+      }
+    }
+  };
+}
+
+tc!(A);
+tc!(A, B);
+tc!(A, B, C);
+tc!(A, B, C, D);
+tc!(A, B, C, D, E);
+tc!(A, B, C, D, E, F);
+tc!(A, B, C, D, E, F, G);
+tc!(A, B, C, D, E, F, G, H);
+tc!(A, B, C, D, E, F, G, H, I);
+tc!(A, B, C, D, E, F, G, H, I, J);
+tc!(A, B, C, D, E, F, G, H, I, J, K);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X);
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y);
+#[rustfmt::skip]
+tc!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+
 macro_rules! collection_callback {
   {$(
     $collection:ident

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -129,31 +129,44 @@ impl<E: FromWasmAbi> Custom<E> {
 macro_rules! generate_event_types {
   {$(
     $( #[$does_not_bubble:ident] )?
-    $event:ident : $web_sys_event:ident
+    $( $event:ident )+ : $web_event:ident
   ),* $(,)?} => {
-
-    $(
-        #[doc = concat!("The `", stringify!($event), "` event, which receives [", stringify!($web_sys_event), "](web_sys::", stringify!($web_sys_event), ") as its argument.")]
+    ::paste::paste! {
+      $(
+        #[doc = "The `" [< $($event)+ >] "` event, which receives [" $web_event "](web_sys::" $web_event ") as its argument."]
         #[derive(Copy, Clone, Debug)]
         #[allow(non_camel_case_types)]
-        pub struct $event;
+        pub struct [<$( $event )+ >];
 
-        impl EventDescriptor for $event {
-          type EventType = web_sys::$web_sys_event;
+        impl EventDescriptor for [< $($event)+ >] {
+          type EventType = web_sys::$web_event;
 
           #[inline(always)]
           fn name(&self) -> Cow<'static, str> {
-            stringify!($event).into()
+            stringify!([< $($event)+ >]).into()
           }
 
           #[inline(always)]
           fn event_delegation_key(&self) -> Cow<'static, str> {
-            concat!("$$$", stringify!($event)).into()
+            concat!("$$$", stringify!([< $($event)+ >])).into()
           }
 
           const BUBBLES: bool = true $(&& generate_event_types!($does_not_bubble))?;
         }
-    )*
+      )*
+
+      // TODO: figure out what should be done about trait impls like Clone and Debug
+      /// An enum holding all basic event types with their respective handler types.
+      ///
+      /// It currently omits [`Custom`] and [`undelegated`] variants.
+      #[non_exhaustive]
+      pub enum EventHandler {
+        $(
+          #[doc = "Variant mapping [`struct@" [< $($event)+ >] "`] to its event handler type."]
+          [< $($event:camel)+ >]([< $($event)+ >], Box<dyn FnMut($web_event) + 'static>),
+        )*
+      }
+    }
   };
 
   (does_not_bubble) => { false }
@@ -164,36 +177,36 @@ generate_event_types! {
   // WindowEventHandlersEventMap
   // =========================================================
   #[does_not_bubble]
-  afterprint: Event,
+  after print: Event,
   #[does_not_bubble]
-  beforeprint: Event,
+  before print: Event,
   #[does_not_bubble]
-  beforeunload: BeforeUnloadEvent,
+  before unload: BeforeUnloadEvent,
   #[does_not_bubble]
-  gamepadconnected: GamepadEvent,
+  gamepad connected: GamepadEvent,
   #[does_not_bubble]
-  gamepaddisconnected: GamepadEvent,
-  hashchange: HashChangeEvent,
+  gamepad disconnected: GamepadEvent,
+  hash change: HashChangeEvent,
   #[does_not_bubble]
-  languagechange: Event,
+  language change: Event,
   #[does_not_bubble]
   message: MessageEvent,
   #[does_not_bubble]
-  messageerror: MessageEvent,
+  message error: MessageEvent,
   #[does_not_bubble]
   offline: Event,
   #[does_not_bubble]
   online: Event,
   #[does_not_bubble]
-  pagehide: PageTransitionEvent,
+  page hide: PageTransitionEvent,
   #[does_not_bubble]
-  pageshow: PageTransitionEvent,
-  popstate: PopStateEvent,
-  rejectionhandled: PromiseRejectionEvent,
+  page show: PageTransitionEvent,
+  pop state: PopStateEvent,
+  rejection handled: PromiseRejectionEvent,
   #[does_not_bubble]
   storage: StorageEvent,
   #[does_not_bubble]
-  unhandledrejection: PromiseRejectionEvent,
+  unhandled rejection: PromiseRejectionEvent,
   #[does_not_bubble]
   unload: Event,
 
@@ -202,38 +215,38 @@ generate_event_types! {
   // =========================================================
   #[does_not_bubble]
   abort: UiEvent,
-  animationcancel: AnimationEvent,
-  animationend: AnimationEvent,
-  animationiteration: AnimationEvent,
-  animationstart: AnimationEvent,
-  auxclick: MouseEvent,
-  beforeinput: InputEvent,
+  animation cancel: AnimationEvent,
+  animation end: AnimationEvent,
+  animation iteration: AnimationEvent,
+  animation start: AnimationEvent,
+  aux click: MouseEvent,
+  before input: InputEvent,
   #[does_not_bubble]
   blur: FocusEvent,
   #[does_not_bubble]
-  canplay: Event,
+  can play: Event,
   #[does_not_bubble]
-  canplaythrough: Event,
+  can play through: Event,
   change: Event,
   click: MouseEvent,
   #[does_not_bubble]
   close: Event,
-  compositionend: CompositionEvent,
-  compositionstart: CompositionEvent,
-  compositionupdate: CompositionEvent,
-  contextmenu: MouseEvent,
+  composition end: CompositionEvent,
+  composition start: CompositionEvent,
+  composition update: CompositionEvent,
+  context menu: MouseEvent,
   #[does_not_bubble]
-  cuechange: Event,
-  dblclick: MouseEvent,
+  cue change: Event,
+  dbl click: MouseEvent,
   drag: DragEvent,
-  dragend: DragEvent,
-  dragenter: DragEvent,
-  dragleave: DragEvent,
-  dragover: DragEvent,
-  dragstart: DragEvent,
+  drag end: DragEvent,
+  drag enter: DragEvent,
+  drag leave: DragEvent,
+  drag over: DragEvent,
+  drag start: DragEvent,
   drop: DragEvent,
   #[does_not_bubble]
-  durationchange: Event,
+  duration change: Event,
   #[does_not_bubble]
   emptied: Event,
   #[does_not_bubble]
@@ -243,110 +256,110 @@ generate_event_types! {
   #[does_not_bubble]
   focus: FocusEvent,
   #[does_not_bubble]
-  focusin: FocusEvent,
+  focus in: FocusEvent,
   #[does_not_bubble]
-  focusout: FocusEvent,
-  formdata: Event, // web_sys does not include `FormDataEvent`
+  focus out: FocusEvent,
+  form data: Event, // web_sys does not include `FormDataEvent`
   #[does_not_bubble]
-  gotpointercapture: PointerEvent,
+  got pointer capture: PointerEvent,
   input: Event,
   #[does_not_bubble]
   invalid: Event,
-  keydown: KeyboardEvent,
-  keypress: KeyboardEvent,
-  keyup: KeyboardEvent,
+  key down: KeyboardEvent,
+  key press: KeyboardEvent,
+  key up: KeyboardEvent,
   #[does_not_bubble]
   load: Event,
   #[does_not_bubble]
-  loadeddata: Event,
+  loaded data: Event,
   #[does_not_bubble]
-  loadedmetadata: Event,
+  loaded metadata: Event,
   #[does_not_bubble]
-  loadstart: Event,
-  lostpointercapture: PointerEvent,
-  mousedown: MouseEvent,
+  load start: Event,
+  lost pointer capture: PointerEvent,
+  mouse down: MouseEvent,
   #[does_not_bubble]
-  mouseenter: MouseEvent,
+  mouse enter: MouseEvent,
   #[does_not_bubble]
-  mouseleave: MouseEvent,
-  mousemove: MouseEvent,
-  mouseout: MouseEvent,
-  mouseover: MouseEvent,
-  mouseup: MouseEvent,
+  mouse leave: MouseEvent,
+  mouse move: MouseEvent,
+  mouse out: MouseEvent,
+  mouse over: MouseEvent,
+  mouse up: MouseEvent,
   #[does_not_bubble]
   pause: Event,
   #[does_not_bubble]
   play: Event,
   #[does_not_bubble]
   playing: Event,
-  pointercancel: PointerEvent,
-  pointerdown: PointerEvent,
+  pointer cancel: PointerEvent,
+  pointer down: PointerEvent,
   #[does_not_bubble]
-  pointerenter: PointerEvent,
+  pointer enter: PointerEvent,
   #[does_not_bubble]
-  pointerleave: PointerEvent,
-  pointermove: PointerEvent,
-  pointerout: PointerEvent,
-  pointerover: PointerEvent,
-  pointerup: PointerEvent,
+  pointer leave: PointerEvent,
+  pointer move: PointerEvent,
+  pointer out: PointerEvent,
+  pointer over: PointerEvent,
+  pointer up: PointerEvent,
   #[does_not_bubble]
   progress: ProgressEvent,
   #[does_not_bubble]
-  ratechange: Event,
+  rate change: Event,
   reset: Event,
   #[does_not_bubble]
   resize: UiEvent,
   #[does_not_bubble]
   scroll: Event,
   #[does_not_bubble]
-  scrollend: Event,
-  securitypolicyviolation: SecurityPolicyViolationEvent,
+  scroll end: Event,
+  security policy violation: SecurityPolicyViolationEvent,
   #[does_not_bubble]
   seeked: Event,
   #[does_not_bubble]
   seeking: Event,
   select: Event,
   #[does_not_bubble]
-  selectionchange: Event,
-  selectstart: Event,
-  slotchange: Event,
+  selection change: Event,
+  select start: Event,
+  slot change: Event,
   #[does_not_bubble]
   stalled: Event,
   submit: SubmitEvent,
   #[does_not_bubble]
   suspend: Event,
   #[does_not_bubble]
-  timeupdate: Event,
+  time update: Event,
   #[does_not_bubble]
   toggle: Event,
-  touchcancel: TouchEvent,
-  touchend: TouchEvent,
-  touchmove: TouchEvent,
-  touchstart: TouchEvent,
-  transitioncancel: TransitionEvent,
-  transitionend: TransitionEvent,
-  transitionrun: TransitionEvent,
-  transitionstart: TransitionEvent,
+  touch cancel: TouchEvent,
+  touch end: TouchEvent,
+  touch move: TouchEvent,
+  touch start: TouchEvent,
+  transition cancel: TransitionEvent,
+  transition end: TransitionEvent,
+  transition run: TransitionEvent,
+  transition start: TransitionEvent,
   #[does_not_bubble]
-  volumechange: Event,
+  volume change: Event,
   #[does_not_bubble]
   waiting: Event,
-  webkitanimationend: Event,
-  webkitanimationiteration: Event,
-  webkitanimationstart: Event,
-  webkittransitionend: Event,
+  webkit animation end: Event,
+  webkit animation iteration: Event,
+  webkit animation start: Event,
+  webkit transitio nend: Event,
   wheel: WheelEvent,
 
   // =========================================================
   // WindowEventMap
   // =========================================================
-  DOMContentLoaded: Event,
+  D O M Content Loaded: Event, // Hack for correct casing
   #[does_not_bubble]
-  devicemotion: DeviceMotionEvent,
+  device motion: DeviceMotionEvent,
   #[does_not_bubble]
-  deviceorientation: DeviceOrientationEvent,
+  device orientation: DeviceOrientationEvent,
   #[does_not_bubble]
-  orientationchange: Event,
+  orientation change: Event,
 
   // =========================================================
   // DocumentAndElementEventHandlersEventMap
@@ -358,13 +371,13 @@ generate_event_types! {
   // =========================================================
   // DocumentEventMap
   // =========================================================
-  fullscreenchange: Event,
-  fullscreenerror: Event,
-  pointerlockchange: Event,
-  pointerlockerror: Event,
+  fullscreen change: Event,
+  fullscreen error: Event,
+  pointer lock change: Event,
+  pointer lock error: Event,
   #[does_not_bubble]
-  readystatechange: Event,
-  visibilitychange: Event,
+  ready state change: Event,
+  visibility change: Event,
 }
 
 // Export `web_sys` event types

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -31,7 +31,7 @@ pub trait EventDescriptor: Clone {
 
 /// Overrides the [`EventDescriptor::BUBBLES`] value to always return
 /// `false`, which forces the event to not be globally delegated.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[allow(non_camel_case_types)]
 pub struct undelegated<Ev: EventDescriptor>(pub Ev);
 
@@ -52,6 +52,7 @@ impl<Ev: EventDescriptor> EventDescriptor for undelegated<Ev> {
 }
 
 /// A custom event.
+#[derive(Debug)]
 pub struct Custom<E: FromWasmAbi = web_sys::Event> {
     name: Cow<'static, str>,
     options: Option<web_sys::AddEventListenerOptions>,
@@ -133,7 +134,7 @@ macro_rules! generate_event_types {
 
     $(
         #[doc = concat!("The `", stringify!($event), "` event, which receives [", stringify!($web_sys_event), "](web_sys::", stringify!($web_sys_event), ") as its argument.")]
-        #[derive(Copy, Clone)]
+        #[derive(Copy, Clone, Debug)]
         #[allow(non_camel_case_types)]
         pub struct $event;
 
@@ -371,7 +372,7 @@ pub use web_sys::{
     AnimationEvent, BeforeUnloadEvent, CompositionEvent, CustomEvent,
     DeviceMotionEvent, DeviceOrientationEvent, DragEvent, ErrorEvent, Event,
     FocusEvent, GamepadEvent, HashChangeEvent, InputEvent, KeyboardEvent,
-    MouseEvent, PageTransitionEvent, PointerEvent, PopStateEvent,
+    MessageEvent, MouseEvent, PageTransitionEvent, PointerEvent, PopStateEvent,
     ProgressEvent, PromiseRejectionEvent, SecurityPolicyViolationEvent,
     StorageEvent, SubmitEvent, TouchEvent, TransitionEvent, UiEvent,
     WheelEvent,

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -126,14 +126,19 @@ impl<E: FromWasmAbi> Custom<E> {
     }
 }
 
-/// TODO: doc
-pub trait DOMEventResponder {
-    /// TODO: doc
+/// Type that can respond to DOM events
+pub trait DOMEventResponder: Sized {
+    /// Adds handler to specified event
     fn add<E: EventDescriptor + 'static>(
         self,
         event: E,
         handler: impl FnMut(E::EventType) + 'static,
     ) -> Self;
+    /// Same as [add](DOMEventResponder::add), but with [`EventHandler`]
+    #[inline]
+    fn add_handler(self, handler: impl EventHandler) -> Self {
+        handler.attach(self)
+    }
 }
 
 impl<T> DOMEventResponder for crate::HtmlElement<T>
@@ -161,7 +166,7 @@ impl DOMEventResponder for crate::View {
     }
 }
 
-/// TODO: doc
+/// Type that can be used to handle DOM events
 pub trait EventHandler {
     /// Attaches event listener to any type that can respond to DOM events
     fn attach<T: DOMEventResponder>(self, target: T) -> T;

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -347,7 +347,7 @@ generate_event_types! {
   webkit animation end: Event,
   webkit animation iteration: Event,
   webkit animation start: Event,
-  webkit transitio nend: Event,
+  webkit transition end: Event,
   wheel: WheelEvent,
 
   // =========================================================

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -190,21 +190,21 @@ macro_rules! generate_event_types {
       $(
         impl<T> crate::IntoEventHandler for ([< $($event)+ >], T)
         where
-          T: Into<Box<dyn FnMut($web_event) + 'static>>
+          T: FnMut($web_event) + 'static
         {
           #[inline]
           fn into_event_handler(self) -> EventHandler {
-            EventHandler::[< $($event:camel)+ >](self.0, self.1.into())
+            EventHandler::[< $($event:camel)+ >](self.0, Box::new(self.1))
           }
         }
         // TODO: figure out if this is even desirable, could be bit confusing
         impl<T> crate::IntoEventHandler for (T, [< $($event)+ >])
         where
-          T: Into<Box<dyn FnMut($web_event) + 'static>>
+          T: FnMut($web_event) + 'static
         {
           #[inline]
           fn into_event_handler(self) -> EventHandler {
-            EventHandler::[< $($event:camel)+ >](self.1, self.0.into())
+            EventHandler::[< $($event:camel)+ >](self.1, Box::new(self.0))
           }
         }
       )*

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -180,10 +180,27 @@ macro_rules! generate_event_types {
         }
       }
 
+      impl crate::IntoEventHandler for EventHandler {
+        /// Irrelevant, closures are thrown away
+        type EventType = Event;
+        /// Provided closure will be thrown away
+        fn into_event_handler(self, _: impl FnMut(Self::EventType) + 'static) -> EventHandler {
+          self
+        }
+        /// Provided boxed closure will be thrown away
+        fn into_event_handler_boxed(self, _: Box<dyn FnMut(Self::EventType) + 'static>) -> EventHandler {
+          self
+        }
+      }
+
       $(
         impl crate::IntoEventHandler for [< $($event)+ >] {
+          type EventType = <Self as EventDescriptor>::EventType;
           fn into_event_handler(self, handler: impl FnMut(Self::EventType) + 'static) -> EventHandler {
             EventHandler::[< $($event:camel)+ >](self, Box::new(handler))
+          }
+          fn into_event_handler_boxed(self, boxed_handler: Box<dyn FnMut(Self::EventType) + 'static>) -> EventHandler {
+            EventHandler::[< $($event:camel)+ >](self, boxed_handler)
           }
         }
       )*

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -68,23 +68,6 @@ pub trait IntoView {
     fn into_view(self, cx: Scope) -> View;
 }
 
-// Maybe could be converted to single generic From impl
-/// Converts the value into a [`EventHandler`]
-pub trait IntoEventHandler {
-    /// TODO: document
-    type Handler: ev::EventHandler;
-    /// Converts the value into a [`EventHandler`]
-    fn into_event_handler(self) -> Self::Handler;
-}
-
-impl<T: ev::EventHandler> IntoEventHandler for T {
-    type Handler = Self;
-    #[inline]
-    fn into_event_handler(self) -> Self::Handler {
-        self
-    }
-}
-
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 #[doc(hidden)]
 pub trait Mountable {

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -29,6 +29,7 @@ pub use components::*;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub use events::add_event_helper;
 pub use events::typed as ev;
+pub use events::typed::EventHandler;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 use events::{add_event_listener, add_event_listener_undelegated};
 pub use html::HtmlElement;
@@ -66,6 +67,15 @@ thread_local! {
 pub trait IntoView {
     /// Converts the value into [`View`].
     fn into_view(self, cx: Scope) -> View;
+}
+
+/// Converts the value into a [`EventHandler`]
+pub trait IntoEventHandler: ev::EventDescriptor {
+    /// Converts the value into a [`EventHandler`]
+    fn into_event_handler(
+        self,
+        handler: impl FnMut(Self::EventType) + 'static,
+    ) -> EventHandler;
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -70,20 +70,8 @@ pub trait IntoView {
 
 /// Converts the value into a [`EventHandler`]
 pub trait IntoEventHandler {
-    /// Type of event that handler takes
-    type EventType;
-
     /// Converts the value into a [`EventHandler`]
-    fn into_event_handler(
-        self,
-        handler: impl FnMut(Self::EventType) + 'static,
-    ) -> EventHandler;
-
-    /// Converts the value into a [`EventHandler`] using boxed closure
-    fn into_event_handler_boxed(
-        self,
-        boxed_handler: Box<dyn FnMut(Self::EventType) + 'static>,
-    ) -> EventHandler;
+    fn into_event_handler(self) -> EventHandler;
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -28,10 +28,9 @@ use cfg_if::cfg_if;
 pub use components::*;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub use events::add_event_helper;
-pub use events::typed as ev;
-pub use events::typed::EventHandler;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 use events::{add_event_listener, add_event_listener_undelegated};
+pub use events::{typed as ev, typed::EventHandler};
 pub use html::HtmlElement;
 use html::{AnyElement, ElementDescriptor};
 pub use hydration::{HydrationCtx, HydrationKey};
@@ -70,11 +69,20 @@ pub trait IntoView {
 }
 
 /// Converts the value into a [`EventHandler`]
-pub trait IntoEventHandler: ev::EventDescriptor {
+pub trait IntoEventHandler {
+    /// Type of event that handler takes
+    type EventType;
+
     /// Converts the value into a [`EventHandler`]
     fn into_event_handler(
         self,
         handler: impl FnMut(Self::EventType) + 'static,
+    ) -> EventHandler;
+
+    /// Converts the value into a [`EventHandler`] using boxed closure
+    fn into_event_handler_boxed(
+        self,
+        boxed_handler: Box<dyn FnMut(Self::EventType) + 'static>,
     ) -> EventHandler;
 }
 

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -68,10 +68,21 @@ pub trait IntoView {
     fn into_view(self, cx: Scope) -> View;
 }
 
+// Maybe could be converted to single generic From impl
 /// Converts the value into a [`EventHandler`]
 pub trait IntoEventHandler {
+    /// TODO: document
+    type Handler: ev::EventHandler;
     /// Converts the value into a [`EventHandler`]
-    fn into_event_handler(self) -> EventHandler;
+    fn into_event_handler(self) -> Self::Handler;
+}
+
+impl<T: ev::EventHandler> IntoEventHandler for T {
+    type Handler = Self;
+    #[inline]
+    fn into_event_handler(self) -> Self::Handler {
+        self
+    }
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]


### PR DESCRIPTION
Hello,

apart from fixing missing reexport I noticed two things:

1. Many struct structs and enums are missing Debug impl
2. There isn't a straightforward way to bundle events with handlers into collection

Is there a reason for not adding Debug? And if not, can I sprinkle in few `#[derive(Debug)]`s?

And as for what I mean by 2, I would like to create some collection to hold different event listeners to be used later:

```rust
#[slot]
pub struct Input {
    #[prop(default = "text".into())]
    itype: TextProp,
    // Event listeners with different types, like input and click
    listeners: Vec<EventListener>
}

#[component]
pub fn FancyForm(cx: Scope, input: Vec<Input>) -> impl IntoView {
    // Attach event listeners to inputs
}
```

However, only way to use EventListener with different types (as far as I know) is to create an enum holding all possible variants. Can I modify generate_event_types macro to also generate this enum, or would that be counterproductive?

```rust
// Something like this
pub enum EventListener {
    Abort(abort, Box<dyn FnMut(UiEvent) + 'static>),
    Input(input, Box<dyn FnMut(Event) + 'static>),
    // And so on, with possible helper IntoEventListener trait
}
```