### PR TITLE
fix: update log debug to use get_untracked for logged in user to resolve client side console error

### DIFF
--- a/examples/login_with_token_csr_only/client/src/lib.rs
+++ b/examples/login_with_token_csr_only/client/src/lib.rs
@@ -70,7 +70,7 @@ pub fn App() -> impl IntoView {
         fetch_user_info.dispatch(());
     }
 
-    log::debug!("User is logged in: {}", logged_in.get());
+    log::debug!("User is logged in: {}", logged_in.get_untracked());
 
     // -- effects -- //
 


### PR DESCRIPTION
Update to use `_untracked` for log::debug to resolve client side console error for `examples/login_with_token_csr_only`

<img width="1440" alt="Screenshot 2023-10-02 at 9 21 12 PM" src="https://github.com/leptos-rs/leptos/assets/21967/48ca810a-5998-4c63-a59e-3ba59a3d2e3d">
