### PR TITLE
workflows: bump setup-node to version 4.

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -53,7 +53,7 @@ jobs:
         run: trunk --version
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
My motivation is to clear warnings in the build artefacts.

Jumping several node version at once has bitten me in the past 
so I favour regular maintenance tasks.


 

