### PR TITLE
fix: impl `IntoView` for `Rc<dyn Fn() -> impl IntoView>`

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -137,6 +137,17 @@ where
     }
 }
 
+impl<N> IntoView for std::rc::Rc<dyn Fn() -> N>
+where
+    N: IntoView + 'static,
+{
+    #[inline]
+    fn into_view(self) -> View {
+        // reuse impl for `Fn() -> impl IntoView`
+        IntoView::into_view(move || self())
+    }
+}
+
 #[cfg(not(feature = "nightly"))]
 impl<T> IntoView for ReadSignal<T>
 where


### PR DESCRIPTION
While moving to `v0.5.0-rc1` for one of my project I realised I made a mistake with #1669, there is a `IntoView` impl for `Fn() -> impl IntoView` but it does not affect `Rc<dyn Fn() -> impl IntoView>`, so `ChildrenFn` does not impl `IntoView` anymore.

```rust
// works
let children: Children = ...;
view! { <b>{children}</b> };

// works
let children_mut: ChildrenFnMut = ...;
view! { <b>{children}</b> };

// fail
let children_fn: ChildrenFn = ...;
view! { <b>{children}</b> };
// need to call it to make it work:
view! { <b>{children()}</b>
```

This PR add a `IntoView` impl for `Rc<dyn Fn() -> impl IntoView>`