### PR TITLE
support effect dispose

### DIFF
--- a/leptos_reactive/src/effect.rs
+++ b/leptos_reactive/src/effect.rs
@@ -145,7 +145,7 @@ where
     create_effect(f);
 }
 
-pub(crate) struct Effect<T, F>
+pub(crate) struct EffectState<T, F>
 where
     T: 'static,
     F: Fn(Option<T>) -> T,
@@ -160,7 +160,7 @@ pub(crate) trait AnyComputation {
     fn run(&self, value: Rc<RefCell<dyn Any>>) -> bool;
 }
 
-impl<T, F> AnyComputation for Effect<T, F>
+impl<T, F> AnyComputation for EffectState<T, F>
 where
     T: 'static,
     F: Fn(Option<T>) -> T,

--- a/leptos_reactive/src/effect.rs
+++ b/leptos_reactive/src/effect.rs
@@ -156,9 +156,15 @@ pub struct Effect {
     pub(crate) id: NodeId,
 }
 
+impl From<Effect> for Disposer {
+    fn from(effect: Effect) -> Self {
+        Disposer(effect.id)
+    }
+}
+
 impl SignalDispose for Effect {
     fn dispose(self) {
-        drop(Disposer(self.id));
+        drop(Disposer::from(self));
     }
 }
 

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -3,7 +3,7 @@ use crate::{
     node::{
         Disposer, NodeId, ReactiveNode, ReactiveNodeState, ReactiveNodeType,
     },
-    AnyComputation, AnyResource, Effect, Memo, MemoState, ReadSignal,
+    AnyComputation, AnyResource, EffectState, Memo, MemoState, ReadSignal,
     ResourceId, ResourceState, RwSignal, SerializableResource,
     SpecialNonReactiveZone, StoredValueId, Trigger, UnserializableResource,
     WriteSignal,
@@ -934,7 +934,7 @@ impl RuntimeId {
     {
         self.create_concrete_effect(
             Rc::new(RefCell::new(None::<T>)),
-            Rc::new(Effect {
+            Rc::new(EffectState {
                 f,
                 ty: PhantomData,
                 #[cfg(any(debug_assertions, feature = "ssr"))]
@@ -998,7 +998,7 @@ impl RuntimeId {
 
         let id = self.create_concrete_effect(
             Rc::new(RefCell::new(None::<()>)),
-            Rc::new(Effect {
+            Rc::new(EffectState {
                 f: effect_fn,
                 ty: PhantomData,
                 #[cfg(any(debug_assertions, feature = "ssr"))]

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -77,7 +77,7 @@ impl SuspenseContext {
                 if pending_resources.get() == 0 {
                     _ = tx.borrow_mut().try_send(());
                 }
-            })
+            });
         });
         async move {
             rx.next().await;


### PR DESCRIPTION
As discussed at #1563, I think it's nice addition for `leptos_reactive`, because `scope` is no longer existed, and there is no way to early dispose an effect.