### PR TITLE
docs: minor fixes for some code examples in the book

### DIFF
--- a/docs/book/src/interlude_projecting_children.md
+++ b/docs/book/src/interlude_projecting_children.md
@@ -135,17 +135,17 @@ pub fn App() -> impl IntoView {
 }
 
 #[component]
-pub fn Outer(ChildrenFn) -> impl IntoView {
+pub fn Outer(children: ChildrenFn) -> impl IntoView {
     children()
 }
 
 #[component]
-pub fn Inner(ChildrenFn) -> impl IntoView {
+pub fn Inner(children: ChildrenFn) -> impl IntoView {
     children()
 }
 
 #[component]
-pub fn Inmost(ng) -> impl IntoView {
+pub fn Inmost(name: String) -> impl IntoView {
     view! {
         <p>{name}</p>
     }

--- a/docs/book/src/testing.md
+++ b/docs/book/src/testing.md
@@ -30,7 +30,7 @@ pub struct Todos(Vec<Todo>);
 
 impl Todos {
     pub fn num_remaining(&self) -> usize {
-        todos.iter().filter(|todo| !todo.completed).sum()
+        self.0.iter().filter(|todo| !todo.completed).sum()
     }
 }
 


### PR DESCRIPTION
Fixed two errors in the code examples while studying the documentation. 
1. Missing the variable names in `docs/book/src/interlude_projecting_children.md`.
2. Referencing to a non-existing variable in `docs/book/src/testing.md`. 