### PR TITLE
chore: leptos_marco: Bumped outdated crates

### DIFF
--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -12,10 +12,10 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
-attribute-derive = { version = "0.6", features = ["syn-full"] }
+attribute-derive = { version = "0.8", features = ["syn-full"] }
 cfg-if = "1"
 html-escape = "0.2"
-itertools = "0.10"
+itertools = "0.11"
 prettyplease = "0.2.4"
 proc-macro-error = { version = "1", default-features = false }
 proc-macro2 = "1"


### PR DESCRIPTION
-attribute-derive = { version = "0.6", features = ["syn-full"] }
+attribute-derive = { version = "0.8", features = ["syn-full"] }

 -itertools = "0.10"
+itertools = "0.11"

cargo outdated reports a long list of issues. but I am only focusing on a small sub-section
Going over them on a case by case basis is tricky as for legacy reasons not all should be fixed.

We still need periodic nudges in the right direction, 
as if we let every thing get stale, the problem festers into a unsolvable mess.