### PR TITLE
Improve macro hygiene

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -415,7 +415,7 @@ impl ToTokens for Model {
                 };
                 let children = if is_island_with_children {
                     quote! {
-                        .children(::std::boxed::Box::new(move || ::leptos::Fragment::lazy(|| vec![
+                        .children(::std::boxed::Box::new(move || ::leptos::Fragment::lazy(|| ::std::vec![
                             ::leptos::SharedContext::with_hydration(move || {
                                 ::leptos::IntoView::into_view(
                                     ::leptos::leptos_dom::html::custom(

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -251,7 +251,7 @@ impl ToTokens for Model {
         } else {
             quote! {
                 ::leptos::leptos_dom::Component::new(
-                    stringify!(#name),
+                    ::std::stringify!(#name),
                     move || {
                         #tracing_guard_expr
                         #tracing_props_expr
@@ -293,13 +293,14 @@ impl ToTokens for Model {
                 && cfg!(feature = "ssr")
             {
                 quote! {
-                    let children = Box::new(|| ::leptos::Fragment::lazy(|| vec![
+                    let children = ::std::boxed::Box::new(|| ::leptos::Fragment::lazy(|| ::std::vec![
                         ::leptos::SharedContext::with_hydration(move || {
-                            ::leptos::leptos_dom::html::custom(
-                                ::leptos::leptos_dom::html::Custom::new("leptos-children"),
+                            ::leptos::IntoView::into_view(
+                                ::leptos::leptos_dom::html::custom(
+                                    ::leptos::leptos_dom::html::Custom::new("leptos-children"),
+                                )
+                                .child(::leptos::SharedContext::no_hydration(children))
                             )
-                            .child(::leptos::SharedContext::no_hydration(children))
-                            .into_view()
                         })
                     ]));
                 }
@@ -414,13 +415,14 @@ impl ToTokens for Model {
                 };
                 let children = if is_island_with_children {
                     quote! {
-                        .children(Box::new(move || ::leptos::Fragment::lazy(|| vec![
+                        .children(::std::boxed::Box::new(move || ::leptos::Fragment::lazy(|| vec![
                             ::leptos::SharedContext::with_hydration(move || {
-                                ::leptos::leptos_dom::html::custom(
-                                    ::leptos::leptos_dom::html::Custom::new("leptos-children"),
+                                ::leptos::IntoView::into_view(
+                                    ::leptos::leptos_dom::html::custom(
+                                        ::leptos::leptos_dom::html::Custom::new("leptos-children"),
+                                    )
+                                    .prop("$$owner", ::leptos::Owner::current().map(|n| n.as_ffi()))
                                 )
-                                .prop("$$owner", ::leptos::Owner::current().map(|n| n.as_ffi()))
-                                .into_view()
                         })])))
                     }
                 } else {

--- a/leptos_macro/src/params.rs
+++ b/leptos_macro/src/params.rs
@@ -20,7 +20,7 @@ pub fn params_impl(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
 
 				quote_spanned! {
 					span=> #ident: <#ty as ::leptos_router::IntoParam>::into_param(
-                        map.get(#field_name_string).map(::std::string::String::as_str), 
+                        map.get(#field_name_string).map(::std::string::String::as_str),
                         #field_name_string
                     )?
 				}

--- a/leptos_macro/src/params.rs
+++ b/leptos_macro/src/params.rs
@@ -19,7 +19,10 @@ pub fn params_impl(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
 				let span = field.span();
 
 				quote_spanned! {
-					span => #ident: <#ty>::into_param(map.get(#field_name_string).map(::std::string::String::as_str), #field_name_string)?
+					span=> #ident: <#ty as ::leptos_router::IntoParam>::into_param(
+                        map.get(#field_name_string).map(::std::string::String::as_str), 
+                        #field_name_string
+                    )?
 				}
 			})
             .collect()

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -47,7 +47,7 @@ pub(crate) fn fragment_to_tokens(
             )?;
 
             Some(quote! {
-                #node.into_view()
+                ::leptos::IntoView::into_view(#node)
             })
         })
         .peekable();
@@ -305,11 +305,8 @@ pub(crate) fn element_to_tokens(
                         global_class,
                         None,
                     )
-                    .unwrap_or({
-                        let span = Span::call_site();
-                        quote_spanned! {
-                            span => ::leptos::leptos_dom::Unit
-                        }
+                    .unwrap_or(quote_spanned! {
+                        Span::call_site()=> ::leptos::leptos_dom::Unit
                     }),
                     false,
                 ),
@@ -378,7 +375,7 @@ pub(crate) fn attribute_to_tokens(
     let name = node.key.to_string();
     if name == "ref" || name == "_ref" || name == "ref_" || name == "node_ref" {
         let value = expr_to_ident(attribute_value(node));
-        let node_ref = quote_spanned! { span => node_ref };
+        let node_ref = quote_spanned! { span=> node_ref };
 
         quote! {
             .#node_ref(#value)
@@ -415,18 +412,14 @@ pub(crate) fn attribute_to_tokens(
             NodeName::Punctuated(parts) => &parts[0],
             _ => unreachable!(),
         };
-        let on = {
-            let span = on.span();
-            quote_spanned! {
-                span => .on
-            }
+        let on = quote_spanned! {
+            on.span()=> .on
         };
         let event_type = if is_custom {
             event_type
         } else if let Some(ev_name) = event_name_ident {
-            let span = ev_name.span();
             quote_spanned! {
-                span => #ev_name
+                ev_name.span()=> #ev_name
             }
         } else {
             event_type
@@ -434,9 +427,8 @@ pub(crate) fn attribute_to_tokens(
 
         let event_type = if is_force_undelegated {
             let undelegated = if let Some(undelegated) = undelegated_ident {
-                let span = undelegated.span();
                 quote_spanned! {
-                    span => #undelegated
+                    undelegated.span()=> #undelegated
                 }
             } else {
                 quote! { undelegated }
@@ -455,11 +447,8 @@ pub(crate) fn attribute_to_tokens(
             NodeName::Punctuated(parts) => &parts[0],
             _ => unreachable!(),
         };
-        let prop = {
-            let span = prop.span();
-            quote_spanned! {
-                span => .prop
-            }
+        let prop = quote_spanned! {
+            prop.span()=> .prop
         };
         quote! {
             #prop(#name, #[allow(unused_braces)] {#value})
@@ -470,11 +459,8 @@ pub(crate) fn attribute_to_tokens(
             NodeName::Punctuated(parts) => &parts[0],
             _ => unreachable!(),
         };
-        let class = {
-            let span = class.span();
-            quote_spanned! {
-                span => .class
-            }
+        let class = quote_spanned! {
+            class.span()=> .class
         };
         quote! {
             #class(#name, #[allow(unused_braces)] {#value})
@@ -485,11 +471,8 @@ pub(crate) fn attribute_to_tokens(
             NodeName::Punctuated(parts) => &parts[0],
             _ => unreachable!(),
         };
-        let style = {
-            let span = style.span();
-            quote_spanned! {
-                span => .style
-            }
+        let style = quote_spanned! {
+            style.span()=> .style
         };
         quote! {
             #style(#name, #[allow(unused_braces)] {#value})
@@ -518,7 +501,7 @@ pub(crate) fn attribute_to_tokens(
             Some(value) => {
                 quote! { #value }
             }
-            None => quote_spanned! { span => "" },
+            None => quote_spanned! { span=> "" },
         };
 
         let attr = match &node.key {
@@ -526,9 +509,8 @@ pub(crate) fn attribute_to_tokens(
             _ => None,
         };
         let attr = if let Some(attr) = attr {
-            let span = attr.span();
             quote_spanned! {
-                span => .attr
+                attr.span()=> .attr
             }
         } else {
             quote! {

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -47,7 +47,7 @@ pub(crate) fn fragment_to_tokens(
             )?;
 
             Some(quote! {
-                ::leptos::IntoView::into_view(#node)
+                ::leptos::IntoView::into_view(#[allow(unused_braces)] {#node})
             })
         })
         .peekable();

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -499,7 +499,7 @@ fn block_to_tokens(
 
     let mount_kind = match &next_sib {
         Some(child) => {
-            quote! { ::leptos::leptos_dom::MountKind::Before(&::std::clone::Clone::clone(#child)) }
+            quote! { ::leptos::leptos_dom::MountKind::Before(&#child.clone()) }
         }
         None => {
             quote! { ::leptos::leptos_dom::MountKind::Append(&#parent) }

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -522,7 +522,7 @@ fn block_to_tokens(
             navigations.push(location);
 
             expressions.push(quote! {
-                ::leptos::leptos_dom::mount_child(#mount_kind, &::leptos::IntoView::into_view(#value));
+                ::leptos::leptos_dom::mount_child(#mount_kind, &::leptos::IntoView::into_view(#[allow(unused_braces)] {#value}));
             });
 
             if let Some(name) = name {

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -147,7 +147,7 @@ fn element_to_tokens(
             span=> let #this_el_ident = #debug_name;
                 let #this_el_ident =
                     ::leptos::wasm_bindgen::JsCast::unchecked_into::<::leptos::web_sys::Node>(
-                        ::std::clone::Clone::clone(#parent)
+                        #parent.clone()
                     );
                 //debug!("=> got {}", #this_el_ident.node_name());
         }
@@ -325,7 +325,7 @@ fn attr_to_tokens(
         expressions.push(quote_spanned! {
             span=> ::leptos::leptos_dom::class_helper(
                 ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
-                ::std::convert::Into::into(#name),
+                #name.into(),
                 ::leptos::IntoClass::into_class(#value),
             )
         });
@@ -353,7 +353,7 @@ fn attr_to_tokens(
                 expressions.push(quote_spanned! {
                     span=> ::leptos::leptos_dom::attribute_helper(
                         ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
-                        ::std::convert::Into::into(#name),
+                        #name.into(),
                         ::leptos::IntoAttribute::into_attribute({#value}),
                     )
                 });
@@ -522,7 +522,7 @@ fn block_to_tokens(
             navigations.push(location);
 
             expressions.push(quote! {
-                ::leptos::leptos_dom::mount_child(#mount_kind, &::leptos::IntoView::into_view({#value}));
+                ::leptos::leptos_dom::mount_child(#mount_kind, &::leptos::IntoView::into_view(#value));
             });
 
             if let Some(name) = name {

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -354,7 +354,7 @@ fn attr_to_tokens(
                     span=> ::leptos::leptos_dom::attribute_helper(
                         ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
                         #name.into(),
-                        ::leptos::IntoAttribute::into_attribute({#value}),
+                        ::leptos::IntoAttribute::into_attribute(#[allow(unused_braces)] {#value}),
                     )
                 });
             }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -105,7 +105,7 @@ pub(crate) fn component_to_tokens(
             let value = attr.value().map(|v| {
                 quote! { #v }
             })?;
-            Some(quote! { (#name, #value.into_attribute()) })
+            Some(quote! { (#name, ::leptos::IntoAttribute::into_attribute(#value)) })
         })
         .collect::<Vec<_>>();
 
@@ -144,7 +144,7 @@ pub(crate) fn component_to_tokens(
 
             let clonables = items_to_clone
                 .iter()
-                .map(|ident| quote! { let #ident = #ident.clone(); });
+                .map(|ident| quote! { let #ident = ::std::clone::Clone::clone(#ident); });
 
             if bindables.len() > 0 {
                 quote! {
@@ -172,7 +172,7 @@ pub(crate) fn component_to_tokens(
         let slot = Ident::new(&slot, span);
         if values.len() > 1 {
             quote! {
-                .#slot(vec![
+                .#slot(::std::vec![
                     #(#values)*
                 ])
             }
@@ -211,7 +211,7 @@ pub(crate) fn component_to_tokens(
         component
     } else {
         quote! {
-            #component.into_view()
+            ::leptos::IntoView::into_view(#component)
             #(#events_and_directives)*
         }
     }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -211,7 +211,7 @@ pub(crate) fn component_to_tokens(
         component
     } else {
         quote! {
-            ::leptos::IntoView::into_view(#component)
+            ::leptos::IntoView::into_view(#[allow(unused_braces)] {#component})
             #(#events_and_directives)*
         }
     }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -144,7 +144,7 @@ pub(crate) fn component_to_tokens(
 
             let clonables = items_to_clone
                 .iter()
-                .map(|ident| quote! { let #ident = ::std::clone::Clone::clone(#ident); });
+                .map(|ident| quote! { let #ident = #ident.clone(); });
 
             if bindables.len() > 0 {
                 quote! {

--- a/leptos_macro/src/view/ide_helper.rs
+++ b/leptos_macro/src/view/ide_helper.rs
@@ -103,13 +103,13 @@ impl IdeTagHelper {
             // todo: check is html, and emit_warning in case of custom tag
             quote! { ::leptos::leptos_dom::html }
         };
-        quote!( #namespace::#name)
+        quote! { #namespace::#name }
     }
 
     /// Returns `syn::Path`-like `TokenStream` to the `custom` section in docs.
     fn create_custom_tag_fn_path(span: Span) -> TokenStream {
         let custom_ident = Ident::new("custom", span);
-        quote! {leptos::leptos_dom::html::#custom_ident::<leptos::leptos_dom::html::Custom>}
+        quote! { ::leptos::leptos_dom::html::#custom_ident::<::leptos::leptos_dom::html::Custom> }
     }
 
     // Extract from NodeName completion idents.

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn render_view(
     let empty = {
         let span = Span::call_site();
         quote_spanned! {
-            span => leptos::leptos_dom::Unit
+            span=> ::leptos::leptos_dom::Unit
         }
     };
 
@@ -402,9 +402,8 @@ fn fancy_class_name<'a>(
     if name == "class" {
         if let Some(Tuple(tuple)) = node.value() {
             if tuple.elems.len() == 2 {
-                let span = node.key.span();
                 let class = quote_spanned! {
-                    span => .class
+                    node.key.span()=> .class
                 };
                 let class_name = &tuple.elems[0];
                 let class_name = if let Expr::Lit(ExprLit {
@@ -472,9 +471,8 @@ fn fancy_style_name<'a>(
     if name == "style" {
         if let Some(Tuple(tuple)) = node.value() {
             if tuple.elems.len() == 2 {
-                let span = node.key.span();
                 let style = quote_spanned! {
-                    span => .style
+                    node.key.span()=> .style
                 };
                 let style_name = &tuple.elems[0];
                 let style_name = if let Expr::Lit(ExprLit {
@@ -539,7 +537,7 @@ pub(crate) fn directive_call_from_attribute_node(
     let handler = format_ident!("{directive_name}", span = attr.key.span());
 
     let param = if let Some(value) = attr.value() {
-        quote! { #value.into() }
+        quote! { ::std::convert::Into::into(#value) }
     } else {
         quote! { () }
     };

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -537,7 +537,7 @@ pub(crate) fn directive_call_from_attribute_node(
     let handler = format_ident!("{directive_name}", span = attr.key.span());
 
     let param = if let Some(value) = attr.value() {
-        quote! { ::std::convert::Into::into(#value) }
+        quote! { #value.into() }
     } else {
         quote! { () }
     };

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -460,7 +460,7 @@ fn attribute_to_tokens_ssr<'a>(
                 } else {
                     template.push_str("{}");
                     holes.push(quote! {
-                        &::leptos::IntoAttribute::into_attribute({#value})
+                        &::leptos::IntoAttribute::into_attribute(#[allow(unused_braces)] {#value})
                             .as_nameless_value_string()
                             .map(|a| ::std::format!(
                                 "{}=\"{}\"",

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -133,16 +133,16 @@ pub(crate) fn root_element_to_tokens_ssr(
                 if holes.is_empty() {
                     let template = template.replace("\\{", "{").replace("\\}", "}");
                     quote! {
-                        ::leptos::leptos_dom::html::StringOrView::String(::std::convert::Into::into(#template))
+                        ::leptos::leptos_dom::html::StringOrView::String(#template.into())
                     }
                 } else {
                 let template = template.replace("\\{", "{{").replace("\\}", "}}");
                     quote! {
                         ::leptos::leptos_dom::html::StringOrView::String(
-                            ::std::convert::Into::into(::std::format!(
+                            ::std::format!(
                                 #template,
                                 #(#holes),*
-                            ))
+                            ).into()
                         )
                     }
                 }
@@ -152,7 +152,7 @@ pub(crate) fn root_element_to_tokens_ssr(
                     #[allow(unused_braces)]
                     {
                         let view = #view;
-                        ::leptos::leptos_dom::html::StringOrView::View(::std::rc::Rc::new(move || ::std::clone::Clone::clone(view)))
+                        ::leptos::leptos_dom::html::StringOrView::View(::std::rc::Rc::new(move || view.clone()))
                     }
                 }
             },
@@ -236,7 +236,7 @@ fn element_to_tokens_ssr(
         }
 
         chunks.push(SsrElementChunks::View(quote! {
-            ::leptos::IntoView::into_view({#component})
+            ::leptos::IntoView::into_view(#component)
         }));
     } else {
         let tag_name = node.name().to_string();
@@ -372,14 +372,14 @@ fn element_to_tokens_ssr(
                                     })
                                 }
                                 chunks.push(SsrElementChunks::View(quote! {
-                                    ::leptos::IntoView::into_view({#block})
+                                    ::leptos::IntoView::into_view(#block)
                                 }));
                             }
                         }
                         // Keep invalid blocks for faster IDE diff (on user type)
                         Node::Block(block @ NodeBlock::Invalid { .. }) => {
                             chunks.push(SsrElementChunks::View(quote! {
-                                ::leptos::IntoView::into_view({#block})
+                                ::leptos::IntoView::into_view(#block)
                             }));
                         }
                         Node::Fragment(_) => abort!(

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -78,7 +78,7 @@ pub(crate) fn fragment_to_tokens_ssr(
     let nodes = nodes.iter().map(|node| {
         let node = root_node_to_tokens_ssr(node, global_class, None);
         quote! {
-            ::leptos::IntoView::into_view(#node)
+            ::leptos::IntoView::into_view(#[allow(unused_braces)] {#node})
         }
     });
     quote! {
@@ -236,7 +236,7 @@ fn element_to_tokens_ssr(
         }
 
         chunks.push(SsrElementChunks::View(quote! {
-            ::leptos::IntoView::into_view(#component)
+            ::leptos::IntoView::into_view(#[allow(unused_braces)] {#component})
         }));
     } else {
         let tag_name = node.name().to_string();
@@ -372,14 +372,14 @@ fn element_to_tokens_ssr(
                                     })
                                 }
                                 chunks.push(SsrElementChunks::View(quote! {
-                                    ::leptos::IntoView::into_view(#block)
+                                    ::leptos::IntoView::into_view(#[allow(unused_braces)] {#block})
                                 }));
                             }
                         }
                         // Keep invalid blocks for faster IDE diff (on user type)
                         Node::Block(block @ NodeBlock::Invalid { .. }) => {
                             chunks.push(SsrElementChunks::View(quote! {
-                                ::leptos::IntoView::into_view(#block)
+                                ::leptos::IntoView::into_view(#[allow(unused_braces)] {#block})
                             }));
                         }
                         Node::Fragment(_) => abort!(

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -42,14 +42,14 @@ pub(crate) fn root_node_to_tokens_ssr(
         Node::Comment(_) | Node::Doctype(_) => quote! {},
         Node::Text(node) => {
             quote! {
-                leptos::leptos_dom::html::text(#node)
+                ::leptos::leptos_dom::html::text(#node)
             }
         }
         Node::RawText(r) => {
             let text = r.to_string_best();
             let text = syn::LitStr::new(&text, r.span());
             quote! {
-                leptos::leptos_dom::html::text(#text)
+                ::leptos::leptos_dom::html::text(#text)
             }
         }
         Node::Block(node) => {
@@ -78,12 +78,12 @@ pub(crate) fn fragment_to_tokens_ssr(
     let nodes = nodes.iter().map(|node| {
         let node = root_node_to_tokens_ssr(node, global_class, None);
         quote! {
-            #node.into_view()
+            ::leptos::IntoView::into_view(#node)
         }
     });
     quote! {
         {
-            leptos::Fragment::lazy(|| ::std::vec![
+            ::leptos::Fragment::lazy(|| ::std::vec![
                 #(#nodes),*
             ])
             #view_marker
@@ -133,17 +133,16 @@ pub(crate) fn root_element_to_tokens_ssr(
                 if holes.is_empty() {
                     let template = template.replace("\\{", "{").replace("\\}", "}");
                     quote! {
-                        leptos::leptos_dom::html::StringOrView::String(#template.into())
+                        ::leptos::leptos_dom::html::StringOrView::String(::std::convert::Into::into(#template))
                     }
                 } else {
                 let template = template.replace("\\{", "{{").replace("\\}", "}}");
                     quote! {
-                        leptos::leptos_dom::html::StringOrView::String(
-                            format!(
+                        ::leptos::leptos_dom::html::StringOrView::String(
+                            ::std::convert::Into::into(::std::format!(
                                 #template,
                                 #(#holes),*
-                            )
-                            .into()
+                            ))
                         )
                     }
                 }
@@ -153,7 +152,7 @@ pub(crate) fn root_element_to_tokens_ssr(
                     #[allow(unused_braces)]
                     {
                         let view = #view;
-                        leptos::leptos_dom::html::StringOrView::View(std::rc::Rc::new(move || view.clone()))
+                        ::leptos::leptos_dom::html::StringOrView::View(::std::rc::Rc::new(move || ::std::clone::Clone::clone(view)))
                     }
                 }
             },
@@ -189,7 +188,7 @@ pub(crate) fn root_element_to_tokens_ssr(
             }
         } else {
             quote! {
-                ::leptos::leptos_dom::#typed_element_name::default()
+                <::leptos::leptos_dom::#typed_element_name as ::std::default::Default>::default()
             }
         };
         let view_marker = if let Some(marker) = view_marker {
@@ -237,7 +236,7 @@ fn element_to_tokens_ssr(
         }
 
         chunks.push(SsrElementChunks::View(quote! {
-          {#component}.into_view()
+            ::leptos::IntoView::into_view({#component})
         }));
     } else {
         let tag_name = node.name().to_string();
@@ -284,8 +283,12 @@ fn element_to_tokens_ssr(
                     template.push_str(" {}");
                     holes.push(quote! {
                         {#end}.into_iter().filter_map(|(name, attr)| {
-                           Some(format!("{}=\"{}\"", name, ::leptos::leptos_dom::ssr::escape_attr(&attr.as_nameless_value_string()?)))
-                        }).collect::<Vec<_>>().join(" ")
+                           Some(::std::format!(
+                                "{}=\"{}\"",
+                                name,
+                                ::leptos::leptos_dom::ssr::escape_attr(&attr.as_nameless_value_string()?)
+                            ))
+                        }).collect::<::std::vec::Vec<_>>().join(" ")
                     });
                 };
             }
@@ -299,7 +302,7 @@ fn element_to_tokens_ssr(
         };
         template.push_str("{}");
         holes.push(quote! {
-            #hydration_id.map(|id| format!(" data-hk=\"{id}\"")).unwrap_or_default()
+            #hydration_id.map(|id| ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default()
         });
 
         set_class_attribute_ssr(node, template, holes, global_class);
@@ -315,7 +318,7 @@ fn element_to_tokens_ssr(
                 let value = inner_html;
 
                 holes.push(quote! {
-                  (#value).into_attribute().as_nameless_value_string().unwrap_or_default()
+                  ::leptos::IntoAttribute::into_attribute(#value).as_nameless_value_string().unwrap_or_default()
                 })
             } else {
                 for child in &node.children {
@@ -369,14 +372,14 @@ fn element_to_tokens_ssr(
                                     })
                                 }
                                 chunks.push(SsrElementChunks::View(quote! {
-                                    {#block}.into_view()
+                                    ::leptos::IntoView::into_view({#block})
                                 }));
                             }
                         }
                         // Keep invalid blocks for faster IDE diff (on user type)
                         Node::Block(block @ NodeBlock::Invalid { .. }) => {
                             chunks.push(SsrElementChunks::View(quote! {
-                                {#block}.into_view()
+                                ::leptos::IntoView::into_view({#block})
                             }));
                         }
                         Node::Fragment(_) => abort!(
@@ -411,7 +414,7 @@ fn attribute_to_tokens_ssr<'a>(
         let (event_type, _, _) = parse_event_name(name);
 
         exprs_for_compiler.push(quote! {
-            leptos::leptos_dom::helpers::ssr_event_listener(::leptos::ev::#event_type, #handler);
+            ::leptos::leptos_dom::helpers::ssr_event_listener(::leptos::ev::#event_type, #handler);
         })
     } else if name.strip_prefix("prop:").is_some()
         || name.strip_prefix("class:").is_some()
@@ -457,9 +460,13 @@ fn attribute_to_tokens_ssr<'a>(
                 } else {
                     template.push_str("{}");
                     holes.push(quote! {
-                        &{#value}.into_attribute()
+                        &::leptos::IntoAttribute::into_attribute({#value})
                             .as_nameless_value_string()
-                            .map(|a| format!("{}=\"{}\"", #name, leptos::leptos_dom::ssr::escape_attr(&a)))
+                            .map(|a| ::std::format!(
+                                "{}=\"{}\"",
+                                #name,
+                                ::leptos::leptos_dom::ssr::escape_attr(&a)
+                            ))
                             .unwrap_or_default()
                     })
                 }
@@ -582,8 +589,8 @@ fn set_class_attribute_ssr(
             if let Some(value) = value {
                 template.push_str(" {}");
                 holes.push(quote! {
-                  &(#value).into_attribute().as_nameless_value_string()
-                    .map(|a| leptos::leptos_dom::ssr::escape_attr(&a).to_string())
+                  &::leptos::IntoAttribute::into_attribute(#value).as_nameless_value_string()
+                    .map(|a| ::leptos::leptos_dom::ssr::escape_attr(&a).to_string())
                     .unwrap_or_default()
                 });
             }
@@ -592,7 +599,7 @@ fn set_class_attribute_ssr(
         for (_span, name, value) in &class_attrs {
             template.push_str(" {}");
             holes.push(quote! {
-              (#value).into_class().as_value_string(#name)
+                ::leptos::IntoClass::into_class(#value).as_value_string(#name)
             });
         }
 
@@ -693,8 +700,8 @@ fn set_style_attribute_ssr(
             if let Some(value) = value {
                 template.push_str(" {};");
                 holes.push(quote! {
-                  &(#value).into_attribute().as_nameless_value_string()
-                    .map(|a| leptos::leptos_dom::ssr::escape_attr(&a).to_string())
+                  &::leptos::IntoAttribute::into_attribute(#value).as_nameless_value_string()
+                    .map(|a| ::leptos::leptos_dom::ssr::escape_attr(&a).to_string())
                     .unwrap_or_default()
                 });
             }
@@ -703,7 +710,7 @@ fn set_style_attribute_ssr(
         for (_span, name, value) in &style_attrs {
             template.push_str(" {}");
             holes.push(quote! {
-              (#value).into_style().as_value_string(#name).unwrap_or_default()
+                ::leptos::IntoStyle::into_style(#value).as_value_string(#name).unwrap_or_default()
             });
         }
 

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -115,7 +115,7 @@ pub(crate) fn slot_to_tokens(
 
             let clonables = items_to_clone
                 .iter()
-                .map(|ident| quote! { let #ident = #ident.clone(); });
+                .map(|ident| quote! { let #ident = ::std::clone::Clone::clone(#ident); });
 
             if bindables.len() > 0 {
                 quote! {
@@ -154,12 +154,13 @@ pub(crate) fn slot_to_tokens(
     });
 
     let slot = quote! {
-        #component_name::builder()
-            #(#props)*
-            #(#slots)*
-            #children
-            .build()
-            .into(),
+        ::std::convert::Into::into(
+            #component_name::builder()
+                #(#props)*
+                #(#slots)*
+                #children
+                .build()
+        ),
     };
 
     parent_slots

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -159,7 +159,7 @@ pub(crate) fn slot_to_tokens(
             #(#slots)*
             #children
             .build()
-            .into()
+            .into(),
     };
 
     parent_slots

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -115,7 +115,7 @@ pub(crate) fn slot_to_tokens(
 
             let clonables = items_to_clone
                 .iter()
-                .map(|ident| quote! { let #ident = ::std::clone::Clone::clone(#ident); });
+                .map(|ident| quote! { let #ident = #ident.clone(); });
 
             if bindables.len() > 0 {
                 quote! {
@@ -154,13 +154,12 @@ pub(crate) fn slot_to_tokens(
     });
 
     let slot = quote! {
-        ::std::convert::Into::into(
-            #component_name::builder()
-                #(#props)*
-                #(#slots)*
-                #children
-                .build()
-        ),
+        #component_name::builder()
+            #(#props)*
+            #(#slots)*
+            #children
+            .build()
+            .into()
     };
 
     parent_slots

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__custom_event.snap
@@ -1,14 +1,17 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-            &ExternalComponent,
-            ::leptos::component_props_builder(&ExternalComponent).build(),
+    ::leptos::IntoView::into_view(
+            #[allow(unused_braces)]
+            {
+                ::leptos::component_view(
+                    &ExternalComponent,
+                    ::leptos::component_props_builder(&ExternalComponent).build(),
+                )
+            },
         )
-        .into_view()
         .on(
             ::leptos::leptos_dom::ev::undelegated(
                 ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__custom_event.snap
@@ -1,6 +1,5 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: result
 ---
 TokenStream [
@@ -24,73 +23,14 @@ TokenStream [
         spacing: Alone,
     },
     Ident {
-        sym: component_view,
-    },
-    Group {
-        delimiter: Parenthesis,
-        stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
-            },
-            Ident {
-                sym: ExternalComponent,
-                span: bytes(11..28),
-            },
-            Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: leptos,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: component_props_builder,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [
-                    Punct {
-                        char: '&',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: ExternalComponent,
-                        span: bytes(11..28),
-                    },
-                ],
-            },
-            Punct {
-                char: '.',
-                spacing: Alone,
-            },
-            Ident {
-                sym: build,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [],
-            },
-        ],
+        sym: IntoView,
     },
     Punct {
-        char: '.',
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
         spacing: Alone,
     },
     Ident {
@@ -98,7 +38,118 @@ TokenStream [
     },
     Group {
         delimiter: Parenthesis,
-        stream: TokenStream [],
+        stream: TokenStream [
+            Punct {
+                char: '#',
+                spacing: Alone,
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unused_braces,
+                            },
+                        ],
+                    },
+                ],
+            },
+            Group {
+                delimiter: Brace,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: component_view,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Punct {
+                                char: '&',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: ExternalComponent,
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: component_props_builder,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: build,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
     },
     Punct {
         char: '.',

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__simple_counter.snap
@@ -1023,6 +1023,16 @@ TokenStream [
                 spacing: Alone,
                 span: bytes(10..15),
             },
+            Punct {
+                char: ':',
+                spacing: Joint,
+                span: bytes(10..15),
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+                span: bytes(10..15),
+            },
             Ident {
                 sym: leptos,
                 span: bytes(10..15),
@@ -1159,6 +1169,30 @@ TokenStream [
                         spacing: Alone,
                         span: bytes(28..67),
                     },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(28..67),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(28..67),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(28..67),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(28..67),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(28..67),
+                    },
                     Ident {
                         sym: panic,
                         span: bytes(28..67),
@@ -1252,6 +1286,30 @@ TokenStream [
                     },
                     Punct {
                         char: '|',
+                        spacing: Alone,
+                        span: bytes(67..74),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(67..74),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(67..74),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(67..74),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(67..74),
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                         span: bytes(67..74),
                     },
@@ -1371,6 +1429,30 @@ TokenStream [
                         spacing: Alone,
                         span: bytes(96..163),
                     },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(96..163),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(96..163),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(96..163),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(96..163),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(96..163),
+                    },
                     Ident {
                         sym: panic,
                         span: bytes(96..163),
@@ -1464,6 +1546,30 @@ TokenStream [
                     },
                     Punct {
                         char: '|',
+                        spacing: Alone,
+                        span: bytes(163..167),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(163..167),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(163..167),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(163..167),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(163..167),
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                         span: bytes(163..167),
                     },
@@ -1583,6 +1689,30 @@ TokenStream [
                         spacing: Alone,
                         span: bytes(189..195),
                     },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(189..195),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(189..195),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(189..195),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(189..195),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(189..195),
+                    },
                     Ident {
                         sym: panic,
                         span: bytes(189..195),
@@ -1676,6 +1806,30 @@ TokenStream [
                     },
                     Punct {
                         char: '|',
+                        spacing: Alone,
+                        span: bytes(195..204),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(195..204),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(195..204),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(195..204),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(195..204),
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                         span: bytes(195..204),
                     },
@@ -1777,6 +1931,30 @@ TokenStream [
                         spacing: Alone,
                         span: bytes(205..212),
                     },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(205..212),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(205..212),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(205..212),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(205..212),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(205..212),
+                    },
                     Ident {
                         sym: panic,
                         span: bytes(205..212),
@@ -1872,6 +2050,30 @@ TokenStream [
                     },
                     Punct {
                         char: '|',
+                        spacing: Alone,
+                        span: bytes(213..216),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(213..216),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(213..216),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(213..216),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(213..216),
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                         span: bytes(213..216),
                     },
@@ -1991,6 +2193,30 @@ TokenStream [
                         spacing: Alone,
                         span: bytes(236..303),
                     },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(236..303),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(236..303),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(236..303),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(236..303),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(236..303),
+                    },
                     Ident {
                         sym: panic,
                         span: bytes(236..303),
@@ -2084,6 +2310,30 @@ TokenStream [
                     },
                     Punct {
                         char: '|',
+                        spacing: Alone,
+                        span: bytes(303..307),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(303..307),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                        span: bytes(303..307),
+                    },
+                    Ident {
+                        sym: std,
+                        span: bytes(303..307),
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                        span: bytes(303..307),
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                         span: bytes(303..307),
                     },
@@ -2308,6 +2558,10 @@ TokenStream [
                             },
                         ],
                         span: bytes(63..66),
+                    },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
                     },
                 ],
             },
@@ -2538,6 +2792,10 @@ TokenStream [
                         ],
                         span: bytes(138..162),
                     },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
+                    },
                 ],
             },
             Punct {
@@ -2660,23 +2918,34 @@ TokenStream [
                         char: '&',
                         spacing: Alone,
                     },
-                    Group {
-                        delimiter: Brace,
-                        stream: TokenStream [
-                            Group {
-                                delimiter: Brace,
-                                stream: TokenStream [
-                                    Ident {
-                                        sym: value,
-                                        span: bytes(206..211),
-                                    },
-                                ],
-                                span: bytes(205..212),
-                            },
-                        ],
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
                     },
                     Punct {
-                        char: '.',
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: IntoView,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
                         spacing: Alone,
                     },
                     Ident {
@@ -2684,7 +2953,43 @@ TokenStream [
                     },
                     Group {
                         delimiter: Parenthesis,
-                        stream: TokenStream [],
+                        stream: TokenStream [
+                            Punct {
+                                char: '#',
+                                spacing: Alone,
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        sym: allow,
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                sym: unused_braces,
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [
+                                            Ident {
+                                                sym: value,
+                                                span: bytes(206..211),
+                                            },
+                                        ],
+                                        span: bytes(205..212),
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 ],
             },
@@ -2914,6 +3219,10 @@ TokenStream [
                             },
                         ],
                         span: bytes(278..302),
+                    },
+                    Punct {
+                        char: ',',
+                        spacing: Alone,
                     },
                 ],
             },

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__simple_counter.snap
@@ -28,42 +28,60 @@ fn view() {
             .unwrap();
         let _el1 = "div";
         let _el1 = ::leptos::wasm_bindgen::JsCast::unchecked_into::<
-            leptos::web_sys::Node,
+            ::leptos::web_sys::Node,
         >(root.clone());
         let _el2 = "button";
         let _el2 = _el1
             .first_child()
-            .unwrap_or_else(|| panic!("error: {} => {}", "button", "firstChild"));
+            .unwrap_or_else(|| ::std::panic!("error: {} => {}", "button", "firstChild"));
         let _el3 = _el2
             .first_child()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "firstChild"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "firstChild")
+            });
         let _el4 = "button";
         let _el4 = _el2
             .next_sibling()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "button", "nextSibling"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "button", "nextSibling")
+            });
         let _el5 = _el4
             .first_child()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "firstChild"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "firstChild")
+            });
         let _el6 = "span";
         let _el6 = _el4
             .next_sibling()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "span", "nextSibling"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "span", "nextSibling")
+            });
         let _el7 = _el6
             .first_child()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "firstChild"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "firstChild")
+            });
         let _el8 = _el7
             .next_sibling()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "nextSibling"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "nextSibling")
+            });
         let _el9 = _el8
             .next_sibling()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "nextSibling"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "nextSibling")
+            });
         let _el10 = "button";
         let _el10 = _el6
             .next_sibling()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "button", "nextSibling"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "button", "nextSibling")
+            });
         let _el11 = _el10
             .first_child()
-            .unwrap_or_else(|| panic!("error : {} => {} ", "{block}", "firstChild"));
+            .unwrap_or_else(|| {
+                ::std::panic!("error : {} => {} ", "{block}", "firstChild")
+            });
         ::leptos::leptos_dom::add_event_helper(
             ::leptos::wasm_bindgen::JsCast::unchecked_ref(&_el2),
             ::leptos::leptos_dom::ev::click,
@@ -76,7 +94,7 @@ fn view() {
         );
         ::leptos::leptos_dom::mount_child(
             ::leptos::leptos_dom::MountKind::Before(&_el8.clone()),
-            &{ { value } }.into_view(),
+            &::leptos::IntoView::into_view(#[allow(unused_braces)] { { value } }),
         );
         ::leptos::leptos_dom::add_event_helper(
             ::leptos::wasm_bindgen::JsCast::unchecked_ref(&_el10),

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__custom_event.snap
@@ -1,14 +1,17 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-            &ExternalComponent,
-            ::leptos::component_props_builder(&ExternalComponent).build(),
+    ::leptos::IntoView::into_view(
+            #[allow(unused_braces)]
+            {
+                ::leptos::component_view(
+                    &ExternalComponent,
+                    ::leptos::component_props_builder(&ExternalComponent).build(),
+                )
+            },
         )
-        .into_view()
         .on(
             ::leptos::leptos_dom::ev::undelegated(
                 ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__custom_event.snap
@@ -1,6 +1,5 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: result
 ---
 TokenStream [
@@ -24,73 +23,14 @@ TokenStream [
         spacing: Alone,
     },
     Ident {
-        sym: component_view,
-    },
-    Group {
-        delimiter: Parenthesis,
-        stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
-            },
-            Ident {
-                sym: ExternalComponent,
-                span: bytes(11..28),
-            },
-            Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: leptos,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: component_props_builder,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [
-                    Punct {
-                        char: '&',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: ExternalComponent,
-                        span: bytes(11..28),
-                    },
-                ],
-            },
-            Punct {
-                char: '.',
-                spacing: Alone,
-            },
-            Ident {
-                sym: build,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [],
-            },
-        ],
+        sym: IntoView,
     },
     Punct {
-        char: '.',
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
         spacing: Alone,
     },
     Ident {
@@ -98,7 +38,118 @@ TokenStream [
     },
     Group {
         delimiter: Parenthesis,
-        stream: TokenStream [],
+        stream: TokenStream [
+            Punct {
+                char: '#',
+                spacing: Alone,
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unused_braces,
+                            },
+                        ],
+                    },
+                ],
+            },
+            Group {
+                delimiter: Brace,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: component_view,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Punct {
+                                char: '&',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: ExternalComponent,
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: component_props_builder,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: build,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
     },
     Punct {
         char: '.',

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__custom_event.snap
@@ -1,14 +1,17 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: pretty(result)
 ---
 fn view() {
-    ::leptos::component_view(
-            &ExternalComponent,
-            ::leptos::component_props_builder(&ExternalComponent).build(),
+    ::leptos::IntoView::into_view(
+            #[allow(unused_braces)]
+            {
+                ::leptos::component_view(
+                    &ExternalComponent,
+                    ::leptos::component_props_builder(&ExternalComponent).build(),
+                )
+            },
         )
-        .into_view()
         .on(
             ::leptos::leptos_dom::ev::undelegated(
                 ::leptos::leptos_dom::ev::Custom::new("custom.event.clear"),

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__custom_event.snap
@@ -1,6 +1,5 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: result
 ---
 TokenStream [
@@ -24,73 +23,14 @@ TokenStream [
         spacing: Alone,
     },
     Ident {
-        sym: component_view,
-    },
-    Group {
-        delimiter: Parenthesis,
-        stream: TokenStream [
-            Punct {
-                char: '&',
-                spacing: Alone,
-            },
-            Ident {
-                sym: ExternalComponent,
-                span: bytes(11..28),
-            },
-            Punct {
-                char: ',',
-                spacing: Alone,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: leptos,
-            },
-            Punct {
-                char: ':',
-                spacing: Joint,
-            },
-            Punct {
-                char: ':',
-                spacing: Alone,
-            },
-            Ident {
-                sym: component_props_builder,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [
-                    Punct {
-                        char: '&',
-                        spacing: Alone,
-                    },
-                    Ident {
-                        sym: ExternalComponent,
-                        span: bytes(11..28),
-                    },
-                ],
-            },
-            Punct {
-                char: '.',
-                spacing: Alone,
-            },
-            Ident {
-                sym: build,
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [],
-            },
-        ],
+        sym: IntoView,
     },
     Punct {
-        char: '.',
+        char: ':',
+        spacing: Joint,
+    },
+    Punct {
+        char: ':',
         spacing: Alone,
     },
     Ident {
@@ -98,7 +38,118 @@ TokenStream [
     },
     Group {
         delimiter: Parenthesis,
-        stream: TokenStream [],
+        stream: TokenStream [
+            Punct {
+                char: '#',
+                spacing: Alone,
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        sym: allow,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                sym: unused_braces,
+                            },
+                        ],
+                    },
+                ],
+            },
+            Group {
+                delimiter: Brace,
+                stream: TokenStream [
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: leptos,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: component_view,
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Punct {
+                                char: '&',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: ExternalComponent,
+                                span: bytes(11..28),
+                            },
+                            Punct {
+                                char: ',',
+                                spacing: Alone,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: leptos,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: component_props_builder,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Punct {
+                                        char: '&',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: ExternalComponent,
+                                        span: bytes(11..28),
+                                    },
+                                ],
+                            },
+                            Punct {
+                                char: '.',
+                                spacing: Alone,
+                            },
+                            Ident {
+                                sym: build,
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
     },
     Punct {
         char: '.',

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__simple_counter.snap
@@ -616,6 +616,14 @@ TokenStream [
                 char: ';',
                 spacing: Alone,
             },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
+                spacing: Alone,
+            },
             Ident {
                 sym: leptos,
             },
@@ -729,6 +737,14 @@ TokenStream [
             },
             Punct {
                 char: ';',
+                spacing: Alone,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
                 spacing: Alone,
             },
             Ident {
@@ -886,6 +902,14 @@ TokenStream [
             },
             Punct {
                 char: ';',
+                spacing: Alone,
+            },
+            Punct {
+                char: ':',
+                spacing: Joint,
+            },
+            Punct {
+                char: ':',
                 spacing: Alone,
             },
             Ident {
@@ -1082,6 +1106,10 @@ TokenStream [
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Punct {
+                        char: '<',
+                        spacing: Alone,
+                    },
+                    Punct {
                         char: ':',
                         spacing: Joint,
                     },
@@ -1125,6 +1153,46 @@ TokenStream [
                     Ident {
                         sym: Div,
                     },
+                    Ident {
+                        sym: as,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: std,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: default,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Joint,
+                    },
+                    Punct {
+                        char: ':',
+                        spacing: Alone,
+                    },
+                    Ident {
+                        sym: Default,
+                    },
+                    Punct {
+                        char: '>',
+                        spacing: Alone,
+                    },
                     Punct {
                         char: ':',
                         spacing: Joint,
@@ -1147,6 +1215,14 @@ TokenStream [
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
                             Ident {
                                 sym: leptos,
                             },
@@ -1197,6 +1273,25 @@ TokenStream [
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: std,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
                                     Ident {
                                         sym: format,
                                     },
@@ -1281,6 +1376,25 @@ TokenStream [
                                                     },
                                                     Punct {
                                                         char: '|',
+                                                        spacing: Alone,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
+                                                    Ident {
+                                                        sym: std,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
                                                         spacing: Alone,
                                                     },
                                                     Ident {
@@ -1385,6 +1499,25 @@ TokenStream [
                                                         char: '|',
                                                         spacing: Alone,
                                                     },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
+                                                    Ident {
+                                                        sym: std,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
                                                     Ident {
                                                         sym: format,
                                                     },
@@ -1485,6 +1618,25 @@ TokenStream [
                                                     },
                                                     Punct {
                                                         char: '|',
+                                                        spacing: Alone,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
+                                                    Ident {
+                                                        sym: std,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
                                                         spacing: Alone,
                                                     },
                                                     Ident {
@@ -1589,6 +1741,25 @@ TokenStream [
                                                         char: '|',
                                                         spacing: Alone,
                                                     },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
+                                                    Ident {
+                                                        sym: std,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
                                                     Ident {
                                                         sym: format,
                                                     },
@@ -1670,23 +1841,34 @@ TokenStream [
                                         char: '=',
                                         spacing: Alone,
                                     },
-                                    Group {
-                                        delimiter: Brace,
-                                        stream: TokenStream [
-                                            Group {
-                                                delimiter: Brace,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        sym: value,
-                                                        span: bytes(206..211),
-                                                    },
-                                                ],
-                                                span: bytes(205..212),
-                                            },
-                                        ],
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
                                     },
                                     Punct {
-                                        char: '.',
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: leptos,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: IntoView,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
                                         spacing: Alone,
                                     },
                                     Ident {
@@ -1694,10 +1876,54 @@ TokenStream [
                                     },
                                     Group {
                                         delimiter: Parenthesis,
-                                        stream: TokenStream [],
+                                        stream: TokenStream [
+                                            Punct {
+                                                char: '#',
+                                                spacing: Alone,
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        sym: allow,
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                sym: unused_braces,
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                            },
+                                            Group {
+                                                delimiter: Brace,
+                                                stream: TokenStream [
+                                                    Group {
+                                                        delimiter: Brace,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                sym: value,
+                                                                span: bytes(206..211),
+                                                            },
+                                                        ],
+                                                        span: bytes(205..212),
+                                                    },
+                                                ],
+                                            },
+                                        ],
                                     },
                                     Punct {
                                         char: ';',
+                                        spacing: Alone,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
                                         spacing: Alone,
                                     },
                                     Ident {
@@ -1750,6 +1976,14 @@ TokenStream [
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
+                                            Punct {
+                                                char: ':',
+                                                spacing: Joint,
+                                            },
+                                            Punct {
+                                                char: ':',
+                                                spacing: Alone,
+                                            },
                                             Ident {
                                                 sym: std,
                                             },
@@ -1824,6 +2058,14 @@ TokenStream [
                                 char: ',',
                                 spacing: Alone,
                             },
+                            Punct {
+                                char: ':',
+                                spacing: Joint,
+                            },
+                            Punct {
+                                char: ':',
+                                spacing: Alone,
+                            },
                             Ident {
                                 sym: leptos,
                             },
@@ -1874,6 +2116,25 @@ TokenStream [
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
+                                    Ident {
+                                        sym: std,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Joint,
+                                    },
+                                    Punct {
+                                        char: ':',
+                                        spacing: Alone,
+                                    },
                                     Ident {
                                         sym: format,
                                     },
@@ -1958,6 +2219,25 @@ TokenStream [
                                                     },
                                                     Punct {
                                                         char: '|',
+                                                        spacing: Alone,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Alone,
+                                                    },
+                                                    Ident {
+                                                        sym: std,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
+                                                        spacing: Joint,
+                                                    },
+                                                    Punct {
+                                                        char: ':',
                                                         spacing: Alone,
                                                     },
                                                     Ident {

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__simple_counter.snap
@@ -15,47 +15,50 @@ fn view() {
         let _ = ::leptos::leptos_dom::html::span;
         let _ = ::leptos::leptos_dom::html::button;
         let _ = ::leptos::leptos_dom::html::button;
-        leptos::leptos_dom::helpers::ssr_event_listener(
+        ::leptos::leptos_dom::helpers::ssr_event_listener(
             ::leptos::ev::click,
             move |_| set_value(0),
         );
-        leptos::leptos_dom::helpers::ssr_event_listener(
+        ::leptos::leptos_dom::helpers::ssr_event_listener(
             ::leptos::ev::click,
             move |_| set_value.update(|value| *value -= step),
         );
-        leptos::leptos_dom::helpers::ssr_event_listener(
+        ::leptos::leptos_dom::helpers::ssr_event_listener(
             ::leptos::ev::click,
             move |_| set_value.update(|value| *value += step),
         );
         ::leptos::HtmlElement::from_chunks(
-            ::leptos::leptos_dom::html::Div::default(),
+            <::leptos::leptos_dom::html::Div as ::std::default::Default>::default(),
             [
-                leptos::leptos_dom::html::StringOrView::String(
-                    format!(
+                ::leptos::leptos_dom::html::StringOrView::String(
+                    ::std::format!(
                         "<div{}><button{}>Clear</button><button{}>-1</button><span{}>Value: ",
                         ::leptos::leptos_dom::HydrationCtx::peek().map(| id |
-                        format!(" data-hk=\"{id}\"")).unwrap_or_default(),
+                        ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default(),
                         ::leptos::leptos_dom::HydrationCtx::id().map(| id |
-                        format!(" data-hk=\"{id}\"")).unwrap_or_default(),
+                        ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default(),
                         ::leptos::leptos_dom::HydrationCtx::id().map(| id |
-                        format!(" data-hk=\"{id}\"")).unwrap_or_default(),
+                        ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default(),
                         ::leptos::leptos_dom::HydrationCtx::id().map(| id |
-                        format!(" data-hk=\"{id}\"")).unwrap_or_default()
+                        ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default()
                     )
                         .into(),
                 ),
                 #[allow(unused_braces)]
                 {
-                    let view = { { value } }.into_view();
-                    leptos::leptos_dom::html::StringOrView::View(
-                        std::rc::Rc::new(move || view.clone()),
+                    let view = ::leptos::IntoView::into_view(
+                        #[allow(unused_braces)]
+                        { { value } },
+                    );
+                    ::leptos::leptos_dom::html::StringOrView::View(
+                        ::std::rc::Rc::new(move || view.clone()),
                     )
                 },
-                leptos::leptos_dom::html::StringOrView::String(
-                    format!(
+                ::leptos::leptos_dom::html::StringOrView::String(
+                    ::std::format!(
                         "!</span><button{}>+1</button></div>",
                         ::leptos::leptos_dom::HydrationCtx::id().map(| id |
-                        format!(" data-hk=\"{id}\"")).unwrap_or_default()
+                        ::std::format!(" data-hk=\"{id}\"")).unwrap_or_default()
                     )
                         .into(),
                 ),


### PR DESCRIPTION
improved macro hygiene by using more fully qualified paths. Main thing was swapping trait methods called with `.` for fully qualified trait methods, so that users don't always need to import `leptos::*` / `leptos_router::*` for macros to work.

Didn't bother as much for fully qualified std traits since no one is working in no_std anyways

(minor bit: also reformatted some `quote_spanned!` bits to follow convention (no space before `=>`) and remove redundant variable bindings)

might need to change up some `#[allow(unused_braces)]` if incorrect warnings appear