### PR TITLE
Scoped Futures

### DIFF
--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -42,7 +42,7 @@ web-sys = { version = "0.3", optional = true, features = [
 cfg-if = "1"
 indexmap = "2"
 self_cell = "1.0.0"
-pin-project = "1.1.3"
+pin-project = "1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -42,6 +42,7 @@ web-sys = { version = "0.3", optional = true, features = [
 cfg-if = "1"
 indexmap = "2"
 self_cell = "1.0.0"
+pin-project = "1.1.3"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -114,9 +114,11 @@ pub use resource::*;
 use runtime::*;
 pub use runtime::{
     as_child_of_current_owner, batch, create_runtime, current_runtime,
-    on_cleanup, run_as_child, set_current_runtime, try_with_owner, untrack,
-    untrack_with_diagnostics, with_current_owner, with_owner, Owner, RuntimeId,
-    ScopedFuture,
+    on_cleanup, run_as_child, set_current_runtime,
+    spawn_local_with_current_owner, spawn_local_with_owner,
+    try_spawn_local_with_current_owner, try_spawn_local_with_owner,
+    try_with_owner, untrack, untrack_with_diagnostics, with_current_owner,
+    with_owner, Owner, RuntimeId, ScopedFuture,
 };
 pub use selector::*;
 pub use serialization::*;

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -114,8 +114,9 @@ pub use resource::*;
 use runtime::*;
 pub use runtime::{
     as_child_of_current_owner, batch, create_runtime, current_runtime,
-    on_cleanup, run_as_child, set_current_runtime, untrack,
+    on_cleanup, run_as_child, set_current_runtime, try_with_owner, untrack,
     untrack_with_diagnostics, with_current_owner, with_owner, Owner, RuntimeId,
+    ScopedFuture,
 };
 pub use selector::*;
 pub use serialization::*;

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -1489,7 +1489,7 @@ pub fn untrack_with_diagnostics<T>(f: impl FnOnce() -> T) -> T {
 
 /// Allows running a future that has access to a given scope.
 #[pin_project]
-pub struct ScopedFuture<Fut: Future + 'static> {
+pub struct ScopedFuture<Fut: Future> {
     owner: Owner,
     #[pin]
     future: Fut,
@@ -1521,3 +1521,5 @@ impl<Fut: Future + 'static> Future for ScopedFuture<Fut> {
         }
     }
 }
+
+impl<Fut: Future> ScopedFuture<Fut> {}

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -866,7 +866,7 @@ pub fn try_with_owner<T>(owner: Owner, f: impl FnOnce() -> T) -> Option<T> {
             .try_borrow()
             .map(|nodes| nodes.contains_key(owner.0))
             .map(|scope_exists| {
-                if scope_exists {
+                scope_exists.then(|| {
                     let prev_observer = runtime.observer.take();
                     let prev_owner = runtime.owner.take();
 
@@ -878,10 +878,8 @@ pub fn try_with_owner<T>(owner: Owner, f: impl FnOnce() -> T) -> Option<T> {
                     runtime.observer.set(prev_observer);
                     runtime.owner.set(prev_owner);
 
-                    Some(v)
-                } else {
-                    None
-                }
+                    v
+                })
             })
             .ok()
             .flatten()

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -1522,4 +1522,10 @@ impl<Fut: Future + 'static> Future for ScopedFuture<Fut> {
     }
 }
 
-impl<Fut: Future> ScopedFuture<Fut> {}
+impl<Fut: Future> ScopedFuture<Fut> {
+    /// Creates a new future that will have access to the `[Owner]`'s
+    /// scope.
+    pub fn new(owner: Owner, fut: Fut) -> Self {
+        Self { owner, future: fut }
+    }
+}

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -16,7 +16,6 @@ use indexmap::IndexSet;
 use pin_project::pin_project;
 use rustc_hash::{FxHashMap, FxHasher};
 use slotmap::{SecondaryMap, SlotMap, SparseSecondaryMap};
-use std::task::Poll;
 use std::{
     any::{Any, TypeId},
     cell::{Cell, RefCell},
@@ -25,6 +24,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     rc::Rc,
+    task::Poll,
 };
 
 pub(crate) type PinnedFuture<T> = Pin<Box<dyn Future<Output = T>>>;
@@ -1536,9 +1536,8 @@ impl<Fut: Future> ScopedFuture<Fut> {
     pub fn new_current(fut: Fut) -> Self {
         Self {
             owner: Owner::current().expect(
-                "`ScopedFuture::new_current()` \
-                to be called within an `Owner` \
-                context",
+                "`ScopedFuture::new_current()` to be called within an `Owner` \
+                 context",
             ),
             future: fut,
         }

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -864,8 +864,9 @@ pub fn try_with_owner<T>(owner: Owner, f: impl FnOnce() -> T) -> Option<T> {
         runtime
             .nodes
             .try_borrow()
-            .map(|nodes| {
-                if nodes.contains_key(owner.0) {
+            .map(|nodes| nodes.contains_key(owner.0))
+            .map(|scope_exists| {
+                if scope_exists {
                     let prev_observer = runtime.observer.take();
                     let prev_owner = runtime.owner.take();
 


### PR DESCRIPTION
This PR serves to extend the current `leptos_runtime` API surface to allow for running futures within an `Owner` scope context.