### PR TITLE
Use method instead of trait for `.call` syntax

### DIFF
--- a/leptos/src/text_prop.rs
+++ b/leptos/src/text_prop.rs
@@ -1,16 +1,16 @@
-use leptos_reactive::Oco;
+use leptos_reactive::{MaybeSignal, Oco, SignalGet};
 use std::{fmt::Debug, rc::Rc};
 
 /// Describes a value that is either a static or a reactive string, i.e.,
 /// a [`String`], a [`&str`], or a reactive `Fn() -> String`.
 #[derive(Clone)]
-pub struct TextProp(Rc<dyn Fn() -> Oco<'static, str>>);
+pub struct TextProp(MaybeSignal<Oco<'static, str>>);
 
 impl TextProp {
     /// Accesses the current value of the property.
     #[inline(always)]
     pub fn get(&self) -> Oco<'static, str> {
-        (self.0)()
+        self.0.get()
     }
 }
 
@@ -23,37 +23,61 @@ impl Debug for TextProp {
 impl From<String> for TextProp {
     fn from(s: String) -> Self {
         let s: Oco<'_, str> = Oco::Counted(Rc::from(s));
-        TextProp(Rc::new(move || s.clone()))
+        TextProp(MaybeSignal::derive(move || s.clone()))
     }
 }
 
 impl From<&'static str> for TextProp {
     fn from(s: &'static str) -> Self {
         let s: Oco<'_, str> = s.into();
-        TextProp(Rc::new(move || s.clone()))
+        TextProp(MaybeSignal::derive(move || s.clone()))
     }
 }
 
 impl From<Rc<str>> for TextProp {
     fn from(s: Rc<str>) -> Self {
         let s: Oco<'_, str> = s.into();
-        TextProp(Rc::new(move || s.clone()))
+        TextProp(MaybeSignal::derive(move || s.clone()))
     }
 }
 
 impl From<Oco<'static, str>> for TextProp {
     fn from(s: Oco<'static, str>) -> Self {
-        TextProp(Rc::new(move || s.clone()))
+        TextProp(MaybeSignal::derive(move || s.clone()))
     }
 }
 
-impl<F, S> From<F> for TextProp
+impl<F, I> From<F> for TextProp
 where
-    F: Fn() -> S + 'static,
-    S: Into<Oco<'static, str>>,
+    F: crate::Invocable<Value = I> + 'static,
+    I: Into<Oco<'static, str>> + 'static + Clone,
 {
     #[inline(always)]
     fn from(s: F) -> Self {
-        TextProp(Rc::new(move || s().into()))
+        TextProp(MaybeSignal::derive(move || s.invoke().into()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Oco, TextProp};
+    use leptos_reactive::Signal;
+
+    #[test]
+    fn string_prop() {
+        let s = String::new();
+        let _prop: TextProp = s.into();
+    }
+
+    #[test]
+    fn fn_oco_prop() {
+        let s = || Oco::from("hi !");
+        let _prop: TextProp = s.into();
+    }
+
+    #[test]
+    fn signal_str_prop() {
+        let s = Signal::derive(move || "hi !");
+        let _prop: TextProp = s.into();
     }
 }

--- a/leptos/src/view_fn.rs
+++ b/leptos/src/view_fn.rs
@@ -1,30 +1,30 @@
 use leptos_dom::{IntoView, View};
-use std::rc::Rc;
+use leptos_reactive::{MaybeSignal, SignalGet};
 
 /// New-type wrapper for the a function that returns a view with `From` and `Default` traits implemented
 /// to enable optional props in for example `<Show>` and `<Suspense>`.
 #[derive(Clone)]
-pub struct ViewFn(Rc<dyn Fn() -> View>);
+pub struct ViewFn(MaybeSignal<View>);
 
 impl Default for ViewFn {
     fn default() -> Self {
-        Self(Rc::new(|| ().into_view()))
+        Self(MaybeSignal::Static(().into_view()))
     }
 }
 
 impl<F, IV> From<F> for ViewFn
 where
-    F: Fn() -> IV + 'static,
-    IV: IntoView,
+    F: crate::Invocable<Value = IV> + 'static,
+    IV: IntoView + Clone + 'static,
 {
     fn from(value: F) -> Self {
-        Self(Rc::new(move || value().into_view()))
+        Self(MaybeSignal::derive(move || value.invoke().into_view()))
     }
 }
 
 impl ViewFn {
     /// Execute the wrapped function
     pub fn run(&self) -> View {
-        (self.0)()
+        self.0.get()
     }
 }

--- a/leptos_reactive/src/callback.rs
+++ b/leptos_reactive/src/callback.rs
@@ -166,6 +166,8 @@ impl<In, Out> Clone for SyncCallback<In, Out> {
     }
 }
 
+impl<In: 'static, Out: 'static> Copy for SyncCallback<In, Out> {}
+
 impl<In: 'static, Out: 'static> SyncCallback<In, Out> {
     /// Creates a new callback from the given function.
     pub fn new<F>(fun: F) -> Self


### PR DESCRIPTION
This PR completely removes the `Callable` trait from `leptos_reactive`, since it was used only in `callback.rs` and it didn't add anything compared to a method call.

It **is** technically a breaking change, but only for people that used the `Callback` trait explicitely. Given that `callbacks` does not even appear in the book, this will likely affect nobody.


The main motivation for this change is to suppress a compiler warning.

If you were on nightly and used the `.call` syntax, the compiler would give you a warning saying "you may need to disambiguate .call in the future because a trait method will be called like that". It can be very annoying when someone writes a library for leptos using stable, and someone use it on nightly.

Since method calls take precedence, you will not get any warning with this new version.

I plan to create a chapter about callbacks and generic function props, but the content will depend on whether this PR is accepted