### PR TITLE
feat: Implement Default trait for RwSignal and StoredValue

### DIFF
--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -1211,6 +1211,12 @@ where
     pub(crate) defined_at: &'static std::panic::Location<'static>,
 }
 
+impl<T: Default> Default for RwSignal<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<T> Clone for RwSignal<T> {
     fn clone(&self) -> Self {
         *self

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -29,6 +29,12 @@ where
     ty: PhantomData<T>,
 }
 
+impl<T: Default> Default for StoredValue<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 impl<T> Clone for StoredValue<T> {
     fn clone(&self) -> Self {
         *self


### PR DESCRIPTION
Implement Default trait for `RwSignal` and `StoredValue` so that optional properties can be implemented, such as:

```rust
#[component]
fn My(#[prop(optional)] value: RwSignal<f32>) -> impl IntoView {
    ...
}


fn main() {
   view! {
       <My />
   }
}
```