### PR TITLE
feat: add component generics

### DIFF
--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -147,11 +147,18 @@ pub(crate) fn component_to_tokens(
         }
     });
 
+    let generics = &node.open_tag.generics;
+    let generics = if generics.lt_token.is_some() {
+        quote! { ::#generics }
+    } else {
+        quote! {}
+    };
+
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         ::leptos::component_view(
             &#name,
-            ::leptos::component_props_builder(&#name)
+            ::leptos::component_props_builder(&#name #generics)
                 #(#props)*
                 #(#slots)*
                 #children


### PR DESCRIPTION
Adds support for passing generics straight into components using native support in rstml, should close #1176.