### PR TITLE
Correctly format `Attribute::Bool(true)` when spreading attrs

### DIFF
--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -283,9 +283,7 @@ fn element_to_tokens_ssr(
                     // the template
                     template.push_str(" {}");
                     holes.push(quote! {
-                        {#end}.into_iter().filter_map(|(name, attr)| {
-                           Some(format!("{}=\"{}\"", name, ::leptos::leptos_dom::ssr::escape_attr(&attr.as_nameless_value_string()?)))
-                        }).collect::<Vec<_>>().join(" ")
+                        ::leptos::Attribute::format_attrs(#end)
                     });
                 };
             }


### PR DESCRIPTION
When an attribute is `Attribute::Bool(true)` the outputed html attribute was `name=` and no value after.

This PR adjust this to output just `name`.