### PR TITLE
Make tailwind examples more clear

### DIFF
--- a/examples/tailwind_actix/Cargo.toml
+++ b/examples/tailwind_actix/Cargo.toml
@@ -78,7 +78,7 @@ opt-level = 'z'
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name   
-output-name = "tailwind"
+output-name = "tailwind_actix"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written

--- a/examples/tailwind_actix/src/app.rs
+++ b/examples/tailwind_actix/src/app.rs
@@ -8,7 +8,7 @@ pub fn App() -> impl IntoView {
 
     view! {
 
-        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
+        <Stylesheet id="leptos" href="/pkg/tailwind_actix.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>

--- a/examples/tailwind_axum/Cargo.toml
+++ b/examples/tailwind_axum/Cargo.toml
@@ -45,7 +45,7 @@ skip_feature_sets = [["ssr", "hydrate"]]
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
-output-name = "tailwind"
+output-name = "tailwind_axum"
 # The site root folder is where cargo-leptos generate all output. WARNING: all content of this folder will be erased on a rebuild. Use it in your server setup.
 site-root = "target/site"
 # The site-root relative folder where all compiled output (JS, WASM and CSS) is written

--- a/examples/tailwind_axum/src/app.rs
+++ b/examples/tailwind_axum/src/app.rs
@@ -8,7 +8,7 @@ pub fn App() -> impl IntoView {
 
     view! {
 
-        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
+        <Stylesheet id="leptos" href="/pkg/tailwind_axum.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>


### PR DESCRIPTION
Make tailwind examples more clear (for newbies) by using an output name other than "tailwind."

I thought that the name "tailwind.css" in "/pkg/tailwind.css" came from the file "style/tailwind.css," but in fact the name comes from the output name specified in Cargo.toml. This small change should help other newbies pick up on what's happening a little quicker.