### PR TITLE
fix: properly handle trailing `/` in more routes

### DIFF
--- a/router/src/matching/matcher.rs
+++ b/router/src/matching/matcher.rs
@@ -57,13 +57,14 @@ impl Matcher {
         let loc_len = loc_segments.len();
         let len_diff: i32 = loc_len as i32 - self.len as i32;
 
+        let trailing_iter = location.chars().rev().take_while(|n| *n == '/');
+
         // quick path: not a match if
         // 1) matcher has add'l segments not found in location
         // 2) location has add'l segments, there's no splat, and partial matches not allowed
         if loc_len < self.len
             || (len_diff > 0 && self.splat.is_none() && !self.partial)
-            || (self.splat.is_none()
-                && location.split('/').count() > (2 * (loc_segments.len() + 1)))
+            || (self.splat.is_none() && trailing_iter.clone().count() > 1)
         {
             None
         }
@@ -95,12 +96,8 @@ impl Matcher {
                     };
 
                     // add trailing slashes to splat
-                    let trailing_slashes = location
-                        .chars()
-                        .rev()
-                        .take_while(|n| *n == '/')
-                        .skip(1)
-                        .collect::<String>();
+                    let trailing_slashes =
+                        trailing_iter.skip(1).collect::<String>();
                     value.push_str(&trailing_slashes);
 
                     params.insert(splat.into(), value);


### PR DESCRIPTION
#1890 fixed the bug
but after that, I've noticed inconsistent router behavior under the following condition:

```jsx
...
<Router>
    <Routes>
        <Route path="*"            view=|| { "A" } />

        <Route path="/"            view=|| { "0" } />
        <Route path="/test"        view=|| { "1" } />
        <Route path="/test/test"   view=|| { "2" } />
    </Routes>
</Router>
...
```

(sorry for the wall of table, but i cant think of any better way to express this)
O: correct
X: incorrect

| URL | View | Correct |
|-|-|-|
| / | `0` | O |
| // | `A` | O |
| ///// | `A` | O |
| /test | `1` | O |
| /test/ | `1` | O |
| /test// | `1` | X (this should be `A`) |
| /test/// | `A` | O |
| //test | `1` | O |
| ///test | `1` | O |
| ////test | `A` | X (this should be `1`) |
| /test/////test | `A` | X (this should be `2`) |
| ///test///test | `A` | X (this should be `2`) |

and there are many more cases...

I just tweaked some of your fixes which I think causing this issue.
Now everything matches correctly and works as I expected.

Let me know if something i changed is wrong 