### PR TITLE
fix: `clippy` "needless lifetimes" warning (closes #1825)

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -511,6 +511,7 @@ impl ToTokens for Model {
             #[doc = ""]
             #component_fn_prop_docs
             #[allow(non_snake_case, clippy::too_many_arguments)]
+            #[allow(clippy::needless_lifetimes)]
             #tracing_instrument_attr
             #vis fn #name #impl_generics (
                 #props_arg


### PR DESCRIPTION
fix #1825