### PR TITLE
docs: remove extra space

### DIFF
--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -18,7 +18,7 @@ use std::hash::Hash;
 ///
 /// #[component]
 /// fn Counters() -> impl IntoView {
-///   let (counters, set_counters) = create_signal::<Vec<Counter>>( vec![]);
+///   let (counters, set_counters) = create_signal::<Vec<Counter>>(vec![]);
 ///
 ///   view! {
 ///     <div>

--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -28,7 +28,7 @@ use std::hash::Hash;
 ///         // a unique key for each item
 ///         key=|counter| counter.id
 ///         // renders each item to a view
-///         view=move | counter: Counter| {
+///         view=move |counter: Counter| {
 ///           view! {
 ///             <button>"Value: " {move || counter.count.get()}</button>
 ///           }


### PR DESCRIPTION
`move | counter: Counter| {...}` -> `move |counter: Counter| {...}`