### PR TITLE
Make leptos_reactive benches run

### DIFF
--- a/leptos_reactive/benches/deep_update.rs
+++ b/leptos_reactive/benches/deep_update.rs
@@ -80,21 +80,18 @@ fn leptos_deep_update(c: &mut Criterion) {
 
     c.bench_function("leptos_deep_update", |b| {
         b.iter(|| {
-            create_scope(runtime, |cx| {
-                let signal = create_rw_signal(cx, 0);
-                let mut memos = Vec::<Memo<usize>>::new();
-                for i in 0..1000usize {
-                    let prev = memos.get(i.saturating_sub(1)).copied();
-                    if let Some(prev) = prev {
-                        memos.push(create_memo(cx, move |_| prev.get() + 1));
-                    } else {
-                        memos.push(create_memo(cx, move |_| signal.get() + 1));
-                    }
+            let signal = create_rw_signal(0);
+            let mut memos = Vec::<Memo<usize>>::new();
+            for i in 0..1000usize {
+                let prev = memos.get(i.saturating_sub(1)).copied();
+                if let Some(prev) = prev {
+                    memos.push(create_memo(move |_| prev.get() + 1));
+                } else {
+                    memos.push(create_memo(move |_| signal.get() + 1));
                 }
-                signal.set(1);
-                assert_eq!(memos[999].get(), 1001);
-            })
-            .dispose()
+            }
+            signal.set(1);
+            assert_eq!(memos[999].get(), 1001);
         });
     });
     runtime.dispose();

--- a/leptos_reactive/benches/fan_out.rs
+++ b/leptos_reactive/benches/fan_out.rs
@@ -18,21 +18,18 @@ fn rs_fan_out(c: &mut Criterion) {
 }
 
 fn l021_fan_out(c: &mut Criterion) {
-    use l021::*;
+    use leptos::*;
 
     c.bench_function("l021_fan_out", |b| {
         let runtime = create_runtime();
         b.iter(|| {
-            create_scope(runtime, |cx| {
-                let sig = create_rw_signal(cx, 0);
-                let memos = (0..1000)
-                    .map(|_| create_memo(cx, move |_| sig.get()))
-                    .collect::<Vec<_>>();
-                assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 0);
-                sig.set(1);
-                assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 1000);
-            })
-            .dispose()
+            let sig = create_rw_signal(0);
+            let memos = (0..1000)
+                .map(|_| create_memo(move |_| sig.get()))
+                .collect::<Vec<_>>();
+            assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 0);
+            sig.set(1);
+            assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 1000);
         });
         runtime.dispose();
     });
@@ -66,16 +63,13 @@ fn leptos_fan_out(c: &mut Criterion) {
 
     c.bench_function("leptos_fan_out", |b| {
         b.iter(|| {
-            create_scope(runtime, |cx| {
-                let sig = create_rw_signal(cx, 0);
-                let memos = (0..1000)
-                    .map(|_| create_memo(cx, move |_| sig.get()))
-                    .collect::<Vec<_>>();
-                assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 0);
-                sig.set(1);
-                assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 1000);
-            })
-            .dispose()
+            let sig = create_rw_signal(0);
+            let memos = (0..1000)
+                .map(|_| create_memo(move |_| sig.get()))
+                .collect::<Vec<_>>();
+            assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 0);
+            sig.set(1);
+            assert_eq!(memos.iter().map(|m| m.get()).sum::<i32>(), 1000);
         });
     });
     runtime.dispose();

--- a/leptos_reactive/benches/narrow_down.rs
+++ b/leptos_reactive/benches/narrow_down.rs
@@ -65,16 +65,12 @@ fn leptos_narrow_down(c: &mut Criterion) {
 
     c.bench_function("leptos_narrow_down", |b| {
         b.iter(|| {
-            create_scope(runtime, |cx| {
-                let sigs =
-                    (0..1000).map(|n| create_signal(cx, n)).collect::<Vec<_>>();
-                let reads = sigs.iter().map(|(r, _)| *r).collect::<Vec<_>>();
-                let memo = create_memo(cx, move |_| {
-                    reads.iter().map(|r| r.get()).sum::<i32>()
-                });
-                assert_eq!(memo(), 499500);
-            })
-            .dispose()
+            let sigs = (0..1000).map(|n| create_signal(n)).collect::<Vec<_>>();
+            let reads = sigs.iter().map(|(r, _)| *r).collect::<Vec<_>>();
+            let memo = create_memo(move |_| {
+                reads.iter().map(|r| r.get()).sum::<i32>()
+            });
+            assert_eq!(memo.get(), 499500);
         });
     });
     runtime.dispose();


### PR DESCRIPTION
The leptos_reactive benchmarks do not build/run. This makes it so they run. I'm not sure about the 1021::* bits and I replaced with `use leptos::*` which woks but may be benchmarking something not desired.