### PR TITLE
change: enable inline children for `For` by switching to `children` and `bind:`

### DIFF
--- a/benchmarks/src/todomvc/leptos.rs
+++ b/benchmarks/src/todomvc/leptos.rs
@@ -192,7 +192,7 @@ pub fn TodoMVC(todos: Todos) -> impl IntoView {
                         <For
                             each=filtered_todos
                             key=|todo| todo.id
-                            view=move |todo: Todo| {
+                            children=move |todo: Todo| {
                                 view! { <Todo todo=todo.clone()/> }
                             }
                         />

--- a/docs/book/src/router/17_nested_routing.md
+++ b/docs/book/src/router/17_nested_routing.md
@@ -143,8 +143,8 @@ pub fn ContactList() -> impl IntoView {
       // the contact list
       <For each=contacts
         key=|contact| contact.id
-        view=|contact| todo!()
-      >
+        children=|contact| todo!()
+      />
       // the nested child, if any
       // don’t forget this!
       <Outlet/>

--- a/examples/counters/src/lib.rs
+++ b/examples/counters/src/lib.rs
@@ -65,7 +65,7 @@ pub fn Counters() -> impl IntoView {
                 <For
                     each=counters
                     key=|counter| counter.0
-                    view=move |(id, (value, set_value)): (usize, (ReadSignal<i32>, WriteSignal<i32>))| {
+                    children=move |(id, (value, set_value)): (usize, (ReadSignal<i32>, WriteSignal<i32>))| {
                         view! {
                             <Counter id value set_value/>
                         }

--- a/examples/counters_stable/src/lib.rs
+++ b/examples/counters_stable/src/lib.rs
@@ -67,7 +67,7 @@ pub fn Counters() -> impl IntoView {
                 <For
                     each={move || counters.get()}
                     key={|counter| counter.0}
-                    view=move |(id, (value, set_value))| {
+                    children=move |(id, (value, set_value))| {
                         view! {
                             <Counter id value set_value/>
                         }

--- a/examples/errors_axum/src/error_template.rs
+++ b/examples/errors_axum/src/error_template.rs
@@ -45,7 +45,7 @@ pub fn ErrorTemplate(
             // a unique key for each item as a reference
             key=|(index, _)| *index
             // renders each item to a view
-            view=move |error| {
+            children=move |error| {
                 let error_string = error.1.to_string();
                 let error_code= error.1.status_code();
                 view! {

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -91,7 +91,7 @@ pub fn Stories() -> impl IntoView {
                                         <For
                                             each=move || stories.clone()
                                             key=|story| story.id
-                                            bind:story
+                                            let:story
                                         >
                                             <Story story/>
                                         </For>

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -91,12 +91,10 @@ pub fn Stories() -> impl IntoView {
                                         <For
                                             each=move || stories.clone()
                                             key=|story| story.id
-                                            view=move |story: api::Story| {
-                                                view! {
-                                                    <Story story/>
-                                                }
-                                            }
-                                        />
+                                            bind:story
+                                        >
+                                            <Story story/>
+                                        </For>
                                     </ul>
                                 }.into_any())
                             }

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -57,7 +57,7 @@ pub fn Story() -> impl IntoView {
                             <For
                                 each=move || story.comments.clone().unwrap_or_default()
                                 key=|comment| comment.id
-                                bind:comment
+                                let:comment
                             >
                                 <Comment comment />
                             </For>
@@ -102,7 +102,7 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
                                 <For
                                     each=move || comments.clone()
                                     key=|comment| comment.id
-                                    bind:comment
+                                    let:comment
                                 >
                                     <Comment comment />
                                 </For>

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -57,8 +57,10 @@ pub fn Story() -> impl IntoView {
                             <For
                                 each=move || story.comments.clone().unwrap_or_default()
                                 key=|comment| comment.id
-                                view=move |comment| view! {  <Comment comment /> }
-                            />
+                                bind:comment
+                            >
+                                <Comment comment />
+                            </For>
                         </ul>
                     </div>
                 </div>
@@ -100,8 +102,10 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
                                 <For
                                     each=move || comments.clone()
                                     key=|comment| comment.id
-                                    view=move |comment: api::Comment| view! { <Comment comment /> }
-                                />
+                                    bind:comment
+                                >
+                                    <Comment comment />
+                                </For>
                             </ul>
                         }
                     })}

--- a/examples/hackernews_axum/src/error_template.rs
+++ b/examples/hackernews_axum/src/error_template.rs
@@ -15,7 +15,7 @@ pub fn error_template(errors: Option<RwSignal<Errors>>) -> View {
           // a unique key for each item as a reference
           key=|(key, _)| key.clone()
           // renders each item to a view
-          view= move | (_, error)| {
+          children=move | (_, error)| {
           let error_string = error.to_string();
             view! {
 

--- a/examples/hackernews_axum/src/routes/stories.rs
+++ b/examples/hackernews_axum/src/routes/stories.rs
@@ -90,12 +90,10 @@ pub fn Stories() -> impl IntoView {
                                         <For
                                             each=move || stories.clone()
                                             key=|story| story.id
-                                            view=move | story: api::Story| {
-                                                view! {
-                                                    <Story story/>
-                                                }
-                                            }
-                                        />
+                                            bind:story
+                                        >
+                                            <Story story/>
+                                        </For>
                                     </ul>
                                 }.into_any())
                             }

--- a/examples/hackernews_axum/src/routes/stories.rs
+++ b/examples/hackernews_axum/src/routes/stories.rs
@@ -90,7 +90,7 @@ pub fn Stories() -> impl IntoView {
                                         <For
                                             each=move || stories.clone()
                                             key=|story| story.id
-                                            bind:story
+                                            let:story
                                         >
                                             <Story story/>
                                         </For>

--- a/examples/hackernews_axum/src/routes/story.rs
+++ b/examples/hackernews_axum/src/routes/story.rs
@@ -57,7 +57,7 @@ pub fn Story() -> impl IntoView {
                             <For
                                 each=move || story.comments.clone().unwrap_or_default()
                                 key=|comment| comment.id
-                                bind:comment
+                                let:comment
                             >
                                 <Comment comment />
                             </For>
@@ -102,7 +102,7 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
                                 <For
                                     each=move || comments.clone()
                                     key=|comment| comment.id
-                                    bind:comment
+                                    let:comment
                                 >
                                     <Comment comment />
                                 </For>

--- a/examples/hackernews_axum/src/routes/story.rs
+++ b/examples/hackernews_axum/src/routes/story.rs
@@ -57,8 +57,10 @@ pub fn Story() -> impl IntoView {
                             <For
                                 each=move || story.comments.clone().unwrap_or_default()
                                 key=|comment| comment.id
-                                view=move | comment| view! { <Comment comment /> }
-                            />
+                                bind:comment
+                            >
+                                <Comment comment />
+                            </For>
                         </ul>
                     </div>
                 </div>
@@ -100,8 +102,10 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
                                 <For
                                     each=move || comments.clone()
                                     key=|comment| comment.id
-                                    view=move | comment: api::Comment| view! {  <Comment comment /> }
-                                />
+                                    bind:comment
+                                >
+                                    <Comment comment />
+                                </For>
                             </ul>
                         }
                     })}

--- a/examples/hackernews_islands_axum/src/error_template.rs
+++ b/examples/hackernews_islands_axum/src/error_template.rs
@@ -15,7 +15,7 @@ pub fn error_template(errors: Option<RwSignal<Errors>>) -> View {
           // a unique key for each item as a reference
           key=|(key, _)| key.clone()
           // renders each item to a view
-          view= move | (_, error)| {
+          children= move | (_, error)| {
           let error_string = error.to_string();
             view! {
 

--- a/examples/hackernews_islands_axum/src/routes/stories.rs
+++ b/examples/hackernews_islands_axum/src/routes/stories.rs
@@ -98,7 +98,7 @@ pub fn Stories() -> impl IntoView {
                                     <For
                                         each=move || stories.clone()
                                         key=|story| story.id
-                                        bind:story
+                                        let:story
                                     >
                                         <Story story/>
                                     </For>

--- a/examples/hackernews_islands_axum/src/routes/stories.rs
+++ b/examples/hackernews_islands_axum/src/routes/stories.rs
@@ -98,12 +98,10 @@ pub fn Stories() -> impl IntoView {
                                     <For
                                         each=move || stories.clone()
                                         key=|story| story.id
-                                        view=move |story: api::Story| {
-                                            view! {
-                                                <Story story/>
-                                            }
-                                        }
-                                    />
+                                        bind:story
+                                    >
+                                        <Story story/>
+                                    </For>
                                 </ul>
                             }))}
                     </Transition>

--- a/examples/hackernews_js_fetch/src/error_template.rs
+++ b/examples/hackernews_js_fetch/src/error_template.rs
@@ -15,7 +15,7 @@ pub fn error_template(errors: Option<RwSignal<Errors>>) -> View {
           // a unique key for each item as a reference
           key=|(key, _)| key.clone()
           // renders each item to a view
-          view= move |(_, error)| {
+          children= move |(_, error)| {
           let error_string = error.to_string();
             view! {
 

--- a/examples/hackernews_js_fetch/src/routes/stories.rs
+++ b/examples/hackernews_js_fetch/src/routes/stories.rs
@@ -95,12 +95,10 @@ pub fn Stories() -> impl IntoView {
                                         <For
                                             each=move || stories.clone()
                                             key=|story| story.id
-                                            view=move |story: api::Story| {
-                                                view! {
-                                                    <Story story/>
-                                                }
-                                            }
-                                        />
+                                            let:story
+                                        >
+                                            <Story story/>
+                                        </For>
                                     </ul>
                                 }.into_any())
                             }

--- a/examples/hackernews_js_fetch/src/routes/story.rs
+++ b/examples/hackernews_js_fetch/src/routes/story.rs
@@ -58,8 +58,10 @@ pub fn Story() -> impl IntoView {
                                     <For
                                         each=move || story.comments.clone().unwrap_or_default()
                                         key=|comment| comment.id
-                                        view=move |comment| view! {  <Comment comment /> }
-                                    />
+                                        let:comment 
+                                    >
+                                        <Comment comment/>
+                                    </For>
                                 </ul>
                             </div>
                         </div>
@@ -103,8 +105,10 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
                                 <For
                                     each=move || comments.clone()
                                     key=|comment| comment.id
-                                    view=move |comment: api::Comment| view! { <Comment comment /> }
-                                />
+                                    let:comment
+                                >
+                                    <Comment comment />
+                                </For>
                             </ul>
                         }
                     })}

--- a/examples/js-framework-benchmark/src/lib.rs
+++ b/examples/js-framework-benchmark/src/lib.rs
@@ -168,7 +168,7 @@ pub fn App() -> impl IntoView {
                     <For
                         each={data}
                         key={|row| row.id}
-                        view=move |row: RowData| {
+                        children=move |row: RowData| {
                             let row_id = row.id;
                             let (label, _) = row.label;
                             on_cleanup({

--- a/examples/session_auth_axum/src/error_template.rs
+++ b/examples/session_auth_axum/src/error_template.rs
@@ -46,7 +46,7 @@ pub fn ErrorTemplate(
         // a unique key for each item as a reference
         key=|(index, _error)| *index
         // renders each item to a view
-        view= move |error| {
+        children=move |error| {
         let error_string = error.1.to_string();
         let error_code= error.1.status_code();
           view! {

--- a/examples/todo_app_sqlite_axum/src/error_template.rs
+++ b/examples/todo_app_sqlite_axum/src/error_template.rs
@@ -46,7 +46,7 @@ pub fn ErrorTemplate(
         // a unique key for each item as a reference
         key=|(index, _error)| *index
         // renders each item to a view
-        view= move |error| {
+        children=move |error| {
         let error_string = error.1.to_string();
         let error_code= error.1.status_code();
           view! {

--- a/examples/todo_app_sqlite_viz/src/error_template.rs
+++ b/examples/todo_app_sqlite_viz/src/error_template.rs
@@ -46,7 +46,7 @@ pub fn ErrorTemplate(
         // a unique key for each item as a reference
         key=|(index, _error)| *index
         // renders each item to a view
-        view= move |error| {
+        children= move |error| {
         let error_string = error.1.to_string();
         let error_code= error.1.status_code();
           view! {

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -240,7 +240,7 @@ pub fn TodoMVC() -> impl IntoView {
                         <For
                             each=filtered_todos
                             key=|todo| todo.id
-                            bind:todo
+                            let:todo
                         >
                             <Todo todo/>
                         </For>

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -240,8 +240,10 @@ pub fn TodoMVC() -> impl IntoView {
                         <For
                             each=filtered_todos
                             key=|todo| todo.id
-                            view=move |todo: Todo| view! { <Todo todo /> }
-                        />
+                            bind:todo
+                        >
+                            <Todo todo/>
+                        </For>
                     </ul>
                 </section>
                 <footer

--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -72,7 +72,7 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     /// let (data, set_data) = create_signal(vec![0, 1, 2]);
     /// view! {
     ///     <For
-    ///         each=data
+    ///         each=move || data.get()
     ///         key=|n| *n
     ///         // stores the item in each row in a variable named `data`
     ///         let:data
@@ -81,7 +81,6 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     ///     </For>
     /// }
     /// # ;
-    /// # runtime.dispose();
     /// # }
     /// ```
     /// is the same as
@@ -91,13 +90,12 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     /// let (data, set_data) = create_signal(vec![0, 1, 2]);
     /// view! {
     ///     <For
-    ///         each=data
+    ///         each=move || data.get()
     ///         key=|n| *n
     ///         children=|data| view! { <p>{data}</p> }
     ///     />
     /// }
     /// # ;
-    /// # runtime.dispose();
     /// # }
     /// ```
     children: EF,

--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -61,11 +61,11 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     /// A key function that will be applied to each item.
     key: KF,
     /// A function that takes the item, and returns the view that will be displayed for each item.
-    /// 
+    ///
     /// ## Syntax
     /// This can be passed directly in the `view` children of the `<For/>` by using the
-    /// `bind:` syntax to specify the name for the data variable passed in the argument.
-    /// 
+    /// `let:` syntax to specify the name for the data variable passed in the argument.
+    ///
     /// ```rust
     /// # use leptos::*;
     /// # if false {
@@ -75,7 +75,7 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     ///         each=data
     ///         key=|n| *n
     ///         // stores the item in each row in a variable named `data`
-    ///         bind:data
+    ///         let:data
     ///     >
     ///         <p>{data}</p>
     ///     </For>

--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -28,7 +28,19 @@ use std::hash::Hash;
 ///         // a unique key for each item
 ///         key=|counter| counter.id
 ///         // renders each item to a view
-///         view=move |counter: Counter| {
+///         children=move |counter: Counter| {
+///           view! {
+///             <button>"Value: " {move || counter.count.get()}</button>
+///           }
+///         }
+///       />
+///       <For
+///         // a function that returns the items we're iterating over; a signal is fine
+///         each=move || counters.get()
+///         // a unique key for each item
+///         key=|counter| counter.id
+///         // renders each item to a view
+///         children=move |counter: Counter| {
 ///           view! {
 ///             <button>"Value: " {move || counter.count.get()}</button>
 ///           }
@@ -48,8 +60,47 @@ pub fn For<IF, I, T, EF, N, KF, K>(
     each: IF,
     /// A key function that will be applied to each item.
     key: KF,
-    /// The view that will be displayed for each item.
-    view: EF,
+    /// A function that takes the item, and returns the view that will be displayed for each item.
+    /// 
+    /// ## Syntax
+    /// This can be passed directly in the `view` children of the `<For/>` by using the
+    /// `bind:` syntax to specify the name for the data variable passed in the argument.
+    /// 
+    /// ```rust
+    /// # use leptos::*;
+    /// # if false {
+    /// let (data, set_data) = create_signal(vec![0, 1, 2]);
+    /// view! {
+    ///     <For
+    ///         each=data
+    ///         key=|n| *n
+    ///         // stores the item in each row in a variable named `data`
+    ///         bind:data
+    ///     >
+    ///         <p>{data}</p>
+    ///     </For>
+    /// }
+    /// # ;
+    /// # runtime.dispose();
+    /// # }
+    /// ```
+    /// is the same as
+    ///  ```rust
+    /// # use leptos::*;
+    /// # if false {
+    /// let (data, set_data) = create_signal(vec![0, 1, 2]);
+    /// view! {
+    ///     <For
+    ///         each=data
+    ///         key=|n| *n
+    ///         children=|data| view! { <p>{data}</p> }
+    ///     />
+    /// }
+    /// # ;
+    /// # runtime.dispose();
+    /// # }
+    /// ```
+    children: EF,
 ) -> impl IntoView
 where
     IF: Fn() -> I + 'static,
@@ -60,5 +111,5 @@ where
     K: Eq + Hash + 'static,
     T: 'static,
 {
-    leptos_dom::Each::new(each, key, view).into_view()
+    leptos_dom::Each::new(each, key, children).into_view()
 }


### PR DESCRIPTION
This PR would change the name of the view function argument to `For` from `view` to `children`. This allows it to written inline using the `bind:` syntax to specify the name of the argument.

```rust
let (data, set_data) = create_signal(vec![0, 1, 2]);
view! {
    <For
        each=data
        key=|n| *n
        // stores the item in each row in a variable named `data`
        let:data
    >
        <p>{data}</p>
    </For>
}
```
is the same as
```rust
let (data, set_data) = create_signal(vec![0, 1, 2]);
view! {
   <For
       each=data
       key=|n| *n
       children=|data| view! { <p>{data}</p> }
   />
}
```
which replaces
```rust
let (data, set_data) = create_signal(vec![0, 1, 2]);
view! {
   <For
       each=data
       key=|n| *n
       view=|data| view! { <p>{data}</p> }
   />
}
```

## Reasoning

The intention here is to make it easier to write views by reducing the number of times you need to break out into a closure and a new `view!` invocation.

## Alternatives

Keep current `view` name, and current syntax.