### PR TITLE
Router version bump

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       # Setup environment
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: actions-rs/toolchain@v1

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -10,7 +10,7 @@ description = "Router for the Leptos web framework."
 
 [dependencies]
 leptos = { workspace = true }
-cached = { version = "0.44.0", optional = true }
+cached = { version = "0.45.0", optional = true }
 cfg-if = "1"
 common_macros = "0.1"
 gloo-net = { version = "0.2", features = ["http"] }
@@ -28,7 +28,7 @@ tracing = "0.1"
 js-sys = { version = "0.3" }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
-lru = { version = "0.10", optional = true }
+lru = { version = "0.11", optional = true }
 serde_json = "1.0.96"
 
 [dependencies.web-sys]


### PR DESCRIPTION
Saw a few outdated package while reading the code

-cached = { version = "0.44.0", optional = true }
+cached = { version = "0.45.0", optional = true }

-lru = { version = "0.10", optional = true }
+lru = { version = "0.11", optional = true }

NB gloo_net needs updating but that would take bigger refactoring as the raw response is now private.