### PR TITLE
Remove unnecessary `move ||`?

### DIFF
--- a/docs/book/src/view/07_errors.md
+++ b/docs/book/src/view/07_errors.md
@@ -143,7 +143,7 @@ fn App() -> impl IntoView {
                         // we can render a list of errors
                         // as strings, if we'd like
                         <ul>
-                            {move || errors.get()
+                            {errors.get()
                                 .into_iter()
                                 .map(|(_, e)| view! { <li>{e.to_string()}</li>})
                                 .collect::<Vec<_>>()


### PR DESCRIPTION
Why do we need the `move ||` here? Doesn't the outer closure already make sure that `errors` is up to date?  I could not notice any difference between the two running this example locally ... I'm also quite new to Leptos though.