### PR TITLE
chore(examples): improve cucumber support #1598

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -53,6 +53,8 @@ echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 workspace = false
 description = "report ci test runners for each example - OPTION: [all]"
 script = '''
+set -emu
+
 BOLD="\e[1m"
 GREEN="\e[0;32m"
 ITALIC="\e[3m"
@@ -77,36 +79,54 @@ for path in $makefile_paths; do
 
   test_runner=
 
-  test_count=$(grep -rl -E "#\[(test|rstest)\]" | wc -l)
+  test_count=$(grep -rl -E "#\[test\]" | wc -l)
   if [ $test_count -gt 0 ]; then
-    test_runner="-C"
+      test_runner="T"
   fi
+
+  while read -r line; do
+      case $line in
+      *"cucumber"*)
+          test_runner=$test_runner"C"
+          ;;
+      *"rstest"*)
+          test_runner=$test_runner"R"
+          ;;
+      esac
+  done <"./Cargo.toml"
 
   while read -r line; do
     case $line in
       *"wasm-test.toml"*)
-          test_runner=$test_runner"-W"
+          test_runner=$test_runner"W"
         ;;
       *"playwright-test.toml"*)
-          test_runner=$test_runner"-P"
+          test_runner=$test_runner"P"
         ;;
       *"cargo-leptos-test.toml"*)
-          test_runner=$test_runner"-L"
+          test_runner=$test_runner"L"
         ;;
     esac
   done <"./Makefile.toml"
 
-  if [ ! -z "$1" ]; then
+  runners=$(echo ${test_runner} | grep -o . | sort | tr -d "\n") 
+
+  if [ ! -z ${1+x} ]; then
     # Show all examples
-    echo "$path ${BOLD}${test_runner}${RESET}"
-  elif [ ! -z $test_runner ]; then
+    echo "$path ➤ ${BOLD}${runners}${RESET}"
+  elif [ ! -z $runners ]; then
     # Filter out examples that do not run tests in `ci`
-    echo "$path ${BOLD}${test_runner}${RESET}"
+    echo "$path ➤ ${BOLD}${runners}${RESET}"
   fi
 
   cd ${start_path}
 done
 echo
-echo "${ITALIC}Runners: C = Cargo Test, L = Cargo Leptos Test, P = Playwright Test, W = WASM Test${RESET}"
+echo "${ITALIC}Runners: C = Cucumber, L = Cargo Leptos, P = Playwright, R = RS Test, T = Cargo, W = WASM${RESET}"
 echo
 '''
+
+# ALIASES
+
+[tasks.tr]
+alias = "test-runner-report"

--- a/examples/cargo-make/clean.toml
+++ b/examples/cargo-make/clean.toml
@@ -1,18 +1,19 @@
 [tasks.clean]
 dependencies = [
-    "clean-cargo",
-    "clean-trunk",
-    "clean-node_modules",
-    "clean-playwright",
+  "clean-cargo",
+  "clean-trunk",
+  "clean-node_modules",
+  "clean-playwright",
 ]
 
 [tasks.clean-cargo]
-command = "cargo"
-args = ["clean"]
+command = "rm"
+args = ["-rf", "target"]
 
 [tasks.clean-trunk]
-command = "trunk"
-args = ["clean"]
+script = '''
+find . -type d -name target | xargs rm -rf
+'''
 
 [tasks.clean-node_modules]
 script = '''


### PR DESCRIPTION
READY FOR REVIEW

Closes #1598

## Changes

- Add `tr` alias for `test-runner-report` for convenience
- Add Cucumber Test Runner Report to make it easy to find cucumber tests
- Clean cargo targets recursively to include cucumber `e2e` directories. These test-only directories are not included as workspace members intentionally.