### PR TITLE
Fix template! cfg condition

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -178,7 +178,7 @@ pub mod error {
 }
 #[cfg(all(target_arch = "wasm32", feature = "template_macro"))]
 pub use leptos_macro::template;
-#[cfg(not(any(target_arch = "wasm32", feature = "template_macro")))]
+#[cfg(not(all(target_arch = "wasm32", feature = "template_macro")))]
 pub use leptos_macro::view as template;
 pub use leptos_macro::{component, island, server, slot, view, Params};
 pub use leptos_reactive::*;


### PR DESCRIPTION
The current `#[cfg]` condition for the `template!` aliased as `view!` is not the negation of the condition for the real `template!`.
This causes an error when the compilation target is not `wasm32` but the `template_macro` feature is enabled, which happens with rust-analyzer in a workspace for example.

The fix is just to use the negation of condition for the real `template!`.