### PR TITLE
chore: typed-builder and typed-builder-macro - bumped version numbers.

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -16,12 +16,16 @@ leptos_reactive = { workspace = true }
 leptos_server = { workspace = true }
 leptos_config = { workspace = true }
 tracing = "0.1"
-typed-builder = "0.16"
-typed-builder-macro = "0.16"
+typed-builder = "0.18"
+typed-builder-macro = "0.18"
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 server_fn = { workspace = true }
-web-sys = { version = "0.3.63", features = ["ShadowRoot", "ShadowRootInit", "ShadowRootMode"] }
+web-sys = { version = "0.3.63", features = [
+  "ShadowRoot",
+  "ShadowRootInit",
+  "ShadowRootMode",
+] }
 wasm-bindgen = { version = "0.2", optional = true }
 
 [features]

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -13,7 +13,7 @@ config = { version = "0.13.3", default-features = false, features = ["toml"] }
 regex = "1.7.0"
 serde = { version = "1.0.151", features = ["derive"] }
 thiserror = "1.0.38"
-typed-builder = "0.16"
+typed-builder = "0.18"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -30,7 +30,7 @@ tracing = "0.1.37"
 
 [dev-dependencies]
 log = "0.4"
-typed-builder = "0.16"
+typed-builder = "0.18"
 trybuild = "1"
 leptos = { path = "../leptos" }
 insta = "1.29"


### PR DESCRIPTION
all changes are of the form 
```
-typed-builder = "0.16"
-typed-builder-macro = "0.16"
+typed-builder = "0.18"
+typed-builder-macro = "0.18"
```