### PR TITLE
docs: update Dockerfile in deployment.md to work with cargo-leptos@0.2.0

### DIFF
--- a/docs/book/src/deployment.md
+++ b/docs/book/src/deployment.md
@@ -54,7 +54,7 @@ RUN cargo leptos build --release -vv
 
 FROM rustlang/rust:nightly-bullseye as runner
 # Copy the server binary to the /app directory
-COPY --from=builder /app/target/server/release/leptos_start /app/
+COPY --from=builder /app/target/release/leptos-start /app/
 # /target/site contains our JS/WASM/CSS, etc.
 COPY --from=builder /app/target/site /app/site
 # Copy Cargo.toml if it’s needed at runtime


### PR DESCRIPTION
- cargo-leptos@0.2.0 changes the file structure under the target folder from `/app/target/server/release/` to `/app/target/release/`. https://github.com/leptos-rs/cargo-leptos/pull/159
- `cargo leptos new` now creates the project with the name `leptos-start` instead of `leptos_start`. So, we need to change the binary filename too.