### PR TITLE
Make the tailwind_axum example work with non-default pkg dir.

### DIFF
--- a/examples/tailwind_axum/src/app.rs
+++ b/examples/tailwind_axum/src/app.rs
@@ -6,9 +6,11 @@ use leptos_router::*;
 pub fn App() -> impl IntoView {
     provide_meta_context();
 
+    let site_pkg_dir = option_env!("LEPTOS_SITE_PKG_DIR").unwrap_or("pkg");
+
     view! {
 
-        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
+        <Stylesheet id="leptos" href=format!("{}/tailwind.css", site_pkg_dir)/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>


### PR DESCRIPTION
The tailwind_axum example would not run correctly if built with LEPTOS_SITE_PKG_DIR env var not set to "pkg" during build. Now it works.