### PR TITLE
fix: add `leptos_axum::build_static_routes` (closes #1843)

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1303,6 +1303,7 @@ pub async fn build_static_routes<IV>(
             &static_data_map,
         )
         .await
+        .expect("could not build static routes")
     });
 }
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1070,38 +1070,41 @@ where
                 let full_path = format!("http://leptos.dev{path}");
 
                 let (tx, rx) = futures::channel::oneshot::channel();
-                let local_pool = get_leptos_pool();
-                local_pool.spawn_pinned(move || {
-                    async move {
-                        let app = {
-                            let full_path = full_path.clone();
-                            let (req, req_parts) = generate_request_and_parts(req).await;
-                            move || {
-                                provide_contexts(full_path, req_parts, req.into(), default_res_options);
-                                app_fn().into_view()
-                            }
-                        };
-
-                        let (stream, runtime) =
-                            render_to_stream_in_order_with_prefix_undisposed_with_context(
-                                app,
-                                || "".into(),
-                                add_context,
+                spawn_task!(async move {
+                    let app = {
+                        let full_path = full_path.clone();
+                        let (req, req_parts) =
+                            generate_request_and_parts(req).await;
+                        move || {
+                            provide_contexts(
+                                full_path,
+                                req_parts,
+                                req.into(),
+                                default_res_options,
                             );
+                            app_fn().into_view()
+                        }
+                    };
 
-                        // Extract the value of ResponseOptions from here
-                        let res_options =
-                            use_context::<ResponseOptions>().unwrap();
+                    let (stream, runtime) =
+                        render_to_stream_in_order_with_prefix_undisposed_with_context(
+                            app,
+                            || "".into(),
+                            add_context,
+                        );
 
-                        let html = build_async_response(stream, &options, runtime).await;
+                    // Extract the value of ResponseOptions from here
+                    let res_options = use_context::<ResponseOptions>().unwrap();
 
-                        let new_res_parts = res_options.0.read().clone();
+                    let html =
+                        build_async_response(stream, &options, runtime).await;
 
-                        let mut writable = res_options2.0.write();
-                        *writable = new_res_parts;
+                    let new_res_parts = res_options.0.read().clone();
 
-                        _ = tx.send(html);
-                    }
+                    let mut writable = res_options2.0.write();
+                    *writable = new_res_parts;
+
+                    _ = tx.send(html);
                 });
 
                 let html = rx.await.expect("to complete HTML rendering");
@@ -1279,6 +1282,28 @@ where
     IV: IntoView + 'static,
 {
     generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
+}
+
+/// TODO docs
+pub async fn build_static_routes<IV>(
+    options: &LeptosOptions,
+    app_fn: impl Fn() -> IV + 'static + Send + Clone,
+    routes: &[RouteListing],
+    static_data_map: StaticDataMap,
+) where
+    IV: IntoView + 'static,
+{
+    let options = options.clone();
+    let routes = routes.to_owned();
+    spawn_task!(async move {
+        leptos_router::build_static_routes(
+            &options,
+            app_fn,
+            &routes,
+            &static_data_map,
+        )
+        .await
+    });
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1493,8 +1518,7 @@ where
 
                     async move {
                         let (tx, rx) = futures::channel::oneshot::channel();
-                        let local_pool = get_leptos_pool();
-                        local_pool.spawn_pinned(move || async move {
+                        spawn_task!(async move {
                             let res = incremental_static_route(
                                 tokio::fs::read_to_string(static_file_path(
                                     &options, &path,
@@ -1537,8 +1561,7 @@ where
 
                     async move {
                         let (tx, rx) = futures::channel::oneshot::channel();
-                        let local_pool = get_leptos_pool();
-                        local_pool.spawn_pinned(move || async move {
+                        spawn_task!(async move {
                             let res = upfront_static_route(
                                 tokio::fs::read_to_string(static_file_path(
                                     &options, &path,

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -10,6 +10,7 @@ use std::{
     future::Future,
     pin::Pin,
     rc::Rc,
+    sync::Arc,
 };
 
 thread_local! {
@@ -179,7 +180,10 @@ where
     E: IntoView,
     F: Fn() -> E + 'static,
     P: std::fmt::Display,
-    S: Fn() -> Pin<Box<dyn Future<Output = StaticParamsMap>>> + 'static,
+    S: Fn() -> Pin<Box<dyn Future<Output = StaticParamsMap> + Send + Sync>>
+        + Send
+        + Sync
+        + 'static,
 {
     define_route(
         children,
@@ -189,7 +193,7 @@ where
         &[Method::Get],
         data,
         Some(mode),
-        static_params.map(|s| Rc::new(s) as _),
+        static_params.map(|s| Arc::new(s) as _),
     )
 }
 

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -163,8 +163,7 @@ pub fn StaticRoute<E, F, P, S>(
     /// or `|| view! { <MyComponent/>` } or even, for a component with no props, `MyComponent`).
     view: F,
     /// Creates a map of the params that should be built for a particular route.
-    #[prop(optional)]
-    static_params: Option<S>,
+    static_params: S,
     /// The static route mode
     #[prop(optional)]
     mode: StaticMode,
@@ -193,7 +192,7 @@ where
         &[Method::Get],
         data,
         Some(mode),
-        static_params.map(|s| Arc::new(s) as _),
+        Some(Arc::new(static_params)),
     )
 }
 

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -15,7 +15,7 @@ use std::{
     hash::{Hash, Hasher},
     path::PathBuf,
     pin::Pin,
-    rc::Rc,
+    sync::Arc,
 };
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -304,10 +304,12 @@ pub fn purge_all_static_routes<IV>(
     purge_dir_of_static_files(Path::new(&options.site_root).to_path_buf())
 }
 
-pub type StaticData = Rc<StaticDataFn>;
+pub type StaticData = Arc<StaticDataFn>;
 
-pub type StaticDataFn =
-    dyn Fn() -> Pin<Box<dyn Future<Output = StaticParamsMap>>> + 'static;
+pub type StaticDataFn = dyn Fn() -> Pin<Box<dyn Future<Output = StaticParamsMap> + Send + Sync>>
+    + Send
+    + Sync
+    + 'static;
 
 pub type StaticDataMap = HashMap<String, Option<StaticData>>;
 


### PR DESCRIPTION
@mrvillage I needed to add some `Send` + `Sync` bounds to the static data generation function, which I *think* should be okay, but I'd appreciate it if you could help out with some testing, since I think you probably have a better example of using this than I do, and/or let me know if this is wrong.

There may be a better way of getting it to work with Axum, I'm not sure, but as of now I think it's broken on Axum.