### PR TITLE
`Rc` backed `ChildrenFn`

### DIFF
--- a/leptos/src/children.rs
+++ b/leptos/src/children.rs
@@ -25,6 +25,7 @@ impl<F> ToChildren<F> for Children
 where
     F: FnOnce() -> Fragment + 'static,
 {
+    #[inline]
     fn to_children(f: F) -> Self {
         Box::new(f)
     }
@@ -34,6 +35,7 @@ impl<F> ToChildren<F> for ChildrenFn
 where
     F: Fn() -> Fragment + 'static,
 {
+    #[inline]
     fn to_children(f: F) -> Self {
         Rc::new(f)
     }
@@ -43,6 +45,7 @@ impl<F> ToChildren<F> for ChildrenFnMut
 where
     F: FnMut() -> Fragment + 'static,
 {
+    #[inline]
     fn to_children(f: F) -> Self {
         Box::new(f)
     }
@@ -52,6 +55,7 @@ impl<F> ToChildren<F> for BoxedChildrenFn
 where
     F: Fn() -> Fragment + 'static,
 {
+    #[inline]
     fn to_children(f: F) -> Self {
         Box::new(f)
     }

--- a/leptos/src/children.rs
+++ b/leptos/src/children.rs
@@ -1,0 +1,58 @@
+use leptos_dom::Fragment;
+use std::rc::Rc;
+
+/// The most common type for the `children` property on components,
+/// which can only be called once.
+pub type Children = Box<dyn FnOnce() -> Fragment>;
+
+/// A type for the `children` property on components that can be called
+/// more than once.
+pub type ChildrenFn = Rc<dyn Fn() -> Fragment>;
+
+/// A type for the `children` property on components that can be called
+/// more than once, but may mutate the children.
+pub type ChildrenFnMut = Box<dyn FnMut() -> Fragment>;
+
+// This is to still support components that accept `Box<dyn Fn() -> Fragment>` as a children.
+type BoxedChildrenFn = Box<dyn Fn() -> Fragment>;
+
+#[doc(hidden)]
+pub trait ToChildren<F> {
+    fn to_children(f: F) -> Self;
+}
+
+impl<F> ToChildren<F> for Children
+where
+    F: FnOnce() -> Fragment + 'static,
+{
+    fn to_children(f: F) -> Self {
+        Box::new(f)
+    }
+}
+
+impl<F> ToChildren<F> for ChildrenFn
+where
+    F: Fn() -> Fragment + 'static,
+{
+    fn to_children(f: F) -> Self {
+        Rc::new(f)
+    }
+}
+
+impl<F> ToChildren<F> for ChildrenFnMut
+where
+    F: FnMut() -> Fragment + 'static,
+{
+    fn to_children(f: F) -> Self {
+        Box::new(f)
+    }
+}
+
+impl<F> ToChildren<F> for BoxedChildrenFn
+where
+    F: Fn() -> Fragment + 'static,
+{
+    fn to_children(f: F) -> Self {
+        Box::new(f)
+    }
+}

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -200,19 +200,9 @@ pub use typed_builder;
 pub use typed_builder::Optional;
 #[doc(hidden)]
 pub use typed_builder_macro;
+mod children;
+pub use children::*;
 extern crate self as leptos;
-
-/// The most common type for the `children` property on components,
-/// which can only be called once.
-pub type Children = Box<dyn FnOnce() -> Fragment>;
-
-/// A type for the `children` property on components that can be called
-/// more than once.
-pub type ChildrenFn = Box<dyn Fn() -> Fragment>;
-
-/// A type for the `children` property on components that can be called
-/// more than once, but may mutate the children.
-pub type ChildrenFnMut = Box<dyn FnMut() -> Fragment>;
 
 /// A type for taking anything that implements [`IntoAttribute`].
 ///

--- a/leptos/src/show.rs
+++ b/leptos/src/show.rs
@@ -1,5 +1,5 @@
-use leptos::component;
-use leptos_dom::{Fragment, IntoView};
+use leptos::{component, ChildrenFn};
+use leptos_dom::IntoView;
 use leptos_reactive::{create_memo, signal_prelude::*};
 
 /// A component that will show its children when the `when` condition is `true`,
@@ -38,7 +38,7 @@ pub fn Show<F, W, IV>(
     /// The scope the component is running in
 
     /// The components Show wraps
-    children: Box<dyn Fn() -> Fragment>,
+    children: ChildrenFn,
     /// A closure that returns a bool that determines whether this thing runs
     when: W,
     /// A closure that returns what gets rendered if the when statement is false

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -61,14 +61,14 @@ pub fn Suspense<F, E, V>(
     /// Returns a fallback UI that will be shown while `async` [`Resource`](leptos_reactive::Resource)s are still loading.
     fallback: F,
     /// Children will be displayed once all `async` [`Resource`](leptos_reactive::Resource)s have resolved.
-    children: Box<dyn Fn() -> V>,
+    children: Rc<dyn Fn() -> V>,
 ) -> impl IntoView
 where
     F: Fn() -> E + 'static,
     E: IntoView,
     V: IntoView + 'static,
 {
-    let orig_children = Rc::new(children);
+    let orig_children = children;
     let context = SuspenseContext::new();
 
     #[cfg(not(any(feature = "csr", feature = "hydrate")))]

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -114,7 +114,7 @@ where
                     }
                 }
             })
-            .children(Box::new(move || {
+            .children(Rc::new(move || {
                 let frag = children().into_view();
 
                 if let Some(suspense_context) = use_context::<SuspenseContext>()

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -124,7 +124,7 @@ pub(crate) fn component_to_tokens(
                     .children({
                         #(#clonables)*
 
-                        Box::new(move || #children #view_marker)
+                        ::leptos::ToChildren::to_children(move || #children #view_marker)
                     })
                 }
             }

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -130,7 +130,7 @@ pub(crate) fn slot_to_tokens(
                     .children({
                         #(#clonables)*
 
-                        Box::new(move || #children #view_marker)
+                        ::leptos::ToChildren::to_children(move || #children #view_marker)
                     })
                 }
             }


### PR DESCRIPTION
Currently components only accept `Box` backed children, it makes sense for `Children` and `ChildrenFnMut` but makes working with `ChildrenFn` difficult as it can't be cloned, so the solution most user would take is to put it in a `Rc` but it introduce more code and unecessary allocations.

This PR change `ChildrenFn` to be `Rc` backed, so component taking `ChildrenFn` as an argument can now clone it directly with minimal cost.