### PR TITLE
Callback proposal

### DIFF
--- a/leptos_dom/src/callback.rs
+++ b/leptos_dom/src/callback.rs
@@ -5,21 +5,22 @@
 //! You can always create a callback from a closure, but the prefered way is to use `prop(into)`
 //! when you define your component:
 //! ```
+//! # use leptos::*;
+//! # use leptos::leptos_dom::{Callback, Callable};
 //! #[component]
-//! fn MyComponent(#[prop(into)] render_number: Callback<i32, String>) {
+//! fn MyComponent(
+//!     #[prop(into)] render_number: Callback<i32, String>,
+//! ) -> impl IntoView {
 //!     view! {
 //!         <div>
 //!             {render_number.call(42)}
 //!         </div>
 //!     }
 //! }
-//! ```
-//!
-//! That way, you can create it from a closure directly:
-//! ```
+//! // now you can use it from a closure directly:
 //! fn test() -> impl IntoView {
 //!     view! {
-//!         <MyComponent render_number = |x| x.to_string()>
+//!         <MyComponent render_number = |x: i32| x.to_string()/>
 //!     }
 //! }
 //! ```
@@ -41,13 +42,20 @@
 //! All callbacks type defined in this module are [Clone] but not [Copy].
 //! To solve this issue, use [StoredValue]; see [StoredCallback] for more
 //! ```
-//! let callback: Callback<i32, String> = Callback::new(|x| x.to_string);
-//! let stored_callback = store_value(callback);
-//! view! {
-//!     <div>
-//!         {move || callback.call(1)}
-//!         {move || callback.call(42)}
-//!     </div>
+//! # use leptos::*;
+//! # use leptos::leptos_dom::{Callback, Callable};
+//! fn test() -> impl IntoView {
+//!     let callback: Callback<i32, String> =
+//!         Callback::new(|x: i32| x.to_string());
+//!     let stored_callback = store_value(callback);
+//!
+//!     view! {
+//!         <div>
+//!             // `stored_callback` can be moved multiple times
+//!             {move || stored_callback.call(1)}
+//!             {move || stored_callback.call(42)}
+//!         </div>
+//!     }
 //! }
 //! ```
 //!
@@ -69,8 +77,12 @@ pub trait Callable<In, Out = ()> {
 ///
 /// # Example
 /// ```
+/// # use leptos::*;
+/// # use leptos::leptos_dom::{Callable, Callback};
 /// #[component]
-/// fn MyComponent(#[prop(into)] render_number: Callback<i32, String>) {
+/// fn MyComponent(
+///     #[prop(into)] render_number: Callback<i32, String>,
+/// ) -> impl IntoView {
 ///     view! {
 ///         <div>
 ///             {render_number.call(42)}
@@ -80,7 +92,7 @@ pub trait Callable<In, Out = ()> {
 ///
 /// fn test() -> impl IntoView {
 ///     view! {
-///         <MyComponent callback=move |x| x.to_string()/>
+///         <MyComponent render_number=move |x: i32| x.to_string()/>
 ///     }
 /// }
 /// ```
@@ -116,18 +128,24 @@ where
     }
 }
 
-/// a callback type that can be copied.
-/// `StoredCallback<In,Out>` is just an alias for `StoredValue<Callback<In, Out>>`.
+/// A callback type that implements `Copy`.
+/// `StoredCallback<In,Out>` is an alias for `StoredValue<Callback<In, Out>>`.
 ///
 /// # Example
 /// ```
-/// let callback: Callback<i32, String> = Callback::new(|x| x.to_string);
-/// let stored_callback: StoredCallback<i32, String> = store_value(callback);
-/// view! {
-///     <div>
-///         {move || callback.call(1)}
-///         {move || callback.call(42)}
-///     </div>
+/// # use leptos::*;
+/// # use leptos::leptos_dom::{Callback, StoredCallback, Callable};
+/// fn test() -> impl IntoView {
+///     let callback: Callback<i32, String> =
+///         Callback::new(|x: i32| x.to_string());
+///     let stored_callback: StoredCallback<i32, String> =
+///         store_value(callback);
+///     view! {
+///         <div>
+///             {move || stored_callback.call(1)}
+///             {move || stored_callback.call(42)}
+///         </div>
+///     }
 /// }
 /// ```
 ///
@@ -170,8 +188,12 @@ impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
 /// # Example
 ///
 /// ```
+/// # use leptos::*;
+/// # use leptos::leptos_dom::{Callable, HtmlCallback};
 /// #[component]
-/// fn MyComponent(#[prop(into)] render_number: HtmlCallback<i32>) {
+/// fn MyComponent(
+///     #[prop(into)] render_number: HtmlCallback<i32>,
+/// ) -> impl IntoView {
 ///     view! {
 ///         <div>
 ///             {render_number.call(42)}
@@ -180,7 +202,7 @@ impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
 /// }
 /// fn test() -> impl IntoView {
 ///     view! {
-///         <MyComponent callback=move |x| view!{<span>{x}</span>}/>
+///         <MyComponent render_number=move |x: i32| view!{<span>{x}</span>}/>
 ///     }
 /// }
 /// ```
@@ -230,14 +252,18 @@ impl IntoView for HtmlCallback<()> {
     }
 }
 
-/// A special callback type that returns any View
+/// A special callback type that returns any [`View`].
 ///
 /// You can use it exactly the same way as a classic callback.
 /// For how to use callbacks, see [here][crate::callback]
 ///
 /// ```
+/// # use leptos::*;
+/// # use leptos::leptos_dom::{ViewCallback, Callable};
 /// #[component]
-/// fn MyComponent(#[prop(into)] render_number: ViewCallback<i32>) {
+/// fn MyComponent(
+///     #[prop(into)] render_number: ViewCallback<i32>,
+/// ) -> impl IntoView {
 ///     view! {
 ///         <div>
 ///             {render_number.call(42)}
@@ -246,7 +272,7 @@ impl IntoView for HtmlCallback<()> {
 /// }
 /// fn test() -> impl IntoView {
 ///     view! {
-///         <MyComponent callback=move |x| view!{<span>{x}</span>}/>
+///         <MyComponent render_number=move |x: i32| view!{<span>{x}</span>}/>
 ///     }
 /// }
 /// ```

--- a/leptos_dom/src/callback.rs
+++ b/leptos_dom/src/callback.rs
@@ -141,7 +141,7 @@ impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
 pub struct HtmlCallback<In>(Rc<dyn Fn(In) -> HtmlElement<AnyElement>>);
 
 impl<In> HtmlCallback<In> {
-    /// todo
+    /// creates a new callback from the function or closure
     pub fn new<F, H>(f: F) -> Self
     where
         F: Fn(In) -> HtmlElement<H> + 'static,

--- a/leptos_dom/src/callback.rs
+++ b/leptos_dom/src/callback.rs
@@ -1,0 +1,245 @@
+// inspired by:
+// https://github.com/lpotthast/leptonic/blob/f8a270ae5512561a92f5deca057f7999940de11b/leptonic/src/callback.rs
+
+use crate::{AnyElement, ElementDescriptor, HtmlElement, IntoView, View};
+use leptos_reactive::StoredValue;
+use std::{rc::Rc, sync::Arc};
+
+/// A wrapper trait for calling callbacks.
+pub trait Callable<In, Out = ()> {
+    /// calls the callback with the specified argument.
+    fn call(&self, input: In) -> Out;
+}
+
+/// The most basic leptos callback type.
+/// It is intended to make passing a function to your component easy.
+///
+/// # Usage when you write a component
+/// ```
+/// #[component]
+/// fn MyComponent(#[prop(into)] render_number: Callback<i32, String>) {
+///     view! {
+///         <div>
+///             {render_number.call(42)}
+///         </div>
+///     }
+/// }
+/// ```
+/// # Usage when you use your component
+/// ```
+/// view! {
+///     <MyComponent callback=move |x| x.to_string()/>
+/// }
+/// ```
+///
+/// Note that in this scenario, you should use a generic component instead.
+/// You should use callback mainly for optional generic props.
+///
+/// # Cloning
+/// The default [Callback] type can be cloned cheaply but cannot be copied.
+/// If you want to use the callback in a lot of closures, you will have to clone it each time.
+/// To avoid that, see [StoredCallback]
+#[derive(Clone)]
+pub struct Callback<In, Out = ()>(Rc<dyn Fn(In) -> Out>);
+
+impl<In, Out> Callback<In, Out> {
+    /// creates a new callback from the function or closure
+    pub fn new<F>(f: F) -> Callback<In, Out>
+    where
+        F: Fn(In) -> Out + 'static,
+    {
+        Self(Rc::new(f))
+    }
+}
+
+impl<In, Out> Callable<In, Out> for Callback<In, Out> {
+    fn call(&self, input: In) -> Out {
+        (self.0)(input)
+    }
+}
+
+impl<F, In, Out> From<F> for Callback<In, Out>
+where
+    F: Fn(In) -> Out + 'static,
+{
+    fn from(f: F) -> Callback<In, Out> {
+        Callback::new(f)
+    }
+}
+
+/// a callback type that can be copied.
+///
+/// To create it, just use [store_value] on your callback.
+///
+/// Note that a prop should never be a [StoredCallback]:
+/// you have to call [store_value] inside your component code.
+///
+/// You can store any callback type, and use it as a callback.
+pub type StoredCallback<In, Out> = StoredValue<Callback<In, Out>>;
+
+impl<F, In, Out> Callable<In, Out> for StoredValue<F>
+where
+    F: Callable<In, Out>,
+{
+    fn call(&self, input: In) -> Out {
+        self.with_value(|cb| cb.call(input))
+    }
+}
+
+/// a callback type that
+/// - can be cloned
+/// - is `Send` and `Sync` if the input type is
+#[derive(Clone)]
+pub struct SyncCallback<In, Out = ()>(Arc<dyn Fn(In) -> Out>);
+
+impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
+    /// creates a new callback from the function or closure
+    pub fn new<F>(fun: F) -> Self
+    where
+        F: Fn(In) -> Out + 'static,
+    {
+        Self(Arc::new(fun))
+    }
+}
+
+/// A special callback type that returns any Html element.
+///
+/// # Usage when you write your component
+/// You can use it exactly the same way as a classic callback.
+///
+///
+/// ```
+/// #[component]
+/// fn MyComponent(#[prop(into)] render_number: HtmlCallback<i32>) {
+///     view! {
+///         <div>
+///             {render_number.call(42)}
+///         </div>
+///     }
+/// }
+/// ```
+///
+/// # Usage when you use your component
+/// Again, use it the same way as a classic callback.
+///
+/// ```
+/// view! {
+///     <MyComponent callback=move |x| view!{<span>{x}</span>}/>
+/// }
+/// ```
+///
+/// # `HtmlCallback` with empty input type.
+/// Note that when `my_html_callback` is `HtmlCallback<()>`, you can use it more easily because it
+/// implements [IntoView]
+///
+/// view!{
+///     <div>
+///         {render_number}
+///     </div>
+/// }
+#[derive(Clone)]
+pub struct HtmlCallback<In>(Rc<dyn Fn(In) -> HtmlElement<AnyElement>>);
+
+impl<In> HtmlCallback<In> {
+    /// todo
+    pub fn new<F, H>(f: F) -> Self
+    where
+        F: Fn(In) -> HtmlElement<H> + 'static,
+        H: ElementDescriptor + 'static,
+    {
+        Self(Rc::new(move |x| f(x).into_any()))
+    }
+}
+
+impl<In> Callable<In, HtmlElement<AnyElement>> for HtmlCallback<In> {
+    fn call(&self, input: In) -> HtmlElement<AnyElement> {
+        (self.0)(input)
+    }
+}
+
+impl<In, F, H> From<F> for HtmlCallback<In>
+where
+    F: Fn(In) -> HtmlElement<H> + 'static,
+    H: ElementDescriptor + 'static,
+{
+    fn from(f: F) -> Self {
+        HtmlCallback(Rc::new(move |x| f(x).into_any()))
+    }
+}
+
+impl IntoView for HtmlCallback<()> {
+    fn into_view(self) -> View {
+        self.call(()).into_view()
+    }
+}
+
+/// A special callback type that returns any View
+///
+/// # Usage when you write your component
+/// You can use it exactly the same way as a classic callback.
+///
+///
+/// ```
+/// #[component]
+/// fn MyComponent(#[prop(into)] render_number: ViewCallback<i32>) {
+///     view! {
+///         <div>
+///             {render_number.call(42)}
+///         </div>
+///     }
+/// }
+/// ```
+///
+/// # Usage when you use your component
+/// Again, use it the same way as a classic callback.
+///
+/// ```
+/// view! {
+///     <MyComponent callback=move |x| view!{<span>{x}</span>}/>
+/// }
+/// ```
+///
+/// # `ViewCallback` with empty input type.
+/// Note that when `my_view_callback` is `ViewCallback<()>`, you can use it more easily because it
+/// implements [IntoView]
+///
+/// view!{
+///     <div>
+///         {render_number}
+///     </div>
+/// }
+#[derive(Clone)]
+pub struct ViewCallback<In>(Rc<dyn Fn(In) -> View>);
+
+impl<In> ViewCallback<In> {
+    /// creates a new callback from the function or closure
+    fn new<F, V>(f: F) -> Self
+    where
+        F: Fn(In) -> V + 'static,
+        V: IntoView + 'static,
+    {
+        ViewCallback(Rc::new(move |x| f(x).into_view()))
+    }
+}
+
+impl<In> Callable<In, View> for ViewCallback<In> {
+    fn call(&self, input: In) -> View {
+        (self.0)(input)
+    }
+}
+
+impl<In, F, V> From<F> for ViewCallback<In>
+where
+    F: Fn(In) -> V + 'static,
+    V: IntoView + 'static,
+{
+    fn from(f: F) -> Self {
+        Self::new(f)
+    }
+}
+
+impl IntoView for ViewCallback<()> {
+    fn into_view(self) -> View {
+        self.call(()).into_view()
+    }
+}

--- a/leptos_dom/src/callback.rs
+++ b/leptos_dom/src/callback.rs
@@ -1,49 +1,58 @@
-/// # Callbacks
-/// Callbacks define a standard way to store functions and closures,
-/// in particular in component properties.
-///
-/// # Creating callbacks
-/// You can always create a callback from a closure, but the prefered way is to use `prop(into)`
-/// inside your component:
-/// ```
-/// #[component]
-/// fn MyComponent(#[prop(into)] render_number: Callback<i32, String>) {
-///     view! {
-///         <div>
-///             {render_number.call(42)}
-///         </div>
-///     }
-/// }
-/// ```
-///
-/// # Calling callbacks
-/// All callbacks implement the [Callable] trait.
-/// Simply use `my_callback.call(input)`
-///
-/// # Types
-/// This modules defines:
-/// - [Callback], the most basic callback type
-/// - [SyncCallback] for scenarios when you need `Send` and `Sync`
-/// - [HtmlCallback] for a function that returns a [HtmlElement]
-/// - [ViewCallback] for a function that returns some kind of [view][IntoView]
-///
-/// # Copying vs cloning
-/// All callbacks type defined in this module are [Clone] but not [Copy].
-/// To solve this issue, use [StoredValue]; see [StoredCallback] for more
-/// ```
-/// let callback: Callback<i32, String> = Callback::new(|x| x.to_string);
-/// let stored_callback = store_value(callback);
-/// view!{
-///     <div>
-///         {move || callback.call(1)}
-///         {move || callback.call(42)}
-///     </div>
-/// }
-/// ```
-///
-/// Note that for each callback type `T`, `StoredValue<T>` implements `Call`, so you can call them
-/// without even thinking about it.
-
+//! Callbacks define a standard way to store functions and closures,
+//! in particular for component properties.
+//!
+//! # How to use them
+//! You can always create a callback from a closure, but the prefered way is to use `prop(into)`
+//! when you define your component:
+//! ```
+//! #[component]
+//! fn MyComponent(#[prop(into)] render_number: Callback<i32, String>) {
+//!     view! {
+//!         <div>
+//!             {render_number.call(42)}
+//!         </div>
+//!     }
+//! }
+//! ```
+//!
+//! That way, you can create it from a closure directly:
+//! ```
+//! fn test() -> impl IntoView {
+//!     view!{
+//!         <MyComponent render_number = |x| x.to_string()>
+//!     }
+//! }
+//! ```
+//!
+//! *Notes*: 
+//! - in this example, you should use a generic type that implements `Fn(i32) -> String`.
+//!   Callbacks are more usefull when you want optional generic props. 
+//! - All callbacks implement the `Callable` trait. You have to write `my_callback.call(input)`
+//!
+//!
+//! # Types
+//! This modules defines:
+//! - [Callback], the most basic callback type
+//! - [SyncCallback] for scenarios when you need `Send` and `Sync`
+//! - [HtmlCallback] for a function that returns a [HtmlElement]
+//! - [ViewCallback] for a function that returns some kind of [view][IntoView]
+//!
+//! # Copying vs cloning
+//! All callbacks type defined in this module are [Clone] but not [Copy].
+//! To solve this issue, use [StoredValue]; see [StoredCallback] for more
+//! ```
+//! let callback: Callback<i32, String> = Callback::new(|x| x.to_string);
+//! let stored_callback = store_value(callback);
+//! view! {
+//!     <div>
+//!         {move || callback.call(1)}
+//!         {move || callback.call(42)}
+//!     </div>
+//! }
+//! ```
+//!
+//! Note that for each callback type `T`, `StoredValue<T>` implements `Call`, so you can call them
+//! without even thinking about it.
 
 use crate::{AnyElement, ElementDescriptor, HtmlElement, IntoView, View};
 use leptos_reactive::StoredValue;
@@ -56,7 +65,7 @@ pub trait Callable<In, Out = ()> {
 }
 
 /// The most basic leptos callback type.
-/// It is intended to make passing a function to your component easy.
+/// For how to use callbacks, see [here][crate::callback]
 ///
 /// # Example
 /// ```
@@ -75,9 +84,6 @@ pub trait Callable<In, Out = ()> {
 ///     }
 /// }
 /// ```
-///
-/// Note that in this scenario, you should use a generic component instead.
-/// You should use callback mainly for optional generic props.
 ///
 /// # Cloning
 /// See [StoredCallback]
@@ -112,12 +118,12 @@ where
 
 /// a callback type that can be copied.
 /// `StoredCallback<In,Out>` is just an alias for `StoredValue<Callback<In, Out>>`.
-/// 
+///
 /// # Example
 /// ```
 /// let callback: Callback<i32, String> = Callback::new(|x| x.to_string);
 /// let stored_callback: StoredCallback<i32, String> = store_value(callback);
-/// view!{
+/// view! {
 ///     <div>
 ///         {move || callback.call(1)}
 ///         {move || callback.call(42)}
@@ -130,7 +136,7 @@ where
 ///
 ///
 /// Note that a prop should never be a [StoredCallback]:
-/// you have to call [store_value] inside your component code.
+/// you have to call [store_value][leptos_reactive::store_value] inside your component code.
 pub type StoredCallback<In, Out> = StoredValue<Callback<In, Out>>;
 
 impl<F, In, Out> Callable<In, Out> for StoredValue<F>
@@ -157,8 +163,9 @@ impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
 }
 
 /// A special callback type that returns any Html element.
-///
 /// You can use it exactly the same way as a classic callback.
+///
+/// For how to use callbacks, see [here][crate::callback]
 ///
 /// # Example
 ///
@@ -188,7 +195,7 @@ impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
 ///     </div>
 /// }
 #[derive(Clone)]
-pub struct HtmlCallback<In=()>(Rc<dyn Fn(In) -> HtmlElement<AnyElement>>);
+pub struct HtmlCallback<In = ()>(Rc<dyn Fn(In) -> HtmlElement<AnyElement>>);
 
 impl<In> HtmlCallback<In> {
     /// creates a new callback from the function or closure
@@ -226,7 +233,7 @@ impl IntoView for HtmlCallback<()> {
 /// A special callback type that returns any View
 ///
 /// You can use it exactly the same way as a classic callback.
-///
+/// For how to use callbacks, see [here][crate::callback]
 ///
 /// ```
 /// #[component]

--- a/leptos_dom/src/callback.rs
+++ b/leptos_dom/src/callback.rs
@@ -18,15 +18,15 @@
 //! That way, you can create it from a closure directly:
 //! ```
 //! fn test() -> impl IntoView {
-//!     view!{
+//!     view! {
 //!         <MyComponent render_number = |x| x.to_string()>
 //!     }
 //! }
 //! ```
 //!
-//! *Notes*: 
+//! *Notes*:
 //! - in this example, you should use a generic type that implements `Fn(i32) -> String`.
-//!   Callbacks are more usefull when you want optional generic props. 
+//!   Callbacks are more usefull when you want optional generic props.
 //! - All callbacks implement the `Callable` trait. You have to write `my_callback.call(input)`
 //!
 //!

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -9,6 +9,7 @@
 #[cfg_attr(any(debug_assertions, feature = "ssr"), macro_use)]
 pub extern crate tracing;
 
+mod callback;
 mod components;
 mod events;
 pub mod helpers;
@@ -24,6 +25,7 @@ pub mod ssr;
 pub mod ssr_in_order;
 pub mod svg;
 mod transparent;
+pub use callback::*;
 use cfg_if::cfg_if;
 pub use components::*;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -9,7 +9,7 @@
 #[cfg_attr(any(debug_assertions, feature = "ssr"), macro_use)]
 pub extern crate tracing;
 
-mod callback;
+pub mod callback;
 mod components;
 mod events;
 pub mod helpers;


### PR DESCRIPTION
This is a proposal to include callbacks in leptos 5.0.

It is heavily inspired by leptonic, see [here](https://github.com/lpotthast/leptonic/blob/f8a270ae5512561a92f5deca057f7999940de11b/leptonic/src/callback.rs
)

It has 2 main goals: 
- creating a stable way to design components that need special interactivity given as a prop. Currently, there are multiple approaches to write the same code, a problem framework like Yew don't have, thank's to callbacks.
- removing any boxed closure from the perspective of the user: if it works like a function, the user should be able to write a function.