### PR TITLE
Fix Issue in `normalized_call_site` Function when Using `cargo leptos`

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -373,7 +373,7 @@ fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
         if #[cfg(all(debug_assertions, feature = "nightly"))] {
             Some(leptos_hot_reload::span_to_stable_id(
                 site.source_file().path(),
-                site.start().line()
+                site.start().line
             ))
         } else {
             _ = site;


### PR DESCRIPTION
While attempting to build my app, I performed the following steps:
1. cargo leptos new --git https://github.com/leptos-rs/start
2. cd project
3. cargo leptos watch

I discovered an issue with the implementation of the `normalized_call_site` function. After removing the parentheses `()`, my code started working as expected. Does this help?
<img width="780" alt="Screenshot 2023-09-03 at 6 43 59 PM" src="https://github.com/leptos-rs/leptos/assets/29725763/af883ef0-a166-4087-aa06-69eb38263f94">
