### PR TITLE
re-export slice!

### DIFF
--- a/examples/tailwind_axum/src/app.rs
+++ b/examples/tailwind_axum/src/app.rs
@@ -8,7 +8,7 @@ pub fn App() -> impl IntoView {
 
     view! {
 
-        <Stylesheet id="leptos" href="/blah/tailwind.css"/>
+        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>

--- a/examples/tailwind_axum/src/app.rs
+++ b/examples/tailwind_axum/src/app.rs
@@ -8,7 +8,7 @@ pub fn App() -> impl IntoView {
 
     view! {
 
-        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
+        <Stylesheet id="leptos" href="/blah/tailwind.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -180,7 +180,7 @@ pub mod error {
 pub use leptos_macro::template;
 #[cfg(not(all(target_arch = "wasm32", feature = "template_macro")))]
 pub use leptos_macro::view as template;
-pub use leptos_macro::{component, island, server, slot, view, Params};
+pub use leptos_macro::{component, island, server, slot, view, Params, slice};
 pub use leptos_reactive::*;
 pub use leptos_server::{
     self, create_action, create_multi_action, create_server_action,

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -180,7 +180,7 @@ pub mod error {
 pub use leptos_macro::template;
 #[cfg(not(all(target_arch = "wasm32", feature = "template_macro")))]
 pub use leptos_macro::view as template;
-pub use leptos_macro::{component, island, server, slot, view, Params, slice};
+pub use leptos_macro::{component, island, server, slice, slot, view, Params};
 pub use leptos_reactive::*;
 pub use leptos_server::{
     self, create_action, create_multi_action, create_server_action,

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -971,9 +971,9 @@ pub(crate) fn attribute_value(attr: &KeyedAttribute) -> &syn::Expr {
     }
 }
 
-/// Generates a `lens` into struct with a default getter and setter
+/// Generates a `slice` into a struct with a default getter and setter.
 ///
-/// Can be used to access deeply nested fields within a global state object
+/// Can be used to access deeply nested fields within a global state object.
 ///
 /// ```rust
 /// # use leptos::{create_runtime, create_rw_signal};

--- a/leptos_macro/tests/slice/red.stderr
+++ b/leptos_macro/tests/slice/red.stderr
@@ -14,7 +14,7 @@ error: expected `.`
    |
    = note: this error originates in the macro `slice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Expected identifier
+error: unexpected end of input, expected identifier
   --> tests/slice/red.rs:25:18
    |
 25 |     let (_, _) = slice!(outer_signal.);
@@ -22,7 +22,7 @@ error: Expected identifier
    |
    = note: this error originates in the macro `slice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: Unexpected trailing `.`
+error: unexpected end of input, expected identifier
   --> tests/slice/red.rs:27:18
    |
 27 |     let (_, _) = slice!(outer_signal.inner.);


### PR DESCRIPTION
re-exports the `leptos_macro::slice!` macro to `leptos::slice!`.

Also changed the implementation a bit to use more idiomatic `syn`/`quote` stuff.