### PR TITLE
Remove extra angle brackets in generate_head_metadata

### DIFF
--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -288,7 +288,7 @@ impl MetaContext {
 #[cfg(feature = "ssr")]
 pub fn generate_head_metadata() -> String {
     let (head, body) = generate_head_metadata_separated();
-    format!("{head}</head><{body}>")
+    format!("{head}</head>{body}")
 }
 
 /// Extracts the metadata that should be inserted at the beginning of the `<head>` tag


### PR DESCRIPTION
`generate_head_metadata_separated` adds a set of angle brackets around the body tag as shown here https://github.com/leptos-rs/leptos/blob/2d634364a9a4087b64389e9cd54ecc337151aaeb/meta/src/lib.rs#L308-L308 That means `generate_head_metadata` introduces an extra set of angle brackets by interpolating that value like so `<{body}>`. This PR removes the extra set of angle brackets.