### PR TITLE
Feedback Wanted  — change: run effects after a tick

### DIFF
--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -210,13 +210,7 @@ pub fn TodoMVC() -> impl IntoView {
     // focus the main input on load
     create_effect(move |_| {
         if let Some(input) = input_ref.get() {
-            // We use request_animation_frame here because the NodeRef
-            // is filled when the element is created, but before it's mounted
-            // to the DOM. Calling .focus() before it's mounted does nothing.
-            // So inside, we wait a tick for the browser to mount it, then .focus()
-            request_animation_frame(move || {
-                let _ = input.focus();
-            });
+            let _ = input.focus();
         }
     });
 

--- a/leptos_dom/src/components/dyn_child.rs
+++ b/leptos_dom/src/components/dyn_child.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, fmt, ops::Deref, rc::Rc};
 cfg_if! {
   if #[cfg(all(target_arch = "wasm32", feature = "web"))] {
     use crate::{mount_child, prepare_to_move, unmount_child, MountKind, Mountable, Text};
-    use leptos_reactive::create_effect;
+    use leptos_reactive::create_render_effect;
     use wasm_bindgen::JsCast;
   }
 }
@@ -181,194 +181,204 @@ where
             let span = tracing::Span::current();
 
             #[cfg(all(target_arch = "wasm32", feature = "web"))]
-            create_effect(move |prev_run: Option<Option<web_sys::Node>>| {
-                #[cfg(debug_assertions)]
-                let _guard = span.enter();
+            create_render_effect(
+                move |prev_run: Option<Option<web_sys::Node>>| {
+                    #[cfg(debug_assertions)]
+                    let _guard = span.enter();
 
-                let new_child = child_fn().into_view();
+                    let new_child = child_fn().into_view();
 
-                let mut child_borrow = child.borrow_mut();
+                    let mut child_borrow = child.borrow_mut();
 
-                // Is this at least the second time we are loading a child?
-                if let Some(prev_t) = prev_run {
-                    let child = child_borrow.take().unwrap();
+                    // Is this at least the second time we are loading a child?
+                    if let Some(prev_t) = prev_run {
+                        let child = child_borrow.take().unwrap();
 
-                    // We need to know if our child wasn't moved elsewhere.
-                    // If it was, `DynChild` no longer "owns" that child, and
-                    // is therefore no longer sound to unmount it from the DOM
-                    // or to reuse it in the case of a text node
+                        // We need to know if our child wasn't moved elsewhere.
+                        // If it was, `DynChild` no longer "owns" that child, and
+                        // is therefore no longer sound to unmount it from the DOM
+                        // or to reuse it in the case of a text node
 
-                    // TODO check does this still detect moves correctly?
-                    let was_child_moved = prev_t.is_none()
-                        && child
-                            .get_closing_node()
-                            .next_non_view_marker_sibling()
-                            .as_ref()
-                            != Some(&closing);
+                        // TODO check does this still detect moves correctly?
+                        let was_child_moved = prev_t.is_none()
+                            && child
+                                .get_closing_node()
+                                .next_non_view_marker_sibling()
+                                .as_ref()
+                                != Some(&closing);
 
-                    // If the previous child was a text node, we would like to
-                    // make use of it again if our current child is also a text
-                    // node
-                    let ret = if let Some(prev_t) = prev_t {
-                        // Here, our child is also a text node
+                        // If the previous child was a text node, we would like to
+                        // make use of it again if our current child is also a text
+                        // node
+                        let ret = if let Some(prev_t) = prev_t {
+                            // Here, our child is also a text node
 
-                        // nb: the match/ownership gymnastics here
-                        // are so that, if we can reuse the text node,
-                        // we can take ownership of new_t so we don't clone
-                        // the contents, which in O(n) on the length of the text
-                        if matches!(new_child, View::Text(_)) {
-                            if !was_child_moved && child != new_child {
-                                let mut new_t = match new_child {
-                                    View::Text(t) => t,
-                                    _ => unreachable!(),
-                                };
-                                prev_t
-                                    .unchecked_ref::<web_sys::Text>()
-                                    .set_data(&new_t.content);
+                            // nb: the match/ownership gymnastics here
+                            // are so that, if we can reuse the text node,
+                            // we can take ownership of new_t so we don't clone
+                            // the contents, which in O(n) on the length of the text
+                            if matches!(new_child, View::Text(_)) {
+                                if !was_child_moved && child != new_child {
+                                    let mut new_t = match new_child {
+                                        View::Text(t) => t,
+                                        _ => unreachable!(),
+                                    };
+                                    prev_t
+                                        .unchecked_ref::<web_sys::Text>()
+                                        .set_data(&new_t.content);
 
-                                // replace new_t's text node with the prev node
-                                // see discussion: https://github.com/leptos-rs/leptos/pull/1472
-                                new_t.node = prev_t.clone();
+                                    // replace new_t's text node with the prev node
+                                    // see discussion: https://github.com/leptos-rs/leptos/pull/1472
+                                    new_t.node = prev_t.clone();
 
-                                let new_child = View::Text(new_t);
-                                **child_borrow = Some(new_child);
+                                    let new_child = View::Text(new_t);
+                                    **child_borrow = Some(new_child);
 
-                                Some(prev_t)
-                            } else {
-                                let new_t = new_child.as_text().unwrap();
+                                    Some(prev_t)
+                                } else {
+                                    let new_t = new_child.as_text().unwrap();
+                                    mount_child(
+                                        MountKind::Before(&closing),
+                                        &new_child,
+                                    );
+
+                                    **child_borrow = Some(new_child.clone());
+
+                                    Some(new_t.node.clone())
+                                }
+                            }
+                            // Child is not a text node, so we can remove the previous
+                            // text node
+                            else {
+                                if !was_child_moved && child != new_child {
+                                    // Remove the text
+                                    closing
+                                        .previous_non_view_marker_sibling()
+                                        .unwrap()
+                                        .unchecked_into::<web_sys::Element>()
+                                        .remove();
+                                }
+
+                                // Mount the new child, and we're done
                                 mount_child(
                                     MountKind::Before(&closing),
                                     &new_child,
                                 );
 
-                                **child_borrow = Some(new_child.clone());
+                                **child_borrow = Some(new_child);
 
-                                Some(new_t.node.clone())
+                                None
                             }
                         }
-                        // Child is not a text node, so we can remove the previous
-                        // text node
+                        // Otherwise, the new child can still be a text node,
+                        // but we know the previous child was not, so no special
+                        // treatment here
                         else {
-                            if !was_child_moved && child != new_child {
-                                // Remove the text
-                                closing
-                                    .previous_non_view_marker_sibling()
-                                    .unwrap()
-                                    .unchecked_into::<web_sys::Element>()
-                                    .remove();
+                            // Technically, I think this check shouldn't be necessary, but
+                            // I can imagine some edge case that the child changes while
+                            // hydration is ongoing
+                            if !HydrationCtx::is_hydrating() {
+                                let same_child = child == new_child;
+                                if !was_child_moved && !same_child {
+                                    // Remove the child
+                                    let start = child.get_opening_node();
+                                    let end = &closing;
+
+                                    match child {
+                                        View::CoreComponent(
+                                            crate::CoreComponent::DynChild(
+                                                child,
+                                            ),
+                                        ) => {
+                                            let start =
+                                                child.get_opening_node();
+                                            let end = child.closing.node;
+                                            prepare_to_move(
+                                                &child.document_fragment,
+                                                &start,
+                                                &end,
+                                            );
+                                        }
+                                        View::Component(child) => {
+                                            let start =
+                                                child.get_opening_node();
+                                            let end = child.closing.node;
+                                            prepare_to_move(
+                                                &child.document_fragment,
+                                                &start,
+                                                &end,
+                                            );
+                                        }
+                                        _ => unmount_child(&start, end),
+                                    }
+                                }
+
+                                // Mount the new child
+                                // If it's the same child, don't re-mount
+                                if !same_child {
+                                    mount_child(
+                                        MountKind::Before(&closing),
+                                        &new_child,
+                                    );
+                                }
                             }
 
-                            // Mount the new child, and we're done
+                            // We want to reuse text nodes, so hold onto it if
+                            // our child is one
+                            let t =
+                                new_child.get_text().map(|t| t.node.clone());
+
+                            **child_borrow = Some(new_child);
+
+                            t
+                        };
+
+                        ret
+                    }
+                    // Otherwise, we know for sure this is our first time
+                    else {
+                        // If it's a text node, we want to use the old text node
+                        // as the text node for the DynChild, rather than the new
+                        // text node being created during hydration
+                        let new_child = if HydrationCtx::is_hydrating()
+                            && new_child.get_text().is_some()
+                        {
+                            let t = closing
+                                .previous_non_view_marker_sibling()
+                                .unwrap()
+                                .unchecked_into::<web_sys::Text>();
+
+                            let new_child = match new_child {
+                                View::Text(text) => text,
+                                _ => unreachable!(),
+                            };
+                            t.set_data(&new_child.content);
+                            View::Text(Text {
+                                node: t.unchecked_into(),
+                                content: new_child.content,
+                            })
+                        } else {
+                            new_child
+                        };
+
+                        // If we are not hydrating, we simply mount the child
+                        if !HydrationCtx::is_hydrating() {
                             mount_child(
                                 MountKind::Before(&closing),
                                 &new_child,
                             );
-
-                            **child_borrow = Some(new_child);
-
-                            None
-                        }
-                    }
-                    // Otherwise, the new child can still be a text node,
-                    // but we know the previous child was not, so no special
-                    // treatment here
-                    else {
-                        // Technically, I think this check shouldn't be necessary, but
-                        // I can imagine some edge case that the child changes while
-                        // hydration is ongoing
-                        if !HydrationCtx::is_hydrating() {
-                            let same_child = child == new_child;
-                            if !was_child_moved && !same_child {
-                                // Remove the child
-                                let start = child.get_opening_node();
-                                let end = &closing;
-
-                                match child {
-                                    View::CoreComponent(
-                                        crate::CoreComponent::DynChild(child),
-                                    ) => {
-                                        let start = child.get_opening_node();
-                                        let end = child.closing.node;
-                                        prepare_to_move(
-                                            &child.document_fragment,
-                                            &start,
-                                            &end,
-                                        );
-                                    }
-                                    View::Component(child) => {
-                                        let start = child.get_opening_node();
-                                        let end = child.closing.node;
-                                        prepare_to_move(
-                                            &child.document_fragment,
-                                            &start,
-                                            &end,
-                                        );
-                                    }
-                                    _ => unmount_child(&start, end),
-                                }
-                            }
-
-                            // Mount the new child
-                            // If it's the same child, don't re-mount
-                            if !same_child {
-                                mount_child(
-                                    MountKind::Before(&closing),
-                                    &new_child,
-                                );
-                            }
                         }
 
-                        // We want to reuse text nodes, so hold onto it if
-                        // our child is one
+                        // We want to update text nodes, rather than replace them, so
+                        // make sure to hold onto the text node
                         let t = new_child.get_text().map(|t| t.node.clone());
 
                         **child_borrow = Some(new_child);
 
                         t
-                    };
-
-                    ret
-                }
-                // Otherwise, we know for sure this is our first time
-                else {
-                    // If it's a text node, we want to use the old text node
-                    // as the text node for the DynChild, rather than the new
-                    // text node being created during hydration
-                    let new_child = if HydrationCtx::is_hydrating()
-                        && new_child.get_text().is_some()
-                    {
-                        let t = closing
-                            .previous_non_view_marker_sibling()
-                            .unwrap()
-                            .unchecked_into::<web_sys::Text>();
-
-                        let new_child = match new_child {
-                            View::Text(text) => text,
-                            _ => unreachable!(),
-                        };
-                        t.set_data(&new_child.content);
-                        View::Text(Text {
-                            node: t.unchecked_into(),
-                            content: new_child.content,
-                        })
-                    } else {
-                        new_child
-                    };
-
-                    // If we are not hydrating, we simply mount the child
-                    if !HydrationCtx::is_hydrating() {
-                        mount_child(MountKind::Before(&closing), &new_child);
                     }
-
-                    // We want to update text nodes, rather than replace them, so
-                    // make sure to hold onto the text node
-                    let t = new_child.get_text().map(|t| t.node.clone());
-
-                    **child_borrow = Some(new_child);
-
-                    t
-                }
-            });
+                },
+            );
 
             #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
             {

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -719,7 +719,7 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
 
             let class_list = self.element.as_ref().class_list();
 
-            leptos_reactive::create_effect(
+            leptos_reactive::create_render_effect(
                 move |prev_classes: Option<
                     SmallVec<[Oco<'static, str>; 4]>,
                 >| {

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -1,6 +1,6 @@
 use crate::{html::ElementDescriptor, HtmlElement};
 use leptos_reactive::{
-    create_effect, create_rw_signal, signal_prelude::*, RwSignal,
+    create_render_effect, create_rw_signal, signal_prelude::*, RwSignal,
 };
 use std::cell::Cell;
 
@@ -134,7 +134,7 @@ impl<T: ElementDescriptor + 'static> NodeRef<T> {
     {
         let f = Cell::new(Some(f));
 
-        create_effect(move |_| {
+        create_render_effect(move |_| {
             if let Some(node_ref) = self.get() {
                 f.take().unwrap()(node_ref);
             }

--- a/leptos_reactive/src/effect.rs
+++ b/leptos_reactive/src/effect.rs
@@ -3,14 +3,21 @@ use cfg_if::cfg_if;
 use std::{any::Any, cell::RefCell, marker::PhantomData, rc::Rc};
 
 /// Effects run a certain chunk of code whenever the signals they depend on change.
-/// `create_effect` immediately runs the given function once, tracks its dependence
+/// `create_effect` queues the given function to run once, tracks its dependence
 /// on any signal values read within it, and reruns the function whenever the value
 /// of a dependency changes.
 ///
 /// Effects are intended to run *side-effects* of the system, not to synchronize state
-/// *within* the system. In other words: don't write to signals within effects.
+/// *within* the system. In other words: don't write to signals within effects, unless
+/// you’re coordinating with some other non-reactive side effect.
 /// (If you need to define a signal that depends on the value of other signals, use a
 /// derived signal or [`create_memo`](crate::create_memo)).
+///
+/// This first run is queued for the next microtask, i.e., it runs after all other
+/// synchronous code has completed. In practical terms, this means that if you use
+/// `create_effect` in the body of the component, it will run *after* the view has been
+/// created and (presumably) mounted. (If you need an effect that runs immediately, use
+/// [`create_render_effect`].)
 ///
 /// The effect function is called with an argument containing whatever value it returned
 /// the last time it ran. On the initial run, this is `None`.
@@ -254,7 +261,10 @@ where
     }
 }
 
-#[doc(hidden)]
+/// Creates an effect exactly like [`create_effect`], but runs immediately rather
+/// than being queued until the end of the current microtask. This is mostly used
+/// inside the renderer but is available for use cases in which scheduling the effect
+/// for the next tick is not optimal.
 #[cfg_attr(
     any(debug_assertions, feature="ssr"),
     instrument(
@@ -266,11 +276,26 @@ where
     )
 )]
 #[inline(always)]
-pub fn create_render_effect<T>(f: impl Fn(Option<T>) -> T + 'static)
+pub fn create_render_effect<T>(
+    f: impl Fn(Option<T>) -> T + 'static,
+) -> Effect<T>
 where
     T: 'static,
 {
-    create_effect(f);
+    cfg_if! {
+        if #[cfg(not(feature = "ssr"))] {
+            let runtime = Runtime::current();
+            let id = runtime.create_effect(f);
+            _ = with_runtime( |runtime| {
+                runtime.update_if_necessary(id);
+            });
+            Effect { id, ty: PhantomData }
+        } else {
+            // clear warnings
+            _ = f;
+            Effect { id: Default::default(), ty: PhantomData }
+        }
+    }
 }
 
 /// A handle to an effect, can be used to explicitly dispose of the effect.


### PR DESCRIPTION
## The Problem

Currently, effects created with `create_effect` run 
1) only in the browser
2) immediately

This means that simple code like this fails silently
```rust
#[component]
pub fn App() -> impl IntoView {
    let input = create_node_ref::<html::Input>();
    create_effect(move |_| {
        if let Some(input) = input.get() {
            logging::log!("focusing");
            input.focus();
        }
    });
    view! {
        <input node_ref=input/>
    }
}
```
This logs `focusing` but does not actually focus the `<input>` because it has not yet been mounted to the DOM. The sequence of events goes:
1. `create_node_ref`: NodeRef is created
2. `create_effect`: creates the effect, and runs once immediately to register its dependencies
3. `<input node_ref=input/>`: creates an `HtmlInputElement` and loads it into the `NodeRef`
4. loading the `NodeRef` triggers the effect to run again, calling `input.focus()`
5. the `HtmlInputElement` is returned and mounted to the DOM

Because 4 happens before 5 — i.e., `.focus()` is called before the element has actually been mounted — the browser does not focus it.

## The Solution

This PR waits to run an effect for the first time until one tick after it's created (determined by `queueMicrotask`: i.e., it runs it after all other synchronous code finishes running.)

This means the same code now runs in the following order:
1. `create_node_ref`: NodeRef is created
2. `create_effect`: creates the effect, and queues first run
3. `<input node_ref=input/>`: creates an `HtmlInputElement` and loads it into the `NodeRef`
4. loading the `NodeRef` does nothing, because the effect hasn't run yet so it hasn't registered the dependency
5. the `HtmlInputElement` is returned and mounted to the DOM
6. at the end of the process of mounting the app, the effect runs once, correctly focusing the element

This also means the effect only ends up running once, for what it's worth.

This is a breaking change, as it affects the scheduling of effects. However, it tends to schedule effects so that they are closer to what people already assume: they run *after* the view has been returned and the component mounted, not immediately (i.e., before it.)

This should fix almost every situation in which the current recommendation is
```rust
create_effect(move |_| {
  request_animation_frame(move || {
  });
});
```

This is how SolidJS runs its effects as well, and it distinguishes between `createEffect()` (user-created effect, runs on next tick) and `createRenderEffect()` (used internally in renderer, runs immediately.) We would do the same, using immediate synchronous effects in the renderer and delayed effects as the default for user code.