### PR TITLE
Feedback Wanted — feat: add `.write()` and `.read()` for signals

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,4 +1,5 @@
-use leptos::*;
+use leptos::{SignalWrite, *};
+use std::cell::{Ref, RefMut};
 
 /// A simple counter component.
 ///
@@ -12,12 +13,20 @@ pub fn SimpleCounter(
 ) -> impl IntoView {
     let (value, set_value) = create_signal(initial_value);
 
+    let something: Ref<'_, i32> = value.read();
+
+    spawn_local(async move {
+        let mut something_else: RefMut<'_, i32> = set_value.write();
+        async {}.await;
+        *something_else = 30;
+    });
+
     view! {
         <div>
             <button on:click=move |_| set_value(0)>"Clear"</button>
-            <button on:click=move |_| set_value.update(|value| *value -= step)>"-1"</button>
+            <button on:click=move |_| *set_value.write() -= step>"-1"</button>
             <span>"Value: " {value} "!"</span>
-            <button on:click=move |_| set_value.update(|value| *value += step)>"+1"</button>
+            <button on:click=move |_| *set_value.write() += step>"+1"</button>
         </div>
     }
 }

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/leptos-rs/leptos"
 description = "Reactive system for the Leptos web framework."
 
 [dependencies]
+elsa = "1"
 slotmap = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde-lite = { version = "0.4", optional = true }

--- a/leptos_reactive/src/arena.rs
+++ b/leptos_reactive/src/arena.rs
@@ -1,0 +1,161 @@
+use elsa::FrozenVec;
+use std::{
+    any::Any,
+    cell::{Cell, Ref, RefCell, RefMut},
+    fmt::Debug,
+    marker::PhantomData,
+    rc::Rc,
+};
+
+#[derive(Clone)]
+pub(crate) struct Arena {
+    #[allow(clippy::type_complexity)]
+    values: &'static FrozenVec<Box<Slot>>,
+    open: Rc<RefCell<Vec<u32>>>,
+}
+
+impl Arena {
+    pub fn new() -> Self {
+        Self {
+            values: Box::leak(Box::new(FrozenVec::new())),
+            open: Default::default(),
+        }
+    }
+
+    fn push<T: 'static>(&self, value: T) -> NodeId {
+        self.push_erased(Box::new(value))
+    }
+
+    pub fn get<T: 'static>(&self, id: &NodeId) -> Option<Ref<'_, T>> {
+        let node = self.get_any(id)?;
+        Ref::filter_map(node, |node| {
+            let node = node.as_ref()?;
+            match node.downcast_ref::<T>() {
+                Some(t) => Some(t),
+                None => None,
+            }
+        })
+        .ok()
+    }
+
+    pub fn get_mut<T: 'static>(&self, id: &NodeId) -> Option<RefMut<'_, T>> {
+        let node = self.get_any_mut(id)?;
+        RefMut::filter_map(node, |node| {
+            let node = node.as_mut()?;
+            match node.downcast_mut::<T>() {
+                Some(t) => Some(t),
+                None => None,
+            }
+        })
+        .ok()
+    }
+
+    pub fn remove(&self, id: &NodeId) -> Option<Box<dyn Any>> {
+        self.recycle(id)
+    }
+
+    fn get_any(&self, id: &NodeId) -> Option<Ref<'_, Option<Box<dyn Any>>>> {
+        let node = self.values.get(id.idx as usize)?;
+        if id.generation == node.generation.get() {
+            Some(node.value.borrow())
+        } else {
+            None
+        }
+    }
+
+    pub fn get_any_mut(
+        &self,
+        id: &NodeId,
+    ) -> Option<RefMut<'_, Option<Box<dyn Any>>>> {
+        let node = self.values.get(id.idx as usize)?;
+        if id.generation == node.generation.get() {
+            Some(node.value.borrow_mut())
+        } else {
+            None
+        }
+    }
+
+    fn recycle(&self, id: &NodeId) -> Option<Box<dyn Any>> {
+        let node = self.values.get(id.idx as usize)?;
+        node.value.borrow_mut().take()
+    }
+
+    fn push_erased(&self, value: Box<dyn Any>) -> NodeId {
+        if let Some(next_node) = self.open.borrow_mut().pop() {
+            let slot = self.values.get(next_node as usize).unwrap();
+            let generation = slot.generation.get() + 1;
+            slot.generation.set(generation);
+            *slot.value.borrow_mut() = Some(value);
+            NodeId {
+                idx: next_node,
+                generation,
+            }
+        } else {
+            self.values.push(Box::new(Slot {
+                generation: Cell::new(0),
+                value: RefCell::new(Some(value)),
+            }));
+            let idx = (self.values.len() - 1) as u32;
+            NodeId { idx, generation: 0 }
+        }
+    }
+}
+
+impl Debug for Arena {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Arena")
+            .field("values", &self.values.len())
+            .field("open", &self.open)
+            .finish()
+    }
+}
+
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
+/// TODO
+pub struct NodeId {
+    idx: u32,
+    generation: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct Slot {
+    generation: Cell<u32>,
+    value: RefCell<Option<Box<dyn Any>>>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Value<T> {
+    id: NodeId,
+    ty: PhantomData<T>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ArenaOwner {
+    pub(crate) arena: &'static Arena,
+    pub(crate) owned: RefCell<Vec<NodeId>>,
+}
+
+impl ArenaOwner {
+    pub fn insert<T: 'static>(&self, value: T) -> NodeId {
+        let id = self.arena.push(value);
+        self.register(id)
+    }
+
+    pub fn insert_boxed(&self, value: Box<dyn Any>) -> NodeId {
+        let id = self.arena.push_erased(value);
+        self.register(id)
+    }
+
+    fn register(&self, id: NodeId) -> NodeId {
+        self.owned.borrow_mut().push(id);
+        id
+    }
+}
+
+impl Drop for ArenaOwner {
+    fn drop(&mut self) {
+        for location in self.owned.borrow().iter() {
+            drop(self.arena.recycle(location));
+        }
+    }
+}

--- a/leptos_reactive/src/context.rs
+++ b/leptos_reactive/src/context.rs
@@ -60,7 +60,7 @@ where
         let mut contexts = runtime.contexts.borrow_mut();
         let owner = runtime.owner.get();
         if let Some(owner) = owner {
-            let context = contexts.entry(owner).unwrap().or_default();
+            let context = contexts.entry(owner).or_default();
             context.insert(id, Box::new(value) as Box<dyn Any>);
         } else {
             crate::macros::debug_warn!(

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(fn_traits))]
 #![cfg_attr(feature = "nightly", feature(unboxed_closures))]
-#![cfg_attr(feature = "nightly", feature(type_name_of_val))]
+#![feature(type_name_of_val)]
 
 //! The reactive system for the [Leptos](https://docs.rs/leptos/latest/leptos/) Web framework.
 //!
@@ -76,6 +76,7 @@
 #[cfg_attr(any(debug_assertions, feature = "ssr"), macro_use)]
 extern crate tracing;
 
+mod arena;
 #[macro_use]
 mod signal;
 mod context;

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1116,8 +1116,7 @@ where
 
         let v = self
             .value
-            .try_with(|n| n.as_ref().map(|n| Some(f(n))))
-            .ok()?
+            .try_with(|n| n.as_ref().map(|n| Some(f(n))))?
             .flatten();
 
         self.handle_result(location, global_suspense_cx, suspense_cx, v)
@@ -1132,7 +1131,7 @@ where
         let global_suspense_cx = use_context::<GlobalSuspenseContext>();
         let suspense_cx = use_context::<SuspenseContext>();
 
-        let v = self.value.try_with(|n| f(n)).ok();
+        let v = self.value.try_with(|n| f(n));
 
         self.handle_result(location, global_suspense_cx, suspense_cx, v)
     }

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -273,7 +273,7 @@ impl<T> SignalWith for Signal<T> {
     )]
     fn try_with<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
         match self.inner {
-            SignalTypes::ReadSignal(r) => r.try_with(f).ok(),
+            SignalTypes::ReadSignal(r) => r.try_with(f),
 
             SignalTypes::Memo(m) => m.try_with(f),
             SignalTypes::DerivedSignal(s) => s.try_with_value(|t| f(&t())),

--- a/leptos_reactive/src/trigger.rs
+++ b/leptos_reactive/src/trigger.rs
@@ -1,7 +1,7 @@
 use crate::{
+    arena::NodeId,
     diagnostics,
     diagnostics::*,
-    node::NodeId,
     runtime::{with_runtime, Runtime},
     SignalGet, SignalSet, SignalUpdate,
 };


### PR DESCRIPTION
## The Problem 

Historically, we have not been able to directly expose (immutable or mutable) references to the values of signals. This is fine for `Copy` types or values you're willing to clone, because you can access their values using getters:
```rust
let (a, set_a) = create_signal(1);
let (b, set_b) = create_signal(2);
let c = move || a() + b();
```
However, for values that are more expensive to clone, this is not ideal:
```rust
let (first, set_first) = create_signal("John".to_string());
let (middle, set_middle) = create_signal("Roberts".to_string());
let (last, set_last) = create_signal("Smith".to_string());
// clones all three Strings unnecessarily
let full_name = move || format!("{} {} {}", first(), middle(), last());
```
The `.with()` function allows you to work on references to signal values, but quickly leads to deep nesting, which has implications on both formatting and code readability
```rust
// this is kind of gross
let name = move || {
    first.with(|first| {
        middle.with(|middle| last.with(|last| format!("Full name is {first} {middle} {last}")))
    })
};
```
It would be very nice to be able to write something like this, instead:
```rust
let name = move || {
    let first = first.read(); // returns a reference, without cloning
    let middle = middle.read();
    let last = last.read();
    format!("{first} {middle} {last}")
};
```

## Proposed Solution

This PR introduces `SignalRead` and `SignalWrite` traits that allow you to access the inner values, either mutably or immutably, using the same API as a `RefCell`. (This includes reorganizing how signal values are stored to make that possible, which had previously been impossible.)
```rust
let (value, set_value) = create_signal(vec![0, 1, 2]);
let value_ref: Ref<'_, Vec<i32>> = value.read();
let value_ref_mut: RefMut<'_, Vec<i32>> = set_value.write();
```
These work reactively: `.read()` registers the access with the nearest effect or memo, just like `.get()` or `.with()` does. `.write()` notifies subscribers that the value has changed, and reruns any effects accordingly.

> Timing this for `.write()` is slightly complicated. You know that the values are done updating at the end of the `.update()` closure or the `.set()` call. But because `.write()` returns a `RefMut`, the signal value has not actually been updated by the end of `.write()`, so you can't run effects yet with the new value. Currently, I have this scheduled with a `queueMicrotask()`. Alternately, implementing a wrapper for `RefMut` that notifies on or after a `DerefMut` could work.

### Pros
- It's nice to be able to work directly with references (or `std` library reference-like RAII types, in any case.)
- Reduced nesting of `.with()` closures
- Encourages better practices: rather than simply `.get()`ing a `String` for convenience when you only need a reference, you can `.read()` it with the same ergonomics
- Small reduction in WASM binary size because of rewritten signal storage system

### Cons
- Exposes users to the same set of possible panics you get with `RefCell`. This example was there to show the types, but it actually panics: the `.read()` guard is still held as an immutable reference when you try to borrow the same value mutably with `.write()`. Users need to be careful when doing things like reading and writing in the same lexical scope, or holding a `RefMut` across a `.await`.
```rust
let (value, set_value) = create_signal(vec![0, 1, 2]);
let value_ref: Ref<'_, Vec<i32>> = value.read();
let value_ref_mut: RefMut<'_, Vec<i32>> = set_value.write();
```
- Uses our own bespoke arena implementation, which is shared thread-locally across runtimes, rather than a single slotmap per runtime. This means we would need to do some testing to make sure that there are no memory leaks and no leakage of signal values across runtimes (i.e., across requests) on the server. I'm not too worried about this but replacing a well-known crate with your own solution is always somewhat risky.