### PR TITLE
Chore: Bump http from 0.2.8 to 0.2.11.

### DIFF
--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -28,7 +28,7 @@ axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
-http = { version = "0.2.8", optional = true }
+http = { version = "0.2.11", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
 wasm-bindgen = "0.2"
 

--- a/examples/hackernews_islands_axum/Cargo.toml
+++ b/examples/hackernews_islands_axum/Cargo.toml
@@ -36,7 +36,7 @@ tower-http = { version = "0.4", features = [
   "compression-br",
 ], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
-http = { version = "0.2.8", optional = true }
+http = { version = "0.2.11", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
 wasm-bindgen = "0.2"
 lazy_static = "1.4.0"

--- a/examples/hackernews_js_fetch/Cargo.toml
+++ b/examples/hackernews_js_fetch/Cargo.toml
@@ -26,7 +26,7 @@ gloo-net = { version = "0.4.0", features = ["http"] }
 reqwest = { version = "0.11.13", features = ["json"] }
 axum = { version = "0.6", default-features = false, optional = true }
 tower = { version = "0.4.13", optional = true }
-http = { version = "0.2.8", optional = true }
+http = { version = "0.2.11", optional = true }
 web-sys = { version = "0.3", features = [
   "AbortController",
   "AbortSignal",

--- a/examples/session_auth_axum/Cargo.toml
+++ b/examples/session_auth_axum/Cargo.toml
@@ -24,7 +24,7 @@ axum = { version = "0.6.1", optional = true, features=["macros"] }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
-http = { version = "0.2.8" }
+http = { version = "0.2.11" }
 sqlx = { version = "0.7.2", features = [
 	"runtime-tokio-rustls",
 	"sqlite",

--- a/examples/tailwind_axum/Cargo.toml
+++ b/examples/tailwind_axum/Cargo.toml
@@ -23,7 +23,7 @@ tower-http = { version = "0.4", features = ["fs"], optional = true }
 wasm-bindgen = "0.2.84"
 thiserror = "1.0.40"
 tracing = { version = "0.1.37", optional = true }
-http = "0.2.9"
+http = "0.2.11"
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
@@ -44,12 +44,12 @@ denylist = ["axum", "tokio", "tower", "tower-http", "leptos_axum"]
 skip_feature_sets = [["ssr", "hydrate"]]
 
 [package.metadata.leptos]
-# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
+# The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
 output-name = "tailwind"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written
-# Defaults to pkg	
+# Defaults to pkg
 site-pkg-dir = "pkg"
 # The tailwind input file.
 #

--- a/examples/todo_app_sqlite_axum/Cargo.toml
+++ b/examples/todo_app_sqlite_axum/Cargo.toml
@@ -22,7 +22,7 @@ axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
-http = { version = "0.2.8" }
+http = { version = "0.2.11" }
 sqlx = { version = "0.6.2", features = [
 	"runtime-tokio-rustls",
 	"sqlite",

--- a/examples/todo_app_sqlite_csr/Cargo.toml
+++ b/examples/todo_app_sqlite_csr/Cargo.toml
@@ -22,7 +22,7 @@ axum = { version = "0.6.1", optional = true }
 tower = { version = "0.4.13", optional = true }
 tower-http = { version = "0.4", features = ["fs"], optional = true }
 tokio = { version = "1.22.0", features = ["full"], optional = true }
-http = { version = "0.2.8" }
+http = { version = "0.2.11" }
 sqlx = { version = "0.6.2", features = [
 	"runtime-tokio-rustls",
 	"sqlite",

--- a/examples/todo_app_sqlite_viz/Cargo.toml
+++ b/examples/todo_app_sqlite_viz/Cargo.toml
@@ -21,7 +21,7 @@ simple_logger = "4.0.0"
 serde = { version = "1", features = ["derive"] }
 viz = { version = "0.4.8", features = ["serve"], optional = true }
 tokio = { version = "1.25.0", features = ["full"], optional = true }
-http = { version = "0.2.8" }
+http = { version = "0.2.11" }
 sqlx = { version = "0.6.2", features = [
   "runtime-tokio-rustls",
   "sqlite",

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -12,7 +12,7 @@ axum = { version = "0.6", default-features = false, features = [
 	"matched-path",
 ] }
 futures = "0.3"
-http = "0.2.8"
+http = "0.2.11"
 hyper = "0.14.23"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }

--- a/integrations/viz/Cargo.toml
+++ b/integrations/viz/Cargo.toml
@@ -10,7 +10,7 @@ description = "Viz integrations for the Leptos web framework."
 [dependencies]
 viz = { version = "0.4.8" }
 futures = "0.3"
-http = "0.2.8"
+http = "0.2.11"
 hyper = "0.14.23"
 leptos = { workspace = true, features = ["ssr"] }
 leptos_meta = { workspace = true, features = ["ssr"] }


### PR DESCRIPTION
The http version [1.0](https://docs.rs/http/latest/http/index.html) is now public 

but moving from 0.2.8 is just picking up non breaking changes.

Covering the breaking changes is a complex conversion 

which I want to leave to a fresh issue.
