### PR TITLE
Remove Clone requirement for slots in Vec

### DIFF
--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -76,18 +76,18 @@ pub(crate) fn fragment_to_tokens(
     let tokens = if lazy {
         quote! {
             {
-                ::leptos::Fragment::lazy(|| [
+                ::leptos::Fragment::lazy(|| ::std::vec![
                     #(#nodes),*
-                ].to_vec())
+                ])
                 #view_marker
             }
         }
     } else {
         quote! {
             {
-                ::leptos::Fragment::new([
+                ::leptos::Fragment::new(::std::vec![
                     #(#nodes),*
-                ].to_vec())
+                ])
                 #view_marker
             }
         }

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -86,9 +86,9 @@ pub(crate) fn fragment_to_tokens_ssr(
     });
     quote! {
         {
-            leptos::Fragment::lazy(|| [
+            leptos::Fragment::lazy(|| ::std::vec![
                 #(#nodes),*
-            ].to_vec())
+            ])
             #view_marker
         }
     }
@@ -607,7 +607,7 @@ fn set_style_attribute_ssr(
     let static_style_attr = node
         .attributes()
         .iter()
-        .filter_map(|a| match a {
+        .find_map(|a| match a {
             NodeAttribute::Attribute(attr)
                 if attr.key.to_string() == "style" =>
             {
@@ -615,7 +615,6 @@ fn set_style_attribute_ssr(
             }
             _ => None,
         })
-        .next()
         .map(|style| format!("{style};"));
 
     let dyn_style_attr = node

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -145,9 +145,9 @@ pub(crate) fn slot_to_tokens(
         let slot = Ident::new(&slot, span);
         if values.len() > 1 {
             quote! {
-                .#slot([
+                .#slot(::std::vec![
                     #(#values)*
-                ].to_vec())
+                ])
             }
         } else {
             let value = &values[0];


### PR DESCRIPTION
This PR removes the requirement for `S: Clone` for when rendering a list of slots `S`.

It is currently required because the `view!` macro is building an array of `S`, then calling `to_vec()` (which obviously requires `S: Clone`). This can be a problem when the slot contains `ChildrenFn` (i.e. `Box<dyn Fn(Scope) -> Fragment`), as this type does not implement `Clone`.

This PR removes this requirement by using the `vec!` macro directly instead.

Take this code for example:
```rust
use leptos::{component, mount_to_body, slot, view, ChildrenFn, CollectView, IntoView, Scope};

#[slot]
pub struct MenuItems {
    pub menu_item: Vec<MenuItem>,
}

#[slot]
pub struct MenuItem {
    pub children: ChildrenFn,
}

#[component]
pub fn Menu(cx: Scope, menu_items: MenuItems) -> impl IntoView {
    view! {
        cx,
        <ul>
            {
                menu_items
                    .menu_item
                    .into_iter()
                    .map(|item| view! {
                        cx,
                        <li>{ (item.children)(cx) }</li>
                    })
                    .collect_view(cx)
            }
        </ul>
    }
}

fn main() {
    mount_to_body(|cx| {
        view! {
            cx,
            <Menu>
                <MenuItems slot>
                    <MenuItem slot>"hello"</MenuItem>
                    <MenuItem slot>"world"</MenuItem>
                </MenuItems>
            </Menu>
        }
    });
}
```

With the current version of leptos, it fails to compile with the following message:
```
error[E0277]: the trait bound `MenuItem: Clone` is not satisfied
note: required by a bound in `std::slice::<impl [T]>::to_vec`
```

With this PR, it build properly.