### PR TITLE
Fix `aria-current` attribute value

### DIFF
--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -217,7 +217,7 @@ where
                     target=target
                     prop:state=state.map(|s| s.to_js_value())
                     prop:replace=replace
-                    aria-current=move || if is_active.get() { Some("a") } else { None }
+                    aria-current=move || if is_active.get() { Some("page") } else { None }
                     class=class
                     id=id
                 >


### PR DESCRIPTION
#1953 modified the `aria-current` attribute of the router link component to an invalid value.

As a result, the CSS selector `[aria-current=page]` is no longer working in the latest release `0.5.3`.