### PR TITLE
Set Content-Type header for all Responses to text/html;charset="utf-8"

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -773,8 +773,13 @@ async fn generate_response(
     if let Some(status) = res_options.status {
         *res.status_mut() = status
     }
+    // Set the Content Type headers on all responses. This makes Firefox show the page source
+    // without complaining
+    let headers = res.headers_mut();
+    headers.insert(http::header::CONTENT_TYPE,HeaderValue::from_str("text/html; charset=utf-8").unwrap(),
+    );
     let mut res_headers = res_options.headers.clone();
-    res.headers_mut().extend(res_headers.drain());
+    headers.extend(res_headers.drain());
 
     res
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -773,16 +773,20 @@ async fn generate_response(
     if let Some(status) = res_options.status {
         *res.status_mut() = status
     }
-    // Set the Content Type headers on all responses. This makes Firefox show the page source
-    // without complaining
+
     let headers = res.headers_mut();
-    headers.insert(
-        http::header::CONTENT_TYPE,
-        HeaderValue::from_str("text/html; charset=utf-8").unwrap(),
-    );
+
     let mut res_headers = res_options.headers.clone();
     headers.extend(res_headers.drain());
 
+    if !headers.contains_key(http::header::CONTENT_TYPE){
+        // Set the Content Type headers on all responses. This makes Firefox show the page source
+        // without complaining
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_str("text/html; charset=utf-8").unwrap(),
+        );
+    }
     res
 }
 #[tracing::instrument(level = "info", fields(error), skip_all)]

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -779,7 +779,7 @@ async fn generate_response(
     let mut res_headers = res_options.headers.clone();
     headers.extend(res_headers.drain());
 
-    if !headers.contains_key(http::header::CONTENT_TYPE){
+    if !headers.contains_key(http::header::CONTENT_TYPE) {
         // Set the Content Type headers on all responses. This makes Firefox show the page source
         // without complaining
         headers.insert(

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -776,7 +776,9 @@ async fn generate_response(
     // Set the Content Type headers on all responses. This makes Firefox show the page source
     // without complaining
     let headers = res.headers_mut();
-    headers.insert(http::header::CONTENT_TYPE,HeaderValue::from_str("text/html; charset=utf-8").unwrap(),
+    headers.insert(
+        http::header::CONTENT_TYPE,
+        HeaderValue::from_str("text/html; charset=utf-8").unwrap(),
     );
     let mut res_headers = res_options.headers.clone();
     headers.extend(res_headers.drain());


### PR DESCRIPTION
This sets the Content Type header for all non serverfn responses. Firefox will complain and show a Content Encoding error if you try to view page source without it. Plus it's good practive