### PR TITLE
chore: set-output is deprecated.

### DIFF
--- a/.github/workflows/get-changed-examples-matrix.yml
+++ b/.github/workflows/get-changed-examples-matrix.yml
@@ -41,7 +41,7 @@ jobs:
           quotepath: false
 
       - name: List example project directories that changed
-        run: echo '${{ steps.changed-dirs.outputs.all_changed_files }}'
+        run: echo '${{ steps.changed-dirs.outputs.all_changed_files }}' >> "$GITHUB_OUTPUT"
 
       - name: Set Matrix
         id: set-matrix

--- a/.github/workflows/get-example-changed.yml
+++ b/.github/workflows/get-example-changed.yml
@@ -31,7 +31,7 @@ jobs:
             !examples/*.md
 
       - name: List example files that changed
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}'
+        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> "$GITHUB_OUTPUT"
 
       - name: Set example_changed
         id: set-example-changed

--- a/.github/workflows/get-leptos-changed.yml
+++ b/.github/workflows/get-leptos-changed.yml
@@ -36,7 +36,7 @@ jobs:
             server_fn_macro
 
       - name: List source files that changed
-        run: echo '${{ steps.changed-source.outputs.all_changed_files }}'
+        run: echo '${{ steps.changed-source.outputs.all_changed_files }}' >> "$GITHUB_OUTPUT"
 
       - name: Set leptos_changed
         id: set-source-changed


### PR DESCRIPTION
Fixes this warning in the build artefacts.

```
Check (examples/counter_without_macros) / Run check (stable)
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files. For more information see:
 https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```