### PR TITLE
change: only run `create_local_resource` in the browser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,22 +26,22 @@ members = [
 exclude = ["benchmarks", "examples"]
 
 [workspace.package]
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 
 [workspace.dependencies]
-leptos = { path = "./leptos", version = "0.5.0-rc2" }
-leptos_dom = { path = "./leptos_dom", version = "0.5.0-rc2" }
-leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.5.0-rc2" }
-leptos_macro = { path = "./leptos_macro", version = "0.5.0-rc2" }
-leptos_reactive = { path = "./leptos_reactive", version = "0.5.0-rc2" }
-leptos_server = { path = "./leptos_server", version = "0.5.0-rc2" }
-server_fn = { path = "./server_fn", version = "0.5.0-rc2" }
-server_fn_macro = { path = "./server_fn_macro", version = "0.5.0-rc2" }
-server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.5.0-rc2" }
-leptos_config = { path = "./leptos_config", version = "0.5.0-rc2" }
-leptos_router = { path = "./router", version = "0.5.0-rc2" }
-leptos_meta = { path = "./meta", version = "0.5.0-rc2" }
-leptos_integration_utils = { path = "./integrations/utils", version = "0.5.0-rc2" }
+leptos = { path = "./leptos", version = "0.5.0-rc3" }
+leptos_dom = { path = "./leptos_dom", version = "0.5.0-rc3" }
+leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.5.0-rc3" }
+leptos_macro = { path = "./leptos_macro", version = "0.5.0-rc3" }
+leptos_reactive = { path = "./leptos_reactive", version = "0.5.0-rc3" }
+leptos_server = { path = "./leptos_server", version = "0.5.0-rc3" }
+server_fn = { path = "./server_fn", version = "0.5.0-rc3" }
+server_fn_macro = { path = "./server_fn_macro", version = "0.5.0-rc3" }
+server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.5.0-rc3" }
+leptos_config = { path = "./leptos_config", version = "0.5.0-rc3" }
+leptos_router = { path = "./router", version = "0.5.0-rc3" }
+leptos_meta = { path = "./meta", version = "0.5.0-rc3" }
+leptos_integration_utils = { path = "./integrations/utils", version = "0.5.0-rc3" }
 
 [profile.release]
 codegen-units = 1

--- a/docs/book/src/01_introduction.md
+++ b/docs/book/src/01_introduction.md
@@ -17,6 +17,6 @@ understand Leptos.
 
 You can find more detailed docs for each part of the API at [Docs.rs](https://docs.rs/leptos/latest/leptos/).
 
-**Important Note**: This current version of the book reflects the upcoming `0.5.0` release, which you can install as version `0.5.0-rc2`. The CodeSandbox versions of the examples still reflect `0.4` and earlier APIs and are in the process of being updated.
+**Important Note**: This current version of the book reflects the upcoming `0.5.0` release, which you can install as version `0.5.0-rc3`. The CodeSandbox versions of the examples still reflect `0.4` and earlier APIs and are in the process of being updated.
 
 > The source code for the book is available [here](https://github.com/leptos-rs/leptos/tree/main/docs/book). PRs for typos or clarification are always welcome.

--- a/docs/book/src/02_getting_started.md
+++ b/docs/book/src/02_getting_started.md
@@ -23,7 +23,7 @@ cargo init leptos-tutorial
 `cd` into your new `leptos-tutorial` project and add `leptos` as a dependency
 
 ```bash
-cargo add leptos@0.5.0-rc2 --features=csr,nightly
+cargo add leptos@0.5.0-rc3 --features=csr,nightly
 ```
 
 > **Note**: This version of the book reflects the upcoming Leptos 0.5.0 release. The CodeSandbox examples have not yet been updated from 0.4 and earlier versions.
@@ -31,7 +31,7 @@ cargo add leptos@0.5.0-rc2 --features=csr,nightly
 Or you can leave off `nightly` if you're using stable Rust
 
 ```bash
-cargo add leptos@0.5.0-rc2 --features=csr
+cargo add leptos@0.5.0-rc3 --features=csr
 ```
 
 > Using `nightly` Rust, and the `nightly` feature in Leptos enables the function-call syntax for signal getters and setters that is used in most of this book.

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -248,7 +248,9 @@ where
 /// value of the `source` changes, a new [`Future`] will be created and run.
 ///
 /// Unlike [`create_resource()`], this [`Future`] is always run on the local system
-/// and therefore it's result type does not need to be [`Serializable`].
+/// and therefore its result type does not need to be [`Serializable`].
+///
+/// Local resources do not load on the server, only in the client’s browser.
 ///
 /// ```
 /// # use leptos_reactive::*;
@@ -303,6 +305,8 @@ where
 /// Unlike [`create_resource_with_initial_value()`], this [`Future`] will always run
 /// on the local system and therefore its output type does not need to be
 /// [`Serializable`].
+///
+/// Local resources do not load on the server, only in the client’s browser.
 #[cfg_attr(
     any(debug_assertions, feature="ssr"),
     instrument(
@@ -358,10 +362,10 @@ where
     })
     .expect("tried to create a Resource in a runtime that has been disposed.");
 
-    create_isomorphic_effect({
+    // This is a local resource, so we're always going to handle it on the
+    // client
+    create_render_effect({
         let r = Rc::clone(&r);
-        // This is a local resource, so we're always going to handle it on the
-        // client
         move |_| r.load(false)
     });
 

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -3,8 +3,8 @@ use crate::SharedContext;
 #[cfg(debug_assertions)]
 use crate::SpecialNonReactiveZone;
 use crate::{
-    create_isomorphic_effect, create_memo, create_signal, queue_microtask,
-    runtime::with_runtime, serialization::Serializable,
+    create_isomorphic_effect, create_memo, create_render_effect, create_signal,
+    queue_microtask, runtime::with_runtime, serialization::Serializable,
     signal_prelude::format_signal_warning, spawn::spawn_local, use_context,
     GlobalSuspenseContext, Memo, ReadSignal, ScopeProperty, Signal,
     SignalDispose, SignalGet, SignalGetUntracked, SignalSet, SignalUpdate,

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_meta"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"


### PR DESCRIPTION
This is one of those changes that is somewhere between a "fix" and a "breaking change." Local resources were intended to run only in the browser, but in fact were running on both the server and in the browser, but without being serialized/shared between the two. This aligns them with the document behavior of only running in the browser. 

(Does this fix #1775?)