### PR TITLE
fix: Prop-drilling example in Parent-Child Communication section of the book

### DIFF
--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -188,7 +188,7 @@ pub fn App() -> impl IntoView {
 }
 
 #[component]
-pub fn Layout(d: WriteSignal<bool>) -> impl IntoView {
+pub fn Layout(set_toggled: WriteSignal<bool>) -> impl IntoView {
     view! {
         <header>
             <h1>"My Page"</h1>
@@ -200,7 +200,7 @@ pub fn Layout(d: WriteSignal<bool>) -> impl IntoView {
 }
 
 #[component]
-pub fn Content(d: WriteSignal<bool>) -> impl IntoView {
+pub fn Content(set_toggled: WriteSignal<bool>) -> impl IntoView {
     view! {
         <div class="content">
             <ButtonD set_toggled/>
@@ -209,7 +209,7 @@ pub fn Content(d: WriteSignal<bool>) -> impl IntoView {
 }
 
 #[component]
-pub fn ButtonD<F>(d: WriteSignal<bool>) -> impl IntoView {
+pub fn ButtonD<F>(set_toggled: WriteSignal<bool>) -> impl IntoView {
     todo!()
 }
 ```


### PR DESCRIPTION
In the [Providing a Context](https://leptos-rs.github.io/leptos/view/08_parent_child.html#4-providing-a-context) section 3.8, the example uses shorthand for passing props to child components, however the function signature for the components takes a different prop name. 

This PR resolves that so that it uses the correct names.