### PR TITLE
fix: add support for placing attributes on server functions

### DIFF
--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -37,7 +37,7 @@ hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
 	"dep:actix-files",
 	"dep:actix-web",
-  "dep:tracing",
+	"dep:tracing",
 	"leptos/ssr",
 	"leptos_actix",
 	"leptos_meta/ssr",

--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -24,9 +24,12 @@ leptos_actix = { path = "../../integrations/actix", optional = true }
 leptos_meta = { path = "../../meta" }
 leptos_router = { path = "../../router" }
 log = "0.4"
+once_cell = "1.18"
 gloo-net = { git = "https://github.com/rustwasm/gloo" }
 wasm-bindgen = "0.2.87"
 serde = { version = "1", features = ["derive"] }
+simple_logger = "4.3"
+tracing = { version = "0.1", optional = true }
 
 [features]
 default = ["nightly"]
@@ -34,6 +37,7 @@ hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
 	"dep:actix-files",
 	"dep:actix-web",
+  "dep:tracing",
 	"leptos/ssr",
 	"leptos_actix",
 	"leptos_meta/ssr",

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -89,6 +89,7 @@ pub fn server_macro_impl(
     let fn_name_as_str = body.ident.to_string();
     let vis = body.vis;
     let block = body.block;
+    let attrs = body.attrs;
 
     let fields = body
         .inputs
@@ -276,6 +277,7 @@ pub fn server_macro_impl(
     let func = if cfg!(feature = "ssr") {
         quote! {
             #docs
+            #(#attrs)*
             #vis async fn #fn_name(#(#fn_args),*) #output_arrow #return_ty {
                 #block
             }
@@ -283,6 +285,7 @@ pub fn server_macro_impl(
     } else {
         quote! {
             #docs
+            #(#attrs)*
             #[allow(unused_variables)]
             #vis async fn #fn_name(#(#fn_args_2),*) #output_arrow #return_ty {
                 #server_fn_path::call_server_fn(


### PR DESCRIPTION
Adding instrumentation to server functions is not straightforward (currently requires calling a different instrumented function). This commit takes all attributes placed on the server function (any attributes between `#[server]` and the source function body) and places them on both the generated front end and back end functions. If those attributes are only desirable on one of the targets (wasm or server side), they can be conditionally included using `cfg_attr`.