### PR TITLE
Make Async Mode return Content-Type header in Response

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -783,7 +783,6 @@ async fn generate_response(
 
     let mut res_headers = res_options.headers.clone();
     headers.extend(res_headers.drain());
-
     if !headers.contains_key(http::header::CONTENT_TYPE) {
         // Set the Content Type headers on all responses. This makes Firefox show the page source
         // without complaining
@@ -1118,8 +1117,21 @@ where
                 if let Some(status) = res_options.status {
                     *res.status_mut() = status
                 }
+                let headers = res.headers_mut();
                 let mut res_headers = res_options.headers.clone();
-                res.headers_mut().extend(res_headers.drain());
+
+                headers.extend(res_headers.drain());
+
+                // This one doesn't use generate_response(), so we need to do this seperately
+                if !headers.contains_key(http::header::CONTENT_TYPE) {
+                    // Set the Content Type headers on all responses. This makes Firefox show the page source
+                    // without complaining
+                    headers.insert(
+                        http::header::CONTENT_TYPE,
+                        HeaderValue::from_str("text/html; charset=utf-8")
+                            .unwrap(),
+                    );
+                }
 
                 res
             }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -783,6 +783,7 @@ async fn generate_response(
 
     let mut res_headers = res_options.headers.clone();
     headers.extend(res_headers.drain());
+
     if !headers.contains_key(http::header::CONTENT_TYPE) {
         // Set the Content Type headers on all responses. This makes Firefox show the page source
         // without complaining


### PR DESCRIPTION
Async mode doesn't use generate_response() but should still return a Content-Type header