### PR TITLE
Fix: use placeholder in comments for empty component names

### DIFF
--- a/leptos_dom/src/ssr.rs
+++ b/leptos_dom/src/ssr.rs
@@ -735,10 +735,16 @@ impl ToMarker for HydrationKey {
     fn to_marker(
         &self,
         closing: bool,
-        #[cfg(debug_assertions)] component_name: &str,
+        #[cfg(debug_assertions)] mut component_name: &str,
     ) -> Oco<'static, str> {
         #[cfg(debug_assertions)]
         {
+            if component_name.is_empty() {
+                // NOTE:
+                // If the name is left empty, this will lead to invalid comments,
+                // so a placeholder is used here.
+                component_name = "<>";
+            }
             if closing || component_name == "unit" {
                 format!("<!--hk={self}c|leptos-{component_name}-end-->").into()
             } else {


### PR DESCRIPTION
In some contexts the generated comments leads to invalid HTML/XML.
This quick fix uses `unknown` as placeholder to avoid the problem.
probably there are cleaner solutions, but it would be a first step.