### PR TITLE
Cleanup some dead code in actix tailwind example

### DIFF
--- a/examples/tailwind_actix/src/main.rs
+++ b/examples/tailwind_actix/src/main.rs
@@ -9,11 +9,6 @@ cfg_if! {
         use crate::app::*;
         use leptos_actix::{generate_route_list, LeptosRoutes};
 
-        #[get("/style.css")]
-        async fn css() -> impl Responder {
-            actix_files::NamedFile::open_async("./style/output.css").await
-        }
-
         #[actix_web::main]
         async fn main() -> std::io::Result<()> {
 
@@ -30,7 +25,6 @@ cfg_if! {
                 let site_root = &leptos_options.site_root;
                 let routes = &routes;
                 App::new()
-                    .service(css)
                     .leptos_routes(leptos_options.to_owned(), routes.to_owned(), || view! { <App/> })
                     .service(Files::new("/", site_root))
                     .wrap(middleware::Compress::default())


### PR DESCRIPTION
The output.css file the actix service in the example references was removed here: https://github.com/leptos-rs/leptos/commit/2798dc455fc44118e0e1f1dd34c169c45184ff83

This was causing confusion for new people looking at the example: https://discord.com/channels/1031524867910148188/1192511724570546197/1192511724570546197

This PR simply removes the unused output.css service/endpoint from the actix tailwind example. The example works without it.