### PR TITLE
Bumping itertool version number, fixes downstream "Clippy" warning issue.

### DIFF
--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 getrandom = { version = "0.2", optional = true }
 html-escape = "0.2"
 indexmap = "2"
-itertools = "0.10"
+itertools = "0.12"
 js-sys = "0.3"
 leptos_reactive = { workspace = true }
 server_fn = { workspace = true }

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 attribute-derive = { version = "0.8", features = ["syn-full"] }
 cfg-if = "1"
 html-escape = "0.2"
-itertools = "0.11"
+itertools = "0.12"
 prettyplease = "0.2.4"
 proc-macro-error = { version = "1", default-features = false }
 proc-macro2 = "1"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -30,7 +30,7 @@ wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4" }
 lru = { version = "0.11", optional = true }
 serde_json = "1.0.96"
-itertools = "0.11.0"
+itertools = "0.12.0"
 
 [dependencies.web-sys]
 version = "0.3"


### PR DESCRIPTION
Regarding a clippy warning seen in a app the uses leptos 

The root cause is the family of leptos modules requiring **BOTH** versions 0.10.5 and 0.11.0 This PR will fix that. ( Also needs a bump to 0.12.0 )

```
warning: multiple versions for dependency `itertools`: 0.10.5, 0.11.0
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions
note: the lint level is defined here
 --> src/lib.rs:4:9
  |
4 | #![warn(clippy::cargo)]
  |         ^^^^^^^^^^^^^
  = note: `#[warn(clippy::multiple_crate_versions)]` implied by `#[warn(clippy::cargo)]`
```