### PR TITLE
build(docs): only publish on new version tags

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -1,9 +1,8 @@
 name: Deploy book
 on:
   push:
-    paths: ['docs/book/**']
-    branches:
-      - main
+    tags:
+      - '*-?v[0-9]+*'
 
 jobs:
   deploy:


### PR DESCRIPTION
The intention here is to make it easier for me to merge a large breaking change (like 0.5) into main even if it's not ready to be released yet; at present the docs always reflect the current state of the main branch, but if there are significant enough discrepancies between that and the latest released version, this is confusing.

An alternative would be to deploy multiple versions of the book corresponding to different versions of the library. That's also possible but seems like more than I need for now.

I will probably revert this once 0.5 is actually released, so that merging PRs to the book republishes it as is currently the case.