### PR TITLE
feat: signal traits should take associated types instead of generics

### DIFF
--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -206,7 +206,9 @@ fn forward_ref_to<T, O, F: FnOnce(&T) -> O>(
     }
 }
 
-impl<T: Clone> SignalGetUntracked<T> for Memo<T> {
+impl<T: Clone> SignalGetUntracked for Memo<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -257,7 +259,9 @@ impl<T: Clone> SignalGetUntracked<T> for Memo<T> {
     }
 }
 
-impl<T> SignalWithUntracked<T> for Memo<T> {
+impl<T> SignalWithUntracked for Memo<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -324,7 +328,9 @@ impl<T> SignalWithUntracked<T> for Memo<T> {
 /// # runtime.dispose();
 /// #
 /// ```
-impl<T: Clone> SignalGet<T> for Memo<T> {
+impl<T: Clone> SignalGet for Memo<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -364,7 +370,9 @@ impl<T: Clone> SignalGet<T> for Memo<T> {
     }
 }
 
-impl<T> SignalWith<T> for Memo<T> {
+impl<T> SignalWith for Memo<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -586,7 +586,9 @@ where
     }
 }
 
-impl<S, T> SignalUpdate<Option<T>> for Resource<S, T> {
+impl<S, T> SignalUpdate for Resource<S, T> {
+    type Value = Option<T>;
+
     #[cfg_attr(
         debug_assertions,
         instrument(
@@ -642,11 +644,13 @@ impl<S, T> SignalUpdate<Option<T>> for Resource<S, T> {
     }
 }
 
-impl<S, T> SignalWith<Option<T>> for Resource<S, T>
+impl<S, T> SignalWith for Resource<S, T>
 where
     S: Clone,
     T: Clone,
 {
+    type Value = Option<T>;
+
     #[cfg_attr(
         debug_assertions,
         instrument(
@@ -708,11 +712,13 @@ where
     }
 }
 
-impl<S, T> SignalGet<Option<T>> for Resource<S, T>
+impl<S, T> SignalGet for Resource<S, T>
 where
     S: Clone,
     T: Clone,
 {
+    type Value = Option<T>;
+
     #[cfg_attr(
         debug_assertions,
         instrument(
@@ -756,7 +762,9 @@ where
     }
 }
 
-impl<S, T> SignalSet<T> for Resource<S, T> {
+impl<S, T> SignalSet for Resource<S, T> {
+    type Value = T;
+
     #[cfg_attr(
         debug_assertions,
         instrument(

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -105,35 +105,41 @@ pub mod prelude {
 
 /// This trait allows getting an owned value of the signals
 /// inner type.
-pub trait SignalGet<T> {
+pub trait SignalGet {
+    /// The value held by the signal.
+    type Value;
+
     /// Clones and returns the current value of the signal, and subscribes
     /// the running effect to this signal.
     ///
     /// # Panics
     /// Panics if you try to access a signal that is owned by a reactive node that has been disposed.
     #[track_caller]
-    fn get(&self) -> T;
+    fn get(&self) -> Self::Value;
 
     /// Clones and returns the signal value, returning [`Some`] if the signal
     /// is still alive, and [`None`] otherwise.
-    fn try_get(&self) -> Option<T>;
+    fn try_get(&self) -> Option<Self::Value>;
 }
 
 /// This trait allows obtaining an immutable reference to the signal's
 /// inner type.
-pub trait SignalWith<T> {
+pub trait SignalWith {
+    /// The value held by the signal.
+    type Value;
+
     /// Applies a function to the current value of the signal, and subscribes
     /// the running effect to this signal.
     ///
     /// # Panics
     /// Panics if you try to access a signal that is owned by a reactive node that has been disposed.
     #[track_caller]
-    fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O;
+    fn with<O>(&self, f: impl FnOnce(&Self::Value) -> O) -> O;
 
     /// Applies a function to the current value of the signal, and subscribes
     /// the running effect to this signal. Returns [`Some`] if the signal is
     /// valid and the function ran, otherwise returns [`None`].
-    fn try_with<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O>;
+    fn try_with<O>(&self, f: impl FnOnce(&Self::Value) -> O) -> Option<O>;
 
     /// Subscribes to this signal in the current reactive scope without doing anything with its value.
     fn track(&self) {
@@ -142,31 +148,37 @@ pub trait SignalWith<T> {
 }
 
 /// This trait allows setting the value of a signal.
-pub trait SignalSet<T> {
+pub trait SignalSet {
+    /// The value held by the signal.
+    type Value;
+
     /// Sets the signal’s value and notifies subscribers.
     ///
     /// **Note:** `set()` does not auto-memoize, i.e., it will notify subscribers
     /// even if the value has not actually changed.
     #[track_caller]
-    fn set(&self, new_value: T);
+    fn set(&self, new_value: Self::Value);
 
     /// Sets the signal’s value and notifies subscribers. Returns [`None`]
     /// if the signal is still valid, [`Some(T)`] otherwise.
     ///
     /// **Note:** `set()` does not auto-memoize, i.e., it will notify subscribers
     /// even if the value has not actually changed.
-    fn try_set(&self, new_value: T) -> Option<T>;
+    fn try_set(&self, new_value: Self::Value) -> Option<Self::Value>;
 }
 
 /// This trait allows updating the inner value of a signal.
-pub trait SignalUpdate<T> {
+pub trait SignalUpdate {
+    /// The value held by the signal.
+    type Value;
+
     /// Applies a function to the current value to mutate it in place
     /// and notifies subscribers that the signal has changed.
     ///
     /// **Note:** `update()` does not auto-memoize, i.e., it will notify subscribers
     /// even if the value has not actually changed.
     #[track_caller]
-    fn update(&self, f: impl FnOnce(&mut T));
+    fn update(&self, f: impl FnOnce(&mut Self::Value));
 
     /// Applies a function to the current value to mutate it in place
     /// and notifies subscribers that the signal has changed. Returns
@@ -174,45 +186,55 @@ pub trait SignalUpdate<T> {
     ///
     /// **Note:** `update()` does not auto-memoize, i.e., it will notify subscribers
     /// even if the value has not actually changed.
-    fn try_update<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O>;
+    fn try_update<O>(&self, f: impl FnOnce(&mut Self::Value) -> O)
+        -> Option<O>;
 }
 
 /// Trait implemented for all signal types which you can `get` a value
 /// from, such as [`ReadSignal`],
 /// [`Memo`](crate::Memo), etc., which allows getting the inner value without
 /// subscribing to the current scope.
-pub trait SignalGetUntracked<T> {
+pub trait SignalGetUntracked {
+    /// The value held by the signal.
+    type Value;
+
     /// Gets the signal's value without creating a dependency on the
     /// current scope.
     ///
     /// # Panics
     /// Panics if you try to access a signal that is owned by a reactive node that has been disposed.
     #[track_caller]
-    fn get_untracked(&self) -> T;
+    fn get_untracked(&self) -> Self::Value;
 
     /// Gets the signal's value without creating a dependency on the
     /// current scope. Returns [`Some(T)`] if the signal is still
     /// valid, [`None`] otherwise.
-    fn try_get_untracked(&self) -> Option<T>;
+    fn try_get_untracked(&self) -> Option<Self::Value>;
 }
 
 /// This trait allows getting a reference to the signals inner value
 /// without creating a dependency on the signal.
-pub trait SignalWithUntracked<T> {
+pub trait SignalWithUntracked {
+    /// The value held by the signal.
+    type Value;
+
     /// Runs the provided closure with a reference to the current
     /// value without creating a dependency on the current scope.
     ///
     /// # Panics
     /// Panics if you try to access a signal that is owned by a reactive node that has been disposed.
     #[track_caller]
-    fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O;
+    fn with_untracked<O>(&self, f: impl FnOnce(&Self::Value) -> O) -> O;
 
     /// Runs the provided closure with a reference to the current
     /// value without creating a dependency on the current scope.
     /// Returns [`Some(O)`] if the signal is still valid, [`None`]
     /// otherwise.
     #[track_caller]
-    fn try_with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O>;
+    fn try_with_untracked<O>(
+        &self,
+        f: impl FnOnce(&Self::Value) -> O,
+    ) -> Option<O>;
 }
 
 /// Trait implemented for all signal types which you can `set` the inner
@@ -419,7 +441,9 @@ where
     pub(crate) defined_at: &'static std::panic::Location<'static>,
 }
 
-impl<T: Clone> SignalGetUntracked<T> for ReadSignal<T> {
+impl<T: Clone> SignalGetUntracked for ReadSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -470,7 +494,9 @@ impl<T: Clone> SignalGetUntracked<T> for ReadSignal<T> {
     }
 }
 
-impl<T> SignalWithUntracked<T> for ReadSignal<T> {
+impl<T> SignalWithUntracked for ReadSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -533,7 +559,9 @@ impl<T> SignalWithUntracked<T> for ReadSignal<T> {
 /// assert_eq!(first_char(), 'B');
 /// # runtime.dispose();
 /// ```
-impl<T> SignalWith<T> for ReadSignal<T> {
+impl<T> SignalWith for ReadSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -600,7 +628,9 @@ impl<T> SignalWith<T> for ReadSignal<T> {
 /// // assert_eq!(count.get(), 0);
 /// # runtime.dispose();
 /// ```
-impl<T: Clone> SignalGet<T> for ReadSignal<T> {
+impl<T: Clone> SignalGet for ReadSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -928,7 +958,9 @@ impl<T> SignalUpdateUntracked<T> for WriteSignal<T> {
 /// assert_eq!(count.get(), 1);
 /// # runtime.dispose();
 /// ```
-impl<T> SignalUpdate<T> for WriteSignal<T> {
+impl<T> SignalUpdate for WriteSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1000,7 +1032,9 @@ impl<T> SignalUpdate<T> for WriteSignal<T> {
 /// assert_eq!(count.get(), 1);
 /// # runtime.dispose();
 /// ```
-impl<T> SignalSet<T> for WriteSignal<T> {
+impl<T> SignalSet for WriteSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1217,7 +1251,9 @@ impl<T> From<T> for RwSignal<T> {
     }
 }
 
-impl<T: Clone> SignalGetUntracked<T> for RwSignal<T> {
+impl<T: Clone> SignalGetUntracked for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1279,7 +1315,9 @@ impl<T: Clone> SignalGetUntracked<T> for RwSignal<T> {
     }
 }
 
-impl<T> SignalWithUntracked<T> for RwSignal<T> {
+impl<T> SignalWithUntracked for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1456,7 +1494,9 @@ impl<T> SignalUpdateUntracked<T> for RwSignal<T> {
 /// # runtime.dispose();
 /// #
 /// ```
-impl<T> SignalWith<T> for RwSignal<T> {
+impl<T> SignalWith for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1524,7 +1564,9 @@ impl<T> SignalWith<T> for RwSignal<T> {
 /// # runtime.dispose();
 /// #
 /// ```
-impl<T: Clone> SignalGet<T> for RwSignal<T> {
+impl<T: Clone> SignalGet for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1604,7 +1646,9 @@ impl<T: Clone> SignalGet<T> for RwSignal<T> {
 /// assert_eq!(count.get(), 1);
 /// # runtime.dispose();
 /// ```
-impl<T> SignalUpdate<T> for RwSignal<T> {
+impl<T> SignalUpdate for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1671,7 +1715,9 @@ impl<T> SignalUpdate<T> for RwSignal<T> {
 /// assert_eq!(count.get(), 1);
 /// # runtime.dispose();
 /// ```
-impl<T> SignalSet<T> for RwSignal<T> {
+impl<T> SignalSet for RwSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -28,12 +28,12 @@ where
 /// function call, `with()`, and `get()` APIs as other signals.
 ///
 /// ## Core Trait Implementations
-/// - [`.get()`](#impl-SignalGet<T>-for-Signal<T>) (or calling the signal as a function) clones the current
+/// - [`.get()`](#impl-SignalGet-for-Signal<T>) (or calling the signal as a function) clones the current
 ///   value of the signal. If you call it within an effect, it will cause that effect
 ///   to subscribe to the signal, and to re-run whenever the value of the signal changes.
 ///   - [`.get_untracked()`](#impl-SignalGetUntracked<T>-for-Signal<T>) clones the value of the signal
 ///   without reactively tracking it.
-/// - [`.with()`](#impl-SignalWith<T>-for-Signal<T>) allows you to reactively access the signal’s value without
+/// - [`.with()`](#impl-SignalWith-for-Signal<T>) allows you to reactively access the signal’s value without
 ///   cloning by applying a callback function.
 ///   - [`.with_untracked()`](#impl-SignalWithUntracked<T>-for-Signal<T>) allows you to access the signal’s
 ///   value without reactively tracking it.
@@ -97,7 +97,9 @@ impl<T> PartialEq for Signal<T> {
 /// Please note that using `Signal::with_untracked` still clones the inner value,
 /// so there's no benefit to using it as opposed to calling
 /// `Signal::get_untracked`.
-impl<T: Clone> SignalGetUntracked<T> for Signal<T> {
+impl<T: Clone> SignalGetUntracked for Signal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -141,7 +143,9 @@ impl<T: Clone> SignalGetUntracked<T> for Signal<T> {
     }
 }
 
-impl<T> SignalWithUntracked<T> for Signal<T> {
+impl<T> SignalWithUntracked for Signal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -218,7 +222,9 @@ impl<T> SignalWithUntracked<T> for Signal<T> {
 /// assert_eq!(memoized_lower.get(), "alice");
 /// # runtime.dispose();
 /// ```
-impl<T> SignalWith<T> for Signal<T> {
+impl<T> SignalWith for Signal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -280,7 +286,9 @@ impl<T> SignalWith<T> for Signal<T> {
 /// assert_eq!(above_3(&memoized_double_count.into()), true);
 /// # runtime.dispose();
 /// ```
-impl<T: Clone> SignalGet<T> for Signal<T> {
+impl<T: Clone> SignalGet for Signal<T> {
+    type Value = T;
+
     fn get(&self) -> T {
         match self.inner {
             SignalTypes::ReadSignal(r) => r.get(),
@@ -475,12 +483,12 @@ impl<T> Eq for SignalTypes<T> where T: PartialEq {}
 /// of the same type. This is especially useful for component properties.
 ///
 /// ## Core Trait Implementations
-/// - [`.get()`](#impl-SignalGet<T>-for-MaybeSignal<T>) (or calling the signal as a function) clones the current
+/// - [`.get()`](#impl-SignalGet-for-MaybeSignal<T>) (or calling the signal as a function) clones the current
 ///   value of the signal. If you call it within an effect, it will cause that effect
 ///   to subscribe to the signal, and to re-run whenever the value of the signal changes.
 ///   - [`.get_untracked()`](#impl-SignalGetUntracked<T>-for-MaybeSignal<T>) clones the value of the signal
 ///   without reactively tracking it.
-/// - [`.with()`](#impl-SignalWith<T>-for-MaybeSignal<T>) allows you to reactively access the signal’s value without
+/// - [`.with()`](#impl-SignalWith-for-MaybeSignal<T>) allows you to reactively access the signal’s value without
 ///   cloning by applying a callback function.
 ///   - [`.with_untracked()`](#impl-SignalWithUntracked<T>-for-MaybeSignal<T>) allows you to access the signal’s
 ///   value without reactively tracking it.
@@ -557,7 +565,9 @@ impl<T: Default> Default for MaybeSignal<T> {
 /// assert_eq!(above_3(&static_value.into()), true);
 /// # runtime.dispose();
 /// ```
-impl<T: Clone> SignalGet<T> for MaybeSignal<T> {
+impl<T: Clone> SignalGet for MaybeSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -624,7 +634,9 @@ impl<T: Clone> SignalGet<T> for MaybeSignal<T> {
 /// assert_eq!(static_value.get(), "Bob");
 /// # runtime.dispose();
 /// ```
-impl<T> SignalWith<T> for MaybeSignal<T> {
+impl<T> SignalWith for MaybeSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -658,7 +670,9 @@ impl<T> SignalWith<T> for MaybeSignal<T> {
     }
 }
 
-impl<T> SignalWithUntracked<T> for MaybeSignal<T> {
+impl<T> SignalWithUntracked for MaybeSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -692,7 +706,9 @@ impl<T> SignalWithUntracked<T> for MaybeSignal<T> {
     }
 }
 
-impl<T: Clone> SignalGetUntracked<T> for MaybeSignal<T> {
+impl<T: Clone> SignalGetUntracked for MaybeSignal<T> {
+    type Value = T;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -831,12 +847,12 @@ impl From<&str> for MaybeSignal<String> {
 /// This creates an extremely flexible type for component libraries, etc.
 ///
 /// ## Core Trait Implementations
-/// - [`.get()`](#impl-SignalGet<T>-for-MaybeProp<T>) (or calling the signal as a function) clones the current
+/// - [`.get()`](#impl-SignalGet-for-MaybeProp<T>) (or calling the signal as a function) clones the current
 ///   value of the signal. If you call it within an effect, it will cause that effect
 ///   to subscribe to the signal, and to re-run whenever the value of the signal changes.
 ///   - [`.get_untracked()`](#impl-SignalGetUntracked<T>-for-MaybeProp<T>) clones the value of the signal
 ///   without reactively tracking it.
-/// - [`.with()`](#impl-SignalWith<T>-for-MaybeProp<T>) allows you to reactively access the signal’s value without
+/// - [`.with()`](#impl-SignalWith-for-MaybeProp<T>) allows you to reactively access the signal’s value without
 ///   cloning by applying a callback function.
 ///   - [`.with_untracked()`](#impl-SignalWithUntracked<T>-for-MaybeProp<T>) allows you to access the signal’s
 ///   value without reactively tracking it.
@@ -902,7 +918,9 @@ impl<T> Default for MaybeProp<T> {
 /// assert_eq!(above_3(&memoized_double_count.into()), true);
 /// # runtime.dispose();
 /// ```
-impl<T: Clone> SignalGet<Option<T>> for MaybeProp<T> {
+impl<T: Clone> SignalGet for MaybeProp<T> {
+    type Value = Option<T>;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(
@@ -1042,7 +1060,9 @@ impl<T> MaybeProp<T> {
     }
 }
 
-impl<T: Clone> SignalGetUntracked<Option<T>> for MaybeProp<T> {
+impl<T: Clone> SignalGetUntracked for MaybeProp<T> {
+    type Value = Option<T>;
+
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(

--- a/leptos_reactive/src/signal_wrappers_write.rs
+++ b/leptos_reactive/src/signal_wrappers_write.rs
@@ -77,7 +77,9 @@ impl<T: Default + 'static> Default for SignalSetter<T> {
 
 impl<T> Copy for SignalSetter<T> {}
 
-impl<T> SignalSet<T> for SignalSetter<T> {
+impl<T> SignalSet for SignalSetter<T> {
+    type Value = T;
+
     fn set(&self, new_value: T) {
         match self.inner {
             SignalSetterTypes::Default => {}

--- a/leptos_reactive/src/trigger.rs
+++ b/leptos_reactive/src/trigger.rs
@@ -97,7 +97,9 @@ pub fn create_trigger() -> Trigger {
     Runtime::current().create_trigger()
 }
 
-impl SignalGet<()> for Trigger {
+impl SignalGet for Trigger {
+    type Value = ();
+
     #[cfg_attr(
         debug_assertions,
         instrument(
@@ -134,7 +136,9 @@ impl SignalGet<()> for Trigger {
     }
 }
 
-impl SignalUpdate<()> for Trigger {
+impl SignalUpdate for Trigger {
+    type Value = ();
+
     #[cfg_attr(
         debug_assertions,
         instrument(
@@ -181,7 +185,9 @@ impl SignalUpdate<()> for Trigger {
     }
 }
 
-impl SignalSet<()> for Trigger {
+impl SignalSet for Trigger {
+    type Value = ();
+
     #[cfg_attr(
         debug_assertions,
         instrument(


### PR DESCRIPTION
I initially began this as part of #1577, before realizing that that had a trait conflict with `Fn()` in any case and needed to use the concrete types instead. It was not possible to do something like
```rust
impl<T, U> IntoAttribute for T where
  T: SignalGet<U>,
  U: IntoAttribute { /* */ }
```
because the compiler says `U` is unused. I guess because it's only used as the generic of the constraint on `T`. 

This led me down a (short) path re: the difference between generics on traits and associated types. I *think* it's probably correct for these to be associated types rather than generics, because there truly only is one value, and it's provided by the implementor of the trait, not the caller: i.e., any `T: SignalGet` will always have some `T::Value` which is the value it returns. It doesn't make sense to have `SignalGet<U>`: the `SignalGet` trait itself isn't generic, i.e., we can't specify different `T` here and get anything else out of our `.get()` call.

@jquesada2016 this was your proposal originally of course. Does making this change make sense to you? I think it's probably more correct. No longer necessary for #1577 but if we're going to do it, we should do it now before 0.5 as it's breaking.
   