### PR TITLE
Change behavior of prop tracing to avoid evaluating lazy values

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1247,7 +1247,9 @@ where
             }
             #[cfg(all(feature = "hydrate", debug_assertions))]
             {
-                if self.serializable != ResourceSerialization::Local {
+                if self.serializable != ResourceSerialization::Local
+                    && !SpecialNonReactiveZone::is_inside()
+                {
                     crate::macros::debug_warn!(
                         "At {location}, you are reading a resource in \
                          `hydrate` mode outside a <Suspense/> or \


### PR DESCRIPTION
The issue is #1952: Passing a lazy type like a derived `Signal` or a `Memo` as a component property now causes them to be eagerly evaluated before they're actually used. This is because the `Serialize` implementation for signals/memos reads their value. This is surprising because users do not expect these values to be read simply by passing through a component, and it changes the behavior/execution order of the program.

Switching to `Debug`, which doesn't read the inner value of a memo/signal, resolves the issue, but changes exactly what is logged by this tracing integration.

@luoxiaozero I'd be curious to hear your thoughts on this, since it was your contribution initially. Is switching to `Debug` here compatible with your use case, or do we need to try some further autoref specialization to create a special implementation for reactive types that doesn't use `Serialize`?