### PR TITLE
fix(macro/params): clippy warning

### DIFF
--- a/leptos_macro/src/params.rs
+++ b/leptos_macro/src/params.rs
@@ -19,7 +19,7 @@ pub fn impl_params(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
 				let span = field.span();
 
 				quote_spanned! {
-					span => #ident: <#ty>::into_param(map.get(#field_name_string).map(|n| n.as_str()), #field_name_string)?
+					span => #ident: <#ty>::into_param(map.get(#field_name_string).map(::std::string::String::as_str), #field_name_string)?
 				}
 			})
             .collect()


### PR DESCRIPTION
I got a `clippy` warning `clippy::redundant_closure_for_method_calls` on the code generated by the `Params` derive macro. This is the fix suggested by `clippy`, which fixes the issue.