### PR TITLE
feat: Allow component names to be paths

### DIFF
--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -45,8 +45,12 @@ pub fn value_to_string(value: &syn::Expr) -> Option<String> {
 pub fn is_component_tag_name(name: &NodeName) -> bool {
     match name {
         NodeName::Path(path) => {
-            path.path.segments.len() > 1
-                || path.path.segments[0]
+            !path.path.segments.is_empty()
+                && path
+                    .path
+                    .segments
+                    .last()
+                    .unwrap()
                     .ident
                     .to_string()
                     .starts_with(|c: char| c.is_ascii_uppercase())

--- a/leptos_hot_reload/src/parsing.rs
+++ b/leptos_hot_reload/src/parsing.rs
@@ -1,4 +1,4 @@
-use rstml::node::NodeElement;
+use rstml::node::{NodeElement, NodeName};
 
 ///
 /// Converts `syn::Block` to simple expression
@@ -42,10 +42,20 @@ pub fn value_to_string(value: &syn::Expr) -> Option<String> {
     }
 }
 
-pub fn is_component_tag_name(name: &str) -> bool {
-    name.starts_with(|c: char| c.is_ascii_uppercase())
+pub fn is_component_tag_name(name: &NodeName) -> bool {
+    match name {
+        NodeName::Path(path) => {
+            path.path.segments.len() > 1
+                || path.path.segments[0]
+                    .ident
+                    .to_string()
+                    .starts_with(|c: char| c.is_ascii_uppercase())
+        }
+        NodeName::Block(_) => false,
+        NodeName::Punctuated(_) => false,
+    }
 }
 
 pub fn is_component_node(node: &NodeElement) -> bool {
-    is_component_tag_name(&node.name().to_string())
+    is_component_tag_name(node.name())
 }

--- a/leptos_macro/src/view/ide_helper.rs
+++ b/leptos_macro/src/view/ide_helper.rs
@@ -24,8 +24,7 @@ impl IdeTagHelper {
     /// Save stmts for tag name.
     /// Emit warning if tag is component.
     pub fn save_tag_completion(&mut self, name: &NodeName) {
-        let tag_name = name.to_string();
-        if is_component_tag_name(&tag_name) {
+        if is_component_tag_name(name) {
             proc_macro_error::emit_warning!(
                 name.span(),
                 "BUG: Component tag is used in regular tag completion."


### PR DESCRIPTION
Simply put, this allows you to do `<module::Component />` on top of the existing `<div />` and `<Component />` style syntaxes.