### PR TITLE
fix: compare path components to detect active link in router

### DIFF
--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -133,7 +133,8 @@ where
                         if exact {
                             loc == path
                         } else {
-                            loc.starts_with(&path)
+                            std::iter::zip(loc.split('/'), path.split('/'))
+                                .all(|(loc_p, path_p)| loc_p == path_p)
                         }
                     })
                 })


### PR DESCRIPTION
With this chage, the two path fragments are compared by their components, not just as strings.
This should fix  #1655.
I'm note sure if this covers each and every corner case though.