### PR TITLE
docs: clarify what "once per signal change" means

### DIFF
--- a/docs/book/src/view/02_dynamic_attributes.md
+++ b/docs/book/src/view/02_dynamic_attributes.md
@@ -145,9 +145,10 @@ Derived signals let you create reactive computed values that can be used in mult
 places in your application with minimal overhead.
 
 Note: Using a derived signal like this means that the calculation runs once per
-signal change and once per place we access `double_count`; in other words, twice. This is a
-very cheap calculation, so that’s fine. We’ll look at memos in a later chapter, which
-are designed to solve this problem for expensive calculations.
+signal change (when `count()` changes) and once per place we access `double_count`;
+in other words, twice. This is a very cheap calculation, so that’s fine.
+We’ll look at memos in a later chapter, which re designed to solve this problem
+for expensive calculations.
 
 > #### Advanced Topic: Injecting Raw HTML
 >


### PR DESCRIPTION
It took me some time to understand what running twice means for derived signals, I think this clarification can help.

If you don't think it's necessary, that's ok, I was able to figure it out while reading anyways haha.

A lot of lines are modified so that they keep around the same width, but I only added the parenthesis.