### PR TITLE
Removed warning in build artefacts.

### DIFF
--- a/.github/workflows/get-changed-examples-matrix.yml
+++ b/.github/workflows/get-changed-examples-matrix.yml
@@ -20,7 +20,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/get-example-changed.yml
+++ b/.github/workflows/get-example-changed.yml
@@ -15,7 +15,7 @@ jobs:
       example_changed: ${{ steps.set-example-changed.outputs.example_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/get-examples-matrix.yml
+++ b/.github/workflows/get-examples-matrix.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install JQ Tool
         uses: mbround18/install-jq@v1
@@ -23,12 +23,12 @@ jobs:
       - name: Set Matrix
         id: set-matrix
         run: |
-          examples=$(ls examples | 
-          awk '{print "examples/" $0}' | 
-          grep -v .md | 
-          grep -v examples/Makefile.toml | 
-          grep -v examples/cargo-make | 
-          grep -v examples/gtk | 
+          examples=$(ls examples |
+          awk '{print "examples/" $0}' |
+          grep -v .md |
+          grep -v examples/Makefile.toml |
+          grep -v examples/cargo-make |
+          grep -v examples/gtk |
           jq -R -s -c 'split("\n")[:-1]')
           echo "Example Directories: $examples"
           echo "matrix={\"directory\":$examples}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-leptos-changed.yml
+++ b/.github/workflows/get-leptos-changed.yml
@@ -15,7 +15,7 @@ jobs:
       leptos_changed: ${{ steps.set-source-changed.outputs.leptos_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get source files that changed
         id: changed-source

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write # To push a branch
       pull-requests: write # To create a PR from that branch
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install mdbook


### PR DESCRIPTION
This warning 

```
The following actions uses node12 which is deprecated and will be forced to run
   on node16: actions-rs/toolchain@v1. For more info:
   https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

In other places @3 was being used, so for consitency I have bumped everything up to @4

```
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
```