### PR TITLE
fix: compile-time regression for deeply-nested component trees

### DIFF
--- a/leptos_macro/src/view.rs
+++ b/leptos_macro/src/view.rs
@@ -1712,8 +1712,10 @@ pub(crate) fn component_to_tokens(
         )
     };
 
-    #[cfg(debug_assertions)]
-    IdeTagHelper::add_component_completion(&mut component, node);
+    // (Temporarily?) removed
+    // See note on the function itself below.
+    /* #[cfg(debug_assertions)]
+    IdeTagHelper::add_component_completion(cx, &mut component, node); */
 
     if events.is_empty() {
         component
@@ -2110,6 +2112,19 @@ impl IdeTagHelper {
         }
     }
 
+    /* This has been (temporarily?) removed.
+     * Its purpose was simply to add syntax highlighting and IDE hints for
+     * component closing tags in debug mode by associating the closing tag
+     * ident with the component function.
+     *
+     * Doing this in a way that correctly inferred types, however, required
+     * duplicating the entire component constructor.
+     *
+     * In view trees with many nested components, this led to a massive explosion
+     * in compile times.
+     *
+     * See https://github.com/leptos-rs/leptos/issues/1283
+     *
     /// Add completion to the closing tag of the component.
     ///
     /// In order to ensure that generics are passed through correctly in the
@@ -2126,22 +2141,21 @@ impl IdeTagHelper {
     /// ```
     #[cfg(debug_assertions)]
     pub fn add_component_completion(
+        cx: &Ident,
         component: &mut TokenStream,
         node: &NodeElement,
     ) {
         // emit ide helper info
-        if node.close_tag.is_some() {
-            let constructor = component.clone();
+        if let Some(close_tag) = node.close_tag.as_ref().map(|c| &c.name) {
             *component = quote! {
-                if false {
-                    #[allow(unreachable_code)]
-                    #constructor
-                } else {
-                    #component
+                {
+                    let #close_tag = |cx| #component;
+                    #close_tag(#cx)
                 }
             }
         }
     }
+     */
 
     /// Returns `syn::Path`-like `TokenStream` to the fn in docs.
     /// If tag name is `Component` returns `None`.


### PR DESCRIPTION
This removes a section of the view macro whose purpose was to add syntax highlighting and IDE hints for component closing tags in debug mode by associating the closing tag ident with the component function.
 
Doing this in a way that correctly inferred types, however, required duplicating the entire component constructor.

In view trees with many nested components, this led to a massive explosion in compile times.

It may be possible to do this correctly some other way, but I think other changes in the commit that caused this (namely, changes that made it possible to call no-prop components as no-argument functions) make it more difficult.

Closes #1283.