### PR TITLE
Remove `Clone` requirement on `SignalWith` for `Resource`

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -709,7 +709,6 @@ impl<S, T> SignalUpdate for Resource<S, T> {
 impl<S, T> SignalWith for Resource<S, T>
 where
     S: Clone,
-    T: Clone,
 {
     type Value = Option<T>;
 


### PR DESCRIPTION
I'm assuming this is a mistake because the point of `with` is to not clone, and the code compiles just fine with the bound removed.