### PR TITLE
fix: correctly mark `Trigger` as clean when it is re-tracked (closes #1948, #2048)

### DIFF
--- a/leptos_reactive/src/trigger.rs
+++ b/leptos_reactive/src/trigger.rs
@@ -94,6 +94,7 @@ impl Trigger {
         let diagnostics = diagnostics!(self);
 
         with_runtime(|runtime| {
+            runtime.update_if_necessary(self.id);
             self.id.subscribe(runtime, diagnostics);
         })
         .is_ok()


### PR DESCRIPTION
`Trigger` has its own implementation to optimize on not actually having a value. Unfortunately, its implementation was actually slightly different from signals, which meant that if it had been marked `DirtyMarked` it would never be marked `Clean` again, which meant it would never actually track in future. This caused tricky issues like #1948 and #2048. This PR should close both of those.