### PR TITLE
Make IntoAttribute more flexible for Options

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -180,7 +180,7 @@ pub async fn generate_request_and_parts(
 ///
 /// This can then be set up at an appropriate route in your application:
 ///
-/// ```rust,ignore
+/// ```
 /// use axum::{handler::Handler, routing::post, Router};
 /// use leptos::*;
 /// use std::net::SocketAddr;
@@ -416,7 +416,7 @@ pub type PinnedHtmlStream =
 /// includes everything described in the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```rust,ignore
+/// ```
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;
@@ -516,7 +516,7 @@ where
 /// the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```rust,ignore
+/// ```
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;
@@ -985,7 +985,7 @@ fn provide_contexts(
 /// the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```rust,ignore
+/// ```
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -180,7 +180,7 @@ pub async fn generate_request_and_parts(
 ///
 /// This can then be set up at an appropriate route in your application:
 ///
-/// ```
+/// ```rust,ignore
 /// use axum::{handler::Handler, routing::post, Router};
 /// use leptos::*;
 /// use std::net::SocketAddr;
@@ -416,7 +416,7 @@ pub type PinnedHtmlStream =
 /// includes everything described in the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```
+/// ```rust,ignore
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;
@@ -516,7 +516,7 @@ where
 /// the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```
+/// ```rust,ignore
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;
@@ -985,7 +985,7 @@ fn provide_contexts(
 /// the documentation for that function.
 ///
 /// This can then be set up at an appropriate route in your application:
-/// ```
+/// ```rust,ignore
 /// use axum::{handler::Handler, Router};
 /// use leptos::*;
 /// use leptos_config::get_configuration;

--- a/leptos_dom/src/nonce.rs
+++ b/leptos_dom/src/nonce.rs
@@ -69,16 +69,6 @@ impl IntoAttribute for Nonce {
     }
 }
 
-impl IntoAttribute for Option<Nonce> {
-    fn into_attribute(self) -> Attribute {
-        Attribute::Option(self.map(|n| n.0.into()))
-    }
-
-    fn into_attribute_boxed(self: Box<Self>) -> Attribute {
-        Attribute::Option(self.map(|n| n.0.into()))
-    }
-}
-
 /// Accesses the nonce that has been generated during the current
 /// server response. This can be added to inline `<script>` and
 /// `<style>` tags for compatibility with a Content Security Policy.


### PR DESCRIPTION
This change should both remove repetition for implementing `IntoAttribute` for `Option`s and help futureproof things by making sure any option of an intoattribute will always also be intoattribute.