### PR TITLE
Fix Suspense issues on subsequent navigations

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -2,10 +2,8 @@ use leptos_dom::{DynChild, HydrationCtx, IntoView};
 use leptos_macro::component;
 #[cfg(any(feature = "csr", feature = "hydrate"))]
 use leptos_reactive::SignalGet;
-#[allow(unused)]
 use leptos_reactive::{
-    create_memo, provide_context, run_as_child, SignalGetUntracked,
-    SuspenseContext,
+    create_memo, provide_context, SignalGetUntracked, SuspenseContext,
 };
 #[cfg(not(any(feature = "csr", feature = "hydrate")))]
 use leptos_reactive::{with_owner, Owner, SharedContext};
@@ -77,6 +75,16 @@ where
     let owner =
         Owner::current().expect("<Suspense/> created with no reactive owner");
 
+    // provide this SuspenseContext to any resources below it
+    // run in a memo so the children are children of this parent
+    let children = create_memo({
+        let orig_children = Rc::clone(&orig_children);
+        move |_| {
+            provide_context(context);
+            orig_children().into_view()
+        }
+    });
+
     // likewise for the fallback
     let fallback = create_memo({
         move |_| {
@@ -92,20 +100,13 @@ where
 
     let child = DynChild::new({
         move || {
-            // provide this SuspenseContext to any resources below it
-            // run in a memo so the children are children of this parent
-            let children = run_as_child({
-                let orig_children = Rc::clone(&orig_children);
-                move || {
-                    provide_context(context);
-                    orig_children().into_view()
-                }
-            });
+            // pull lazy memo before checking if context is ready
+            let children_rendered = children.get_untracked();
 
             #[cfg(any(feature = "csr", feature = "hydrate"))]
             {
                 if ready.get() {
-                    children
+                    children_rendered
                 } else {
                     fallback.get_untracked()
                 }
@@ -122,7 +123,8 @@ where
                     if context.pending_resources.get() == 0 {
                         with_owner(owner, move || {
                             //HydrationCtx::continue_from(current_id);
-                            DynChild::new(move || children.clone()).into_view()
+                            DynChild::new(move || children_rendered.clone())
+                                .into_view()
                         })
                     }
                     // show the fallback, but also prepare to stream HTML

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -2,7 +2,7 @@ use leptos_dom::{Fragment, HydrationCtx, IntoView, View};
 use leptos_macro::component;
 use leptos_reactive::{
     create_isomorphic_effect, create_rw_signal, use_context, RwSignal,
-    SignalGet, SignalSet, SignalSetter, SuspenseContext,
+    SignalGet, SignalGetUntracked, SignalSet, SignalSetter, SuspenseContext,
 };
 use std::{
     cell::{Cell, RefCell},
@@ -125,7 +125,7 @@ where
                 let suspense_context = held_suspense_context.borrow().unwrap();
 
                 if cfg!(feature = "hydrate")
-                    || !first_run.get()
+                    || !first_run.get_untracked()
                     || (cfg!(feature = "csr") && first_run.get())
                 {
                     *prev_children.borrow_mut() = Some(frag.clone());
@@ -161,7 +161,7 @@ fn is_first_run(
         false
     } else {
         match (
-            first_run.get(),
+            first_run.get_untracked(),
             cfg!(feature = "hydrate"),
             suspense_context.has_local_only(),
         ) {

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -114,8 +114,8 @@ pub use resource::*;
 use runtime::*;
 pub use runtime::{
     as_child_of_current_owner, batch, create_runtime, current_runtime,
-    on_cleanup, run_as_child, set_current_runtime, untrack,
-    untrack_with_diagnostics, with_current_owner, with_owner, Owner, RuntimeId,
+    on_cleanup, set_current_runtime, untrack, untrack_with_diagnostics,
+    with_current_owner, with_owner, Owner, RuntimeId,
 };
 pub use selector::*;
 pub use serialization::*;


### PR DESCRIPTION
#1753 broke Suspense loading in hydration mode on subsequent navigations. This PR reverts its changes, while addressing the issue about CSS animations raised in #1742 and caused by rendering the Suspense children twice initially.