### PR TITLE
chore: Removed resolver link warning.

### DIFF
--- a/examples/login_with_token_csr_only/Cargo.toml
+++ b/examples/login_with_token_csr_only/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["client", "api-boundary", "server"]
 
 [profile.release]


### PR DESCRIPTION
tiny fix, seen while running the examples