### PR TITLE
rkyv `copy` feature is now only enabled if nightly feature is enabled

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -17,7 +17,6 @@ miniserde = { version = "0.1", optional = true }
 rkyv = { version = "0.7.39", features = [
   "validation",
   "uuid",
-  "copy",
   "strict",
 ], optional = true }
 bytecheck = { version = "0.7", features = [
@@ -68,7 +67,7 @@ hydrate = [
   "dep:web-sys",
 ]
 ssr = ["dep:tokio"]
-nightly = []
+nightly = ["rkyv?/copy"]
 serde = []
 serde-lite = ["dep:serde-lite"]
 miniserde = ["dep:miniserde"]


### PR DESCRIPTION
There is a slight problem with rkyv dependency. Leptos Reactive seems to request copy feature here: 
https://github.com/leptos-rs/leptos/blob/2f860b37bd1e76ef9ced15ce1d99e2055c1c426b/leptos_reactive/Cargo.toml#L20

The copy feature requires nightly therefore making it impossible to use stable Leptos with `rkyv`:
https://github.com/rkyv/rkyv/blob/bf39dbc3a61783774fc7e1d47b8bf75db2581be7/rkyv/src/lib.rs#L117

This PR makes `rkyv` `copy` feature only available on nightly.