### PR TITLE
Have fetch example conform to docs guidance around using <ErrorBoundary> and <Transition> in conjunction

### DIFF
--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -89,15 +89,15 @@ pub fn fetch_example() -> impl IntoView {
                     }
                 />
             </label>
-            <ErrorBoundary fallback>
-                <Transition fallback=move || {
-                    view! { <div>"Loading (Suspense Fallback)..."</div> }
-                }>
-                <div>
-                    {cats_view}
-                </div>
-                </Transition>
-            </ErrorBoundary>
+            <Transition fallback=move || {
+                view! { <div>"Loading (Suspense Fallback)..."</div> }
+            }>
+                <ErrorBoundary fallback>
+                    <div>
+                        {cats_view}
+                    </div>
+                </ErrorBoundary>
+            </Transition>
         </div>
     }
 }

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -93,9 +93,9 @@ pub fn fetch_example() -> impl IntoView {
                 view! { <div>"Loading (Suspense Fallback)..."</div> }
             }>
                 <ErrorBoundary fallback>
-                    <div>
-                        {cats_view}
-                    </div>
+                <div>
+                    {cats_view}
+                </div>
                 </ErrorBoundary>
             </Transition>
         </div>


### PR DESCRIPTION
The docs state that when used in conjunction, `<ErrorBoundary>` should be inside `<Transition>`, not the other way around. This didn't have a functional effect on the fetch example because it happens to use `create_local_resource` which guarantees that the resource will be loaded on the client side. https://docs.rs/leptos/latest/leptos/fn.ErrorBoundary.html#interaction-with-suspense

But I was working on an application that uses `create_resource`, and I happened to be using this example as a model of using `<ErrorBoundary>` and `<Transition>` in conjunction. When server side rendering is a possibility, reversing them seems to cause an issue where the `<ErrorBoundary>` fallback doesn't render properly.

So I thought maybe we should use them in the recommended order in this example.