### PR TITLE
Remove hyper: Use methods in viz and axum.

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.6", default-features = false, features = [
 ] }
 futures = "0.3"
 http = "0.2.8"
-hyper = "0.14.23"
+hyper = "~1"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -13,7 +13,6 @@ axum = { version = "0.6", default-features = false, features = [
 ] }
 futures = "0.3"
 http = "0.2.8"
-hyper = "~1"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -51,7 +51,6 @@ use http::{
     header, method::Method, request::Parts, uri::Uri, version::Version,
     Response,
 };
-use hyper::body;
 use leptos::{
     leptos_server::{server_fn_by_path, Payload},
     server_fn::Encoding,
@@ -162,7 +161,9 @@ pub async fn generate_request_and_parts(
 ) -> (Request<Body>, RequestParts) {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let body = body::to_bytes(body).await.unwrap_or_default();
+    let a = body.collect::<Vec<_>>().await;
+    let b = a.into_iter().filter_map(|a| a.ok()).collect::<Vec<_>>();
+    let body: Bytes = b.concat().into();
     let request_parts = RequestParts {
         method: parts.method.clone(),
         uri: parts.uri.clone(),

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -161,14 +161,15 @@ pub async fn generate_request_and_parts(
 ) -> (Request<Body>, RequestParts) {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let body: Bytes = body
+    let body = match body
         .collect::<Vec<_>>()
         .await
         .into_iter()
-        .filter_map(|a| a.ok())
-        .collect::<Vec<Bytes>>()
-        .concat()
-        .into();
+        .collect::<Result<Vec<Bytes>, _>>()
+    {
+        Ok(body) => body.concat().into(),
+        Err(_) => Bytes::default(),
+    };
     let request_parts = RequestParts {
         method: parts.method.clone(),
         uri: parts.uri.clone(),

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -161,9 +161,14 @@ pub async fn generate_request_and_parts(
 ) -> (Request<Body>, RequestParts) {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let a = body.collect::<Vec<_>>().await;
-    let b = a.into_iter().filter_map(|a| a.ok()).collect::<Vec<_>>();
-    let body: Bytes = b.concat().into();
+    let body: Bytes = body
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .filter_map(|a| a.ok())
+        .collect::<Vec<Bytes>>()
+        .concat()
+        .into();
     let request_parts = RequestParts {
         method: parts.method.clone(),
         uri: parts.uri.clone(),

--- a/integrations/viz/Cargo.toml
+++ b/integrations/viz/Cargo.toml
@@ -11,7 +11,7 @@ description = "Viz integrations for the Leptos web framework."
 viz = { version = "0.4.8" }
 futures = "0.3"
 http = "0.2.8"
-hyper = "0.14.23"
+hyper = "~1"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/integrations/viz/Cargo.toml
+++ b/integrations/viz/Cargo.toml
@@ -11,7 +11,6 @@ description = "Viz integrations for the Leptos web framework."
 viz = { version = "0.4.8" }
 futures = "0.3"
 http = "0.2.8"
-hyper = "~1"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -107,14 +107,16 @@ pub fn redirect(path: &str) {
 pub async fn generate_request_parts(req: Request) -> RequestParts {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let body = body
+    let body = match body
         .collect::<Vec<_>>()
         .await
         .into_iter()
-        .filter_map(|result| result.ok())
-        .collect::<Vec<Bytes>>()
-        .concat()
-        .into();
+        .collect::<Result<Vec<Bytes>, _>>()
+    {
+        Ok(body) => body.concat().into(),
+        Err(_) => Bytes::default(),
+    };
+
     RequestParts {
         method: parts.method,
         uri: parts.uri,

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -108,9 +108,14 @@ pub fn redirect(path: &str) {
 pub async fn generate_request_parts(req: Request) -> RequestParts {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let a = body.collect::<Vec<_>>().await;
-    let b = a.into_iter().filter_map(|a| a.ok()).collect::<Vec<_>>();
-    let body: Bytes = b.concat().into();
+    let body = body
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .filter_map(|result| result.ok())
+        .collect::<Vec<Bytes>>()
+        .concat()
+        .into();
     RequestParts {
         method: parts.method,
         uri: parts.uri,

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -11,7 +11,6 @@ use futures::{
     Future, SinkExt, Stream, StreamExt,
 };
 use http::{header, method::Method, uri::Uri, version::Version, StatusCode};
-
 use leptos::{
     leptos_server::{server_fn_by_path, Payload},
     server_fn::Encoding,

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -11,7 +11,7 @@ use futures::{
     Future, SinkExt, Stream, StreamExt,
 };
 use http::{header, method::Method, uri::Uri, version::Version, StatusCode};
-use hyper::body;
+
 use leptos::{
     leptos_server::{server_fn_by_path, Payload},
     server_fn::Encoding,
@@ -108,7 +108,9 @@ pub fn redirect(path: &str) {
 pub async fn generate_request_parts(req: Request) -> RequestParts {
     // provide request headers as context in server scope
     let (parts, body) = req.into_parts();
-    let body = body::to_bytes(body).await.unwrap_or_default();
+    let a = body.collect::<Vec<_>>().await;
+    let b = a.into_iter().filter_map(|a| a.ok()).collect::<Vec<_>>();
+    let body: Bytes = b.concat().into();
     RequestParts {
         method: parts.method,
         uri: parts.uri,


### PR DESCRIPTION
hyper 1.0 has been released 

-hyper = "0.14.23"
+hyper = "1"

Conventionally  0.x releases are considered pre-releases.
It seems hyper is acting in this vein.

here is the relevant blogs post, which is linked in the release notes. 

[stability-promise](https://hyper.rs/contrib/vision/#stability-promise)