### PR TITLE
Support additional context for route generation

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -886,7 +886,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -898,7 +898,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
+    generate_route_list_with_exclusions_and_ssg(app_fn, None)
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -912,7 +912,7 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -922,13 +922,28 @@ where
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+) -> (Vec<RouteListing>, StaticDataMap)
+    where
+        IV: IntoView + 'static,
+{
+    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+}
+
+/// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
+/// create routes in Actix's App without having to use wildcard matching or fallbacks. Takes in your root app Element
+/// as an argument so it can walk you app tree. This version is tailored to generated Actix compatible paths. Adding excluded_routes
+/// to this function will stop `.leptos_routes()` from generating a route for it, allowing a custom handler. These need to be in Actix path format.
+/// Additional context will be provided to the app Element.
+pub fn generate_route_list_with_exclusions_and_ssg_and_context<IV>(
+    app_fn: impl Fn() -> IV + 'static + Clone,
+    excluded_routes: Option<Vec<String>>,
     additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (mut routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
 
     // Actix's Router doesn't follow Leptos's
     // Match `*` or `*someword` to replace with replace it with "/{tail.*}

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -886,7 +886,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -898,7 +898,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None)
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -912,7 +912,7 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -922,12 +922,13 @@ where
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+    additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (mut routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn);
+        leptos_router::generate_route_list_inner(app_fn, additional_context);
 
     // Actix's Router doesn't follow Leptos's
     // Match `*` or `*someword` to replace with replace it with "/{tail.*}

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -923,10 +923,14 @@ pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
 ) -> (Vec<RouteListing>, StaticDataMap)
-    where
-        IV: IntoView + 'static,
+where
+    IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+    generate_route_list_with_exclusions_and_ssg_and_context(
+        app_fn,
+        excluded_routes,
+        || {},
+    )
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -943,7 +947,10 @@ where
     IV: IntoView + 'static,
 {
     let (mut routes, static_data_map) =
-        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(
+            app_fn,
+            additional_context,
+        );
 
     // Actix's Router doesn't follow Leptos's
     // Match `*` or `*someword` to replace with replace it with "/{tail.*}

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1301,7 +1301,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1314,7 +1314,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
+    generate_route_list_with_exclusions_and_ssg(app_fn, None)
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1329,7 +1329,7 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
 }
 
 /// TODO docs
@@ -1363,13 +1363,29 @@ pub async fn build_static_routes<IV>(
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+) -> (Vec<RouteListing>, StaticDataMap)
+    where
+        IV: IntoView + 'static,
+{
+    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+}
+
+/// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
+/// create routes in Axum's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
+/// as an argument so it can walk you app tree. This version is tailored to generate Axum compatible paths. Adding excluded_routes
+/// to this function will stop `.leptos_routes()` from generating a route for it, allowing a custom handler. These need to be in Axum path format
+/// Additional context will be provided to the app Element.
+#[tracing::instrument(level = "trace", fields(error), skip_all)]
+pub fn generate_route_list_with_exclusions_and_ssg_and_context<IV>(
+    app_fn: impl Fn() -> IV + 'static + Clone,
+    excluded_routes: Option<Vec<String>>,
     additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
     // Axum's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1301,7 +1301,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1314,7 +1314,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None)
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1329,7 +1329,7 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
 }
 
 /// TODO docs
@@ -1363,12 +1363,13 @@ pub async fn build_static_routes<IV>(
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+    additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn);
+        leptos_router::generate_route_list_inner(app_fn, additional_context);
     // Axum's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1364,10 +1364,14 @@ pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
 ) -> (Vec<RouteListing>, StaticDataMap)
-    where
-        IV: IntoView + 'static,
+where
+    IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+    generate_route_list_with_exclusions_and_ssg_and_context(
+        app_fn,
+        excluded_routes,
+        || {},
+    )
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1385,7 +1389,10 @@ where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(
+            app_fn,
+            additional_context,
+        );
     // Axum's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -1000,7 +1000,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1012,7 +1012,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None)
+    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1025,20 +1025,22 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
 }
+
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
 /// create routes in Viz's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
 /// as an argument so it can walk you app tree. This version is tailored to generate Viz compatible paths.
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+    additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn);
+        leptos_router::generate_route_list_inner(app_fn, additional_context);
     // Viz's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -1035,10 +1035,14 @@ pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
 ) -> (Vec<RouteListing>, StaticDataMap)
-    where
-        IV: IntoView + 'static,
+where
+    IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+    generate_route_list_with_exclusions_and_ssg_and_context(
+        app_fn,
+        excluded_routes,
+        || {},
+    )
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1054,7 +1058,10 @@ where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(
+            app_fn,
+            additional_context,
+        );
     // Viz's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/integrations/viz/src/lib.rs
+++ b/integrations/viz/src/lib.rs
@@ -1000,7 +1000,7 @@ pub fn generate_route_list<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, None).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1012,7 +1012,7 @@ pub fn generate_route_list_with_ssg<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, None, || {})
+    generate_route_list_with_exclusions_and_ssg(app_fn, None)
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1025,7 +1025,7 @@ pub fn generate_route_list_with_exclusions<IV>(
 where
     IV: IntoView + 'static,
 {
-    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes, || {}).0
+    generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
@@ -1034,13 +1034,27 @@ where
 pub fn generate_route_list_with_exclusions_and_ssg<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
     excluded_routes: Option<Vec<String>>,
+) -> (Vec<RouteListing>, StaticDataMap)
+    where
+        IV: IntoView + 'static,
+{
+    generate_route_list_with_exclusions_and_ssg_and_context(app_fn, excluded_routes, || {})
+}
+
+/// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
+/// create routes in Viz's Router without having to use wildcard matching or fallbacks. Takes in your root app Element
+/// as an argument so it can walk you app tree. This version is tailored to generate Viz compatible paths.
+/// Additional context will be provided to the app Element.
+pub fn generate_route_list_with_exclusions_and_ssg_and_context<IV>(
+    app_fn: impl Fn() -> IV + 'static + Clone,
+    excluded_routes: Option<Vec<String>>,
     additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
 {
     let (routes, static_data_map) =
-        leptos_router::generate_route_list_inner(app_fn, additional_context);
+        leptos_router::generate_route_list_inner_with_context(app_fn, additional_context);
     // Viz's Router defines Root routes as "/" not ""
     let mut routes = routes
         .into_iter()

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -108,6 +108,7 @@ impl RouteListing {
 /// [`viz`]: <https://docs.rs/viz/>
 pub fn generate_route_list_inner<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
+    additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where
     IV: IntoView + 'static,
@@ -121,6 +122,8 @@ where
     provide_context(RouterIntegrationContext::new(integration));
     let branches = PossibleBranchContext::default();
     provide_context(branches.clone());
+
+    additional_context();
 
     leptos::suppress_resource_load(true);
     _ = app_fn().into_view();

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -109,10 +109,10 @@ impl RouteListing {
 pub fn generate_route_list_inner<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
-    where
-        IV: IntoView + 'static,
+where
+    IV: IntoView + 'static,
 {
-    generate_route_list_inner_with_context(app_fn, ||{})
+    generate_route_list_inner_with_context(app_fn, || {})
 }
 /// Generates a list of all routes this application could possibly serve. This returns the raw routes in the leptos_router
 /// format. Odds are you want `generate_route_list()` from either the [`actix`], [`axum`], or [`viz`] integrations if you want

--- a/router/src/extract_routes.rs
+++ b/router/src/extract_routes.rs
@@ -108,6 +108,21 @@ impl RouteListing {
 /// [`viz`]: <https://docs.rs/viz/>
 pub fn generate_route_list_inner<IV>(
     app_fn: impl Fn() -> IV + 'static + Clone,
+) -> (Vec<RouteListing>, StaticDataMap)
+    where
+        IV: IntoView + 'static,
+{
+    generate_route_list_inner_with_context(app_fn, ||{})
+}
+/// Generates a list of all routes this application could possibly serve. This returns the raw routes in the leptos_router
+/// format. Odds are you want `generate_route_list()` from either the [`actix`], [`axum`], or [`viz`] integrations if you want
+/// to work with their router.
+///
+/// [`actix`]: <https://docs.rs/actix/>
+/// [`axum`]: <https://docs.rs/axum/>
+/// [`viz`]: <https://docs.rs/viz/>
+pub fn generate_route_list_inner_with_context<IV>(
+    app_fn: impl Fn() -> IV + 'static + Clone,
     additional_context: impl Fn() + 'static + Clone,
 ) -> (Vec<RouteListing>, StaticDataMap)
 where


### PR DESCRIPTION
Using Leptos as a static site generator currently has two main steps:
1. generating routes
2. building static routes

The second step allows passing additional context (e.g. global state) via `build_static_routes_with_additional_context` that can then be used in components, but the first step doesn't. This means all components that get evaluated during step 1 will fail to get the additional context, while others that are only evaluated during 2 will be able to use it.

This PR adds support for additional context during step 1