### PR TITLE
Chore: Remove ambiguity surrounding version numbers.

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -19,8 +19,8 @@ leptos_config = { workspace = true }
 tracing = "0.1"
 typed-builder = "0.16"
 typed-builder-macro = "0.16"
-serde = { optional = true }
-serde_json = { optional = true }
+serde = { version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 server_fn = { workspace = true }
 web-sys = { version = "0.3.63", optional = true }
 wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
These lint warnings.

> warning: /home/martin/build/leptos/leptos/Cargo.toml: dependency (serde) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
> warning: /home/martin/build/leptos/leptos/Cargo.toml: dependency (serde_json) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions