### PR TITLE
Fix render_route error message and matching of non standard routes in…

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/leptos-rs/leptos"
 description = "Axum integrations for the Leptos web framework."
 
 [dependencies]
-axum = { version = "0.6", default-features = false }
+axum = { version = "0.6", default-features = false, features=["matched-path"] }
 futures = "0.3"
 http = "0.2.8"
 hyper = "0.14.23"

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -653,7 +653,7 @@ where
         // 2. Find RouteListing in paths. This should probably be optimized, we probably don't want to
         // search for this every time
         let listing: &RouteListing =
-            paths.iter().find(|r| r.path() == path).unwrap_or_else(|_| {
+            paths.iter().find(|r| r.path() == path).unwrap_or_else(|| {
                 panic!(
                     "Failed to find the route {path} requested by the user. \
                      This suggests that the routing rules in the Router that \

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
-    extract::{FromRef, FromRequestParts, Path, RawQuery, MatchedPath},
+    extract::{FromRef, FromRequestParts, MatchedPath, Path, RawQuery},
     http::{
         header::{HeaderName, HeaderValue},
         HeaderMap, Request, StatusCode,
@@ -645,15 +645,20 @@ where
 
     move |req| {
         // 1. Process route to match the values in routeListing
-        let path = req.extensions().get::<MatchedPath>().expect("Failed to get Axum router rule").as_str();
+        let path = req
+            .extensions()
+            .get::<MatchedPath>()
+            .expect("Failed to get Axum router rule")
+            .as_str();
         // 2. Find RouteListing in paths. This should probably be optimized, we probably don't want to
         // search for this every time
         let listing: &RouteListing =
-            paths.iter().find(|r| r.path() == path).expect(
-                &format!("Failed to find the route {} requested by the user. This \
+            paths.iter().find(|r| r.path() == path).expect(&format!(
+                "Failed to find the route {} requested by the user. This \
                  suggests that the routing rules in the Router that call this \
-                 handler needs to be edited!", path)
-            );
+                 handler needs to be edited!",
+                path
+            ));
         // 3. Match listing mode against known, and choose function
         match listing.mode() {
             SsrMode::OutOfOrder => ooo(req),

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::{Body, Bytes, Full, StreamBody},
-    extract::{FromRef, FromRequestParts, Path, RawQuery},
+    extract::{FromRef, FromRequestParts, Path, RawQuery, MatchedPath},
     http::{
         header::{HeaderName, HeaderValue},
         HeaderMap, Request, StatusCode,
@@ -644,16 +644,15 @@ where
     );
 
     move |req| {
-        let uri = req.uri();
         // 1. Process route to match the values in routeListing
-        let path = uri.path();
+        let path = req.extensions().get::<MatchedPath>().expect("Failed to get Axum router rule").as_str();
         // 2. Find RouteListing in paths. This should probably be optimized, we probably don't want to
         // search for this every time
         let listing: &RouteListing =
             paths.iter().find(|r| r.path() == path).expect(
-                "Failed to find the route {path} requested by the user. This \
+                &format!("Failed to find the route {} requested by the user. This \
                  suggests that the routing rules in the Router that call this \
-                 handler needs to be edited!",
+                 handler needs to be edited!", path)
             );
         // 3. Match listing mode against known, and choose function
         match listing.mode() {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -653,12 +653,13 @@ where
         // 2. Find RouteListing in paths. This should probably be optimized, we probably don't want to
         // search for this every time
         let listing: &RouteListing =
-            paths.iter().find(|r| r.path() == path).expect(&format!(
-                "Failed to find the route {} requested by the user. This \
-                 suggests that the routing rules in the Router that call this \
-                 handler needs to be edited!",
-                path
-            ));
+            paths.iter().find(|r| r.path() == path).unwrap_or_else(|_| {
+                panic!(
+                    "Failed to find the route {path} requested by the user. \
+                     This suggests that the routing rules in the Router that \
+                     call this handler needs to be edited!"
+                )
+            });
         // 3. Match listing mode against known, and choose function
         match listing.mode() {
             SsrMode::OutOfOrder => ooo(req),


### PR DESCRIPTION
Fixed the render_route route matching for wildcard/param routes by getting the matched rule from Axum for the comparison to the Leptos Router. Should close #1798 