### PR TITLE
fix: improve rust-analyzer auto-completion

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -597,10 +597,17 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
         false
     };
 
-    parse_macro_input!(s as component::Model)
-        .is_transparent(is_transparent)
-        .into_token_stream()
-        .into()
+    let parse_result = syn::parse::<component::Model>(s.clone());
+
+    match parse_result {
+        Ok(model) => model
+            .is_transparent(is_transparent)
+            .into_token_stream()
+            .into(),
+        // Returning the original input stream in the case of a parsing
+        // error helps IDEs and rust-analyzer with auto-completion.
+        Err(_) => s,
+    }
 }
 
 /// Defines a component as an interactive island when you are using the

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -599,14 +599,18 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 
     let parse_result = syn::parse::<component::Model>(s.clone());
 
-    match parse_result {
-        Ok(model) => model
+    if let Ok(model) = parse_result {
+        model
             .is_transparent(is_transparent)
             .into_token_stream()
-            .into(),
-        // Returning the original input stream in the case of a parsing
-        // error helps IDEs and rust-analyzer with auto-completion.
-        Err(_) => s,
+            .into()
+    } else {
+        // When the input syntax is invalid, e.g. while typing, we let
+        // the dummy model output tokens similar to the input, which improves
+        // IDEs and rust-analyzer's auto-complete capabilities.
+        parse_macro_input!(s as component::DummyModel)
+            .into_token_stream()
+            .into()
     }
 }
 

--- a/leptos_macro/src/server.rs
+++ b/leptos_macro/src/server.rs
@@ -11,11 +11,12 @@ pub fn server_impl(
     args: proc_macro::TokenStream,
     s: TokenStream,
 ) -> TokenStream {
-    let function: syn::ItemFn =
-        match syn::parse(s).map_err(|e| e.to_compile_error()) {
-            Ok(f) => f,
-            Err(e) => return e.into(),
-        };
+    let function: syn::ItemFn = match syn::parse(s.clone()) {
+        Ok(f) => f,
+        // Returning the original input stream in the case of a parsing
+        // error helps IDEs and rust-analyzer with auto-completion.
+        Err(_) => return s,
+    };
     let ItemFn {
         attrs,
         vis,

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -50,32 +50,32 @@ error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `de
 10 | fn unknown_prop_option(#[prop(hello)] test: bool) -> impl IntoView {
    |                               ^^^^^
 
-error: cannot find attribute `prop` in this scope
-  --> tests/ui/component.rs:49:7
+error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+  --> tests/ui/component.rs:16:5
    |
-49 |     #[prop(default= |)] default: bool,
-   |       ^^^^
+16 |     ,
+   |     ^
 
-error: cannot find attribute `prop` in this scope
-  --> tests/ui/component.rs:41:7
+error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+  --> tests/ui/component.rs:24:5
    |
-41 |     #[prop(default)] default: bool,
-   |       ^^^^
+24 |     ,
+   |     ^
 
-error: cannot find attribute `prop` in this scope
-  --> tests/ui/component.rs:33:7
+error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+  --> tests/ui/component.rs:32:5
    |
-33 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |       ^^^^
+32 |     ,
+   |     ^
 
-error: cannot find attribute `prop` in this scope
-  --> tests/ui/component.rs:25:7
+error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+  --> tests/ui/component.rs:40:5
    |
-25 |     #[prop(optional, strip_option)] conflicting: bool,
-   |       ^^^^
+40 |     ,
+   |     ^
 
-error: cannot find attribute `prop` in this scope
-  --> tests/ui/component.rs:17:7
+error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+  --> tests/ui/component.rs:48:5
    |
-17 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |       ^^^^
+48 |     ,
+   |     ^

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -50,32 +50,32 @@ error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `de
 10 | fn unknown_prop_option(#[prop(hello)] test: bool) -> impl IntoView {
    |                               ^^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:16:5
+error: cannot find attribute `prop` in this scope
+  --> tests/ui/component.rs:49:7
    |
-16 |     ,
-   |     ^
+49 |     #[prop(default= |)] default: bool,
+   |       ^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:24:5
+error: cannot find attribute `prop` in this scope
+  --> tests/ui/component.rs:41:7
    |
-24 |     ,
-   |     ^
+41 |     #[prop(default)] default: bool,
+   |       ^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:32:5
+error: cannot find attribute `prop` in this scope
+  --> tests/ui/component.rs:33:7
    |
-32 |     ,
-   |     ^
+33 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
+   |       ^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:40:5
+error: cannot find attribute `prop` in this scope
+  --> tests/ui/component.rs:25:7
    |
-40 |     ,
-   |     ^
+25 |     #[prop(optional, strip_option)] conflicting: bool,
+   |       ^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:48:5
+error: cannot find attribute `prop` in this scope
+  --> tests/ui/component.rs:17:7
    |
-48 |     ,
-   |     ^
+17 |     #[prop(optional, optional_no_strip)] conflicting: bool,
+   |       ^^^^


### PR DESCRIPTION
This change fixes #1781. Please do try it out. You might have to restart rust-analyzer for it to "rebuild" the macros.

## HOWEVER

There is a caveat.

The situation is a bit more tricky than I initially thought, because the macros (at least the client macro) actually uses non-standard Rust syntax: Function parameter documentation comments (and potentially more, I'm not sure). Here's what happens:

![image](https://github.com/leptos-rs/leptos/assets/8947616/a233039e-4e26-44fd-afc6-8c4ad8149f13)

1. The macro is fed the token stream with my extraneous `let`
2. The macro realizes that the syntax is broken and returns the token stream as is
3. The Rust compiler and rust-analyzer get token stream _with_ function parameter doc comments, and then complain

This is not a problem with valid syntax, as the behavior there is unchanged. However, it might confuse users, and they might remove the doc comments (thinking they are not allowed) before fixing the actual issue.

## Can we fix this?

I believe so. For this particular case, a simple fix would be to parse and re-serialize the function signature and body separately. This way, the macro can remove the doc comments before rust-analyzer sees them, even if there is a syntax error in the function body. Before I attempt this, I wanted to make sure you are fine with bigger changes?

I leave it up to you if the PR in its current state is an improvement or a regression (though I'm guessing the latter).