### PR TITLE
fix: properly replace text nodes in DynChild (closes #1456)

### DIFF
--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -228,6 +228,10 @@ where
                                         .unchecked_ref::<web_sys::Text>()
                                         .set_data(&new_t.content);
 
+                                    let new_child = View::Text(crate::Text {
+                                        node: prev_t.clone(),
+                                        content: new_t.content.clone(),
+                                    });
                                     **child_borrow = Some(new_child);
 
                                     (Some(prev_t), disposer)

--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -222,20 +222,31 @@ where
                         // node
                         let ret = if let Some(prev_t) = prev_t {
                             // Here, our child is also a text node
-                            if let Some(new_t) = new_child.get_text() {
+
+                            // nb: the match/ownership gymnastics here
+                            // are so that, if we can reuse the text node,
+                            // we can take ownership of new_t so we don't clone
+                            // the contents, which in O(n) on the length of the text
+                            if matches!(new_child, View::Text(_)) {
                                 if !was_child_moved && child != new_child {
+                                    let mut new_t = match new_child {
+                                        View::Text(t) => t,
+                                        _ => unreachable!(),
+                                    };
                                     prev_t
                                         .unchecked_ref::<web_sys::Text>()
                                         .set_data(&new_t.content);
 
-                                    let new_child = View::Text(crate::Text {
-                                        node: prev_t.clone(),
-                                        content: new_t.content.clone(),
-                                    });
+                                    // replace new_t's text node with the prev node
+                                    // see discussion: https://github.com/leptos-rs/leptos/pull/1472
+                                    new_t.node = prev_t.clone();
+
+                                    let new_child = View::Text(new_t);
                                     **child_borrow = Some(new_child);
 
                                     (Some(prev_t), disposer)
                                 } else {
+                                    let new_t = new_child.as_text().unwrap();
                                     mount_child(
                                         MountKind::Before(&closing),
                                         &new_child,


### PR DESCRIPTION
fix #1456

In release mode, the `DynChild` (like many elements) uses the opening node of its child as its opening node. It also has a "previous text" optimization which, if you're replacing a text node with a new text node, reuses the previous node and sets its data, rather than replacing it with the new node. This is slightly but measurably faster.

However, while it was reusing the previous text node for what was mounted in the DOM, it was still passing the new text node in as the text-node part of the new child. This meant that, if the first child of a DynChild was a text node, if it was edited and then removed it would actually end up moving *both* text nodes back into the `DocumentFragment` and subsequently into the DOM.

This should fix that issue.