### PR TITLE
Don't print `=` on empty attribute when spreading

### DIFF
--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -284,7 +284,10 @@ fn element_to_tokens_ssr(
                     template.push_str(" {}");
                     holes.push(quote! {
                         {#end}.into_iter().filter_map(|(name, attr)| {
-                           Some(format!("{}=\"{}\"", name, ::leptos::leptos_dom::ssr::escape_attr(&attr.as_nameless_value_string()?)))
+                            Some(match attr {
+                                ::leptos::Attribute::Option(None) => <::leptos::Oco as ::core::convert::From>::from(name),
+                                attr => ::leptos::Oco::Owned(format!("{}=\"{}\"", name, ::leptos::leptos_dom::ssr::escape_attr(&attr.as_nameless_value_string()?)))
+                            })
                         }).collect::<Vec<_>>().join(" ")
                     });
                 };


### PR DESCRIPTION
If one attribute was `Attribute::Option(None)` when spreading the `=` is still printed.
This PR remove that equal sign.