### PR TITLE
fix: broken `Suspense` when a resource loads immediately (closes #1805)

### DIFF
--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -118,33 +118,29 @@ impl SuspenseContext {
         let setter = self.set_pending_resources;
         let serializable_resources = self.pending_serializable_resources;
         let has_local_only = self.has_local_only;
-        queue_microtask(move || {
-            setter.update(|n| *n += 1);
-            if serializable {
-                serializable_resources.update(|n| *n += 1);
-                has_local_only.set_value(false);
-            }
-        });
+        setter.update(|n| *n += 1);
+        if serializable {
+            serializable_resources.update(|n| *n += 1);
+            has_local_only.set_value(false);
+        }
     }
 
     /// Notifies the suspense context that a resource has resolved.
     pub fn decrement(&self, serializable: bool) {
         let setter = self.set_pending_resources;
         let serializable_resources = self.pending_serializable_resources;
-        queue_microtask(move || {
-            setter.update(|n| {
-                if *n > 0 {
-                    *n -= 1
-                }
-            });
-            if serializable {
-                serializable_resources.update(|n| {
-                    if *n > 0 {
-                        *n -= 1;
-                    }
-                });
+        setter.update(|n| {
+            if *n > 0 {
+                *n -= 1
             }
         });
+        if serializable {
+            serializable_resources.update(|n| {
+                if *n > 0 {
+                    *n -= 1;
+                }
+            });
+        }
     }
 
     /// Resets the counter of pending resources.


### PR DESCRIPTION
At some point in the distant past, I added a delay here, probably as a hacky workaround for some other failing I can no longer remember.

It causes an issue if you have multiple resources loading in the same `Suspense`, and one of them is immediately loaded without any further delay.

In the near future, I'm sure removing this will surface some other bug, but I can't find it now!