### PR TITLE
tracing component property

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -31,6 +31,7 @@ smallvec = "1"
 tracing = "0.1"
 wasm-bindgen = { version = "0.2", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.31"
+serde = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/leptos_dom/src/macro_helpers/mod.rs
+++ b/leptos_dom/src/macro_helpers/mod.rs
@@ -2,6 +2,9 @@ mod into_attribute;
 mod into_class;
 mod into_property;
 mod into_style;
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+pub mod tracing_property;
 pub use into_attribute::*;
 pub use into_class::*;
 pub use into_property::*;

--- a/leptos_dom/src/macro_helpers/mod.rs
+++ b/leptos_dom/src/macro_helpers/mod.rs
@@ -2,7 +2,6 @@ mod into_attribute;
 mod into_class;
 mod into_property;
 mod into_style;
-#[cfg(debug_assertions)]
 #[doc(hidden)]
 pub mod tracing_property;
 pub use into_attribute::*;

--- a/leptos_dom/src/macro_helpers/tracing_property.rs
+++ b/leptos_dom/src/macro_helpers/tracing_property.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::UnwrapThrowExt;
 
-#[cfg_attr(debug_assertions, macro_export)]
+#[macro_export]
 /// Use for tracing property
 macro_rules! tracing_props {
     () => {

--- a/leptos_dom/src/macro_helpers/tracing_property.rs
+++ b/leptos_dom/src/macro_helpers/tracing_property.rs
@@ -68,3 +68,99 @@ impl<T> DefaultMatch for Match<&T> {
         )
     }
 }
+
+#[test]
+fn match_primitive() {
+    // String
+    let test = String::from("string");
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": "string"}"#);
+
+    // &str
+    let test = "string";
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": "string"}"#);
+
+    // u128
+    let test: u128 = 1;
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": 1}"#);
+
+    // i128
+    let test: i128 = -1;
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": -1}"#);
+
+    // f64
+    let test = 3.14;
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": 3.14}"#);
+
+    // bool
+    let test = true;
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": true}"#);
+}
+
+#[test]
+fn match_serialize() {
+    use serde::Serialize;
+    #[derive(Serialize)]
+    struct CustomStruct {
+        field: &'static str,
+    }
+
+    let test = CustomStruct { field: "field" };
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(prop, r#"{"name": "test", "value": {"field":"field"}}"#);
+    // Verification of ownership
+    assert_eq!(test.field, "field");
+}
+
+#[test]
+fn match_no_serialize() {
+    struct CustomStruct {
+        field: &'static str,
+    }
+
+    let test = CustomStruct { field: "field" };
+    let prop = (&&Match {
+        name: stringify! {test},
+        value: std::cell::Cell::new(Some(&test)),
+    })
+        .spez();
+    assert_eq!(
+        prop,
+        r#"{"name": "test", "error": "The trait `serde::Serialize` is not implemented"}"#
+    );
+    // Verification of ownership
+    assert_eq!(test.field, "field");
+}

--- a/leptos_dom/src/macro_helpers/tracing_property.rs
+++ b/leptos_dom/src/macro_helpers/tracing_property.rs
@@ -1,0 +1,70 @@
+use wasm_bindgen::UnwrapThrowExt;
+
+#[cfg_attr(debug_assertions, macro_export)]
+/// Use for tracing property
+macro_rules! tracing_props {
+    () => {
+        ::leptos::leptos_dom::tracing::span!(
+            ::leptos::leptos_dom::tracing::Level::INFO,
+            "leptos_dom::tracing_props",
+            props = String::from("[]")
+        );
+    };
+    ($($prop:tt),+ $(,)?) => {
+        {
+            use ::leptos::leptos_dom::tracing_property::{Match, SerializeMatch, DefaultMatch};
+            let mut props = String::from('[');
+            $(
+                let prop = (&&Match {
+                    name: stringify!{$prop},
+                    value: std::cell::Cell::new(Some(&$prop))
+                }).spez();
+                props.push_str(&format!("{prop},"));
+            )*
+            props.pop();
+            props.push(']');
+            ::leptos::leptos_dom::tracing::span!(
+                ::leptos::leptos_dom::tracing::Level::INFO,
+                "leptos_dom::tracing_props",
+                props
+            );
+        }
+    };
+}
+
+// Implementation based on spez
+// see https://github.com/m-ou-se/spez
+
+pub struct Match<T> {
+    pub name: &'static str,
+    pub value: std::cell::Cell<Option<T>>,
+}
+
+pub trait SerializeMatch {
+    type Return;
+    fn spez(&self) -> Self::Return;
+}
+impl<T: serde::Serialize> SerializeMatch for &Match<&T> {
+    type Return = String;
+    fn spez(&self) -> Self::Return {
+        let name = self.name;
+        serde_json::to_string(self.value.get().unwrap_throw()).map_or_else(
+            |err| format!(r#"{{"name": "{name}", "error": "{err}"}}"#),
+            |value| format!(r#"{{"name": "{name}", "value": {value}}}"#),
+        )
+    }
+}
+
+pub trait DefaultMatch {
+    type Return;
+    fn spez(&self) -> Self::Return;
+}
+impl<T> DefaultMatch for Match<&T> {
+    type Return = String;
+    fn spez(&self) -> Self::Return {
+        let name = self.name;
+        format!(
+            r#"{{"name": "{name}", "error": "The trait `serde::Serialize` is not implemented"}}"#
+        )
+    }
+}


### PR DESCRIPTION
Use for tracing component property.

![截屏2023-08-13 01 45 16](https://github.com/leptos-rs/leptos/assets/48741584/58a19a4f-148e-48d4-bf36-561877c327e4)

Returns a json value when the property is serializable.  If serialization is not possible, the reason for the failure is returned.
