### PR TITLE
fix: router animations should reset to `Start` state (closes #1754)

### DIFF
--- a/router/src/animation.rs
+++ b/router/src/animation.rs
@@ -27,6 +27,7 @@ impl Animation {
             outro,
             intro,
             intro_back,
+            finally,
             ..
         } = self;
         match current {
@@ -35,8 +36,10 @@ impl Animation {
                     AnimationState::Start
                 } else if intro.is_some() {
                     AnimationState::Intro
-                } else {
+                } else if finally.is_some() {
                     AnimationState::Finally
+                } else {
+                    AnimationState::Start
                 };
                 (next, true)
             }
@@ -47,21 +50,37 @@ impl Animation {
                     AnimationState::IntroBack
                 } else if intro.is_some() {
                     AnimationState::Intro
-                } else {
+                } else if finally.is_some() {
                     AnimationState::Finally
+                } else {
+                    AnimationState::Start
                 };
                 (next, true)
             }
             AnimationState::Start => {
                 let next = if intro.is_some() {
                     AnimationState::Intro
-                } else {
+                } else if finally.is_some() {
                     AnimationState::Finally
+                } else {
+                    AnimationState::Start
                 };
                 (next, false)
             }
-            AnimationState::Intro => (AnimationState::Finally, false),
-            AnimationState::IntroBack => (AnimationState::Finally, false),
+            AnimationState::Intro => {
+                if finally.is_some() {
+                    (AnimationState::Finally, false)
+                } else {
+                    (AnimationState::Start, false)
+                }
+            }
+            AnimationState::IntroBack => {
+                if finally.is_some() {
+                    (AnimationState::Finally, false)
+                } else {
+                    (AnimationState::Start, false)
+                }
+            }
             AnimationState::Finally => {
                 if outro.is_some() {
                     if is_back {
@@ -77,8 +96,10 @@ impl Animation {
                     } else {
                         (AnimationState::Intro, false)
                     }
-                } else {
+                } else if finally.is_some() {
                     (AnimationState::Finally, true)
+                } else {
+                    (AnimationState::Start, true)
                 }
             }
         }

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -179,7 +179,7 @@ pub fn AnimatedRoutes(
     };
     let is_back = use_is_back_navigation();
     let (animation_state, set_animation_state) =
-        create_signal(AnimationState::Finally);
+        create_signal(AnimationState::Start);
     let next_route = router.pathname();
 
     let is_complete = Rc::new(Cell::new(true));
@@ -190,6 +190,7 @@ pub fn AnimatedRoutes(
         move |prev: Option<&(AnimationState, String)>| {
             let animation_state = animation_state.get();
             let next_route = next_route.get();
+            logging::log!("{animation_state:?} {next_route:?}");
             let prev_matches = prev
                 .map(|(_, r)| r)
                 .cloned()


### PR DESCRIPTION
The `AnimatedRoutes` and `AnimationOutlet` transitions are quite tricky. I think this at least fixes the test case in #1754, but not sure if it's actually correct.