### PR TITLE
fix: suppress warning about non-reactivity when calling `.refetch()` (occurs in e.g., async blocks in actions)

### DIFF
--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -59,10 +59,10 @@ pub fn add_event_listener<E>(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = Box::new(move |e| {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb(e);
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         });
       }
     }
@@ -88,10 +88,10 @@ pub(crate) fn add_event_listener_undelegated<E>(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = Box::new(move |e| {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb(e);
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         });
       }
     }

--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -218,10 +218,10 @@ pub fn set_timeout_with_handle(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = move || {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb();
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         };
       }
     }
@@ -273,10 +273,10 @@ pub fn debounce<T: 'static>(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = move |value| {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb(value);
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         };
       }
     }
@@ -351,10 +351,10 @@ pub fn set_interval_with_handle(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = move || {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb();
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         };
       }
     }
@@ -392,10 +392,10 @@ pub fn window_event_listener_untyped(
       if #[cfg(debug_assertions)] {
         let span = ::tracing::Span::current();
         let cb = move |e| {
-          leptos_reactive::SpecialNonReactiveZone::enter();
+          let prev = leptos_reactive::SpecialNonReactiveZone::enter();
           let _guard = span.enter();
           cb(e);
-          leptos_reactive::SpecialNonReactiveZone::exit();
+          leptos_reactive::SpecialNonReactiveZone::exit(prev);
         };
       }
     }

--- a/leptos_reactive/src/diagnostics.rs
+++ b/leptos_reactive/src/diagnostics.rs
@@ -43,18 +43,18 @@ impl SpecialNonReactiveZone {
         false
     }
 
-    #[inline(always)]
-    pub fn enter() {
-        #[cfg(debug_assertions)]
-        {
-            IS_SPECIAL_ZONE.with(|val| val.set(true))
-        }
+    #[cfg(debug_assertions)]
+    pub fn enter() -> bool {
+        IS_SPECIAL_ZONE.with(|val| {
+            let prev = val.get();
+            val.set(true);
+            prev
+        })
     }
 
-    #[inline(always)]
-    pub fn exit() {
-        #[cfg(debug_assertions)]
-        {
+    #[cfg(debug_assertions)]
+    pub fn exit(prev: bool) {
+        if !prev {
             IS_SPECIAL_ZONE.with(|val| val.set(false))
         }
     }

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -4,7 +4,7 @@ use crate::{
     signal_prelude::format_signal_warning, spawn::spawn_local, use_context,
     GlobalSuspenseContext, Memo, ReadSignal, ScopeProperty, SignalDispose,
     SignalGet, SignalGetUntracked, SignalSet, SignalUpdate, SignalWith,
-    SuspenseContext, WriteSignal,
+    SpecialNonReactiveZone, SuspenseContext, WriteSignal,
 };
 use std::{
     any::Any,
@@ -523,7 +523,9 @@ where
     pub fn refetch(&self) {
         _ = with_runtime(|runtime| {
             runtime.resource(self.id, |resource: &ResourceState<S, T>| {
-                resource.refetch()
+                SpecialNonReactiveZone::enter();
+                resource.refetch();
+                SpecialNonReactiveZone::exit();
             })
         });
     }

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -523,9 +523,13 @@ where
     pub fn refetch(&self) {
         _ = with_runtime(|runtime| {
             runtime.resource(self.id, |resource: &ResourceState<S, T>| {
-                SpecialNonReactiveZone::enter();
+                #[cfg(debug_assertions)]
+                let prev = SpecialNonReactiveZone::enter();
                 resource.refetch();
-                SpecialNonReactiveZone::exit();
+                #[cfg(debug_assertions)]
+                {
+                    SpecialNonReactiveZone::exit(prev);
+                }
             })
         });
     }


### PR DESCRIPTION
This warning is already suppressed in event listeners anyway. This suppresses for resource refetches in general, in case they are called in async blocks like an action or `spawn_local`. `.refetch()` re-loads the resource, which makes some reactive calls, but this shouldn't be reactive in any case.