### PR TITLE
fix: custom events on components

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -522,17 +522,7 @@ pub(crate) fn event_from_attribute_node(
 
     let handler = attribute_value(attr);
 
-    #[allow(unused_variables)]
-    let (name, name_undelegated) = parse_event(&event_name);
-
-    let event_type = TYPED_EVENTS
-        .binary_search(&name)
-        .map(|_| (name))
-        .unwrap_or(CUSTOM_EVENT);
-
-    let Ok(event_type) = event_type.parse::<TokenStream>() else {
-        abort!(attr.key, "couldn't parse event name");
-    };
+    let (event_type, _, name_undelegated) = parse_event_name(&event_name);
 
     let event_type = if force_undelegated || name_undelegated {
         quote! { ::leptos::leptos_dom::ev::undelegated(::leptos::leptos_dom::ev::#event_type) }

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
@@ -1,0 +1,19 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: pretty(result)
+---
+fn view() {
+    ::leptos::component_view(
+            &ExternalComponent,
+            ::leptos::component_props_builder(&ExternalComponent).build(),
+        )
+        .into_view()
+        .on(
+            ::leptos::leptos_dom::ev::undelegated(
+                ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),
+            ),
+            move |_: Event| set_value(0),
+        )
+}
+

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
@@ -1,0 +1,272 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: result
+---
+TokenStream [
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: leptos,
+    },
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: component_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: '&',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ExternalComponent,
+                span: bytes(11..28),
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: component_props_builder,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ExternalComponent,
+                        span: bytes(11..28),
+                    },
+                ],
+            },
+            Punct {
+                char: '.',
+                spacing: Alone,
+            },
+            Ident {
+                sym: build,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [],
+            },
+        ],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: into_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: on,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos_dom,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ev,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: undelegated,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos_dom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ev,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: Custom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: new,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Literal {
+                                lit: "custom.event.clear",
+                            },
+                        ],
+                    },
+                ],
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Ident {
+                sym: move,
+                span: bytes(51..55),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(56..57),
+            },
+            Ident {
+                sym: _,
+                span: bytes(57..58),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(58..59),
+            },
+            Ident {
+                sym: Event,
+                span: bytes(60..65),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(65..66),
+            },
+            Ident {
+                sym: set_value,
+                span: bytes(67..76),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Literal {
+                        lit: 0,
+                        span: bytes(77..78),
+                    },
+                ],
+                span: bytes(76..79),
+            },
+        ],
+    },
+]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
@@ -1,0 +1,19 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: pretty(result)
+---
+fn view() {
+    ::leptos::component_view(
+            &ExternalComponent,
+            ::leptos::component_props_builder(&ExternalComponent).build(),
+        )
+        .into_view()
+        .on(
+            ::leptos::leptos_dom::ev::undelegated(
+                ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),
+            ),
+            move |_: Event| set_value(0),
+        )
+}
+

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
@@ -1,0 +1,272 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: result
+---
+TokenStream [
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: leptos,
+    },
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: component_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: '&',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ExternalComponent,
+                span: bytes(11..28),
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: component_props_builder,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ExternalComponent,
+                        span: bytes(11..28),
+                    },
+                ],
+            },
+            Punct {
+                char: '.',
+                spacing: Alone,
+            },
+            Ident {
+                sym: build,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [],
+            },
+        ],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: into_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: on,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos_dom,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ev,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: undelegated,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos_dom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ev,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: Custom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: new,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Literal {
+                                lit: "custom.event.clear",
+                            },
+                        ],
+                    },
+                ],
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Ident {
+                sym: move,
+                span: bytes(51..55),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(56..57),
+            },
+            Ident {
+                sym: _,
+                span: bytes(57..58),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(58..59),
+            },
+            Ident {
+                sym: Event,
+                span: bytes(60..65),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(65..66),
+            },
+            Ident {
+                sym: set_value,
+                span: bytes(67..76),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Literal {
+                        lit: 0,
+                        span: bytes(77..78),
+                    },
+                ],
+                span: bytes(76..79),
+            },
+        ],
+    },
+]

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
@@ -1,0 +1,19 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: pretty(result)
+---
+fn view() {
+    ::leptos::component_view(
+            &ExternalComponent,
+            ::leptos::component_props_builder(&ExternalComponent).build(),
+        )
+        .into_view()
+        .on(
+            ::leptos::leptos_dom::ev::undelegated(
+                ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),
+            ),
+            move |_: Event| set_value(0),
+        )
+}
+

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
@@ -1,0 +1,272 @@
+---
+source: leptos_macro/src/view/tests.rs
+assertion_line: 101
+expression: result
+---
+TokenStream [
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: leptos,
+    },
+    Punct {
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
+        spacing: Alone,
+    },
+    Ident {
+        sym: component_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: '&',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ExternalComponent,
+                span: bytes(11..28),
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: component_props_builder,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: '&',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ExternalComponent,
+                        span: bytes(11..28),
+                    },
+                ],
+            },
+            Punct {
+                char: '.',
+                spacing: Alone,
+            },
+            Ident {
+                sym: build,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [],
+            },
+        ],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: into_view,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+    },
+    Punct {
+        char: '.',
+        spacing: Alone,
+    },
+    Ident {
+        sym: on,
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: leptos_dom,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: ev,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
+            Ident {
+                sym: undelegated,
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos_dom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: ev,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: Custom,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: new,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Literal {
+                                lit: "custom.event.clear",
+                            },
+                        ],
+                    },
+                ],
+            },
+            Punct {
+                char: ',',
+                spacing: Alone,
+            },
+            Ident {
+                sym: move,
+                span: bytes(51..55),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(56..57),
+            },
+            Ident {
+                sym: _,
+                span: bytes(57..58),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(58..59),
+            },
+            Ident {
+                sym: Event,
+                span: bytes(60..65),
+            },
+            Punct {
+                char: '|',
+                spacing: Alone,
+                span: bytes(65..66),
+            },
+            Ident {
+                sym: set_value,
+                span: bytes(67..76),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Literal {
+                        lit: 0,
+                        span: bytes(77..78),
+                    },
+                ],
+                span: bytes(76..79),
+            },
+        ],
+    },
+]

--- a/leptos_macro/src/view/tests.rs
+++ b/leptos_macro/src/view/tests.rs
@@ -112,5 +112,8 @@ for_all_modes! {
             initial_value=0
             step=1
         />
+    "#,
+    test_custom_event => r#"
+        <ExternalComponent on:custom.event.clear=move |_: Event| set_value(0) />
     "#
 }


### PR DESCRIPTION
**This PR fixes the following bug**
I was using events on components like in the chapter [Parent-Child Communication](https://leptos-rs.github.io/leptos/view/08_parent_child.html#3-use-an-event-listener) of the book:
```rust
<ButtonC on:click=move |_| set_toggled.update(|value| *value = !*value)/>
```
But I was using custom events like this:
```rust
<Modal header="Hello, World!" id="test-modal" on:hidden.bs.modal=|_: Event| log!("modal closed")>
    "This is a test message."
</Modal>
```
Which resulted into a compiler error on `0.5.0-beta2` and also on commit 4a43983f4ed4472d8c34f51a069d4f2c5b4a40e0:
rustc 1.74.0-nightly (4e78abb43 2023-08-28)
```
error[E0423]: expected value, found struct `leptos::leptos_dom::ev::Custom`
```
This is because the macro was generating
```rust
.on(
    ::leptos::leptos_dom::ev::undelegated(
        ::leptos::leptos_dom::ev::Custom,
    ),
    |_: Event| ::leptos_dom::console_log(
        &format_args!("modal closed").to_string(),
    ),
)
```
instead of
```rust
.on(
    ::leptos::leptos_dom::ev::undelegated(
        ::leptos::leptos_dom::ev::Custom::new("hidden.bs.modal"),
    ),
    |_: Event| ::leptos_dom::console_log(
        &format_args!("modal closed").to_string(),
    ),
)
```
**Use case**
My use case for using custom events on components is that I am using the Bootstrap 5.3 [Modal](https://getbootstrap.com/docs/5.3/components/modal/) component.
When I am using this component within my leptos application, the external component is sending a custom event `hidden.bs.modal` whenever the modal is closed and it is very convenient to add the event handler onto the component instead of using a callback property on the component and adding the event handler on the `<div class="modal fade" ...>` inside the component.