### PR TITLE
perf(examples): speed up the test-info report (#1446)

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -48,9 +48,9 @@ jq -R -s -c 'split("\n")[:-1]')
 echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 '''
 
-[tasks.test-info]
+[tasks.test-runner-report]
 workspace = false
-description = "report ci test runners for each example - Option [all]"
+description = "report ci test runners for each example - OPTION: [all]"
 script = '''
 BOLD="\e[1m"
 GREEN="\e[0;32m"
@@ -59,63 +59,53 @@ YELLOW="\e[0;33m"
 RESET="\e[0m"
 
 echo
-echo "${YELLOW}CI test runners by example...${RESET}"
+echo "${YELLOW}Test Runner Report${RESET}"
+echo "${ITALIC}Pass the option \"all\" to show all the examples${RESET}"
 echo
 
-examples=$(ls | 
-grep -v README.md | 
-grep -v Makefile.toml | 
-grep -v cargo-make | 
-grep -v gtk |
-sort -u | 
-awk '{print $0 ", "}')
+makefile_paths=$(find . -name Makefile.toml -not -path '*/target/*' |
+  sed 's%./%%' |
+  sed 's%/Makefile.toml%%' |
+  grep -v Makefile.toml |
+  sort -u)
 
-example_root_dir=$(pwd)
+start_path=$(pwd)
 
-for example_dir in $examples
-do
-  clean_name=$(echo $example_dir | sed 's%,%%')
-  cd $clean_name
-
-  c_tests=$(grep -rl --fixed-strings "#[test]" | wc -l)
-  rs_tests=$(grep -rl --fixed-strings "#[rstest]" | wc -l)
-  w_configs=$(grep -rl "\/wasm-test.toml\"" | wc -l)
-  pw_configs=$(grep -rl "\/playwright-test.toml\"" | wc -l)
-  cl_configs=$(grep -rl "\/cargo-leptos-test.toml\"" | wc -l)
+for path in $makefile_paths; do
+  cd $path
 
   test_runner=
 
-  if [ $c_tests -gt 0 ]; then
+  test_count=$(grep -rl -E "#\[(test|rstest)\]" | wc -l)
+  if [ $test_count -gt 0 ]; then
     test_runner="-C"
   fi
 
-  if [ $rs_tests -gt 0 ]; then
-    test_runner=$test_runner"-R"
-  fi
+  while read -r line; do
+    case $line in
+      *"wasm-test.toml"*)
+          test_runner=$test_runner"-W"
+        ;;
+      *"playwright-test.toml"*)
+          test_runner=$test_runner"-P"
+        ;;
+      *"cargo-leptos-test.toml"*)
+          test_runner=$test_runner"-L"
+        ;;
+    esac
+  done <"./Makefile.toml"
 
-  if [ $w_configs -gt 0 ]; then
-    test_runner=$test_runner"-W"
-  fi
-
-  if [ $pw_configs -gt 0 ]; then
-    test_runner=$test_runner"-P"
-  fi
-
-  if [ $cl_configs -gt 0 ]; then
-    test_runner=$test_runner"-L"
-  fi
-  
   if [ ! -z "$1" ]; then
     # Show all examples
-    echo "$clean_name ${BOLD}${test_runner}${RESET}"
+    echo "$path ${BOLD}${test_runner}${RESET}"
   elif [ ! -z $test_runner ]; then
     # Filter out examples that do not run tests in `ci`
-    echo "$clean_name ${BOLD}${test_runner}${RESET}"
+    echo "$path ${BOLD}${test_runner}${RESET}"
   fi
 
-  cd $example_root_dir
+  cd ${start_path}
 done
 echo
-echo "${ITALIC}Test Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, R = RS Test, W = WASM Test${RESET}"
+echo "${ITALIC}Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, W = WASM Test${RESET}"
 echo
 '''


### PR DESCRIPTION
Fix #1446

### Changes

- Refactor to do less work (_now runs in a 1/5 of the time_)
- Rename `test-info` task as `test-runner-report`
- Report the RS Tests as Cargo Tests (_no need to separate them_)
- Add instructions to show all examples

### Verification

1. Run `cargo make test-runner-task` from the `examples` directory
2. See a report similar to the following...
```rust
Test Runner Report
Pass the option "all" to show all the examples

animated_show -C
counter -W
counters -C-W
counters_stable -C-W-P
counter_without_macros -C-W
js-framework-benchmark -C-W
router -P
tailwind -L
todo_app_sqlite -C

Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, W = WASM Test
```