### PR TITLE
Documentation update for <Show/> 

### DIFF
--- a/docs/book/src/view/06_control_flow.md
+++ b/docs/book/src/view/06_control_flow.md
@@ -208,7 +208,8 @@ view! { cx,
 
 `<Show/>` memoizes the `when` condition, so it only renders its `<Small/>` once,
 continuing to show the same component until `value` is greater than five;
-then it renders `<Big/>` once, continuing to show it indefinitely.
+then it renders `<Big/>` once, continuing to show it indefinitely or until `value`
+goes below five and then renders `<Small/>` again.
 
 This is a helpful tool to avoid rerendering when using dynamic `if` expressions.
 As always, there's some overhead: for a very simple node (like updating a single


### PR DESCRIPTION
Small tweak to highlight `<Show/>` doesn't just work one way. 