### PR TITLE
doc(examples): add fantoccini to test-runner-report (#1615)

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -51,7 +51,7 @@ echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 
 [tasks.test-runner-report]
 workspace = false
-description = "report ci test runners for each example - OPTION: [all]"
+description = "report ci test runners and tools for each example - OPTION: [all]"
 script = '''
 set -emu
 
@@ -62,7 +62,7 @@ YELLOW="\e[0;33m"
 RESET="\e[0m"
 
 echo
-echo "${YELLOW}Test Runner Report${RESET}"
+echo "${YELLOW}Test Runner & Tool Report${RESET}"
 echo "${ITALIC}Pass the option \"all\" to show all the examples${RESET}"
 echo
 
@@ -77,20 +77,23 @@ start_path=$(pwd)
 for path in $makefile_paths; do
   cd $path
 
-  test_runner=
+  crate_symbols=
 
   test_count=$(grep -rl -E "#\[test\]" | wc -l)
   if [ $test_count -gt 0 ]; then
-      test_runner="T"
+      crate_symbols="T"
   fi
 
   while read -r line; do
       case $line in
       *"cucumber"*)
-          test_runner=$test_runner"C"
+          crate_symbols=$crate_symbols"C"
+          ;;
+      *"fantoccini"*)
+          crate_symbols=$crate_symbols"F"
           ;;
       *"rstest"*)
-          test_runner=$test_runner"R"
+          crate_symbols=$crate_symbols"R"
           ;;
       esac
   done <"./Cargo.toml"
@@ -98,31 +101,47 @@ for path in $makefile_paths; do
   while read -r line; do
     case $line in
       *"wasm-test.toml"*)
-          test_runner=$test_runner"W"
+          crate_symbols=$crate_symbols"W"
         ;;
       *"playwright-test.toml"*)
-          test_runner=$test_runner"P"
+          crate_symbols=$crate_symbols"P"
         ;;
       *"cargo-leptos-test.toml"*)
-          test_runner=$test_runner"L"
+          crate_symbols=$crate_symbols"L"
         ;;
     esac
   done <"./Makefile.toml"
 
-  runners=$(echo ${test_runner} | grep -o . | sort | tr -d "\n") 
+  # Sort list of tools
+  sorted_crate_symbols=$(echo ${crate_symbols} | grep -o . | sort | tr -d "\n") 
 
+  formatted_crate_symbols=" ➤ ${BOLD}${YELLOW}${sorted_crate_symbols}${RESET}"
+  crate_line=$path
   if [ ! -z ${1+x} ]; then
     # Show all examples
-    echo "$path ➤ ${BOLD}${runners}${RESET}"
-  elif [ ! -z $runners ]; then
+    if [ ! -z $crate_symbols ]; then
+      crate_line=$crate_line$formatted_crate_symbols
+    fi
+    echo $crate_line
+  elif [ ! -z $crate_symbols ]; then
     # Filter out examples that do not run tests in `ci`
-    echo "$path ➤ ${BOLD}${runners}${RESET}"
+    crate_line=$crate_line$formatted_crate_symbols
+    echo $crate_line
   fi
 
   cd ${start_path}
 done
+
+c="${BOLD}${YELLOW}C${RESET} = Cucumber"
+f="${BOLD}${YELLOW}F${RESET} = Fantoccini WebDriver"
+l="${BOLD}${YELLOW}L${RESET} = Cargo Leptos"
+p="${BOLD}${YELLOW}P${RESET} = Playwright"
+r="${BOLD}${YELLOW}R${RESET} = RS Test"
+t="${BOLD}${YELLOW}T${RESET} = Cargo"
+w="${BOLD}${YELLOW}W${RESET} = WASM"
+
 echo
-echo "${ITALIC}Runners: C = Cucumber, L = Cargo Leptos, P = Playwright, R = RS Test, T = Cargo, W = WASM${RESET}"
+echo "${ITALIC}Key:${RESET} $c, $f, $l, $p, $r, $t, $w"
 echo
 '''
 


### PR DESCRIPTION
READY FOR REVIEW

Show which examples use [Fantoccini WebDriver](https://github.com/jonhoo/fantoccini).

## Verification

1. Run `cargo make test-runner-report` or  `cargo make test-runner-report all` from the **examples** directory
2. See that the report shows examples that use Fantoccini WebDriver

Closes #1615