### PR TITLE
chore(leptos_marco): enhancement of document generation

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -175,7 +175,7 @@ impl ToTokens for Model {
         let prop_names = prop_names(props);
 
         let builder_name_doc = LitStr::new(
-            &format!("Props for the [`{name}`] component."),
+            &format!(" Props for the [`{name}`] component."),
             name.span(),
         );
 
@@ -476,6 +476,7 @@ impl ToTokens for Model {
             #[doc = #builder_name_doc]
             #[doc = ""]
             #docs
+            #[doc = ""]
             #component_fn_prop_docs
             #[derive(::leptos::typed_builder_macro::TypedBuilder #props_derive_serialize)]
             //#[builder(doc)]
@@ -506,6 +507,7 @@ impl ToTokens for Model {
             #into_view
 
             #docs
+            #[doc = ""]
             #component_fn_prop_docs
             #[allow(non_snake_case, clippy::too_many_arguments)]
             #tracing_instrument_attr
@@ -612,7 +614,8 @@ impl Docs {
 
         // Seperated out of chain to allow rustfmt to work
         let map = |(doc, span): (String, Span)| {
-            doc.lines()
+            doc.split('\n')
+                .map(str::trim_end)
                 .flat_map(|doc| {
                     let trimmed_doc = doc.trim_start();
                     let leading_ws = &doc[..doc.len() - trimmed_doc.len()];
@@ -932,7 +935,7 @@ fn generate_component_fn_prop_docs(props: &[Prop]) -> TokenStream {
 
     let required_prop_docs = if !required_prop_docs.is_empty() {
         quote! {
-            #[doc = "# Required Props"]
+            #[doc = " # Required Props"]
             #required_prop_docs
         }
     } else {
@@ -941,7 +944,7 @@ fn generate_component_fn_prop_docs(props: &[Prop]) -> TokenStream {
 
     let optional_prop_docs = if !optional_prop_docs.is_empty() {
         quote! {
-            #[doc = "# Optional Props"]
+            #[doc = " # Optional Props"]
             #optional_prop_docs
         }
     } else {
@@ -1043,10 +1046,10 @@ fn prop_to_doc(
         PropDocStyle::List => {
             let arg_ty_doc = LitStr::new(
                 &if !prop_opts.into {
-                    format!("- **{}**: [`{pretty_ty}`]", quote!(#name))
+                    format!(" - **{}**: [`{pretty_ty}`]", quote!(#name))
                 } else {
                     format!(
-                        "- **{}**: [`impl Into<{pretty_ty}>`]({pretty_ty})",
+                        " - **{}**: [`impl Into<{pretty_ty}>`]({pretty_ty})",
                         quote!(#name),
                     )
                 },


### PR DESCRIPTION
Use [expand](https://github.com/dtolnay/cargo-expand) to show result

```shell
$ cd router
$ cargo expand ::components::redirect
```

### before

```rust
    ///Props for the [`Redirect`] component.
    ///
    /// Redirects the user to a new URL, whether on the client side or on the server
    /// side. If rendered on the server, this sets a `302` status code and sets a `Location`
    /// header. If rendered in the browser, it uses client-side navigation to redirect.
    /// In either case, it resolves the route relative to the current route. (To use
    /// an absolute path, prefix it with `/`).
    /// **Note**: Support for server-side redirects is provided by the server framework
    /// integrations ([`leptos_actix`], [`leptos_axum`], and [`leptos_viz`]). If you’re not using one of those
    /// integrations, you should manually provide a way of redirecting on the server
    /// using [`provide_server_redirect`].
    /// [`leptos_actix`]: <https://docs.rs/leptos_actix/>
    /// [`leptos_axum`]: <https://docs.rs/leptos_axum/>
    /// [`leptos_viz`]: <https://docs.rs/leptos_viz/>
    ///# Required Props
    ///- **path**: [`P`]
    ///    -  The relative path to which the user should be redirected.
    ///# Optional Props
    ///- **options**: [`NavigateOptions`]
    ///    -  Navigation options to be used on the client side.
    #[builder(crate_module_path = ::leptos::typed_builder)]
    pub struct RedirectProps<P>
```

### after

```rust
    /// Props for the [`Redirect`] component.
    ///
    /// Redirects the user to a new URL, whether on the client side or on the server
    /// side. If rendered on the server, this sets a `302` status code and sets a `Location`
    /// header. If rendered in the browser, it uses client-side navigation to redirect.
    /// In either case, it resolves the route relative to the current route. (To use
    /// an absolute path, prefix it with `/`).
    ///
    /// **Note**: Support for server-side redirects is provided by the server framework
    /// integrations ([`leptos_actix`], [`leptos_axum`], and [`leptos_viz`]). If you’re not using one of those
    /// integrations, you should manually provide a way of redirecting on the server
    /// using [`provide_server_redirect`].
    ///
    /// [`leptos_actix`]: <https://docs.rs/leptos_actix/>
    /// [`leptos_axum`]: <https://docs.rs/leptos_axum/>
    /// [`leptos_viz`]: <https://docs.rs/leptos_viz/>
    ///
    /// # Required Props
    /// - **path**: [`P`]
    ///    -  The relative path to which the user should be redirected.
    /// # Optional Props
    /// - **options**: [`NavigateOptions`]
    ///    -  Navigation options to be used on the client side.
    #[builder(crate_module_path = ::leptos::typed_builder)]
    pub struct RedirectProps<P>
```