### PR TITLE
fix: treat Suspense as containing a Set of resources, not a counter

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -140,7 +140,7 @@ where
 
                 {
                     // no resources were read under this, so just return the child
-                    if context.pending_resources.get() == 0 {
+                    if context.none_pending() {
                         with_owner(owner, move || {
                             //HydrationCtx::continue_from(current_id);
                             DynChild::new(move || children_rendered.clone())

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -139,10 +139,9 @@ pub fn Transition(
                 }
                 child_runs.set(child_runs.get() + 1);
 
-                let pending = suspense_context.pending_resources;
                 create_isomorphic_effect(move |_| {
                     if let Some(set_pending) = set_pending {
-                        set_pending.set(pending.get() > 0)
+                        set_pending.set(!suspense_context.none_pending())
                     }
                 });
                 frag

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -2,7 +2,7 @@
 use crate::Owner;
 use crate::{
     runtime::PinnedFuture, suspense::StreamChunk, with_runtime, ResourceId,
-    SuspenseContext,
+    SignalGet, SuspenseContext,
 };
 use futures::stream::FuturesUnordered;
 #[cfg(feature = "experimental-islands")]
@@ -84,9 +84,9 @@ impl SharedContext {
                 let pending = context
                     .pending_serializable_resources
                     .read_only()
-                    .try_with(|n| *n)
-                    .unwrap_or(0);
-                if pending == 0 {
+                    .try_get()
+                    .unwrap_or_default();
+                if pending.is_empty() {
                     _ = tx1.unbounded_send(());
                     _ = tx2.unbounded_send(());
                     _ = tx3.unbounded_send(());


### PR DESCRIPTION
Closes #1805, closes #1905.

This one was a poor decision with some odd edge cases. Basically, the value "number of resources the Suspense is currently waiting for" was treated as a simple integer counter, rather than a `Set<Resource>`. This meant that things like reading two resources in the same reactive `move ||` block would be inherently broken, as on of them resolving would trigger the second one to read again, incrementing the Suspense counter again.

I am going to be changing how Suspense works pretty significantly in 0.6, but I'm hopeful that for now, this will manage to fix those edge cases without breaking the API or existing examples.