### PR TITLE
fix: improved rust-analyzer support in `#[component]` macro?

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -586,7 +586,21 @@ impl ToTokens for DummyModel {
             let mut sig = sig.clone();
             sig.inputs.iter_mut().for_each(|arg| {
                 if let FnArg::Typed(ty) = arg {
-                    ty.attrs.clear();
+                    ty.attrs.retain(|attr| match &attr.meta {
+                        Meta::List(list) => list
+                            .path
+                            .segments
+                            .first()
+                            .map(|n| n.ident != "prop")
+                            .unwrap_or(true),
+                        Meta::NameValue(name_value) => name_value
+                            .path
+                            .segments
+                            .first()
+                            .map(|n| n.ident != "doc")
+                            .unwrap_or(true),
+                        _ => true,
+                    });
                 }
             });
             sig

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -232,6 +232,7 @@ impl ToTokens for Model {
             quote! {}
         };
 
+        let body_name = unmodified_fn_name_from_fn_name(&body_name);
         let body_expr = if *is_island {
             quote! {
                 ::leptos::SharedContext::with_hydration(move || {
@@ -1168,4 +1169,8 @@ pub fn module_name_from_fn_signature(sig: &Signature) -> Ident {
         .to_case(Case::Snake);
     let name = format!("component_module_{snake}");
     Ident::new(&name, sig.ident.span())
+}
+
+pub fn unmodified_fn_name_from_fn_name(ident: &Ident) -> Ident {
+    Ident::new(&format!("__{ident}"), ident.span())
 }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -137,7 +137,7 @@ impl ToTokens for Model {
             }
         }
 
-        let module_name = module_name_from_fn(body);
+        let module_name = module_name_from_fn_signature(&body.sig);
         #[allow(clippy::redundant_clone)] // false positive
         let body_name = body.sig.ident.clone();
 
@@ -544,10 +544,10 @@ impl Model {
 /// used to improve IDEs and rust-analyzer's auto-completion behavior in case
 /// of a syntax error.
 pub struct DummyModel {
-    attrs: Vec<Attribute>,
-    vis: Visibility,
-    sig: Signature,
-    body: TokenStream,
+    pub attrs: Vec<Attribute>,
+    pub vis: Visibility,
+    pub sig: Signature,
+    pub body: TokenStream,
 }
 
 impl Parse for DummyModel {
@@ -1160,21 +1160,12 @@ fn is_valid_into_view_return_type(ty: &ReturnType) -> bool {
     .any(|test| ty == test)
 }
 
-pub fn module_name_from_fn(body: &ItemFn) -> Ident {
-    let snake = &body
-        .sig
+pub fn module_name_from_fn_signature(sig: &Signature) -> Ident {
+    let snake = &sig
         .ident
         .to_string()
         .from_case(Case::Camel)
         .to_case(Case::Snake);
     let name = format!("component_module_{snake}");
-    Ident::new(&name, body.sig.ident.span())
-}
-
-pub fn strip_argument_attributes(fun: &mut ItemFn) {
-    for argument in fun.sig.inputs.iter_mut() {
-        if let FnArg::Typed(ref mut argument) = argument {
-            argument.attrs.clear();
-        }
-    }
+    Ident::new(&name, sig.ident.span())
 }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1,6 +1,6 @@
 use attribute_derive::Attribute as AttributeDerive;
 use convert_case::{
-    Case::{self, Pascal, Snake},
+    Case::{Pascal, Snake},
     Casing,
 };
 use itertools::Itertools;
@@ -137,7 +137,6 @@ impl ToTokens for Model {
             }
         }
 
-        let module_name = module_name_from_fn_signature(&body.sig);
         #[allow(clippy::redundant_clone)] // false positive
         let body_name = body.sig.ident.clone();
 
@@ -236,12 +235,12 @@ impl ToTokens for Model {
         let body_expr = if *is_island {
             quote! {
                 ::leptos::SharedContext::with_hydration(move || {
-                    #module_name::#body_name(#prop_names)
+                    #body_name(#prop_names)
                 })
             }
         } else {
             quote! {
-                #module_name::#body_name(#prop_names)
+                #body_name(#prop_names)
             }
         };
 
@@ -1173,16 +1172,6 @@ fn is_valid_into_view_return_type(ty: &ReturnType) -> bool {
     ]
     .iter()
     .any(|test| ty == test)
-}
-
-pub fn module_name_from_fn_signature(sig: &Signature) -> Ident {
-    let snake = &sig
-        .ident
-        .to_string()
-        .from_case(Case::Camel)
-        .to_case(Case::Snake);
-    let name = format!("component_module_{snake}");
-    Ident::new(&name, sig.ident.span())
 }
 
 pub fn unmodified_fn_name_from_fn_name(ident: &Ident) -> Ident {

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -621,7 +621,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             mod #module_name {
                 use super::*;
 
-                #[allow(non_snake_case, dead_code)]
+                #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes, unused_variables)]
                 #unexpanded
             }
         }
@@ -633,7 +633,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             mod #module_name {
                 use super::*;
 
-                #[allow(non_snake_case, dead_code)]
+                #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes, unused_variables)]
                 #dummy
             }
         }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -32,7 +32,9 @@ impl Default for Mode {
 
 mod params;
 mod view;
-use crate::component::module_name_from_fn_signature;
+use crate::component::{
+    module_name_from_fn_signature, unmodified_fn_name_from_fn_name,
+};
 use view::{client_template::render_template, render_view};
 mod component;
 mod server;
@@ -610,6 +612,8 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 span: unexpanded.vis.span(),
             })
         }
+        unexpanded.sig.ident =
+            unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
         let module_name = module_name_from_fn_signature(&unexpanded.sig);
         quote! {
             #expanded
@@ -621,7 +625,8 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 #unexpanded
             }
         }
-    } else if let Ok(dummy) = dummy {
+    } else if let Ok(mut dummy) = dummy {
+        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         let module_name = module_name_from_fn_signature(&dummy.sig);
         quote! {
             #[doc(hidden)]

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -605,11 +605,6 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_transparent(is_transparent).into_token_stream();
-        if !matches!(unexpanded.vis, Visibility::Public(_)) {
-            unexpanded.vis = Visibility::Public(Pub {
-                span: unexpanded.vis.span(),
-            })
-        }
         unexpanded.sig.ident =
             unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
         quote! {

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -612,9 +612,9 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 span: unexpanded.vis.span(),
             })
         }
+        let module_name = module_name_from_fn_signature(&unexpanded.sig);
         unexpanded.sig.ident =
             unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
-        let module_name = module_name_from_fn_signature(&unexpanded.sig);
         quote! {
             #expanded
             #[doc(hidden)]
@@ -626,8 +626,8 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             }
         }
     } else if let Ok(mut dummy) = dummy {
-        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         let module_name = module_name_from_fn_signature(&dummy.sig);
+        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
             mod #module_name {

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -621,7 +621,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             mod #module_name {
                 use super::*;
 
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes, unused_variables)]
+                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
                 #unexpanded
             }
         }
@@ -633,7 +633,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             mod #module_name {
                 use super::*;
 
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes, unused_variables)]
+                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
                 #dummy
             }
         }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -32,9 +32,7 @@ impl Default for Mode {
 
 mod params;
 mod view;
-use crate::component::{
-    module_name_from_fn_signature, unmodified_fn_name_from_fn_name,
-};
+use crate::component::unmodified_fn_name_from_fn_name;
 use view::{client_template::render_template, render_view};
 mod component;
 mod server;
@@ -612,30 +610,20 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 span: unexpanded.vis.span(),
             })
         }
-        let module_name = module_name_from_fn_signature(&unexpanded.sig);
         unexpanded.sig.ident =
             unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
         quote! {
             #expanded
             #[doc(hidden)]
-            mod #module_name {
-                use super::*;
-
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
-                #unexpanded
-            }
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #unexpanded
         }
     } else if let Ok(mut dummy) = dummy {
-        let module_name = module_name_from_fn_signature(&dummy.sig);
         dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
-            mod #module_name {
-                use super::*;
-
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
-                #dummy
-            }
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #dummy
         }
     } else {
         quote! {}
@@ -727,30 +715,20 @@ pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 span: unexpanded.vis.span(),
             })
         }
-        let module_name = module_name_from_fn_signature(&unexpanded.sig);
         unexpanded.sig.ident =
             unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
         quote! {
             #expanded
             #[doc(hidden)]
-            mod #module_name {
-                use super::*;
-
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
-                #unexpanded
-            }
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #unexpanded
         }
     } else if let Ok(mut dummy) = dummy {
-        let module_name = module_name_from_fn_signature(&dummy.sig);
         dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
-            mod #module_name {
-                use super::*;
-
-                #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
-                #dummy
-            }
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #dummy
         }
     } else {
         quote! {}

--- a/leptos_macro/tests/ui/component.rs
+++ b/leptos_macro/tests/ui/component.rs
@@ -13,7 +13,6 @@ fn unknown_prop_option(#[prop(hello)] test: bool) -> impl IntoView {
 
 #[component]
 fn optional_and_optional_no_strip(
-    ,
     #[prop(optional, optional_no_strip)] conflicting: bool,
 ) -> impl IntoView {
     _ = conflicting;
@@ -21,7 +20,6 @@ fn optional_and_optional_no_strip(
 
 #[component]
 fn optional_and_strip_option(
-    ,
     #[prop(optional, strip_option)] conflicting: bool,
 ) -> impl IntoView {
     _ = conflicting;
@@ -29,23 +27,18 @@ fn optional_and_strip_option(
 
 #[component]
 fn optional_no_strip_and_strip_option(
-    ,
     #[prop(optional_no_strip, strip_option)] conflicting: bool,
 ) -> impl IntoView {
     _ = conflicting;
 }
 
 #[component]
-fn default_without_value(
-    ,
-    #[prop(default)] default: bool,
-) -> impl IntoView {
+fn default_without_value(#[prop(default)] default: bool) -> impl IntoView {
     _ = default;
 }
 
 #[component]
 fn default_with_invalid_value(
-    ,
     #[prop(default= |)] default: bool,
 ) -> impl IntoView {
     _ = default;

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -1,33 +1,3 @@
-error: expected parameter name, found `,`
-  --> tests/ui/component.rs:16:5
-   |
-16 |     ,
-   |     ^ expected parameter name
-
-error: expected parameter name, found `,`
-  --> tests/ui/component.rs:24:5
-   |
-24 |     ,
-   |     ^ expected parameter name
-
-error: expected parameter name, found `,`
-  --> tests/ui/component.rs:32:5
-   |
-32 |     ,
-   |     ^ expected parameter name
-
-error: expected parameter name, found `,`
-  --> tests/ui/component.rs:40:5
-   |
-40 |     ,
-   |     ^ expected parameter name
-
-error: expected parameter name, found `,`
-  --> tests/ui/component.rs:48:5
-   |
-48 |     ,
-   |     ^ expected parameter name
-
 error: return type is incorrect
  --> tests/ui/component.rs:4:1
   |
@@ -50,32 +20,34 @@ error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `de
 10 | fn unknown_prop_option(#[prop(hello)] test: bool) -> impl IntoView {
    |                               ^^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:16:5
+error: `optional` conflicts with mutually exclusive `optional_no_strip`
+  --> tests/ui/component.rs:16:12
    |
-16 |     ,
-   |     ^
+16 |     #[prop(optional, optional_no_strip)] conflicting: bool,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:24:5
+error: `optional` conflicts with mutually exclusive `strip_option`
+  --> tests/ui/component.rs:23:12
    |
-24 |     ,
-   |     ^
+23 |     #[prop(optional, strip_option)] conflicting: bool,
+   |            ^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:32:5
+error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
+  --> tests/ui/component.rs:30:12
    |
-32 |     ,
-   |     ^
+30 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:40:5
+error: unexpected end of input, expected assignment `=`
+  --> tests/ui/component.rs:36:40
    |
-40 |     ,
-   |     ^
+36 | fn default_without_value(#[prop(default)] default: bool) -> impl IntoView {
+   |                                        ^
 
-error: expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
-  --> tests/ui/component.rs:48:5
+error: unexpected end of input, expected one of: identifier, `::`, `<`, `_`, literal, `const`, `ref`, `mut`, `&`, parentheses, square brackets, `..`, `const`
+
+       = help: try `#[prop(default=5 * 10)]`
+  --> tests/ui/component.rs:42:22
    |
-48 |     ,
-   |     ^
+42 |     #[prop(default= |)] default: bool,
+   |                      ^


### PR DESCRIPTION
This restructures the component macro so that it always emits a function with the identical name into a `#[doc(hidden)]` module named like `component_module_my_component`, whether the rest of the `#[component]` expands successfully or not.

The goal here is to provide a better rust-analyzer experience when there are syntax errors, when you are typing, etc (see #1781 and #1782, which doesn't really fix it)

If some others could let me know if this actually helps, I'd appreciate it and will fix any CI errors that arise.