### PR TITLE
chore: fixed lint warning seen while running ```cargo doc```

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -721,7 +721,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// ```
 ///
 /// /// Here are some important details about how slots work within the framework:
-/// 1. Most of the same rules from [component](crate::component!) macro should also be followed on slots.
+/// 1. Most of the same rules from [`macro@component`] macro should also be followed on slots.
 ///
 /// 2. Specifying only `slot` without a name (such as in `<HelloSlot slot>`) will default the chosen slot to
 /// the a snake case version of the slot struct name (`hello_slot` for `<HelloSlot>`).
@@ -829,7 +829,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// #[server(ReadPosts, "/api")]
 /// pub async fn read_posts(how_many: u8, query: String) -> Result<Vec<Post>, ServerFnError> {
 ///   // do some work on the server to access the database
-///   todo!()   
+///   todo!()
 /// }
 /// ```
 ///


### PR DESCRIPTION
"component" is both a module and a macro and so we must disambiguate

Here is the lint warning see by running cargo doc
```
warning: incompatible link kind for `crate::component`
   --> leptos_macro/src/lib.rs:678:1
    |
678 | / /// Annotates a struct so that it can be used with your Component as a `slot`.
679 | | ///
680 | | /// The `#[slot]` macro allows you to annotate plain Rust struct as component slots and use them
681 | | /// within your Leptos [`component`](macro@crate::component) properties. The struct can contain any number
...   |
782 | | /// }
783 | | /// ```
    | |_______^
    |
    = note: the link appears in this line:
            
            1. Most of the same rules from [component](crate::component!) macro should also be followed on slots.
                                                       ^^^^^^^^^^^^^^^^^
    = note: this link resolved to an attribute macro, which is not a macro
    = help: to link to the attribute macro, prefix with `macro@`: macro@crate::component
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `leptos_macro` (lib doc) generated 1 warning
```