### PR TITLE
Namespace caches and branches with new router IDs

### DIFF
--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -20,7 +20,6 @@ linear-map = { version = "1", features = ["serde_impl"] }
 once_cell = "1.18"
 regex = { version = "1", optional = true }
 url = { version = "2", optional = true }
-uuid = { version = "1", features = ["v4"] }
 percent-encoding = "2"
 thiserror = "1"
 serde_qs = "0.12"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -20,6 +20,7 @@ linear-map = { version = "1", features = ["serde_impl"] }
 once_cell = "1.18"
 regex = { version = "1", optional = true }
 url = { version = "2", optional = true }
+uuid = { version = "1", features = ["v4"] }
 percent-encoding = "2"
 thiserror = "1"
 serde_qs = "0.12"

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -8,11 +8,16 @@ use cfg_if::cfg_if;
 use leptos::*;
 #[cfg(feature = "transition")]
 use leptos_reactive::use_transition;
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 use thiserror::Error;
-use uuid::Uuid;
 #[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsCast;
+
+static GLOBAL_ROUTERS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// Provides for client-side and server-side routing. This should usually be somewhere near
 /// the root of the application.
@@ -52,7 +57,7 @@ pub struct RouterContext {
     pub(crate) inner: Rc<RouterContextInner>,
 }
 pub(crate) struct RouterContextInner {
-    id: Uuid,
+    id: usize,
     pub location: Location,
     pub base: RouteContext,
     pub possible_routes: RefCell<Option<Vec<Branch>>>,
@@ -167,7 +172,7 @@ impl RouterContext {
         });
 
         let inner = Rc::new(RouterContextInner {
-            id: Uuid::new_v4(),
+            id: GLOBAL_ROUTERS_COUNT.fetch_add(1, Ordering::SeqCst),
             base_path: base_path.into_owned(),
             path_stack: store_value(vec![location.pathname.get_untracked()]),
             location,
@@ -206,7 +211,7 @@ impl RouterContext {
         self.inner.base.clone()
     }
 
-    pub(crate) fn id(&self) -> Uuid {
+    pub(crate) fn id(&self) -> usize {
         self.inner.id
     }
 

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -10,6 +10,7 @@ use leptos::*;
 use leptos_reactive::use_transition;
 use std::{cell::RefCell, rc::Rc};
 use thiserror::Error;
+use uuid::Uuid;
 #[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsCast;
 
@@ -51,6 +52,7 @@ pub struct RouterContext {
     pub(crate) inner: Rc<RouterContextInner>,
 }
 pub(crate) struct RouterContextInner {
+    id: Uuid,
     pub location: Location,
     pub base: RouteContext,
     pub possible_routes: RefCell<Option<Vec<Branch>>>,
@@ -165,6 +167,7 @@ impl RouterContext {
         });
 
         let inner = Rc::new(RouterContextInner {
+            id: Uuid::new_v4(),
             base_path: base_path.into_owned(),
             path_stack: store_value(vec![location.pathname.get_untracked()]),
             location,
@@ -201,6 +204,10 @@ impl RouterContext {
     /// The [`RouteContext`] of the base route.
     pub fn base(&self) -> RouteContext {
         self.inner.base.clone()
+    }
+
+    pub(crate) fn id(&self) -> Uuid {
+        self.inner.id
     }
 
     /// A list of all possible routes this router can match.

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -272,8 +272,9 @@ pub fn AnimatedRoutes(
 
 pub(crate) struct Branches;
 
+type BranchesCacheKey = (usize, Cow<'static, str>);
 thread_local! {
-    static BRANCHES: RefCell<HashMap<(usize, Cow<'static, str>), Vec<Branch>>> = RefCell::new(HashMap::new());
+    static BRANCHES: RefCell<HashMap<BranchesCacheKey, Vec<Branch>>> = RefCell::new(HashMap::new());
 }
 
 impl Branches {

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -336,7 +336,7 @@ impl Branches {
             let branches = branches.borrow();
             let branches = branches.get(&(router_id, Cow::from(base))).expect(
                 "Branches::initialize() should be called before \
-                     Branches::with()",
+                 Branches::with()",
             );
             cb(branches)
         })

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -9,7 +9,6 @@ pub use matcher::*;
 pub use resolve_path::*;
 pub use route::*;
 use std::rc::Rc;
-use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RouteMatch {
@@ -18,28 +17,26 @@ pub(crate) struct RouteMatch {
 }
 
 pub(crate) fn get_route_matches(
-    router_id: Uuid,
+    router_id: usize,
     base: &str,
     location: String,
 ) -> Rc<Vec<RouteMatch>> {
     #[cfg(feature = "ssr")]
     {
         use lru::LruCache;
-        use std::{cell::RefCell, collections::HashMap, num::NonZeroUsize};
-        type RouteMatchCache = LruCache<String, Rc<Vec<RouteMatch>>>;
+        use std::{cell::RefCell, num::NonZeroUsize};
+        type RouteMatchCache = LruCache<(usize, String), Rc<Vec<RouteMatch>>>;
         thread_local! {
-            static ROUTE_MATCH_CACHES: RefCell<HashMap<Uuid , RouteMatchCache>> = RefCell::new(HashMap::new());
+            static ROUTE_MATCH_CACHE: RefCell<RouteMatchCache> = RefCell::new(LruCache::new(NonZeroUsize::new(32).unwrap()));
         }
 
-        ROUTE_MATCH_CACHES.with(|caches| {
-            let mut caches = caches.borrow_mut();
-            caches.entry(router_id).or_insert_with(|| {
-                LruCache::new(NonZeroUsize::new(32).unwrap())
-            });
-            let cache = caches.get_mut(&router_id).unwrap();
-            Rc::clone(cache.get_or_insert(location.clone(), || {
-                build_route_matches(router_id, base, location)
-            }))
+        ROUTE_MATCH_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            Rc::clone(
+                cache.get_or_insert((router_id, location.clone()), || {
+                    build_route_matches(router_id, base, location)
+                }),
+            )
         })
     }
 
@@ -48,7 +45,7 @@ pub(crate) fn get_route_matches(
 }
 
 fn build_route_matches(
-    router_id: Uuid,
+    router_id: usize,
     base: &str,
     location: String,
 ) -> Rc<Vec<RouteMatch>> {

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -9,6 +9,7 @@ pub use matcher::*;
 pub use resolve_path::*;
 pub use route::*;
 use std::rc::Rc;
+use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RouteMatch {
@@ -17,31 +18,41 @@ pub(crate) struct RouteMatch {
 }
 
 pub(crate) fn get_route_matches(
+    router_id: Uuid,
     base: &str,
     location: String,
 ) -> Rc<Vec<RouteMatch>> {
     #[cfg(feature = "ssr")]
     {
         use lru::LruCache;
-        use std::{cell::RefCell, num::NonZeroUsize};
+        use std::{cell::RefCell, collections::HashMap, num::NonZeroUsize};
+        type RouteMatchCache = LruCache<String, Rc<Vec<RouteMatch>>>;
         thread_local! {
-            static ROUTE_MATCH_CACHE: RefCell<LruCache<String, Rc<Vec<RouteMatch>>>> = RefCell::new(LruCache::new(NonZeroUsize::new(32).unwrap()));
+            static ROUTE_MATCH_CACHES: RefCell<HashMap<Uuid , RouteMatchCache>> = RefCell::new(HashMap::new());
         }
 
-        ROUTE_MATCH_CACHE.with(|cache| {
-            let mut cache = cache.borrow_mut();
+        ROUTE_MATCH_CACHES.with(|caches| {
+            let mut caches = caches.borrow_mut();
+            caches.entry(router_id).or_insert_with(|| {
+                LruCache::new(NonZeroUsize::new(32).unwrap())
+            });
+            let cache = caches.get_mut(&router_id).unwrap();
             Rc::clone(cache.get_or_insert(location.clone(), || {
-                build_route_matches(base, location)
+                build_route_matches(router_id, base, location)
             }))
         })
     }
 
     #[cfg(not(feature = "ssr"))]
-    build_route_matches(base, location)
+    build_route_matches(router_id, base, location)
 }
 
-fn build_route_matches(base: &str, location: String) -> Rc<Vec<RouteMatch>> {
-    Rc::new(Branches::with(base, |branches| {
+fn build_route_matches(
+    router_id: Uuid,
+    base: &str,
+    location: String,
+) -> Rc<Vec<RouteMatch>> {
+    Rc::new(Branches::with(router_id, base, |branches| {
         for branch in branches {
             if let Some(matches) = branch.matcher(&location) {
                 return matches;


### PR DESCRIPTION
I had another go #1806 and it turned out to be easier than I previously thought to solve naively. But I'm not sure this is an ideal solution, maybe the IDs shouldn't be UUIDs, or maybe the caches should be held by the objects directly.

I'm also finding it hard to add a unit/integration test, so I would welcome a suggestion on this as well.