### PR TITLE
Deprecate the `path` argument in the relevant `LeptosRoutes` trait methods.

### DIFF
--- a/examples/counter_isomorphic/src/main.rs
+++ b/examples/counter_isomorphic/src/main.rs
@@ -9,7 +9,7 @@ cfg_if! {
         use actix_files::{Files};
         use actix_web::*;
         use crate::counters::*;
-        use leptos_actix::{generate_route_list, LeptosRoutes};
+        use leptos_actix::LeptosRoutes;
 
         #[get("/api/events")]
         async fn counter_events() -> impl Responder {
@@ -41,9 +41,7 @@ cfg_if! {
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             // when not using cargo-leptos None must be replaced with Some("Cargo.toml")
             let conf = get_configuration(None).await.unwrap();
-
             let addr = conf.leptos_options.site_addr;
-            let routes = generate_route_list(|| view! { <Counters/> });
 
             HttpServer::new(move || {
                 let leptos_options = &conf.leptos_options;
@@ -52,7 +50,7 @@ cfg_if! {
                 App::new()
                     .service(counter_events)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .leptos_routes(leptos_options.to_owned(), routes.to_owned(), || view! { <Counters/> })
+                    .leptos_routes(leptos_options.to_owned(), Counters)
                     .service(Files::new("/", site_root))
                     //.wrap(middleware::Compress::default())
             })

--- a/examples/errors_axum/src/main.rs
+++ b/examples/errors_axum/src/main.rs
@@ -13,7 +13,7 @@ cfg_if! { if #[cfg(feature = "ssr")] {
     };
     use errors_axum::*;
     use leptos::{logging::log, *};
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
 }}
 
 //Define a handler to test extractor with state
@@ -48,13 +48,12 @@ async fn main() {
     let conf = get_configuration(None).await.unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
-    let routes = generate_route_list(App);
 
     // build our application with a route
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .route("/special/:id", get(custom_handler))
-        .leptos_routes(&leptos_options, routes, App)
+        .leptos_routes(&leptos_options, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -5,10 +5,10 @@ use leptos::*;
 cfg_if! {
     // server-only stuff
     if #[cfg(feature = "ssr")] {
-        use actix_files::{Files};
+        use actix_files::Files;
         use actix_web::*;
-        use hackernews::{App};
-        use leptos_actix::{LeptosRoutes, generate_route_list};
+        use hackernews::App;
+        use leptos_actix::LeptosRoutes;
 
         #[get("/style.css")]
         async fn css() -> impl Responder {
@@ -25,8 +25,6 @@ cfg_if! {
             let conf = get_configuration(None).await.unwrap();
 
             let addr = conf.leptos_options.site_addr;
-            // Generate the list of routes in your Leptos App
-            let routes = generate_route_list(App);
 
             HttpServer::new(move || {
                 let leptos_options = &conf.leptos_options;
@@ -36,7 +34,7 @@ cfg_if! {
                     .service(css)
                     .service(favicon)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .leptos_routes(leptos_options.to_owned(), routes.to_owned(), App)
+                    .leptos_routes(leptos_options.to_owned(), App)
                     .service(Files::new("/", site_root))
                 //.wrap(middleware::Compress::default())
             })

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -8,7 +8,7 @@ if #[cfg(feature = "ssr")] {
         Router,
         routing::get,
     };
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
     use hackernews_axum::fallback::file_and_error_handler;
 
     #[tokio::main]
@@ -18,14 +18,13 @@ if #[cfg(feature = "ssr")] {
         let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
         let leptos_options = conf.leptos_options;
         let addr = leptos_options.site_addr;
-        let routes = generate_route_list(App);
 
         simple_logger::init_with_level(log::Level::Debug).expect("couldn't initialize logging");
 
         // build our application with a route
         let app = Router::new()
         .route("/favicon.ico", get(file_and_error_handler))
-        .leptos_routes(&leptos_options, routes, || view! {  <App/> } )
+        .leptos_routes(&leptos_options, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/hackernews_islands_axum/src/main.rs
+++ b/examples/hackernews_islands_axum/src/main.rs
@@ -3,7 +3,7 @@ mod ssr_imports {
     pub use axum::{routing::get, Router};
     pub use hackernews_islands::fallback::file_and_error_handler;
     pub use leptos::*;
-    pub use leptos_axum::{generate_route_list, LeptosRoutes};
+    pub use leptos_axum::LeptosRoutes;
 }
 
 #[cfg(feature = "ssr")]
@@ -15,12 +15,11 @@ async fn main() {
     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
-    let routes = generate_route_list(App);
 
     // build our application with a route
     let app = Router::new()
         .route("/favicon.ico", get(file_and_error_handler))
-        .leptos_routes(&leptos_options, routes, App)
+        .leptos_routes(&leptos_options, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/hackernews_js_fetch/src/lib.rs
+++ b/examples/hackernews_js_fetch/src/lib.rs
@@ -45,7 +45,7 @@ cfg_if! {
         Router,
         routing::post
     };
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
     use leptos::*;
     use log::{info, Level};
 
@@ -59,11 +59,10 @@ cfg_if! {
             console_error_panic_hook::set_once();
 
             let leptos_options = LeptosOptions::builder().output_name("client").site_pkg_dir("pkg").build();
-            let routes = generate_route_list(App);
 
             // build our application with a route
             let app: axum::Router<(), axum::body::Body> = Router::new()
-            .leptos_routes(&leptos_options, routes, || view! { <App/> } )
+            .leptos_routes(&leptos_options, App)
             .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
             .with_state(leptos_options);
 

--- a/examples/session_auth_axum/src/main.rs
+++ b/examples/session_auth_axum/src/main.rs
@@ -15,7 +15,7 @@ if #[cfg(feature = "ssr")] {
     use session_auth_axum::auth::*;
     use session_auth_axum::state::AppState;
     use session_auth_axum::fallback::file_and_error_handler;
-    use leptos_axum::{generate_route_list, LeptosRoutes, handle_server_fns_with_context};
+    use leptos_axum::{generate_route_list_with_ssg, LeptosRoutes, handle_server_fns_with_context};
     use leptos::{logging::log, provide_context, get_configuration};
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use axum_session::{SessionConfig, SessionLayer, SessionStore};
@@ -80,7 +80,7 @@ if #[cfg(feature = "ssr")] {
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;
         let addr = leptos_options.site_addr;
-        let routes = generate_route_list(TodoApp);
+        let routes = generate_route_list_with_sgg(TodoApp).0;
 
         let app_state = AppState{
             leptos_options,
@@ -90,13 +90,13 @@ if #[cfg(feature = "ssr")] {
 
         // build our application with a route
         let app = Router::new()
-        .route("/api/*fn_name", get(server_fn_handler).post(server_fn_handler))
-        .leptos_routes_with_handler(routes, get(leptos_routes_handler) )
-        .fallback(file_and_error_handler)
-        .layer(AuthSessionLayer::<User, i64, SessionSqlitePool, SqlitePool>::new(Some(pool.clone()))
-        .with_config(auth_config))
-        .layer(SessionLayer::new(session_store))
-        .with_state(app_state);
+            .route("/api/*fn_name", get(server_fn_handler).post(server_fn_handler))
+            .leptos_routes_with_handler(routes, get(leptos_routes_handler) )
+            .fallback(file_and_error_handler)
+            .layer(AuthSessionLayer::<User, i64, SessionSqlitePool, SqlitePool>::new(Some(pool.clone()))
+            .with_config(auth_config))
+            .layer(SessionLayer::new(session_store))
+            .with_state(app_state);
 
         // run our app with hyper
         // `axum::Server` is a re-export of `hyper::Server`

--- a/examples/ssr_modes/src/main.rs
+++ b/examples/ssr_modes/src/main.rs
@@ -4,13 +4,11 @@ async fn main() -> std::io::Result<()> {
     use actix_files::Files;
     use actix_web::*;
     use leptos::*;
-    use leptos_actix::{generate_route_list, LeptosRoutes};
+    use leptos_actix::LeptosRoutes;
     use ssr_modes::app::*;
 
     let conf = get_configuration(None).await.unwrap();
     let addr = conf.leptos_options.site_addr;
-    // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(|| view! { <App/> });
 
     // Explicit server function registration is no longer required
     // on the main branch. On 0.3.0 and earlier, uncomment the lines
@@ -24,11 +22,7 @@ async fn main() -> std::io::Result<()> {
 
         App::new()
             .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-            .leptos_routes(
-                leptos_options.to_owned(),
-                routes.to_owned(),
-                || view! { <App/> },
-            )
+            .leptos_routes(leptos_options.to_owned(), App)
             .service(Files::new("/", site_root))
         //.wrap(middleware::Compress::default())
     })

--- a/examples/ssr_modes_axum/src/main.rs
+++ b/examples/ssr_modes_axum/src/main.rs
@@ -3,14 +3,12 @@
 async fn main() {
     use axum::{routing::post, Router};
     use leptos::{logging::log, *};
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
     use ssr_modes_axum::{app::*, fallback::file_and_error_handler};
 
     let conf = get_configuration(None).await.unwrap();
     let addr = conf.leptos_options.site_addr;
     let leptos_options = conf.leptos_options;
-    // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(App);
 
     // Explicit server function registration is no longer required
     // on the main branch. On 0.3.0 and earlier, uncomment the lines
@@ -20,7 +18,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-        .leptos_routes(&leptos_options, routes, || view! { <App/> })
+        .leptos_routes(&leptos_options, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/suspense_tests/src/main.rs
+++ b/examples/suspense_tests/src/main.rs
@@ -4,13 +4,11 @@ async fn main() -> std::io::Result<()> {
     use actix_files::Files;
     use actix_web::*;
     use leptos::*;
-    use leptos_actix::{generate_route_list, LeptosRoutes};
+    use leptos_actix::LeptosRoutes;
     use suspense_tests::app::*;
 
     let conf = get_configuration(None).await.unwrap();
     let addr = conf.leptos_options.site_addr;
-    // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(|| view! {  <App/> });
 
     HttpServer::new(move || {
         let leptos_options = &conf.leptos_options;
@@ -18,11 +16,7 @@ async fn main() -> std::io::Result<()> {
 
         App::new()
             .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-            .leptos_routes(
-                leptos_options.to_owned(),
-                routes.to_owned(),
-                || view! {  <App/> },
-            )
+            .leptos_routes(leptos_options.to_owned(), App)
             .service(Files::new("/", site_root))
         //.wrap(middleware::Compress::default())
     })

--- a/examples/tailwind_actix/src/main.rs
+++ b/examples/tailwind_actix/src/main.rs
@@ -7,7 +7,7 @@ cfg_if! {
         use actix_web::*;
         use leptos::*;
         use crate::app::*;
-        use leptos_actix::{generate_route_list, LeptosRoutes};
+        use leptos_actix::LeptosRoutes;
 
         #[get("/style.css")]
         async fn css() -> impl Responder {
@@ -16,22 +16,16 @@ cfg_if! {
 
         #[actix_web::main]
         async fn main() -> std::io::Result<()> {
-
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
-
             let addr = conf.leptos_options.site_addr;
-
-            // Generate the list of routes in your Leptos App
-            let routes = generate_route_list(|| view! { <App/> });
 
             HttpServer::new(move || {
                 let leptos_options = &conf.leptos_options;
                 let site_root = &leptos_options.site_root;
-                let routes = &routes;
                 App::new()
                     .service(css)
-                    .leptos_routes(leptos_options.to_owned(), routes.to_owned(), || view! { <App/> })
+                    .leptos_routes(leptos_options.to_owned(), App)
                     .service(Files::new("/", site_root))
                     .wrap(middleware::Compress::default())
             })

--- a/examples/tailwind_axum/src/main.rs
+++ b/examples/tailwind_axum/src/main.rs
@@ -3,7 +3,7 @@
 async fn main() {
     use axum::{routing::post, Router};
     use leptos::*;
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
     use leptos_tailwind::{app::*, fallback::file_and_error_handler};
     use log::info;
 
@@ -18,13 +18,11 @@ async fn main() {
     let conf = get_configuration(None).await.unwrap();
     let addr = conf.leptos_options.site_addr;
     let leptos_options = conf.leptos_options;
-    // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(App);
 
     // build our application with a route
     let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
-        .leptos_routes(&leptos_options, routes, || view! { <App/> })
+        .leptos_routes(&leptos_options, App)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -9,7 +9,7 @@ cfg_if! {
         use actix_web::*;
         use crate::todo::*;
         use leptos::*;
-        use leptos_actix::{generate_route_list, LeptosRoutes};
+        use leptos_actix::LeptosRoutes;
 
         #[get("/style.css")]
         async fn css() -> impl Responder {
@@ -33,21 +33,16 @@ cfg_if! {
 
             // Setting this to None means we'll be using cargo-leptos and its env vars.
             let conf = get_configuration(None).await.unwrap();
-
             let addr = conf.leptos_options.site_addr;
-
-            // Generate the list of routes in your Leptos App
-            let routes = generate_route_list(TodoApp);
 
             HttpServer::new(move || {
                 let leptos_options = &conf.leptos_options;
                 let site_root = &leptos_options.site_root;
-                let routes = &routes;
 
                 App::new()
                     .service(css)
                     .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
-                    .leptos_routes(leptos_options.to_owned(), routes.to_owned(), TodoApp)
+                    .leptos_routes(leptos_options.to_owned(), TodoApp)
                     .service(Files::new("/", site_root))
                     //.wrap(middleware::Compress::default())
             })

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -14,7 +14,7 @@ cfg_if! {
     use crate::todo::*;
     use todo_app_sqlite_axum::*;
     use crate::fallback::file_and_error_handler;
-    use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_axum::LeptosRoutes;
 
     //Define a handler to test extractor with state
     async fn custom_handler(Path(id): Path<String>, State(options): State<LeptosOptions>, req: Request<AxumBody>) -> Response{
@@ -48,13 +48,12 @@ cfg_if! {
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;
         let addr = leptos_options.site_addr;
-        let routes = generate_route_list(TodoApp);
 
         // build our application with a route
         let app = Router::new()
         .route("/api/*fn_name", post(leptos_axum::handle_server_fns))
         .route("/special/:id", get(custom_handler))
-        .leptos_routes(&leptos_options, routes, || view! { <TodoApp/> } )
+        .leptos_routes(&leptos_options, TodoApp)
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/todo_app_sqlite_viz/src/main.rs
+++ b/examples/todo_app_sqlite_viz/src/main.rs
@@ -6,7 +6,7 @@ cfg_if! {
     use leptos::*;
     use crate::fallback::file_and_error_handler;
     use crate::todo::*;
-    use leptos_viz::{generate_route_list, LeptosRoutes};
+    use leptos_viz::LeptosRoutes;
     use todo_app_sqlite_viz::*;
     use viz::{
         types::{State, StateError},
@@ -51,7 +51,6 @@ cfg_if! {
         let conf = get_configuration(None).await.unwrap();
         let leptos_options = conf.leptos_options;
         let addr = leptos_options.site_addr;
-        let routes = generate_route_list(TodoApp);
 
         // build our application with a route
         let app = Router::new()
@@ -59,7 +58,6 @@ cfg_if! {
             .get("/special/:id", custom_handler)
             .leptos_routes(
                 leptos_options.clone(),
-                routes,
                 TodoApp,
             )
             .get("/*", file_and_error_handler)

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -874,18 +874,6 @@ async fn render_app_async_helper(
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
 /// create routes in Actix's App without having to use wildcard matching or fallbacks. Takes in your root app Element
 /// as an argument so it can walk you app tree. This version is tailored to generated Actix compatible paths.
-pub fn generate_route_list<IV>(
-    app_fn: impl Fn() -> IV + 'static + Clone,
-) -> Vec<RouteListing>
-where
-    IV: IntoView + 'static,
-{
-    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
-}
-
-/// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
-/// create routes in Actix's App without having to use wildcard matching or fallbacks. Takes in your root app Element
-/// as an argument so it can walk you app tree. This version is tailored to generated Actix compatible paths.
 pub fn generate_route_list_with_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
@@ -1171,7 +1159,6 @@ pub trait LeptosRoutes {
     fn leptos_routes<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
     where
@@ -1180,7 +1167,6 @@ pub trait LeptosRoutes {
     fn leptos_routes_with_context<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         additional_context: impl Fn() + 'static + Clone + Send,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
@@ -1203,20 +1189,18 @@ where
     fn leptos_routes<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
     where
         IV: IntoView + 'static,
     {
-        self.leptos_routes_with_context(options, paths, || {}, app_fn)
+        self.leptos_routes_with_context(options, || {}, app_fn)
     }
 
     #[tracing::instrument(level = "trace", fields(error), skip_all)]
     fn leptos_routes_with_context<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         additional_context: impl Fn() + 'static + Clone + Send,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
@@ -1224,6 +1208,7 @@ where
         IV: IntoView + 'static,
     {
         let mut router = self;
+        let paths = generate_route_list_with_ssg(app_fn.clone()).0;
         for listing in paths.iter() {
             let path = listing.path();
             let mode = listing.mode();
@@ -1291,20 +1276,18 @@ impl LeptosRoutes for &mut ServiceConfig {
     fn leptos_routes<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
     where
         IV: IntoView + 'static,
     {
-        self.leptos_routes_with_context(options, paths, || {}, app_fn)
+        self.leptos_routes_with_context(options, || {}, app_fn)
     }
 
     #[tracing::instrument(level = "trace", fields(error), skip_all)]
     fn leptos_routes_with_context<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         additional_context: impl Fn() + 'static + Clone + Send,
         app_fn: impl Fn() -> IV + Clone + Send + 'static,
     ) -> Self
@@ -1312,6 +1295,7 @@ impl LeptosRoutes for &mut ServiceConfig {
         IV: IntoView + 'static,
     {
         let mut router = self;
+        let paths = generate_route_list_with_ssg(app_fn.clone()).0;
         for listing in paths.iter() {
             let path = listing.path();
             let mode = listing.mode();

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -988,18 +988,6 @@ where
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
 /// create routes in Viz's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
 /// as an argument so it can walk you app tree. This version is tailored to generate Viz compatible paths.
-pub fn generate_route_list<IV>(
-    app_fn: impl Fn() -> IV + 'static + Clone,
-) -> Vec<RouteListing>
-where
-    IV: IntoView + 'static,
-{
-    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
-}
-
-/// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
-/// create routes in Viz's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
-/// as an argument so it can walk you app tree. This version is tailored to generate Viz compatible paths.
 pub fn generate_route_list_with_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
@@ -1315,7 +1303,6 @@ pub trait LeptosRoutes {
     fn leptos_routes<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         app_fn: impl Fn() -> IV + Clone + Send + Sync + 'static,
     ) -> Self
     where
@@ -1324,7 +1311,6 @@ pub trait LeptosRoutes {
     fn leptos_routes_with_context<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         additional_context: impl Fn() + Clone + Send + Sync + 'static,
         app_fn: impl Fn() -> IV + Clone + Send + Sync + 'static,
     ) -> Self
@@ -1346,25 +1332,24 @@ impl LeptosRoutes for Router {
     fn leptos_routes<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         app_fn: impl Fn() -> IV + Clone + Send + Sync + 'static,
     ) -> Self
     where
         IV: IntoView + 'static,
     {
-        self.leptos_routes_with_context(options, paths, || {}, app_fn)
+        self.leptos_routes_with_context(options, || {}, app_fn)
     }
 
     fn leptos_routes_with_context<IV>(
         self,
         options: LeptosOptions,
-        paths: Vec<RouteListing>,
         additional_context: impl Fn() + Clone + Send + Sync + 'static,
         app_fn: impl Fn() -> IV + Clone + Send + Sync + 'static,
     ) -> Self
     where
         IV: IntoView + 'static,
     {
+        let paths = generate_route_list_with_ssg(app_fn.clone()).0;
         paths.iter().fold(self, |router, listing| {
             let path = listing.path();
             let mode = listing.mode();

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -100,7 +100,7 @@ impl RouteListing {
 }
 
 /// Generates a list of all routes this application could possibly serve. This returns the raw routes in the leptos_router
-/// format. Odds are you want `generate_route_list()` from either the [`actix`], [`axum`], or [`viz`] integrations if you want
+/// format. Odds are you want `generate_route_list_with_ssg()` from either the [`actix`], [`axum`], or [`viz`] integrations if you want
 /// to work with their router.
 ///
 /// [`actix`]: <https://docs.rs/actix/>


### PR DESCRIPTION
```rust
let app = Router::new()
    .leptos_routes(&leptos_options, generate_route_list(app), app)
// ...
```
becomes 

```rust
let app = Router::new()
    .leptos_routes(&leptos_options, app)
// ...
```

Might be too much of a breaking change for such a subjective improvement. I'll refrain from sending in a PR updating `start_axum` until this change is deemed appropriate. 😊

