### PR TITLE
fix: documentation in `leptos_reactive::Trigger`

### DIFF
--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -554,7 +554,7 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
     /// Checks to see if this element is mounted to the DOM as a child
     /// of `body`.
     ///
-    /// This method will always return [`None`] on non-wasm CSR targets.
+    /// This method will always return `false` on non-wasm CSR targets.
     #[inline(always)]
     pub fn is_mounted(&self) -> bool {
         #[cfg(all(target_arch = "wasm32", feature = "web"))]

--- a/leptos_reactive/src/trigger.rs
+++ b/leptos_reactive/src/trigger.rs
@@ -29,7 +29,7 @@ impl Trigger {
 
     /// Attempts to notify any reactive code where this trigger is tracked to rerun.
     ///
-    /// Returns `None` if the runtime has been disposed.
+    /// Returns `false` if there is no current reactive runtime.
     pub fn try_notify(&self) -> bool {
         with_runtime(|runtime| {
             runtime.mark_dirty(self.id);
@@ -48,7 +48,7 @@ impl Trigger {
     }
 
     /// Attempts to subscribe the running effect to this trigger, returning
-    /// `None` if the runtime has been disposed.
+    /// `false` if there is no current reactive runtime.
     pub fn try_track(&self) -> bool {
         let diagnostics = diagnostics!(self);
 


### PR DESCRIPTION
So I've been using `leptos` for a while, and I stumbled upon one tiny mistake while going through the documentation.

The documentation for [`Trigger::try_notify`](https://github.com/leptos-rs/leptos/blob/e0d15c1a094f193a85cd9304bf86edabbf46a902/leptos_reactive/src/trigger.rs#L32C9-L32C57) and [`Trigger::try_track`](https://github.com/leptos-rs/leptos/blob/e0d15c1a094f193a85cd9304bf86edabbf46a902/leptos_reactive/src/trigger.rs#L50C67-L51C49) states that they **return `None`** if the runtime has been disposed:

> (...) Returns `None` if the runtime has been disposed.

...when, in fact, they **return `false`** in such a case.

To rectify this, changing `None` to `false` could be sufficient, but I thought it might make sense to use the same wording as in [`Trigger::notify`](https://github.com/leptos-rs/leptos/blob/e0d15c1a094f193a85cd9304bf86edabbf46a902/leptos_reactive/src/trigger.rs#L24C16-L24C55) and [`Trigger::track`](https://github.com/leptos-rs/leptos/blob/e0d15c1a094f193a85cd9304bf86edabbf46a902/leptos_reactive/src/trigger.rs#L44C16-L44C55):

> (...) if there is no current reactive runtime, (...)

---

I haven't checked for similar occurrences, so there might be more present.