### PR TITLE
Fixes #1828, making SSR behavior match the Hydrate behavior.

### DIFF
--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -149,9 +149,15 @@ pub fn Html(
             }
         } else if #[cfg(feature = "ssr")] {
             let meta = crate::use_head();
-            *meta.html.lang.borrow_mut() = lang;
-            *meta.html.dir.borrow_mut() = dir;
-            *meta.html.class.borrow_mut() = class;
+            if let Some(lang) = lang {
+                *meta.html.lang.borrow_mut() = lang;
+            }
+            if let Some(dir) = dir {
+                *meta.html.dir.borrow_mut() = dir;
+            }
+            if let Some(class) = class {
+                *meta.html.class.borrow_mut() = class;
+            }
             meta.html.attributes.borrow_mut().extend(attributes);
         } else {
                         _ = lang;

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -149,13 +149,13 @@ pub fn Html(
             }
         } else if #[cfg(feature = "ssr")] {
             let meta = crate::use_head();
-            if let Some(lang) = lang {
+            if lang.is_some() {
                 *meta.html.lang.borrow_mut() = lang;
             }
-            if let Some(dir) = dir {
+            if dir.is_some() {
                 *meta.html.dir.borrow_mut() = dir;
             }
-            if let Some(class) = class {
+            if class.is_some() {
                 *meta.html.class.borrow_mut() = class;
             }
             meta.html.attributes.borrow_mut().extend(attributes);


### PR DESCRIPTION
This is a simple fix to make the behavior of SSR the same as Hydrate. I think it's expected to be able to mismatch in different places attributes of Html.