### PR TITLE
fix: versioned resources never decrement Suspense (closes #1640)

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1166,14 +1166,12 @@ where
                         resolved.set(true);
                         set_value.try_update(|n| *n = Some(res));
                         set_loading.try_update(|n| *n = false);
+                    }
 
-                        for suspense_context in
-                            suspense_contexts.borrow().iter()
-                        {
-                            suspense_context.decrement(
-                                serializable != ResourceSerialization::Local,
-                            );
-                        }
+                    for suspense_context in suspense_contexts.borrow().iter() {
+                        suspense_context.decrement(
+                            serializable != ResourceSerialization::Local,
+                        );
                     }
                 }
             })


### PR DESCRIPTION
This should close #1640, in which the resource version was checked both to determine whether to set the value and whether to decrement the Suspense count, but the Suspense count was incremented in every case. i.e., if a resource refetches multiple times before loading, the version check prevents a race condition by ensuring that only the resolved result of the most-recently-fired async call is used. However, this was causing Suspense to hang indefinitely on its loading state, as it would never decrement the count.

This fixes this bug by decrementing the count in every situation, just as the count is incremented in every situation, no matter the result of the version check; but it only updates the value if the version check passes.