### PR TITLE
fix: render empty dynamic text node in HTML as ` ` (closes #1382)

### DIFF
--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -483,26 +483,36 @@ impl View {
                             true,
                             Box::new(move || {
                                 if let Some(child) = *child {
-                                    // On debug builds, `DynChild` has two marker nodes,
-                                    // so there is no way for the text to be merged with
-                                    // surrounding text when the browser parses the HTML,
-                                    // but in release, `DynChild` only has a trailing marker,
-                                    // and the browser automatically merges the dynamic text
-                                    // into one single node, so we need to artificially make the
-                                    // browser create the dynamic text as it's own text node
                                     if let View::Text(t) = child {
-                                        if !cfg!(debug_assertions) {
-                                            format!(
-                                                "<!>{}",
-                                                html_escape::encode_safe(
-                                                    &t.content
-                                                )
-                                            )
-                                            .into()
+                                        // if we don't check if the string is empty,
+                                        // the HTML is an empty string; but an empty string
+                                        // is not a text node in HTML, so can't be updated
+                                        // in the future. so we put a one-space text node instead
+                                        let was_empty = t.content.is_empty();
+                                        let content = if was_empty {
+                                            " ".into()
                                         } else {
-                                            html_escape::encode_safe(&t.content)
+                                            t.content
+                                        };
+                                        // escape content unless we're in a <script> or <style>
+                                        let content = if dont_escape_text {
+                                            content
+                                        } else {
+                                            html_escape::encode_safe(&content)
                                                 .to_string()
                                                 .into()
+                                        };
+                                        // On debug builds, `DynChild` has two marker nodes,
+                                        // so there is no way for the text to be merged with
+                                        // surrounding text when the browser parses the HTML,
+                                        // but in release, `DynChild` only has a trailing marker,
+                                        // and the browser automatically merges the dynamic text
+                                        // into one single node, so we need to artificially make the
+                                        // browser create the dynamic text as it's own text node
+                                        if !cfg!(debug_assertions) {
+                                            format!("<!>{content}",).into()
+                                        } else {
+                                            content
                                         }
                                     } else {
                                         child.render_to_string_helper(


### PR DESCRIPTION
Rendering an empty string to HTML currently renders it as ``, i.e., an empty string. This is fine but makes it impossible to hydrate, because `` in HTML doesn't become an empty text node in the DOM; it simply doesn't exist. 

This PR instead renders it as ` `, i.e., a string with a single space. Because it will be wrapped in comments in debug mode (and has an extra comment inserted before it in release mode to separate it from other surrounding text nodes), this should not display but can be hydrated correctly.

This may cause layout issues but only in cases where whitespace is preformatted.

This should fix the panics described in #1382.