### PR TITLE
Minor: stop using std::fmt, instead used core::fmt.

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -384,7 +384,7 @@ async fn handle_server_fns_inner(
                 Response::builder().status(StatusCode::BAD_REQUEST).body(
                     Full::from(format!(
                         "Could not find a server function at the route \
-                         {fn_name}. \n\nIt's likely that either 
+                         {fn_name}. \n\nIt's likely that either
                          1. The API prefix you specify in the `#[server]` \
                          macro doesn't match the prefix at which your server \
                          function handler is mounted, or \n2. You are on a \
@@ -1835,8 +1835,8 @@ impl ExtractorHelper {
     where
         S: Sized,
         F: Extractor<T, U, S>,
-        T: std::fmt::Debug + Send + FromRequestParts<S> + 'static,
-        T::Rejection: std::fmt::Debug + Send + 'static,
+        T: core::fmt::Debug + Send + FromRequestParts<S> + 'static,
+        T::Rejection: core::fmt::Debug + Send + 'static,
     {
         let mut parts = self.parts.lock().await;
         let data = T::from_request_parts(&mut parts, &s).await?;
@@ -1879,8 +1879,8 @@ pub async fn extract<T, U>(
     f: impl Extractor<T, U, ()>,
 ) -> Result<U, T::Rejection>
 where
-    T: std::fmt::Debug + Send + FromRequestParts<()> + 'static,
-    T::Rejection: std::fmt::Debug + Send + 'static,
+    T: core::fmt::Debug + Send + FromRequestParts<()> + 'static,
+    T::Rejection: core::fmt::Debug + Send + 'static,
 {
     extract_with_state((), f).await
 }
@@ -1947,8 +1947,8 @@ pub async fn extract_with_state<T, U, S>(
 ) -> Result<U, T::Rejection>
 where
     S: Sized,
-    T: std::fmt::Debug + Send + FromRequestParts<S> + 'static,
-    T::Rejection: std::fmt::Debug + Send + 'static,
+    T: core::fmt::Debug + Send + FromRequestParts<S> + 'static,
+    T::Rejection: core::fmt::Debug + Send + 'static,
 {
     use_context::<ExtractorHelper>()
         .expect(

--- a/leptos_dom/src/events/typed.rs
+++ b/leptos_dom/src/events/typed.rs
@@ -324,8 +324,8 @@ macro_rules! generate_event_types {
         )*
       }
 
-      impl ::std::fmt::Debug for GenericEventHandler {
-        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+      impl ::core::fmt::Debug for GenericEventHandler {
+        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
           match self {
             $(
               Self::[< $($event:camel)+ >](event, _) => f

--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -458,8 +458,8 @@ where
 /// A handle that can be called to remove a global event listener.
 pub struct WindowListenerHandle(Box<dyn FnOnce()>);
 
-impl std::fmt::Debug for WindowListenerHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for WindowListenerHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("WindowListenerHandle").finish()
     }
 }

--- a/leptos_dom/src/hydration.rs
+++ b/leptos_dom/src/hydration.rs
@@ -84,7 +84,7 @@ pub struct HydrationKey {
 }
 
 impl Display for HydrationKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{}-{}-{}-{}",

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1179,7 +1179,7 @@ where
     }
 }
 
-impl IntoView for std::fmt::Arguments<'_> {
+impl IntoView for core::fmt::Arguments<'_> {
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),
         instrument(level = "info", name = "#text", skip_all)

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -88,8 +88,8 @@ impl PartialEq for Attribute {
     }
 }
 
-impl std::fmt::Debug for Attribute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Attribute {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::String(arg0) => f.debug_tuple("String").field(arg0).finish(),
             Self::Fn(_) => f.debug_tuple("Fn").finish(),
@@ -278,7 +278,7 @@ impl IntoAttribute for TextProp {
     impl_into_attr_boxed! {}
 }
 
-impl IntoAttribute for std::fmt::Arguments<'_> {
+impl IntoAttribute for core::fmt::Arguments<'_> {
     fn into_attribute(self) -> Attribute {
         match self.as_str() {
             Some(s) => s.into_attribute(),

--- a/leptos_dom/src/macro_helpers/into_style.rs
+++ b/leptos_dom/src/macro_helpers/into_style.rs
@@ -27,8 +27,8 @@ impl PartialEq for Style {
     }
 }
 
-impl std::fmt::Debug for Style {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Style {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Value(arg0) => f.debug_tuple("Value").field(arg0).finish(),
             Self::Fn(_) => f.debug_tuple("Fn").finish(),

--- a/leptos_dom/src/nonce.rs
+++ b/leptos_dom/src/nonce.rs
@@ -54,7 +54,7 @@ impl Deref for Nonce {
 }
 
 impl Display for Nonce {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/leptos_hot_reload/src/lib.rs
+++ b/leptos_hot_reload/src/lib.rs
@@ -131,8 +131,8 @@ pub struct MacroInvocation {
     template: LNode,
 }
 
-impl std::fmt::Debug for MacroInvocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MacroInvocation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MacroInvocation")
             .field("id", &self.id)
             .finish_non_exhaustive()

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -242,8 +242,8 @@ pub struct FragmentData {
     pub local_only: bool,
 }
 
-impl std::fmt::Debug for SharedContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SharedContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("SharedContext").finish()
     }
 }

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -675,7 +675,7 @@ impl Runtime {
 }
 
 impl Debug for Runtime {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Runtime").finish()
     }
 }

--- a/leptos_reactive/src/selector.rs
+++ b/leptos_reactive/src/selector.rs
@@ -111,11 +111,11 @@ where
     f: Rc<dyn Fn(&T, &T) -> bool>,
 }
 
-impl<T> std::fmt::Debug for Selector<T>
+impl<T> core::fmt::Debug for Selector<T>
 where
     T: PartialEq + Eq + Clone + Hash + 'static,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Selector").finish()
     }
 }

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -91,8 +91,8 @@ impl<T> Clone for Signal<T> {
 
 impl<T> Copy for Signal<T> {}
 
-impl<T> std::fmt::Debug for Signal<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T> core::fmt::Debug for Signal<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut s = f.debug_struct("Signal");
         s.field("inner", &self.inner);
         #[cfg(any(debug_assertions, feature = "ssr"))]
@@ -458,8 +458,8 @@ impl<T> Clone for SignalTypes<T> {
 
 impl<T> Copy for SignalTypes<T> {}
 
-impl<T> std::fmt::Debug for SignalTypes<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T> core::fmt::Debug for SignalTypes<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::ReadSignal(arg0) => {
                 f.debug_tuple("ReadSignal").field(arg0).finish()
@@ -1313,7 +1313,7 @@ impl TextProp {
 }
 
 impl Debug for TextProp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("TextProp").finish()
     }
 }

--- a/leptos_reactive/src/signal_wrappers_write.rs
+++ b/leptos_reactive/src/signal_wrappers_write.rs
@@ -234,11 +234,11 @@ impl<T> Clone for SignalSetterTypes<T> {
 
 impl<T> Copy for SignalSetterTypes<T> {}
 
-impl<T> std::fmt::Debug for SignalSetterTypes<T>
+impl<T> core::fmt::Debug for SignalSetterTypes<T>
 where
-    T: std::fmt::Debug,
+    T: core::fmt::Debug,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Write(arg0) => {
                 f.debug_tuple("WriteSignal").field(arg0).finish()

--- a/leptos_reactive/src/suspense.rs
+++ b/leptos_reactive/src/suspense.rs
@@ -291,8 +291,8 @@ pub enum StreamChunk {
     },
 }
 
-impl std::fmt::Debug for StreamChunk {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StreamChunk {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             StreamChunk::Sync(data) => write!(f, "StreamChunk::Sync({data:?})"),
             StreamChunk::Async { .. } => write!(f, "StreamChunk::Async(_)"),

--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -55,8 +55,8 @@ impl BodyContext {
     }
 }
 
-impl std::fmt::Debug for BodyContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BodyContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("TitleContext").finish()
     }
 }

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -70,8 +70,8 @@ impl HtmlContext {
     }
 }
 
-impl std::fmt::Debug for HtmlContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HtmlContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("TitleContext").finish()
     }
 }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -106,8 +106,8 @@ pub struct MetaTagsContext {
     >,
 }
 
-impl std::fmt::Debug for MetaTagsContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MetaTagsContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MetaTagsContext").finish()
     }
 }

--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -28,8 +28,8 @@ impl TitleContext {
     }
 }
 
-impl std::fmt::Debug for TitleContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TitleContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_tuple("TitleContext").finish()
     }
 }

--- a/router/src/components/redirect.rs
+++ b/router/src/components/redirect.rs
@@ -32,7 +32,7 @@ pub fn Redirect<P>(
     options: Option<NavigateOptions>,
 ) -> impl IntoView
 where
-    P: std::fmt::Display + 'static,
+    P: core::fmt::Display + 'static,
 {
     // resolve relative path
     let path = use_resolved_path(move || path.to_string());
@@ -68,8 +68,8 @@ pub struct ServerRedirectFunction {
     f: Rc<dyn Fn(&str)>,
 }
 
-impl std::fmt::Debug for ServerRedirectFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ServerRedirectFunction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ServerRedirectFunction").finish()
     }
 }

--- a/router/src/components/route.rs
+++ b/router/src/components/route.rs
@@ -72,7 +72,7 @@ pub fn Route<E, F, P>(
 where
     E: IntoView,
     F: Fn() -> E + 'static,
-    P: std::fmt::Display,
+    P: core::fmt::Display,
 {
     define_route(
         children,
@@ -122,7 +122,7 @@ pub fn ProtectedRoute<P, E, F, C>(
 where
     E: IntoView,
     F: Fn() -> E + 'static,
-    P: std::fmt::Display + 'static,
+    P: core::fmt::Display + 'static,
     C: Fn() -> bool + 'static,
 {
     use crate::Redirect;
@@ -178,7 +178,7 @@ pub fn StaticRoute<E, F, P, S>(
 where
     E: IntoView,
     F: Fn() -> E + 'static,
-    P: std::fmt::Display,
+    P: core::fmt::Display,
     S: Fn() -> Pin<Box<dyn Future<Output = StaticParamsMap> + Send + Sync>>
         + Send
         + Sync
@@ -407,8 +407,8 @@ impl PartialEq for RouteContextInner {
     }
 }
 
-impl std::fmt::Debug for RouteContextInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RouteContextInner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RouteContextInner")
             .field("path", &self.path)
             .field("ParamsMap", &self.params)

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -66,8 +66,8 @@ pub(crate) struct RouterContextInner {
     pub(crate) path_stack: StoredValue<Vec<String>>,
 }
 
-impl std::fmt::Debug for RouterContextInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RouterContextInner {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RouterContextInner")
             .field("location", &self.location)
             .field("base", &self.base)

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -161,7 +161,7 @@ impl StaticPath<'_, '_> {}
 pub struct ResolvedStaticPath(pub String);
 
 impl Display for ResolvedStaticPath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -12,8 +12,8 @@ pub use location::*;
 pub use params::*;
 pub use state::*;
 
-impl std::fmt::Debug for RouterIntegrationContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RouterIntegrationContext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RouterIntegrationContext").finish()
     }
 }

--- a/router/src/history/params.rs
+++ b/router/src/history/params.rs
@@ -78,7 +78,7 @@ impl Default for ParamsMap {
 /// # use leptos_router::params_map;
 /// let map = params_map! {
 ///     "crate" => "leptos",
-///     42 => true, // where key & val: std::fmt::Display
+///     42 => true, // where key & val: core::fmt::Display
 /// };
 /// assert_eq!(map.get("crate"), Some(&"leptos".to_string()));
 /// assert_eq!(map.get("42"), Some(&true.to_string()))

--- a/router/src/matching/route.rs
+++ b/router/src/matching/route.rs
@@ -27,8 +27,8 @@ pub struct RouteDefinition {
     pub static_params: Option<StaticData>,
 }
 
-impl std::fmt::Debug for RouteDefinition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RouteDefinition {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("RouteDefinition")
             .field("path", &self.path)
             .field("children", &self.children)

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -72,7 +72,7 @@ pub enum ServerFnError {
     MissingArg(String),
 }
 
-impl std::fmt::Display for ServerFnError {
+impl core::fmt::Display for ServerFnError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,


### PR DESCRIPTION
This is a coding standard, I have adopted in my own libraries, and well this is open source, so I want to start using this practice in modules that I use on a regular basis too..

It follows a recent trend in the rust community.

It is a aspiration, rather than an achievable goal - One day someone will try and run my library of an IOT device 
and I will have to answer question on the lines of

What portions of the library can I still use in a "no_std" environment.

So the is a defensive change .. and to drop std::fmt and use core::fmt  where possible 

I hope this helps.
 