### PR TITLE
Add render_route functions to respect SsrMode on routes when using custom handlers

### DIFF
--- a/examples/session_auth_axum/src/main.rs
+++ b/examples/session_auth_axum/src/main.rs
@@ -33,7 +33,8 @@ if #[cfg(feature = "ssr")] {
     }
 
     async fn leptos_routes_handler(auth_session: AuthSession, State(app_state): State<AppState>, req: Request<AxumBody>) -> Response{
-            let handler = leptos_axum::render_app_to_stream_with_context(app_state.leptos_options.clone(),
+            let handler = leptos_axum::render_route_with_context(app_state.leptos_options.clone(),
+            app_state.routes.clone(),
             move || {
                 provide_context(auth_session.clone());
                 provide_context(app_state.pool.clone());
@@ -84,6 +85,7 @@ if #[cfg(feature = "ssr")] {
         let app_state = AppState{
             leptos_options,
             pool: pool.clone(),
+            routes: routes.clone(),
         };
 
         // build our application with a route

--- a/examples/session_auth_axum/src/state.rs
+++ b/examples/session_auth_axum/src/state.rs
@@ -5,13 +5,14 @@ cfg_if! {
 use leptos::LeptosOptions;
 use sqlx::SqlitePool;
 use axum::extract::FromRef;
-
+use leptos_router::RouteListing;
 /// This takes advantage of Axum's SubStates feature by deriving FromRef. This is the only way to have more than one
 /// item in Axum's State. Leptos requires you to have leptosOptions in your State struct for the leptos route handlers
 #[derive(FromRef, Debug, Clone)]
 pub struct AppState{
     pub leptos_options: LeptosOptions,
-    pub pool: SqlitePool
+    pub pool: SqlitePool,
+    pub routes: Vec<RouteListing>,
 }
     }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -419,6 +419,7 @@ pub fn render_app_to_stream<IV>(
             + Send
             + 'static,
     >>
+       + Clone
        + Send
        + 'static
 where

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -418,8 +418,8 @@ pub fn render_app_to_stream<IV>(
         dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>>
             + Send
             + 'static,
-    >>
-       + Clone
+    >,
+> + Clone
        + Send
        + 'static
 where
@@ -442,17 +442,17 @@ pub fn render_route<IV>(
     Request<Body>,
 ) -> Pin<
     Box<
-        dyn Future<Output=Response<StreamBody<PinnedHtmlStream>>>
-        + Send
-        + 'static,
+        dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>>
+            + Send
+            + 'static,
     >,
 > + Clone
-+ Send
-+ 'static
-    where
-        IV: IntoView,
+       + Send
+       + 'static
+where
+    IV: IntoView,
 {
-    render_route_with_context(options, paths,|| {}, app_fn)
+    render_route_with_context(options, paths, || {}, app_fn)
 }
 /// Returns an Axum [Handler](axum::handler::Handler) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an in-order HTML stream of your application.
@@ -596,14 +596,14 @@ pub fn render_route_with_context<IV>(
 ) -> Pin<
     Box<
         dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>>
-        + Send
-        + 'static,
+            + Send
+            + 'static,
     >,
 > + Clone
-+ Send
-+ 'static
-    where
-        IV: IntoView,
+       + Send
+       + 'static
+where
+    IV: IntoView,
 {
     let ooo = render_app_to_stream_with_context(
         LeptosOptions::from_ref(&options),
@@ -1007,8 +1007,13 @@ pub fn render_app_async_stream_with_context<IV>(
     app_fn: impl Fn() -> IV + Clone + Send + 'static,
 ) -> impl Fn(
     Request<Body>,
-) -> Pin<Box<dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>> + Send + 'static>>
-       + Clone
+) -> Pin<
+    Box<
+        dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>>
+            + Send
+            + 'static,
+    >,
+> + Clone
        + Send
        + 'static
 where
@@ -1073,9 +1078,10 @@ where
                 let complete_stream =
                     futures::stream::iter([Ok(Bytes::from(html))]);
 
-                let mut res = Response::new(StreamBody::new(
-                    Box::pin(complete_stream) as PinnedHtmlStream
-                ));
+                let mut res = Response::new(StreamBody::new(Box::pin(
+                    complete_stream,
+                )
+                    as PinnedHtmlStream));
                 if let Some(status) = res_options.status {
                     *res.status_mut() = status
                 }
@@ -1122,11 +1128,11 @@ pub fn render_app_async_with_context<IV>(
 ) -> impl Fn(
     Request<Body>,
 ) -> Pin<Box<dyn Future<Output = Response<String>> + Send + 'static>>
-+ Clone
-+ Send
-+ 'static
-    where
-        IV: IntoView,
+       + Clone
+       + Send
+       + 'static
+where
+    IV: IntoView,
 {
     move |req: Request<Body>| {
         Box::pin({

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -579,13 +579,6 @@ where
         false,
     )
 }
-trait NewTrait: std::ops::Fn(http::Request<hyper::Body>) -> Pin<
-    Box<
-        dyn Future<Output = Response<StreamBody<PinnedHtmlStream>>>
-        + Send
-        + 'static,
-    >,
-> + Clone{}
 /// Returns an Axum [Handler](axum::handler::Handler) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application. It allows you
 /// to pass in a context function with additional info to be made available to the app


### PR DESCRIPTION
Created render_route() and render_route_with_context() so that people can use custom handlers and SsrModes together in the Axum integration