### PR TITLE
Add tooling for nix flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             pkg-config
             cacert
             cargo-make
+            trunk
             (rust-bin.selectLatestNightlyWith( toolchain: toolchain.default.override {
               extensions= [ "rust-src" "rust-analyzer" ];
               targets = [ "wasm32-unknown-unknown" ];

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
             openssl
             pkg-config
             cacert
+            cargo-make
             (rust-bin.selectLatestNightlyWith( toolchain: toolchain.default.override {
               extensions= [ "rust-src" "rust-analyzer" ];
               targets = [ "wasm32-unknown-unknown" ];


### PR DESCRIPTION
Now, the nix flakes declares a shell with `cargo-make` and `trunk`