### PR TITLE
Allow default values for absent server_fn argument deserialization

### DIFF
--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -110,7 +110,10 @@ pub fn server_macro_impl(
                 }
                 FnArg::Typed(t) => t,
             };
-            quote! { pub #typed_arg }
+            quote! {
+                #[serde(default)]
+                pub #typed_arg
+            }
         });
 
     let cx_arg = body.inputs.iter().next().and_then(|f| {


### PR DESCRIPTION
This allows form submission with checkbox inputs to work.
For example:

    let doit = create_server_action::<DoItSFn>();
    <ActionForm action=doit>
      <input type="checkbox" name="is_good" value="true"/>
      <input type="submit"/>
    </ActionForm>

    #[server(DoItSFn, "/api")]
    pub async fn doit(is_good: bool) -> Result<(), ServerFnError> {}

Arguments absent in the request to the server API will use the Default::default() constructor.

Discussion

Maybe this could be restricted to only certain types; at the moment bool and String need it (for checkboxes and radio buttons) and I don't see a way to customize the (de)serialisation.
Another attempted workaround was to add
<input type"hidden" name="is_good" value="false"/>
immediately before the checkbox; serde refuses to deserialize a field that appears twice but that could probably be tweaked as well.