### PR TITLE
feat: implement `IntoView` for `Oco<'static, str>`

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -149,6 +149,12 @@ where
     }
 }
 
+impl IntoView for Oco<'static, str> {
+    fn into_view(self) -> View {
+        View::Text(Text::new(self))
+    }
+}
+
 #[cfg(not(feature = "nightly"))]
 impl<T> IntoView for ReadSignal<T>
 where


### PR DESCRIPTION
Implements `IntoView` for `Oco<'static, str>`