### PR TITLE
fix: emit original token stream when there are syntax errors in `#[component]` or `#[island]` function signature (closes #2133)

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -603,7 +603,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     };
 
     let Ok(mut dummy) = syn::parse::<DummyModel>(s.clone()) else {
-        return s.into();
+        return s;
     };
     let parse_result = syn::parse::<component::Model>(s);
 
@@ -703,11 +703,11 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let Ok(mut dummy) = syn::parse::<DummyModel>(s.clone()) else {
-        return s.into();
+        return s;
     };
     let parse_result = syn::parse::<component::Model>(s);
 
-    if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
+    if let (ref mut unexpanded, Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_island().into_token_stream();
         if !matches!(unexpanded.vis, Visibility::Public(_)) {
             unexpanded.vis = Visibility::Public(Pub {
@@ -722,15 +722,13 @@ pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
             #unexpanded
         }
-    } else if let Ok(mut dummy) = dummy {
+    } else {
         dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
             #dummy
         }
-    } else {
-        s.into()
     }
     .into()
 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -602,10 +602,12 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
         false
     };
 
-    let mut dummy = syn::parse::<DummyModel>(s.clone());
-    let parse_result = syn::parse::<component::Model>(s.clone());
+    let Ok(mut dummy) = syn::parse::<DummyModel>(s.clone()) else {
+        return s.into();
+    };
+    let parse_result = syn::parse::<component::Model>(s);
 
-    if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
+    if let (ref mut unexpanded, Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_transparent(is_transparent).into_token_stream();
         unexpanded.sig.ident =
             unmodified_fn_name_from_fn_name(&unexpanded.sig.ident);
@@ -615,15 +617,13 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
             #unexpanded
         }
-    } else if let Ok(mut dummy) = dummy {
+    } else {
         dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
             #dummy
         }
-    } else {
-        s.into()
     }
     .into()
 }
@@ -702,8 +702,10 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 #[proc_macro_error::proc_macro_error]
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
-    let mut dummy = syn::parse::<DummyModel>(s.clone());
-    let parse_result = syn::parse::<component::Model>(s.clone());
+    let Ok(mut dummy) = syn::parse::<DummyModel>(s.clone()) else {
+        return s.into();
+    };
+    let parse_result = syn::parse::<component::Model>(s);
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_island().into_token_stream();

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -603,7 +603,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     };
 
     let mut dummy = syn::parse::<DummyModel>(s.clone());
-    let parse_result = syn::parse::<component::Model>(s);
+    let parse_result = syn::parse::<component::Model>(s.clone());
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_transparent(is_transparent).into_token_stream();
@@ -623,7 +623,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             #dummy
         }
     } else {
-        quote! {}
+        s.into()
     }
     .into()
 }
@@ -703,7 +703,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let mut dummy = syn::parse::<DummyModel>(s.clone());
-    let parse_result = syn::parse::<component::Model>(s);
+    let parse_result = syn::parse::<component::Model>(s.clone());
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
         let expanded = model.is_island().into_token_stream();
@@ -728,7 +728,7 @@ pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             #dummy
         }
     } else {
-        quote! {}
+        s.into()
     }
     .into()
 }


### PR DESCRIPTION
There's a compile-time trade-off here, as this requires cloning the `TokenStream` another time so makes every `#[component]` macro slightly slower in exchange for correctly passing along errors when the function signature is broken. 