### PR TITLE
fix: correctly escape HTML in DynChild text nodes

### DIFF
--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -405,11 +405,14 @@ impl View {
         self,
         dont_escape_text: bool,
     ) -> Cow<'static, str> {
+        println!("render_to_string_helper {:?}", self);
         match self {
             View::Text(node) => {
                 if dont_escape_text {
+                    println!("don't escape {:?}", node.content);
                     node.content
                 } else {
+                    println!("encode_safe {:?}", node.content);
                     html_escape::encode_safe(&node.content).to_string().into()
                 }
             }
@@ -492,9 +495,17 @@ impl View {
                                     // browser create the dynamic text as it's own text node
                                     if let View::Text(t) = child {
                                         if !cfg!(debug_assertions) {
-                                            format!("<!>{}", t.content).into()
+                                            format!(
+                                                "<!>{}",
+                                                html_escape::encode_safe(
+                                                    &t.content
+                                                )
+                                            )
+                                            .into()
                                         } else {
-                                            t.content
+                                            html_escape::encode_safe(&t.content)
+                                                .to_string()
+                                                .into()
                                         }
                                     } else {
                                         child.render_to_string_helper(

--- a/leptos_dom/src/ssr_in_order.rs
+++ b/leptos_dom/src/ssr_in_order.rs
@@ -438,12 +438,16 @@ impl View {
                                                     StreamChunk::Sync(
                                                         format!(
                                                             "<!>{}",
-                                                            content
+                                                            html_escape::encode_safe(
+                                                                &content
+                                                            )
                                                         )
                                                         .into(),
                                                     )
                                                 } else {
-                                                    StreamChunk::Sync(content)
+                                                    StreamChunk::Sync(html_escape::encode_safe(
+                                                        &content
+                                                    ).to_string().into())
                                                 },
                                             );
                                         } else {


### PR DESCRIPTION
See comment on #1475: `move || some_script.get()` was inadvertently not being escaped, allowing script injection.