### PR TITLE
chore: cargo doc -- removed lint warnings.

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -115,7 +115,7 @@ pub fn redirect(path: &str) {
     }
 }
 
-/// An Actix [Route](actix_web::Route) that listens for a `POST` request with
+/// An Actix [struct@Route](actix_web::Route) that listens for a `POST` request with
 /// Leptos server function arguments in the body, runs the server function if found,
 /// and returns the resulting [HttpResponse].
 ///
@@ -156,7 +156,7 @@ pub fn handle_server_fns() -> Route {
     handle_server_fns_with_context(|| {})
 }
 
-/// An Actix [Route](actix_web::Route) that listens for `GET` or `POST` requests with
+/// An Actix [struct@Route](actix_web::Route) that listens for `GET` or `POST` requests with
 /// Leptos server function arguments in the URL (`GET`) or body (`POST`),
 /// runs the server function if found, and returns the resulting [HttpResponse].
 ///
@@ -292,7 +292,7 @@ pub fn handle_server_fns_with_context(
                 } else {
                     HttpResponse::BadRequest().body(format!(
                         "Could not find a server function at the route {:?}. \
-                         \n\nIt's likely that either 
+                         \n\nIt's likely that either
                          1. The API prefix you specify in the `#[server]` \
                          macro doesn't match the prefix at which your server \
                          function handler is mounted, or \n2. You are on a \
@@ -308,7 +308,7 @@ pub fn handle_server_fns_with_context(
     )
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application. The stream
 /// will include fallback content for any `<Suspense/>` nodes, and be immediately interactive,
 /// but requires some client-side JavaScript.
@@ -376,7 +376,7 @@ where
     render_app_to_stream_with_context(options, || {}, app_fn, method)
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an in-order HTML stream of your application.
 /// This stream will pause at each `<Suspense/>` node and wait for it to resolve before
 /// sending down its HTML. The app will become interactive once it has fully loaded.
@@ -445,7 +445,7 @@ where
     render_app_to_stream_in_order_with_context(options, || {}, app_fn, method)
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], asynchronously rendering an HTML page after all
 /// `async` [Resource](leptos::Resource)s have loaded.
 ///
@@ -512,7 +512,7 @@ where
     render_app_async_with_context(options, || {}, app_fn, method)
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
 /// This function allows you to provide additional information to Leptos for your route.
@@ -543,7 +543,7 @@ where
     )
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
 /// This function allows you to provide additional information to Leptos for your route.
@@ -606,7 +606,7 @@ where
     }
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an in-order HTML stream of your application.
 ///
 /// This function allows you to provide additional information to Leptos for your route.
@@ -657,7 +657,7 @@ where
     }
 }
 
-/// Returns an Actix [Route](actix_web::Route) that listens for a `GET` request and tries
+/// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], asynchronously serving the page once all `async`
 /// [Resource](leptos::Resource)s have loaded.
 ///
@@ -1361,7 +1361,7 @@ impl LeptosRoutes for &mut ServiceConfig {
 
 /// A helper to make it easier to use Actix extractors in server functions. This takes
 /// a handler function as its argument. The handler follows similar rules to an Actix
-/// [Handler](actix_web::Handler): it is an async function that receives arguments that
+/// [Handler]: it is an async function that receives arguments that
 /// will be extracted from the request and returns some value.
 ///
 /// ```rust,ignore
@@ -1416,9 +1416,9 @@ where
 }
 
 /// A helper to make it easier to use Axum extractors in server functions, with a
-/// simpler API than [`extract`].
+/// simpler API than [`extract()`].
 ///
-/// It is generic over some type `T` that implements [`FromRequestParts`] and can
+/// It is generic over some type `T` that implements [`FromRequest`] and can
 /// therefore be used in an extractor. The compiler can often infer this type.
 ///
 /// Any error that occurs during extraction is converted to a [`ServerFnError`].

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -306,7 +306,7 @@ async fn handle_server_fns_inner(
                                 .body(Body::from(format!(
                                     "Could not find a server function at the \
                                      route {fn_name}. \n\nIt's likely that \
-                                     either 
+                                     either
                                     1. The API prefix you specify in the \
                                      `#[server]` macro doesn't match the \
                                      prefix at which your server function \
@@ -329,7 +329,7 @@ async fn handle_server_fns_inner(
 
     rx.await.map_err(Error::normal)
 }
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
 /// The provides a [MetaContext] and a [RouterIntegrationContext] to app’s context before
@@ -380,8 +380,8 @@ async fn handle_server_fns_inner(
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_to_stream<IV>(
     options: LeptosOptions,
     app_fn: impl Fn() -> IV + Clone + Send + 'static,
@@ -397,7 +397,7 @@ where
     render_app_to_stream_with_context(options, || {}, app_fn)
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 /// This stream will pause at each `<Suspense/>` node and wait for it to resolve before
 /// sending down its HTML. The app will become interactive once it has fully loaded.
@@ -450,8 +450,8 @@ where
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_to_stream_in_order<IV>(
     options: LeptosOptions,
     app_fn: impl Fn() -> IV + Clone + Send + 'static,
@@ -467,7 +467,7 @@ where
     render_app_to_stream_in_order_with_context(options, || {}, app_fn)
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
 /// This version allows us to pass Viz State/Extractor or other infro from Viz or network
@@ -492,8 +492,8 @@ where
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_to_stream_with_context<IV>(
     options: LeptosOptions,
     additional_context: impl Fn() + Clone + Send + 'static,
@@ -515,7 +515,7 @@ where
     )
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an HTML stream of your application.
 ///
 /// This version allows us to pass Viz State/Extractor or other infro from Viz or network
@@ -533,8 +533,8 @@ where
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_to_stream_with_context_and_replace_blocks<IV>(
     options: LeptosOptions,
     additional_context: impl Fn() + Clone + Send + 'static,
@@ -675,7 +675,7 @@ async fn forward_stream(
     tx.close_channel();
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an in-order HTML stream of your application.
 /// This stream will pause at each `<Suspense/>` node and wait for it to resolve before
 /// sending down its HTML. The app will become interactive once it has fully loaded.
@@ -702,8 +702,8 @@ async fn forward_stream(
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_to_stream_in_order_with_context<IV>(
     options: LeptosOptions,
     additional_context: impl Fn() + 'static + Clone + Send,
@@ -794,9 +794,9 @@ fn provide_contexts(
     leptos::nonce::provide_nonce();
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], asynchronously rendering an HTML page after all
-/// `async` [Resource](leptos::Resource)s have loaded.
+/// `async` [Resource]s have loaded.
 ///
 /// The provides a [MetaContext] and a [RouterIntegrationContext] to app’s context before
 /// rendering it, and includes any meta tags injected using [leptos_meta].
@@ -843,8 +843,8 @@ fn provide_contexts(
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_async<IV>(
     options: LeptosOptions,
     app_fn: impl Fn() -> IV + Clone + Send + 'static,
@@ -860,9 +860,9 @@ where
     render_app_async_with_context(options, || {}, app_fn)
 }
 
-/// Returns a Viz [Handler](viz::Handler) that listens for a `GET` request and tries
+/// Returns a Viz [Handler] that listens for a `GET` request and tries
 /// to route it using [leptos_router], asynchronously rendering an HTML page after all
-/// `async` [Resource](leptos::Resource)s have loaded.
+/// `async` [Resource]s have loaded.
 ///
 /// This version allows us to pass Viz State/Extractor or other infro from Viz or network
 /// layers above Leptos itself. To use it, you'll need to write your own handler function that provides
@@ -886,8 +886,8 @@ where
 /// This function always provides context values including the following types:
 /// - [RequestParts]
 /// - [ResponseOptions]
-/// - [MetaContext](leptos_meta::MetaContext)
-/// - [RouterIntegrationContext](leptos_router::RouterIntegrationContext)
+/// - [MetaContext]
+/// - [RouterIntegrationContext]
 pub fn render_app_async_with_context<IV>(
     options: LeptosOptions,
     additional_context: impl Fn() + 'static + Clone + Send,

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -34,7 +34,7 @@
 //! - [`parent_child`](https://github.com/leptos-rs/leptos/tree/main/examples/parent_child) shows four different
 //!   ways a parent component can communicate with a child, including passing a closure, context, and more
 //! - [`fetch`](https://github.com/leptos-rs/leptos/tree/main/examples/fetch) introduces
-//!   [Resource](leptos_reactive::Resource)s, which allow you to integrate arbitrary `async` code like an
+//!   [Resource]s, which allow you to integrate arbitrary `async` code like an
 //!   HTTP request within your reactive code.
 //! - [`router`](https://github.com/leptos-rs/leptos/tree/main/examples/router) shows how to use Leptos’s nested router
 //!   to enable client-side navigation and route-specific, reactive data loading.
@@ -114,7 +114,7 @@
 //!     let increment = move |_| set_value.update(|value| *value += 1);
 //!
 //!     view! {
-//!         
+//!
 //!         <div>
 //!             <button on:click=clear>"Clear"</button>
 //!             <button on:click=decrement>"-1"</button>

--- a/leptos_dom/src/nonce.rs
+++ b/leptos_dom/src/nonce.rs
@@ -11,7 +11,7 @@ use std::{fmt::Display, ops::Deref};
 /// scripts used for HTML streaming and resource loading.
 ///
 /// The nonce being used during the current server response can be
-/// accessed using [`use_nonce`](use_nonce).
+/// accessed using [`use_nonce`].
 ///
 /// ```rust,ignore
 /// #[component]

--- a/leptos_reactive/src/lib.rs
+++ b/leptos_reactive/src/lib.rs
@@ -20,19 +20,19 @@
 //! Here are the most commonly-used functions and types you'll need to build a reactive system:
 //!
 //! ### Signals
-//! 1. *Signals:* [`create_signal`](crate::create_signal), which returns a ([`ReadSignal`](crate::ReadSignal),
-//!    [`WriteSignal`](crate::WriteSignal)) tuple, or [`create_rw_signal`](crate::create_rw_signal), which returns
-//!    a signal [`RwSignal`](crate::RwSignal) without this read-write segregation.
+//! 1. *Signals:* [`create_signal`], which returns a ([`ReadSignal`],
+//!    [`WriteSignal`] tuple, or [`create_rw_signal`], which returns
+//!    a signal [`RwSignal`] without this read-write segregation.
 //! 2. *Derived Signals:* any function that relies on another signal.
-//! 3. *Memos:* [`create_memo`], which returns a [`Memo`](crate::Memo).
+//! 3. *Memos:* [`create_memo`], which returns a [`Memo`].
 //! 4. *Resources:* [`create_resource`], which converts an `async` [`Future`](std::future::Future) into a
-//!    synchronous [`Resource`](crate::Resource) signal.
+//!    synchronous [`Resource`] signal.
 //! 5. *Triggers:* [`create_trigger`], creates a purely reactive [`Trigger`] primitive without any associated state.
 //!
 //! ### Effects
-//! 1. Use [`create_effect`](crate::create_effect) when you need to synchronize the reactive system
+//! 1. Use [`create_effect`] when you need to synchronize the reactive system
 //!    with something outside it (for example: logging to the console, writing to a file or local storage)
-//! 2. The Leptos DOM renderer wraps any [`Fn`] in your template with [`create_effect`](crate::create_effect), so
+//! 2. The Leptos DOM renderer wraps any [`Fn`] in your template with [`create_effect`], so
 //!    components you write do *not* need explicit effects to synchronize with the DOM.
 //!
 //! ### Example

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -28,7 +28,7 @@
 //! ## Example
 //!
 //! ```rust
-//! 
+//!
 //! use leptos::*;
 //! use leptos_router::*;
 //!


### PR DESCRIPTION
Seen when running 
```
cargo doc
```

There were a couple of disambiguation issues hiding behind the list of minor issues 
scrolling off the page 

So 

[Route] becomes [struct@Route]

and 

[`extract`] becomes [`extract()`].