### PR TITLE
fix: `AnimatedShow` - possible panic on cleanup

### DIFF
--- a/leptos/src/animated_show.rs
+++ b/leptos/src/animated_show.rs
@@ -98,7 +98,7 @@ pub fn AnimatedShow(
     });
 
     on_cleanup(cx, move || {
-        if let Some(h) = handle.get_value() {
+        if let Ok(Some(h)) = handle.try_get_value() {
             h.clear();
         }
     });

--- a/leptos/src/animated_show.rs
+++ b/leptos/src/animated_show.rs
@@ -98,7 +98,7 @@ pub fn AnimatedShow(
     });
 
     on_cleanup(cx, move || {
-        if let Ok(Some(h)) = handle.try_get_value() {
+        if let Some(Some(h)) = handle.try_get_value() {
             h.clear();
         }
     });


### PR DESCRIPTION
This is a very tiny bugfix for the `AnimatedShow` component.
When you use the `AnimatedShow` component together with `AnimatedRoutes`, you could create a panic in the `on_cleanup` function. If you start a hide animation with the `AnimatedShow` and then start a route change on the client side at the same time before the hide animation was finished, you could end up in a situation where the context is already disposed for the `on_cleanup` inside the `AnimatedShow` while the route switching animation is still running, which throws a panic in the browsers console.