### PR TITLE
Fix Trunk not finding Rust project in "Getting Started"

### DIFF
--- a/docs/book/src/02_getting_started.md
+++ b/docs/book/src/02_getting_started.md
@@ -55,7 +55,9 @@ Create a simple `index.html` in the root of the `leptos-tutorial` directory
 <!DOCTYPE html>
 <html>
   <head></head>
-  <body></body>
+  <body>
+    <link data-trunk rel="rust" href="Cargo.toml"/>
+  </body>
 </html>
 ```
 


### PR DESCRIPTION
As stated, the Getting Started directions would result in a blank page being served up. This is because Trunk's behavior is to look for Cargo.toml in the **parent** directory of the source HTML file https://trunkrs.dev/assets/#rust. In the provided instructions the source HTML file (index.html) and the Cargo.toml file are in the same directory, so Trunk would not find the Cargo.toml, serving up a blank page and emitting the warning "WARN no rust project found"

This behavior is not obvious as the homepage for Trunk suggests that the Cargo.toml and index.html can be in the same directory.

To fix this specify the path to Cargo.toml as laid out in the Trunk documentation https://trunkrs.dev/assets/#rust