### PR TITLE
`IntoView` and `IntoAttribute` for `std::fmt::Arguments` improvements

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1173,6 +1173,19 @@ where
     }
 }
 
+impl IntoView for std::fmt::Arguments<'_> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(level = "info", name = "#text", skip_all)
+    )]
+    fn into_view(self) -> View {
+        match self.as_str() {
+            Some(s) => s.into_view(),
+            None => self.to_string().into_view(),
+        }
+    }
+}
+
 macro_rules! viewable_primitive {
   ($($child_type:ty),* $(,)?) => {
     $(
@@ -1226,7 +1239,6 @@ viewable_primitive![
     std::num::NonZeroIsize,
     std::num::NonZeroUsize,
     std::panic::Location<'_>,
-    std::fmt::Arguments<'_>,
 ];
 
 cfg_if! {

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -261,6 +261,17 @@ impl IntoAttribute for Option<Box<dyn IntoAttribute>> {
     impl_into_attr_boxed! {}
 }
 
+impl IntoAttribute for std::fmt::Arguments<'_> {
+    fn into_attribute(self) -> Attribute {
+        match self.as_str() {
+            Some(s) => s.into_attribute(),
+            None => self.to_string().into_attribute(),
+        }
+    }
+
+    impl_into_attr_boxed! {}
+}
+
 /* impl IntoAttribute for Box<dyn IntoAttribute> {
     #[inline(always)]
     fn into_attribute(self) -> Attribute {


### PR DESCRIPTION
- Avoids an allocation when possible when using `std::fmt::Argumenets` in `IntoView`.
- Implements `IntoAttribute` for `std::fmt::Arguments`.