### PR TITLE
fix: Add missing argument name to WrapsChildren component in section 3.9 of the book

### DIFF
--- a/docs/book/src/view/09_component_children.md
+++ b/docs/book/src/view/09_component_children.md
@@ -96,7 +96,7 @@ a component that takes its children and turns them into an unordered list.
 
 ```rust
 #[component]
-pub fn WrapsChildren(Children) -> impl IntoView {
+pub fn WrapsChildren(children: Children) -> impl IntoView {
     // Fragment has `nodes` field that contains a Vec<View>
     let children = children()
         .nodes


### PR DESCRIPTION
In 3.9, the [Manipulating children](https://leptos-rs.github.io/leptos/view/09_component_children.html#manipulating-children) section, the `WrapsChildren` example component was missing the argument name. This PR adds the name.