### PR TITLE
Fix WASI builds trying to use JS for `spawn_local`

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -66,6 +66,7 @@ miniserde = ["leptos_reactive/miniserde"]
 rkyv = ["leptos_reactive/rkyv"]
 tracing = ["leptos_macro/tracing"]
 nonce = ["leptos_dom/nonce"]
+spin = ["leptos_reactive/spin"]
 experimental-islands = [
   "leptos_dom/experimental-islands",
   "leptos_macro/experimental-islands",

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -26,6 +26,7 @@ bytecheck = { version = "0.7", features = [
 rustc-hash = "1"
 serde-wasm-bindgen = "0.5"
 serde_json = "1"
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.0.1", optional = true }
 base64 = "0.21"
 thiserror = "1"
 tokio = { version = "1", features = [
@@ -76,6 +77,7 @@ serde-lite = ["dep:serde-lite"]
 miniserde = ["dep:miniserde"]
 rkyv = ["dep:rkyv", "dep:bytecheck"]
 experimental-islands = []
+spin = ["ssr", "dep:spin-sdk"]
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly"]

--- a/leptos_reactive/src/spawn.rs
+++ b/leptos_reactive/src/spawn.rs
@@ -75,7 +75,10 @@ where
     F: Future<Output = ()> + 'static,
 {
     cfg_if! {
-        if #[cfg(target_arch = "wasm32")] {
+        if #[cfg(all(target_arch = "wasm32", target_os = "wasi", feature = "ssr", feature = "spin"))] {
+            spin_sdk::http::run(fut)
+        }
+        else if #[cfg(target_arch = "wasm32")] {
             wasm_bindgen_futures::spawn_local(fut)
         }
         else if #[cfg(any(test, doctest))] {

--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -39,8 +39,8 @@ impl BrowserIntegration {
         let loc = leptos_dom::helpers::location();
         LocationChange {
             value: loc.pathname().unwrap_or_default()
-                + &loc.search().unwrap_or_default()
-                + &loc.hash().unwrap_or_default(),
+                + loc.search().unwrap_or_default().as_str()
+                + loc.hash().unwrap_or_default().as_str(),
             replace: true,
             scroll: true,
             state: State(None),

--- a/router/src/matching/resolve_path.rs
+++ b/router/src/matching/resolve_path.rs
@@ -62,7 +62,7 @@ fn normalize(path: &str, omit_slash: bool) -> Cow<'_, str> {
 #[doc(hidden)]
 pub fn join_paths<'a>(from: &'a str, to: &'a str) -> String {
     let from = remove_wildcard(&normalize(from, false));
-    from + &normalize(to, false)
+    from + normalize(to, false).as_ref()
 }
 
 fn begins_with_query_or_hash(text: &str) -> bool {


### PR DESCRIPTION
Fixes #2056.

This is a change to the original fix proposed in the issue.  After talking to colleagues working on upstream WASI, the recommendation was to poll the future only _once_, on the basis that if the future were pending at that point, `futures::executor::block_on` would block forever, and it was better to panic with a specific message than to do that.

The caveat here is that `spawn_local` is a very low level function.  My fix works for the case I ran into, which was `create_resource`.  But if `spawn_local` is used elsewhere for a future that is truly long-running and non-blocking (such as a WASI Preview 2 outbound HTTP request) then this will fail.  Hopefully in that case the message will at least point us to the fix that's needed.  I don't think this is an issue as yet, but I don't know how `spawn_local` really gets used in SSR, so advice is welcome!

The risk on top of that caveat is that, as far as I know, the Leptos test suite doesn't currently build for WASI, and I haven't tried to tackle that as part of this PR.  So this new case is extremely Works On My Machine.  I am not sure how to move forward with testing on WASI I'm afraid.
