### PR TITLE
Fix book chapter 3.9 #3

### DIFF
--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -151,7 +151,7 @@ pub fn App() -> impl IntoView {
 
 
 #[component]
-pub fn ButtonC<F>() -> impl IntoView {
+pub fn ButtonC() -> impl IntoView {
     view! {
         <button>"Toggle"</button>
     }

--- a/docs/book/src/view/08_parent_child.md
+++ b/docs/book/src/view/08_parent_child.md
@@ -261,7 +261,7 @@ Isn’t there some way to skip levels?
 
 There is!
 
-### The Context API
+### 4.1 The Context API
 
 You can provide data that skips levels by using [`provide_context`](https://docs.rs/leptos/latest/leptos/fn.provide_context.html)
 and [`use_context`](https://docs.rs/leptos/latest/leptos/fn.use_context.html). Contexts are identified
@@ -284,6 +284,7 @@ pub fn App() -> impl IntoView {
 }
 
 // <Layout/> and <Content/> omitted
+// To work in this version, drop their references to set_toggled
 
 #[component]
 pub fn ButtonD() -> impl IntoView {


### PR DESCRIPTION
This seems to have been left in as a typo. 

With the `F` present, it gives an error of:

```
error[E0392]: parameter `F` is never used
  --> src/main.rs:16:16
   |
16 | pub fn ButtonC<F>() -> impl IntoView {
   |                ^ unused parameter
   |
   = help: consider removing `F`, referring to it in a field, or using a marker such as `PhantomData`
   = help: if you intended `F` to be a const parameter, use `const F: usize` instead

error[E0282]: type annotations needed
  --> src/main.rs:11:10
   |
11 |         <ButtonC on:click=move |_| set_toggled.update(|value| *value = !*value)/>
   |          ^^^^^^^ cannot infer type of the type parameter `F` declared on the function `ButtonC`
   |
help: consider specifying the generic argument
   |
11 |         <ButtonC::<F> on:click=move |_| set_toggled.update(|value| *value = !*value)/>
   |                 +++++

error[E0282]: type annotations needed
  --> src/main.rs:16:8
   |
16 | pub fn ButtonC<F>() -> impl IntoView {
   |        ^^^^^^^ cannot infer type of the type parameter `F` declared on the function `__ButtonC`
   |
help: consider specifying the generic argument
   |
16 | pub fn ButtonC::<F><F>() -> impl IntoView {
   |               +++++

error[E0282]: type annotations needed
  --> src/main.rs:16:8
   |
16 | pub fn ButtonC<F>() -> impl IntoView {
   |        ^^^^^^^ cannot infer type of the type parameter `F` declared on the function `ButtonC`
   |
help: consider specifying the generic argument
   |
16 | pub fn ButtonC::<F><F>() -> impl IntoView {
   |               +++++
```

and works fine without it. 