### PR TITLE
Don't try to parse as JSON the result from a server function redirect

### DIFF
--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -409,6 +409,13 @@ where
 
     let on_response = Rc::new(move |resp: &web_sys::Response| {
         let resp = resp.clone().expect("couldn't get Response");
+
+        // If the response was redirected then a JSON will not be available in the response, instead
+        // it will be an actual page, so we don't want to try to parse it.
+        if resp.redirected() {
+            return;
+        }
+
         spawn_local(async move {
             let body = JsFuture::from(
                 resp.text().expect("couldn't get .text() from Response"),


### PR DESCRIPTION
When a server function redirects using `leptos_actix::redirect` or `leptos_axum::redirect` the result of that redirect will be a page not JSON, but the `ActionForm` `on_response` still attempts to parse it as JSON. This change just adds a guard to not attempt to parse the body of a redirected response.

This should address the error part of #1600 