### PR TITLE
fix!: remove clone in `Cow<'static, str>` `IntoView` impl

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1146,6 +1146,17 @@ impl IntoView for &'static str {
     }
 }
 
+impl IntoView for Cow<'static, str> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(level = "info", name = "#text", skip_all)
+    )]
+    #[inline(always)]
+    fn into_view(self) -> View {
+        View::Text(Text::new(self.into()))
+    }
+}
+
 impl IntoView for Oco<'static, str> {
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
@@ -1204,7 +1215,6 @@ viewable_primitive![
     f64,
     char,
     bool,
-    Cow<'_, str>,
     std::net::IpAddr,
     std::net::SocketAddr,
     std::net::SocketAddrV4,


### PR DESCRIPTION
Removes a clone when using a `Cow<'static, str>` in a view.

**:warning: Contains breaking change**

`Cow<'_, str>` no longer implements `IntoView`, now only `Cow<'static, str>` does.

The reason being: `Cow<'_, str>` requires a clone when converting to a view, since we don't know if the str is static.