### PR TITLE
feat: implement simple spread attributes

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -63,7 +63,9 @@ cfg_if! {
 use crate::{
     ev::EventDescriptor,
     hydration::HydrationCtx,
-    macro_helpers::{IntoAttribute, IntoClass, IntoProperty, IntoStyle},
+    macro_helpers::{
+        Attribute, IntoAttribute, IntoClass, IntoProperty, IntoStyle,
+    },
     Element, Fragment, IntoView, NodeRef, Text, View,
 };
 use leptos_reactive::Oco;
@@ -593,8 +595,6 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
 
         #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
         {
-            use crate::macro_helpers::Attribute;
-
             let mut this = self;
 
             let mut attr = attr.into_attribute();
@@ -620,6 +620,18 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
 
             this
         }
+    }
+
+    /// Adds multiple attributes to the element
+    #[track_caller]
+    pub fn attrs(
+        mut self,
+        attrs: impl std::iter::IntoIterator<Item = (&'static str, Attribute)>,
+    ) -> Self {
+        for (name, value) in attrs {
+            self = self.attr(name, value);
+        }
+        self
     }
 
     /// Adds a class to an element.


### PR DESCRIPTION
As discussed in Discord, here's a simple PR for some basic spread attributes support for items implementing `IntoIterator<Item= (&'static str, Attribute)>`.

Essentially, you can do the following:
```rs
let attrs = ["value", 1.into_attribute()];
view! { <input {..attrs} /> }
```
and it'll spread the attributes from the iterator into the component as if they were applied normally.

I've tested it and it seems to work correctly, this is my first PR to leptos as well so no idea if I did any of this correctly but please let me know. :)