### PR TITLE
impl `From<HtmlElement<El>> for HtmlElement<AnyElement>`

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -1301,18 +1301,24 @@ macro_rules! generate_html_tags {
           generate_html_tags! { @void $($void)? }
         }
 
+        impl From<HtmlElement<[<$tag:camel $($trailing_)?>]>> for HtmlElement<AnyElement> {
+            fn from(element: HtmlElement<[<$tag:camel $($trailing_)?>]>) -> Self {
+                element.into_any()
+            }
+        }
+
         #[$meta]
-      #[cfg_attr(
-        any(debug_assertions, feature = "ssr"),
-        instrument(
-          level = "trace",
-          name = "HtmlElement",
-          skip_all,
-          fields(
-            tag = %format!("<{}/>", stringify!($tag))
-          )
-        )
-      )]
+        #[cfg_attr(
+            any(debug_assertions, feature = "ssr"),
+            instrument(
+            level = "trace",
+            name = "HtmlElement",
+            skip_all,
+            fields(
+                tag = %format!("<{}/>", stringify!($tag))
+            )
+            )
+        )]
         pub fn $tag() -> HtmlElement<[<$tag:camel $($trailing_)?>]> {
           HtmlElement::new( [<$tag:camel $($trailing_)?>]::default())
         }

--- a/leptos_dom/src/math.rs
+++ b/leptos_dom/src/math.rs
@@ -1,6 +1,6 @@
 //! Exports types for working with MathML elements.
 
-use super::{ElementDescriptor, HtmlElement};
+use super::{AnyElement, ElementDescriptor, HtmlElement};
 use crate::HydrationCtx;
 use cfg_if::cfg_if;
 use leptos_reactive::Oco;
@@ -146,6 +146,12 @@ macro_rules! generate_math_tags {
           }
 
           generate_math_tags! { @void $($void)? }
+        }
+
+        impl From<HtmlElement<[<$tag:camel $($second:camel $($third:camel)?)?>]>> for HtmlElement<AnyElement> {
+          fn from(element: HtmlElement<[<$tag:camel $($second:camel $($third:camel)?)?>]>) -> Self {
+            element.into_any()
+          }
         }
 
         #[$meta]

--- a/leptos_dom/src/svg.rs
+++ b/leptos_dom/src/svg.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(all(target_arch = "wasm32", feature = "web")))]
 use super::{html::HTML_ELEMENT_DEREF_UNIMPLEMENTED_MSG, HydrationKey};
-use super::{ElementDescriptor, HtmlElement};
+use super::{AnyElement, ElementDescriptor, HtmlElement};
 use crate::HydrationCtx;
 use leptos_reactive::Oco;
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
@@ -142,6 +142,12 @@ macro_rules! generate_svg_tags {
           }
 
           generate_svg_tags! { @void $($void)? }
+        }
+
+        impl From<HtmlElement<[<$tag:camel $($second:camel $($third:camel)?)?>]>> for HtmlElement<AnyElement> {
+          fn from(element: HtmlElement<[<$tag:camel $($second:camel $($third:camel)?)?>]>) -> Self {
+            element.into_any()
+          }
         }
 
         #[$meta]


### PR DESCRIPTION
Closes #1699 

As it's not possible to implement this as a blanket implementation, at least, not as it's currently implemented, I added some codegen to the macros to make this work.