### PR TITLE
'a lifetime are not linking input params to the output. Should be replaced by static

### DIFF
--- a/leptos_macro/example/src/lib.rs
+++ b/leptos_macro/example/src/lib.rs
@@ -38,7 +38,7 @@ pub fn TestComponent(
 }
 
 #[component]
-fn TestMutCallback<'a, F>(mut callback: F, value: &'a str) -> impl IntoView
+fn TestMutCallback<F>(mut callback: F, value: &'static str) -> impl IntoView
 where
     F: FnMut(u32) + 'static,
 {


### PR DESCRIPTION
to reprodce this clippy warning

```bash
cd leptos/leptos_macro/example
cargo clippy
```

warning: the following explicit lifetimes could be elided: 'a
  --> src/lib.rs:41:20
   |
41 | fn TestMutCallback<'a, F>(mut callback: F, value: &'a str) -> impl IntoView
   |                    ^^                              ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
41 - fn TestMutCallback<'a, F>(mut callback: F, value: &'a str) -> impl IntoView
41 + fn TestMutCallback<F>(mut callback: F, value: &str) -> impl IntoView
   |

warning: `example` (lib) generated 1 warning (run `cargo clippy --fix --lib -p example` to apply 1 suggestion)