### PR TITLE
feat: Add owning memos to allow memos that re-use the previous value

### DIFF
--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -86,7 +86,7 @@ pub fn create_memo<T>(f: impl Fn(Option<&T>) -> T + 'static) -> Memo<T>
 where
     T: PartialEq + 'static,
 {
-    Runtime::current().create_raw_memo(move |current_value| {
+    Runtime::current().create_owning_memo(move |current_value| {
         let new_value = f(current_value.as_ref());
         let is_different = current_value.as_ref() != Some(&new_value);
         (new_value, is_different)
@@ -106,13 +106,13 @@ where
 )]
 #[track_caller]
 #[inline(always)]
-pub fn create_raw_memo<T>(
+pub fn create_owning_memo<T>(
     f: impl Fn(Option<T>) -> (T, bool) + 'static,
 ) -> Memo<T>
 where
     T: PartialEq + 'static,
 {
-    Runtime::current().create_raw_memo(f)
+    Runtime::current().create_owning_memo(f)
 }
 
 /// An efficient derived reactive value based on other reactive values.
@@ -246,11 +246,11 @@ impl<T> Memo<T> {
     #[allow(missing_docs)] // TODO
     #[inline(always)]
     #[track_caller]
-    pub fn new_raw(f: impl Fn(Option<T>) -> (T, bool) + 'static) -> Memo<T>
+    pub fn new_owning(f: impl Fn(Option<T>) -> (T, bool) + 'static) -> Memo<T>
     where
         T: PartialEq + 'static,
     {
-        create_raw_memo(f)
+        create_owning_memo(f)
     }
 }
 

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -1191,12 +1191,12 @@ impl RuntimeId {
 
     #[track_caller]
     #[inline(always)]
-    pub(crate) fn create_memo<T>(
+    pub(crate) fn create_raw_memo<T>(
         self,
-        f: impl Fn(Option<&T>) -> T + 'static,
+        f: impl Fn(Option<T>) -> (T, bool) + 'static,
     ) -> Memo<T>
     where
-        T: PartialEq + Any + 'static,
+        T: 'static,
     {
         Memo {
             id: self.create_concrete_memo(

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -1191,7 +1191,7 @@ impl RuntimeId {
 
     #[track_caller]
     #[inline(always)]
-    pub(crate) fn create_raw_memo<T>(
+    pub(crate) fn create_owning_memo<T>(
         self,
         f: impl Fn(Option<T>) -> (T, bool) + 'static,
     ) -> Memo<T>

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -212,3 +212,61 @@ fn dynamic_dependencies() {
 
     runtime.dispose();
 }
+
+#[test]
+fn raw_memo_slice() {
+    use std::rc::Rc;
+    let runtime = create_runtime();
+
+    // this could be serialized to and from localstorage with miniserde
+    pub struct State {
+        token: String,
+        dark_mode: bool,
+    }
+
+    let state = create_rw_signal(State {
+        token: "".into(),
+        // this would cause flickering on reload,
+        // use a cookie for the initial value in real projects
+        dark_mode: false,
+    });
+
+    let token = create_raw_memo(move |old_token| {
+        state.with(move |state| {
+            if let Some(token) = old_token.filter(|old_token| old_token == &state.token) {
+                (token, false)
+            } else {
+                (state.token.clone(), true)
+            }
+        })
+    });
+    let set_token =
+        move |new_token| state.update(|state| state.token = new_token);
+
+    let (_, set_dark_mode) = create_slice(
+        state,
+        |state| state.dark_mode,
+        |state, value| state.dark_mode = value,
+    );
+
+    let count_token_updates = Rc::new(std::cell::Cell::new(0));
+
+    assert_eq!(count_token_updates.get(), 0);
+    create_isomorphic_effect({
+        let count_token_updates = Rc::clone(&count_token_updates);
+        move |_| {
+            token.track();
+            count_token_updates.set(count_token_updates.get() + 1);
+        }
+    });
+    assert_eq!(count_token_updates.get(), 1);
+    set_token("this is not a token!".into());
+    // token was updated with the new token
+    token.with(|token| assert_eq!(token, "this is not a token!"));
+    assert_eq!(count_token_updates.get(), 2);
+    set_dark_mode.set(true);
+    // since token didn't change, there was also no update emitted
+    assert_eq!(count_token_updates.get(), 2);
+
+    runtime.dispose();
+}

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -229,7 +229,7 @@ fn owning_memo_slice() {
         token: "is this a token????".to_owned(),
     });
 
-    // We can allocate only when the value actually changes
+    // We can allocate only when `state.name` changes
     let name = create_owning_memo(move |old_name| {
         state.with(move |state| {
             if let Some(name) =
@@ -243,8 +243,8 @@ fn owning_memo_slice() {
     });
     let set_name = move |name| state.update(|state| state.name = name);
 
-    // We can also re-use the last token allocation, which is a better if the token has always the
-    // same length
+    // We can also re-use the last token allocation, which may be even better if the tokens are
+    // always of the same length
     let token = create_owning_memo(move |old_token| {
         state.with(move |state| {
             let is_different = old_token.as_ref() != Some(&state.token);

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -214,7 +214,7 @@ fn dynamic_dependencies() {
 }
 
 #[test]
-fn raw_memo_slice() {
+fn owning_memo_slice() {
     use std::rc::Rc;
     let runtime = create_runtime();
 
@@ -231,7 +231,7 @@ fn raw_memo_slice() {
         dark_mode: false,
     });
 
-    let token = create_raw_memo(move |old_token| {
+    let token = create_owning_memo(move |old_token| {
         state.with(move |state| {
             if let Some(token) =
                 old_token.filter(|old_token| old_token == &state.token)

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -233,7 +233,9 @@ fn raw_memo_slice() {
 
     let token = create_raw_memo(move |old_token| {
         state.with(move |state| {
-            if let Some(token) = old_token.filter(|old_token| old_token == &state.token) {
+            if let Some(token) =
+                old_token.filter(|old_token| old_token == &state.token)
+            {
                 (token, false)
             } else {
                 (state.token.clone(), true)


### PR DESCRIPTION
Currently the memo function:
- Only receives a reference to the previous value when running
- Is required to return an owned value, even if it didn't change

This means that:
- The returned type needs to be allocated and copied one time per source signal change, something that may be very common for slices

This PR implements a Proof Of Concept proposing a new, more primitive, "raw memo", that allows the memo function to receive the previous value as owned, allowing it to be re-used by the memo, like effects (in fact, part of the implementation was taken from there).

"Normal" memos were changed to be implemented by using the raw memo, so there's no need to create a new reactive node. It should be backwards compatible. I haven't checked if there's any performance / binary size impact (benchmarks seems to be broken).

Unfortunately, I don't think the `create_slice` functions can take advantage of the raw memos with their current signature, but the `slice!` macro should be able to.

Related discussion: https://github.com/leptos-rs/leptos/discussions/1034#discussioncomment-5898913

# Main use-case: slices

The most prominent use-case is for slices[1][2][3], which can then be implemented to only clone if the value has changed. In [1], being forced to clone on every "source signal" change is actually noted as a major drawback. ([1](https://book.leptos.dev/15_global_state.html#option-3-create-a-global-state-struct-and-slices) [2](https://book.leptos.dev/view/04b_iteration.html#option-3-memoized-slices) [3](https://docs.rs/leptos/latest/leptos/macro.slice.html))

You can use to only clone when the value has changed:

```rust
let token = create_raw_memo(move |old_token| {
    state.with(move |state| {
        if let Some(token) = old_token.filter(|old_token| old_token == &state.token) {
            (token, false)
        } else {
            (state.token.clone(), true)
        }
    })
});
```

You can even re-use the allocation:

```rust
let token = create_raw_memo(move |old_token| {
    state.with(move |state| {
        let is_different = old_token.as_ref() != Some(&state.token);
        let mut token = old_token.unwrap_or_else(String::new);

        if is_different {
            token.clone_from(&state.token);
        }
        (token, is_different)
    })
});
```
