### PR TITLE
fix: replace uses of `create_effect` internally with `create_isomorphic_effect` (closes #1709)

### DIFF
--- a/leptos/src/animated_show.rs
+++ b/leptos/src/animated_show.rs
@@ -4,7 +4,8 @@ use leptos::component;
 use leptos_dom::{helpers::TimeoutHandle, IntoView};
 use leptos_macro::view;
 use leptos_reactive::{
-    create_effect, on_cleanup, signal_prelude::*, store_value, StoredValue,
+    create_render_effect, on_cleanup, signal_prelude::*, store_value,
+    StoredValue,
 };
 
 /// A component that will show its children when the `when` condition is `true`.
@@ -70,7 +71,7 @@ pub fn AnimatedShow(
     });
     let show = create_rw_signal(when.get_untracked());
 
-    create_effect(move |_| {
+    create_render_effect(move |_| {
         if when.get() {
             // clear any possibly active timer
             if let Some(h) = handle.get_value() {

--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -1,7 +1,8 @@
 use crate::{
-    create_effect, diagnostics::AccessDiagnostics, node::NodeId, on_cleanup,
-    with_runtime, AnyComputation, Runtime, SignalDispose, SignalGet,
-    SignalGetUntracked, SignalStream, SignalWith, SignalWithUntracked,
+    create_isomorphic_effect, diagnostics::AccessDiagnostics, node::NodeId,
+    on_cleanup, with_runtime, AnyComputation, Runtime, SignalDispose,
+    SignalGet, SignalGetUntracked, SignalStream, SignalWith,
+    SignalWithUntracked,
 };
 use std::{any::Any, cell::RefCell, fmt, marker::PhantomData, rc::Rc};
 
@@ -500,7 +501,7 @@ impl<T: Clone> SignalStream<T> for Memo<T> {
 
         let this = *self;
 
-        create_effect(move |_| {
+        create_isomorphic_effect(move |_| {
             let _ = tx.unbounded_send(this.get());
         });
 

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1003,7 +1003,9 @@ where
     /// }
     ///
     /// // create the resource; it will run but not be serialized
-    /// # if cfg!(not(any(feature = "csr", feature = "hydrate"))) {
+    /// # // `csr`, `hydrate`, and `ssr` all have issues here
+    /// # // because we're not running in a browser or in Tokio. Let's just ignore it.
+    /// # if false {
     /// let result =
     ///     create_local_resource(move || (), |_| setup_complicated_struct());
     /// # }

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -259,7 +259,9 @@ where
 /// }
 ///
 /// // create the resource; it will run but not be serialized
-/// # if cfg!(not(any(feature = "csr", feature = "hydrate"))) {
+/// # // `csr`, `hydrate`, and `ssr` all have issues here
+/// # // because we're not running in a browser or in Tokio. Let's just ignore it.
+/// # if false {
 /// let result =
 ///     create_local_resource(move || (), |_| setup_complicated_struct());
 /// # }

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1152,11 +1152,6 @@ where
         suspense_cx: Option<SuspenseContext>,
         v: Option<U>,
     ) -> Option<U> {
-        crate::macros::debug_warn!(
-            "reading resource: suspense_cx.is_some() = {}",
-            suspense_cx.is_some()
-        );
-
         let suspense_contexts = self.suspense_contexts.clone();
         let has_value = v.is_some();
 

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1211,7 +1211,6 @@ where
                         // because the context has been tracked here
                         // on the first read, resource is already loading without having incremented
                         if !has_value {
-                            crate::macros::debug_warn!("incrementing at 1214");
                             s.increment(
                                 serializable != ResourceSerialization::Local,
                             );
@@ -1259,10 +1258,8 @@ where
         instrument(level = "trace", skip_all,)
     )]
     fn load(&self, refetching: bool) {
-        crate::macros::debug_warn!("calling load()");
         // doesn't refetch if already refetching
         if refetching && self.scheduled.get() {
-            crate::macros::debug_warn!("already fetching, cancel");
             return;
         }
 
@@ -1296,13 +1293,7 @@ where
             // increment counter everywhere it's read
             let suspense_contexts = self.suspense_contexts.clone();
 
-            crate::macros::debug_warn!(
-                "here suspense_contexts.len() == {}",
-                suspense_contexts.borrow().len()
-            );
             for suspense_context in suspense_contexts.borrow().iter() {
-                crate::macros::debug_warn!("incrementing at 1302");
-
                 suspense_context.increment(
                     self.serializable != ResourceSerialization::Local,
                 );

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    console_warn, create_effect, diagnostics, diagnostics::*,
+    console_warn, create_isomorphic_effect, diagnostics, diagnostics::*,
     macros::debug_warn, node::NodeId, on_cleanup, runtime::with_runtime,
     Runtime,
 };
@@ -702,7 +702,7 @@ impl<T: Clone> SignalStream<T> for ReadSignal<T> {
 
         let this = *self;
 
-        create_effect(move |_| {
+        create_isomorphic_effect(move |_| {
             let _ = tx.unbounded_send(this.get());
         });
 
@@ -1775,7 +1775,7 @@ impl<T: Clone> SignalStream<T> for RwSignal<T> {
 
         let this = *self;
 
-        create_effect(move |_| {
+        create_isomorphic_effect(move |_| {
             let _ = tx.unbounded_send(this.get());
         });
 

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -1,7 +1,7 @@
 use crate::{
-    create_effect, on_cleanup, runtime::untrack, store_value, Memo, ReadSignal,
-    RwSignal, SignalGet, SignalGetUntracked, SignalStream, SignalWith,
-    SignalWithUntracked, StoredValue,
+    create_isomorphic_effect, on_cleanup, runtime::untrack, store_value, Memo,
+    ReadSignal, RwSignal, SignalGet, SignalGetUntracked, SignalStream,
+    SignalWith, SignalWithUntracked, StoredValue,
 };
 
 /// Helper trait for converting `Fn() -> T` closures into
@@ -332,7 +332,7 @@ impl<T: Clone> SignalStream<T> for Signal<T> {
 
                 on_cleanup(move || close_channel.close_channel());
 
-                create_effect(move |_| {
+                create_isomorphic_effect(move |_| {
                     let _ = s.try_with_value(|t| tx.unbounded_send(t()));
                 });
 

--- a/router/src/components/outlet.rs
+++ b/router/src/components/outlet.rs
@@ -68,7 +68,7 @@ pub fn Outlet() -> impl IntoView {
 
             let (current_view, set_current_view) = create_signal(None);
 
-            create_effect({
+            create_render_effect({
                 move |prev| {
                     let outlet = outlet.get();
                     let is_fallback =

--- a/router/src/components/progress.rs
+++ b/router/src/components/progress.rs
@@ -31,7 +31,7 @@ pub fn RoutingProgress(
     let (is_showing, set_is_showing) = create_signal(false);
     let (progress, set_progress) = create_signal(0.0);
 
-    create_effect(move |prev: Option<Option<IntervalHandle>>| {
+    create_render_effect(move |prev: Option<Option<IntervalHandle>>| {
         if is_routing.get() && !is_showing.get() {
             set_is_showing.set(true);
             set_interval_with_handle(

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -504,7 +504,7 @@ fn root_route(
 
         let (current_view, set_current_view) = create_signal(None);
 
-        create_effect(move |prev| {
+        create_render_effect(move |prev| {
             let root = root_view.get();
             let is_fallback = !global_suspense.with_inner(|c| c.ready().get());
             if prev.is_none() {


### PR DESCRIPTION
In a number of places, the reactive system was using `create_effect`. Now that `create_effect` is defined as a user-created effect that runs on the next tick, this is wrong and it caused #1709 because of a discrepancy between resources and local resources, where local resources used `create_effect`. 

This also changes several places in the router to use `create_render_effect` (matches old behavior of `create_effect`) in case they were generating similar issues.