### PR TITLE
fix document book input name query

### DIFF
--- a/docs/book/src/router/20_form.md
+++ b/docs/book/src/router/20_form.md
@@ -34,7 +34,7 @@ pub fn FormExample() -> impl IntoView {
 
 	view! {
 		<Form method="GET" action="">
-			<input type="search" name="search" value=search/>
+			<input type="search" name="q" value=search/>
 			<input type="submit"/>
 		</Form>
 		<Transition fallback=move || ()>
@@ -53,7 +53,7 @@ We can actually take it a step further and do something kind of clever:
 ```rust
 view! {
 	<Form method="GET" action="">
-		<input type="search" name="search" value=search
+		<input type="search" name="q" value=search
 			oninput="this.form.requestSubmit()"
 		/>
 	</Form>


### PR DESCRIPTION
I believe it is a typo in The document book section [form]( https://leptos-rs.github.io/leptos/router/20_form.html).

The input name attribute should be `q` for `let search = move || query().get("q").cloned().unwrap_or_default();` working.