### PR TITLE
fix: nightly warning in server macro for lifetime

### DIFF
--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -281,7 +281,7 @@ pub fn server_macro_impl(
         }
 
         impl #struct_name {
-            const URL: &str = if #fn_path.is_empty() {
+            const URL: &'static str = if #fn_path.is_empty() {
                     #server_fn_path::const_format::concatcp!(
                     #fn_name_as_str,
                     #server_fn_path::xxhash_rust::const_xxh64::xxh64(
@@ -292,7 +292,7 @@ pub fn server_macro_impl(
             } else {
                 #fn_path
             };
-            const PREFIX: &str = #prefix;
+            const PREFIX: &'static str = #prefix;
             const ENCODING: #server_fn_path::Encoding = #encoding;
         }
 


### PR DESCRIPTION
On the latest lifetime we're getting the following warning in the server macro:
 warning: `&` without an explicit lifetime name cannot be used here
   --> src/login.rs:19:1
    |
 19 | #[server(Login, "/api")]
    | ^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
    = note: this warning originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)