### PR TITLE
fix: dead `params` attribute on `Params` derive

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -954,7 +954,7 @@ pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 
 /// Derives a trait that parses a map of string keys and values into a typed
 /// data structure, e.g., for route params.
-#[proc_macro_derive(Params, attributes(params))]
+#[proc_macro_derive(Params)]
 pub fn params_derive(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {


### PR DESCRIPTION
Dead attributes like this can show up in docs, leading to confusion.

[implementation where it is not used](https://github.com/leptos-rs/leptos/blob/91f482992331fc9ce3379e39a4a69a94c4f9f09b/leptos_macro/src/params.rs#L16).