### PR TITLE
feat: Add local attribute for Await

### DIFF
--- a/leptos/src/await_.rs
+++ b/leptos/src/await_.rs
@@ -2,7 +2,8 @@ use crate::Suspense;
 use leptos_dom::IntoView;
 use leptos_macro::{component, view};
 use leptos_reactive::{
-    create_blocking_resource, create_resource, store_value, Serializable,
+    create_blocking_resource, create_local_resource, create_resource,
+    store_value, Serializable,
 };
 
 #[component]
@@ -44,6 +45,11 @@ pub fn Await<T, Fut, FF, VF, V>(
     /// the HTML stream from returning anything before `future` has resolved.
     #[prop(optional)]
     blocking: bool,
+    /// If `true`, the component will use [`create_local_resource`], this will
+    /// always run on the local system and therefore its result type does not
+    /// need to be `Serializable`.
+    #[prop(optional)]
+    local: bool,
     /// A function that takes a reference to the resolved data from the `future`
     /// renders a view.
     ///
@@ -101,6 +107,8 @@ where
 {
     let res = if blocking {
         create_blocking_resource(|| (), move |_| future())
+    } else if local {
+        create_local_resource(|| (), move |_| future())
     } else {
         create_resource(|| (), move |_| future())
     };


### PR DESCRIPTION
This PR adds the ability to use `create_local_resource` instead of `create_resource`. This will run the create resource locally on the system and therefore its result type does not need to be `Seriaziable`.

Closes #1567