### PR TITLE
fix(examples/build): do not require stop to end trunk

### DIFF
--- a/examples/cargo-make/client-process.toml
+++ b/examples/cargo-make/client-process.toml
@@ -23,7 +23,7 @@ condition = { env_set = ["CLIENT_PROCESS_NAME"] }
 script = '''
   if [ -z $(pidof ${CLIENT_PROCESS_NAME}) ]; then
     echo "  Starting ${CLIENT_PROCESS_NAME}"
-    cargo make start-client ${@} & 
+    cargo make start-client ${@}
   else
     echo "  ${CLIENT_PROCESS_NAME} is already started"
   fi

--- a/examples/cargo-make/server-process.toml
+++ b/examples/cargo-make/server-process.toml
@@ -21,8 +21,12 @@ script = '''
 [tasks.maybe-start-server]
 condition = { env_set = ["SERVER_PROCESS_NAME"] }
 script = '''
+  YELLOW="\e[0;33m"
+  RESET="\e[0m"
+
   if [ -z $(pidof ${SERVER_PROCESS_NAME}) ]; then
     echo "  Starting ${SERVER_PROCESS_NAME}"
+    echo "  ${YELLOW}>> Run cargo make stop to end process${RESET}"
     cargo make start-server ${@} & 
   else
     echo "  ${SERVER_PROCESS_NAME} is already started"

--- a/examples/login_with_token_csr_only/README.md
+++ b/examples/login_with_token_csr_only/README.md
@@ -9,3 +9,5 @@ The `api-boundary` crate contains data structures that are used by the server an
 ## Getting Started
 
 See the [Examples README](../README.md) for setup and run instructions.
+
+You will also need to run `cargo make stop` to end the server process.


### PR DESCRIPTION
READY FOR REVIEW

Do not run trunk in a separate process.

## Verification

From the **examples/login_with_token_csr_only** directory...

### Should stop trunk with CTRL+C

1. Run `cargo make status` (Terminal 1) - Output reports client and server are not running
2. Run `cargo make start` (Terminal 1) 
3. Run `cargo make status` (Terminal 2) - Output reports client and server are up
4. Execute CTRL+C (Terminal 1)
5. Run `cargo make status` (Terminal 2) - Output reports client is not running and server is up
6. Run `cargo make stop` (Terminal 2)
7. Run `cargo make status` (Terminal 2) - Output reports client and server are not running

### Should stop trunk with `cargo make stop`

1. Run `cargo make status` (Terminal 1) - Output reports client and server are not running
2. Run `cargo make start` (Terminal 1) 
3. Run `cargo make status` (Terminal 2) - Output reports client and server are up
4. Run `cargo make stop` (Terminal 2)
5. Run `cargo make status` (Terminal 2) - Output reports client and server are not running

Closes #1712