### PR TITLE
Configuration for Hot-Reloading Websocket Protocol and enable ENV PROD selection

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -11,14 +11,17 @@ fn autoreload(nonce_str: &str, options: &LeptosOptions) -> String {
         Some(val) => val,
         None => options.reload_port,
     };
+    let protocol = match options.reload_ws_protocol {
+        leptos_config::ReloadWSProtocol::WS => "'ws://'",
+        leptos_config::ReloadWSProtocol::WSS => "'wss://'",
+    };
     match std::env::var("LEPTOS_WATCH").is_ok() {
         true => format!(
             r#"
                 <script crossorigin=""{nonce_str}>(function () {{
                     {}
-                    let protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
                     let host = window.location.hostname;
-                    let ws = new WebSocket(protocol + host + ':{reload_port}/live_reload');
+                    let ws = new WebSocket({protocol} + host + ':{reload_port}/live_reload');
                     ws.onmessage = (ev) => {{
                         let msg = JSON.parse(ev.data);
                         if (msg.all) window.location.reload();

--- a/leptos_config/src/tests.rs
+++ b/leptos_config/src/tests.rs
@@ -1,18 +1,31 @@
-use crate::{env_w_default, env_wo_default, from_str, Env, LeptosOptions};
+use crate::{
+    env_from_str, env_w_default, env_wo_default, ws_from_str, Env,
+    LeptosOptions, ReloadWSProtocol,
+};
 use std::{net::SocketAddr, str::FromStr};
 
 #[test]
-fn from_str_env() {
-    assert!(matches!(from_str("dev").unwrap(), Env::DEV));
-    assert!(matches!(from_str("development").unwrap(), Env::DEV));
-    assert!(matches!(from_str("DEV").unwrap(), Env::DEV));
-    assert!(matches!(from_str("DEVELOPMENT").unwrap(), Env::DEV));
-    assert!(matches!(from_str("prod").unwrap(), Env::PROD));
-    assert!(matches!(from_str("production").unwrap(), Env::PROD));
-    assert!(matches!(from_str("PROD").unwrap(), Env::PROD));
-    assert!(matches!(from_str("PRODUCTION").unwrap(), Env::PROD));
-    assert!(from_str("TEST").is_err());
-    assert!(from_str("?").is_err());
+fn env_from_str_test() {
+    assert!(matches!(env_from_str("dev").unwrap(), Env::DEV));
+    assert!(matches!(env_from_str("development").unwrap(), Env::DEV));
+    assert!(matches!(env_from_str("DEV").unwrap(), Env::DEV));
+    assert!(matches!(env_from_str("DEVELOPMENT").unwrap(), Env::DEV));
+    assert!(matches!(env_from_str("prod").unwrap(), Env::PROD));
+    assert!(matches!(env_from_str("production").unwrap(), Env::PROD));
+    assert!(matches!(env_from_str("PROD").unwrap(), Env::PROD));
+    assert!(matches!(env_from_str("PRODUCTION").unwrap(), Env::PROD));
+    assert!(env_from_str("TEST").is_err());
+    assert!(env_from_str("?").is_err());
+}
+
+#[test]
+fn ws_from_str_test() {
+    assert!(matches!(ws_from_str("ws").unwrap(), ReloadWSProtocol::WS));
+    assert!(matches!(ws_from_str("WS").unwrap(), ReloadWSProtocol::WS));
+    assert!(matches!(ws_from_str("wss").unwrap(), ReloadWSProtocol::WSS));
+    assert!(matches!(ws_from_str("WSS").unwrap(), ReloadWSProtocol::WSS));
+    assert!(ws_from_str("TEST").is_err());
+    assert!(ws_from_str("?").is_err());
 }
 
 #[test]
@@ -49,6 +62,8 @@ fn try_from_env_test() {
     std::env::set_var("LEPTOS_SITE_ADDR", "0.0.0.0:80");
     std::env::set_var("LEPTOS_RELOAD_PORT", "8080");
     std::env::set_var("LEPTOS_RELOAD_EXTERNAL_PORT", "8080");
+    std::env::set_var("LEPTOS_ENV", "PROD");
+    std::env::set_var("LEPTOS_RELOAD_WS_PROTOCOL", "WSS");
 
     let config = LeptosOptions::try_from_env().unwrap();
     assert_eq!(config.output_name, "app_test");
@@ -61,4 +76,6 @@ fn try_from_env_test() {
     );
     assert_eq!(config.reload_port, 8080);
     assert_eq!(config.reload_external_port, Some(8080));
+    assert_eq!(config.env, Env::PROD);
+    assert_eq!(config.reload_ws_protocol, ReloadWSProtocol::WSS)
 }


### PR DESCRIPTION
1. Allows the PROD selection for LEPTOS_ENV, previously it was locked to DEV at all times.
2. Adds a new configuration: LEPTOS_RELOAD_WS_PROTOCOL which must be either `ws` or `wss`.
   - cargo-leptos can only perform hot-reloading over non-secure websockets so `ws` is used by default, but this option allows `wss` to be selected when the site is behind a reverse https proxy. The default of `ws` is also useful when your server binary supports https without a reverse proxy.
3. Updates the tests to verify that LEPTOS_ENV: PROD and LEPTOS_RELOAD_WS_PROTOCOL: WSS can be selected if set in the environment variables.