### PR TITLE
Select stable

### DIFF
--- a/examples/counters_stable/src/lib.rs
+++ b/examples/counters_stable/src/lib.rs
@@ -1,5 +1,6 @@
 use leptos::*;
 use leptos_meta::*;
+use log::info;
 
 const MANY_COUNTERS: usize = 1000;
 
@@ -38,6 +39,19 @@ pub fn Counters() -> impl IntoView {
         set_counters.update(|counters| counters.clear());
     };
 
+    let (x_counters_input, set_x_counters_input) = create_signal(2);
+    let add_x_counters = move |_| {
+        let v = x_counters_input.get() as usize;
+        info!("add_x_counters: {}", v);
+        let next_id = next_counter_id.get();
+        let new_counters = (next_id..next_id + v).map(|id| {
+            let signal = create_signal(0);
+            (id, signal)
+        });
+        set_counters.update(move |counters| counters.extend(new_counters));
+        set_next_counter_id.update(|id| *id += v);
+    };
+
     view! {
         <Title text="Counters (Stable)" />
         <div>
@@ -50,6 +64,17 @@ pub fn Counters() -> impl IntoView {
             <button on:click=clear_counters>
                 "Clear Counters"
             </button>
+            <p>
+            <input data-testid="add_x_counters_input" type="text" on:input=move |ev| {
+                let x = event_target_value(&ev).parse::<i32>().unwrap_or_default();
+                set_x_counters_input.set(x)
+              }
+              prop:value=x_counters_input/>
+            <button on:click=add_x_counters>
+                "Add " {move || x_counters_input.get()} " counters"
+            </button>
+            </p>
+
             <p>
                 "Total: "
                 <span data-testid="total">{move ||

--- a/examples/select_stable/Cargo.toml
+++ b/examples/select_stable/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "select_stable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+leptos = { path = "../../leptos", features = ["csr"] }
+leptos_meta = { path = "../../meta", features = ["csr"] }
+log = "0.4"
+console_log = "1"
+console_error_panic_hook = "0.1.7"
+
+[dev-dependencies]
+wasm-bindgen = "0.2.87"
+wasm-bindgen-test = "0.3.37"
+pretty_assertions = "1.4.0"
+
+[dev-dependencies.web-sys]
+features = [
+    "Event",
+    "EventInit",
+    "EventTarget",
+    "HtmlElement",
+    "HtmlInputElement",
+    "XPathResult",
+]
+version = "0.3.64"

--- a/examples/select_stable/Makefile.toml
+++ b/examples/select_stable/Makefile.toml
@@ -1,0 +1,18 @@
+extend = [
+    { path = "../cargo-make/main.toml" },
+    { path = "../cargo-make/wasm-test.toml" },
+    { path = "../cargo-make/trunk_server.toml" },
+    { path = "../cargo-make/playwright-test.toml" },
+]
+
+[tasks.build]
+toolchain = "stable"
+command = "cargo"
+args = ["build-all-features"]
+install_crate = "cargo-all-features"
+
+[tasks.check]
+toolchain = "stable"
+command = "cargo"
+args = ["check-all-features"]
+install_crate = "cargo-all-features"

--- a/examples/select_stable/README.md
+++ b/examples/select_stable/README.md
@@ -1,0 +1,8 @@
+# Leptos Select Example on Rust Stable
+
+This example showcases a basic Leptos app with a select drop-down. It is a good example of how to setup a basic reactive app with signals and effects, and how to interact with browser events. 
+It will compile on Rust stable, because it has the `stable` feature enabled.
+
+## Getting Started
+
+See the [Examples README](../README.md) for setup and run instructions.

--- a/examples/select_stable/index.html
+++ b/examples/select_stable/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link data-trunk rel="rust" data-wasm-opt="z" data-weak-refs />
+  </head>
+  <body></body>
+</html>

--- a/examples/select_stable/package.json
+++ b/examples/select_stable/package.json
@@ -1,0 +1,11 @@
+{
+  "private": "true",
+  "scripts": {
+    "start-server": "trunk serve",
+    "e2e": "cargo make test-playwright",
+    "e2e:auto-start": "start-server-and-test start-server http://127.0.0.1:8080 e2e"
+  },
+  "devDependencies": {
+    "start-server-and-test": "^1.15.4"
+  }
+}

--- a/examples/select_stable/src/lib.rs
+++ b/examples/select_stable/src/lib.rs
@@ -1,0 +1,164 @@
+use leptos::*;
+use log::info;
+use log::error;
+
+#[component]
+pub fn Selector() -> impl IntoView {
+    #[derive(Debug, Clone, Copy)]
+    pub struct SelectOption {
+        pub label: &'static str,
+        pub pos: usize,
+    }
+    let options: Vec<SelectOption> =  vec![
+        SelectOption{ label: "h0rses", pos: 0},
+        SelectOption{ label: "b1rds", pos: 1},
+        SelectOption{ label: "2nfish", pos: 2},
+    ];
+
+    let options_clone = options.clone();
+    let selection: RwSignal<Option<usize>> = create_rw_signal(Some(1)); // initial selection
+
+    view! {
+      <div style="background:#ffffbf">
+      <h2>Selector</h2>
+      <select
+        id = "selector"
+        on:change = move |ev| {
+          let new_selection = event_target_value(&ev);
+          if new_selection.is_empty() {
+            selection.set(None);
+          } else {
+            match new_selection.parse() {
+              Ok(v) => {
+                info!("You selected {}", v);
+                selection.set(Some(v))
+              },
+              Err(_) => {
+                error!("Error: Unexpected option value {new_selection}");
+              },
+            }
+          }
+        }
+      >
+      <For
+        each = move || options_clone.clone()
+        key = |option| option.pos
+        let:option
+          >
+          <option
+            value = option.pos
+            selected = (selection.get() == Some(option.pos))
+            >
+            { option.label }
+          </option>
+      </For>
+      </select>
+        <p>
+        "You selected: "
+        <span data-testid="my_selection">{move || {
+          match selection.get() {
+            Some(v) => {
+              options[v].label
+            },
+            None => "No idea..."
+          }
+        }
+        }</span>
+        </p>
+      </div>
+    }
+}
+
+#[component]
+pub fn Dynamic_selector() -> impl IntoView {
+    #[derive(Debug, Clone, Copy)]
+    pub struct SelectionOption {
+        pub label: &'static str,
+        pub id: u32,
+        pub amount: RwSignal<u32>,
+    }
+    let selection_options_default: Vec<SelectionOption> = vec![
+        SelectionOption{ label: "h0rses", id: 0, amount: create_rw_signal::<u32>(0)},
+        SelectionOption{ label: "b1rds", id: 1, amount: create_rw_signal::<u32>(10)},
+        SelectionOption{ label: "2nfish", id: 2, amount: create_rw_signal::<u32>(20)},
+        SelectionOption{ label: "3lk", id: 3, amount: create_rw_signal::<u32>(30)},
+    ];
+    let default_selection: RwSignal<Option<u32>> = create_rw_signal(Some(0));
+    let selection_options = create_rw_signal::<Vec<SelectionOption>>(selection_options_default);
+    let print = move |_| {
+        let s = selection_options.get();
+        info!("{} {}", s[0].label, s[0].amount.get());
+    };
+    let add_option = move |_| {
+        let a = SelectionOption{ label: "4eel", id: 4, amount: create_rw_signal::<u32>(20)};
+        selection_options.update(|n| {
+            if n.len() > 0 {
+                n[0].amount.set(200);
+                info!("n[0]: {} {}", n[0].label, n[0].amount.get())
+            }
+            n.push(a);
+        });
+    };
+    view! {
+      <div style="background:#eae3ff">
+        <h2>Dynamic_selector</h2>
+        <select
+          id = "dynamic_selector"
+          on:change = move |ev| {
+            let target_value = event_target_value(&ev);
+            if target_value.is_empty() {
+              default_selection.set(None);
+            } else {
+               match target_value.parse() {
+                 Ok(v) => {
+                   info!("You selected {}", v);
+                   default_selection.set(Some(v))
+                 },
+                 Err(_) => {
+                   error!("Error: Unexpected option value {target_value}");
+                 },
+              }
+            }
+          }
+        >
+          <For
+            each = {move || selection_options.clone().get()}
+            key = |option| option.id
+            let:option
+          >
+            <option
+              value = move || option.id
+              default_selection = (default_selection.get() == Some(option.id))
+            > { move || {
+               let z = option.amount.get();
+               let v = format!("{} - {}", option.label, z);
+               v
+               }
+              }
+            </option>
+          </For>
+        </select>
+        <p>
+        "You selected: "
+        <span data-testid="mymultiselection">{move || {
+          let selected_option = default_selection.get();
+            match selected_option {
+                Some(v) => {
+                    let l = selection_options.get()[v as usize].label;
+                    let a = selection_options.get()[v as usize].amount.get();
+                    format!("{} - {}", l, a.to_string())
+                },
+                None => "no idea...".to_string()
+            }
+        }
+        }</span>
+         <button on:click=add_option>
+           "Add another option to selector"
+         </button>
+         <button on:click=print>
+           "Print"
+         </button>
+        </p>
+      </div>
+    }
+}

--- a/examples/select_stable/src/main.rs
+++ b/examples/select_stable/src/main.rs
@@ -1,0 +1,9 @@
+use leptos::*;
+use select_stable::Selector;
+use select_stable::Dynamic_selector;
+
+fn main() {
+    _ = console_log::init_with_level(log::Level::Debug);
+    console_error_panic_hook::set_once();
+    mount_to_body(|| view! { <Selector/> <Dynamic_selector/> })
+}


### PR DESCRIPTION
This is the select_stable example I wrote which is referenced https://github.com/leptos-rs/leptos/issues/1937.

![grafik](https://github.com/leptos-rs/leptos/assets/137406/82b15a7c-bacf-41a2-81dd-29afe2aa4bb2)


I fixed to snake_case but the issue with adding an item while the first item is selected still persists. 

I compiled this on NixOS linux with rustc 1.73.0 (cc66ad468 2023-10-03)

The javascript console on windows prints:

```
panicked at /mnt/c/Users/joschie/Desktop/Projects/leptos/leptos_reactive/src/signal.rs:1595:21:
already mutably borrowed: BorrowError

Stack:

__wbg_get_imports/imports.wbg.__wbg_new_abda76e883ba8a5f@http://localhost:8080/select_stable-83ba49344c9a9434.js:275:17
console_error_panic_hook::Error::new::hcdbd44f71c4eef70@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[3693]:0x155189
console_error_panic_hook::hook_impl::h9a27a81a72d3ab0a@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[702]:0xdcae9
console_error_panic_hook::hook::h071a3539a231d7c6@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[3944]:0x158a0a
core::ops::function::Fn::call::ha0265fe8294d21dd@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[3543]:0x152c3f
std::panicking::rust_panic_with_hook::h3aa054d35a0817d7@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1534]:0x118baf
std::panicking::begin_panic_handler::{{closure}}::h2f73e4cf6cd6319a@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1962]:0x12c439
std::sys_common::backtrace::__rust_end_short_backtrace::h98ac61a6abbff7e9@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[4832]:0x161255
rust_begin_unwind@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[2901]:0x146b05
core::panicking::panic_fmt::h3e1dd3d08288569e@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[3935]:0x158839
core::result::unwrap_failed::h8b3db0f11171b57b@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[2472]:0x13c709
core::cell::RefCell<T>::borrow::h063d31768f9242b3@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1334]:0x10da0f
<leptos_reactive::signal::RwSignal<T> as leptos_reactive::signal::SignalGet>::get::{{closure}}::h0c18694cc90b20b0@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[313]:0xa6246
leptos_reactive::runtime::with_runtime::{{closure}}::ha3e804e041f1e9df@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[2964]:0x148054
std::thread::local::LocalKey<T>::try_with::h55a00239f93c5647@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[710]:0xdd7bf
std::thread::local::LocalKey<T>::with::h929fc35c8742d85d@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1106]:0xfee8b
<leptos_reactive::signal::RwSignal<T> as leptos_reactive::signal::SignalGet>::get::h1b8522df7d3c5575@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[83]:0x29d90
select_stable::Dynamic_selector::__Dynamic_selector::{{closure}}::h37f712de3c9992db@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[370]:0xb197e
<leptos_dom::components::dyn_child::DynChild<CF,N> as leptos_dom::IntoView>::into_view::{{closure}}::he7f3bb0503be3291@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[138]:0x643c0
<alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::hb9983e9e6e55b1dc@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[3249]:0x14d9f7
<leptos_dom::components::dyn_child::DynChild<CF,N> as leptos_dom::IntoView>::into_view::create_dyn_view::{{closure}}::hf9af3a26b33ce6d1@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[73]:0x13208
<leptos_reactive::effect::EffectState<T,F> as leptos_reactive::effect::AnyComputation>::run::h5d59989cc9e97874@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[97]:0x3d513
leptos_reactive::runtime::Runtime::update::{{closure}}::h8ea5a995a9918473@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1379]:0x1103fd
leptos_reactive::runtime::Runtime::with_observer::h92503f9685301ed9@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[920]:0xf0a2f
leptos_reactive::runtime::Runtime::update::h287e125ad8fc6fcc@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[180]:0x7eeae
leptos_reactive::runtime::Runtime::update_if_necessary::h4e7e860ed1a94e93@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[271]:0x9cb00
leptos_reactive::runtime::Runtime::run_effects::ha7ffa8ea78723211@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[649]:0xd74f8
leptos_reactive::signal::<impl leptos_reactive::node::NodeId>::update::{{closure}}::h1fbdea59f9e0d06b@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[172]:0x7b8f4
leptos_reactive::runtime::with_runtime::{{closure}}::h13dc29d0836f082b@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1905]:0x129f72
std::thread::local::LocalKey<T>::try_with::hde523048e3cd0852@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[686]:0xdb2c6
std::thread::local::LocalKey<T>::with::h12383194f145d02b@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1218]:0x10673d
<leptos_reactive::signal::RwSignal<T> as leptos_reactive::signal::SignalSet>::set::hd085c305837ea6a4@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[84]:0x2be7f
select_stable::Dynamic_selector::__Dynamic_selector::{{closure}}::{{closure}}::hdb12f971aeaab445@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[335]:0xaae07
leptos_reactive::signal::<impl leptos_reactive::node::NodeId>::update::{{closure}}::hc0b4cd9a1d4ab924@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[173]:0x7bbe7
leptos_reactive::runtime::with_runtime::{{closure}}::h94f006737a49fc21@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1906]:0x12a010
std::thread::local::LocalKey<T>::try_with::h78e0c2f5f8e3e2f3@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[687]:0xdb462
std::thread::local::LocalKey<T>::with::h94117890acf49b29@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1219]:0x106841
select_stable::Dynamic_selector::__Dynamic_selector::{{closure}}::h02c32cf80e2626e2@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[75]:0x19851
<alloc::boxed::Box<F,A> as core::ops::function::FnMut<Args>>::call_mut::h5174bd8e9595fd2c@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[2840]:0x14558d
leptos_dom::events::add_event_listener::{{closure}}::he6dae7f73dd234d5@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1075]:0xfcc31
<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::hb6241c2901a82808@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1590]:0x11ba3d
__wbg_adapter_18@http://localhost:8080/select_stable-83ba49344c9a9434.js:208:10
real@http://localhost:8080/select_stable-83ba49344c9a9434.js:193:20
__wbg_get_imports/imports.wbg.__wbg_call_01734de55d61e11d/<@http://localhost:8080/select_stable-83ba49344c9a9434.js:510:33
handleError@http://localhost:8080/select_stable-83ba49344c9a9434.js:229:18
__wbg_get_imports/imports.wbg.__wbg_call_01734de55d61e11d@http://localhost:8080/select_stable-83ba49344c9a9434.js:509:63
js_sys::Function::call1::h7f82a1f4cafd97af@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1006]:0xf7855
leptos_dom::events::add_delegated_event_listener::{{closure}}::{{closure}}::h140405257a8fd2e2@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[162]:0x767ec
leptos_dom::events::add_delegated_event_listener::{{closure}}::{{closure}}::h1163d97d646444ea@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1236]:0x107a5d
<dyn core::ops::function::FnMut<(A,)>+Output = R as wasm_bindgen::closure::WasmClosure>::describe::invoke::h5bb55416984d417a@http://localhost:8080/select_stable-83ba49344c9a9434_bg.wasm:wasm-function[1591]:0x11bb1a
__wbg_adapter_21@http://localhost:8080/select_stable-83ba49344c9a9434.js:212:10
real@http://localhost:8080/select_stable-83ba49344c9a9434.js:193:20
```


