### PR TITLE
fix: use `create_effect` for `<Portal/>` to avoid hydration issues (closes #2010)

### DIFF
--- a/leptos/src/portal.rs
+++ b/leptos/src/portal.rs
@@ -29,13 +29,13 @@ pub fn Portal(
 ) -> impl IntoView {
     cfg_if! { if #[cfg(all(target_arch = "wasm32", any(feature = "hydrate", feature = "csr")))] {
         use leptos_dom::{document, Mountable};
-        use leptos_reactive::{create_render_effect, on_cleanup};
+        use leptos_reactive::{create_effect, on_cleanup};
         use wasm_bindgen::JsCast;
 
         let mount = mount
             .unwrap_or_else(|| document().body().expect("body to exist").unchecked_into());
 
-        create_render_effect(move |_| {
+        create_effect(move |_| {
             let tag = if is_svg { "g" } else { "div" };
 
             let container = document()


### PR DESCRIPTION
This would close #2010. 

`create_render_effect` runs immediately/synchronously during rendering. `create_effect` doesn't run until the tick after it's created.

This means that if used during hydration, `create_render_effect` runs during the hydration process and `create_effect` runs after hydration.

`<Portal/>` was causing a bug during hydration because its elements were created inside a render effect, which meant they happened during hydration, and when they went to create elements thought they should be looking them up in the existing HTML in the DOM rather than creating them afresh.

This fixes the issue by switching to `create_effect`, so a `<Portal/>` only creates elements after hydration is done and there is no error.

@maccesch This does have the effect of slightly changing execution order: Portals whose `mount` is `None` will end up being placed after all other children in the body, *not* just after the children in the body as it exists at the moment they're created. My assumption is that portals are usually used with `Some(mount)` so this is not a big deal. Does this sound right to you?

An alternative would be to temporarily suspend hydration during the creation of a Portal. I haven't explored this as this is a one-line fix otherwise.