### PR TITLE
Tell where the source is

### DIFF
--- a/docs/book/src/01_introduction.md
+++ b/docs/book/src/01_introduction.md
@@ -17,5 +17,4 @@ understand Leptos.
 
 You can find more detailed docs for each part of the API at [Docs.rs](https://docs.rs/leptos/latest/leptos/).
 
-**The guide is a work in progress.**
-( [`source`](https://github.com/leptos-rs/leptos/tree/main/docs/book) )
+> The source code for the book is available [here](https://github.com/leptos-rs/leptos/tree/main/docs/book). PRs for typos or clarification are always welcome.

--- a/docs/book/src/01_introduction.md
+++ b/docs/book/src/01_introduction.md
@@ -18,3 +18,4 @@ understand Leptos.
 You can find more detailed docs for each part of the API at [Docs.rs](https://docs.rs/leptos/latest/leptos/).
 
 **The guide is a work in progress.**
+( [`source`](https://github.com/leptos-rs/leptos/tree/main/docs/book) )


### PR DESCRIPTION
Prevent that contributors need to search
which of several git repositories of the Leptos project contains the source of what they are feeling to need changing.