### PR TITLE
router: Retain trailing slashes in paths

### DIFF
--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -636,7 +636,10 @@ fn create_routes(
     }
     let mut acc = Vec::new();
     for original_path in expand_optionals(&route_def.path) {
-        let path = join_paths(base, &original_path);
+        // compat: trim_end_matches ensures that routes with trailing slash still match ones with no trailing slash
+        let path = join_paths(base, &original_path)
+            .trim_end_matches('/')
+            .to_string();
         let pattern = if is_leaf {
             path
         } else {

--- a/router/src/matching/resolve_path.rs
+++ b/router/src/matching/resolve_path.rs
@@ -51,7 +51,14 @@ fn has_scheme(path: &str) -> bool {
 
 #[doc(hidden)]
 fn normalize(path: &str, omit_slash: bool) -> Cow<'_, str> {
-    let s = path.trim_start_matches('/').trim_end_matches('/');
+    let s = path.trim_start_matches('/');
+    let trim_end = s
+        .chars()
+        .rev()
+        .take_while(|c| *c == '/')
+        .count()
+        .saturating_sub(1);
+    let s = &s[0..s.len() - trim_end];
     if s.is_empty() || omit_slash || begins_with_query_or_hash(s) {
         s.into()
     } else {
@@ -70,9 +77,10 @@ fn begins_with_query_or_hash(text: &str) -> bool {
 }
 
 fn remove_wildcard(text: &str) -> String {
-    text.split_once('*')
-        .map(|(prefix, _)| prefix.trim_end_matches('/'))
+    text.rsplit_once('*')
+        .map(|(prefix, _)| prefix)
         .unwrap_or(text)
+        .trim_end_matches('/')
         .to_string()
 }
 
@@ -82,5 +90,15 @@ mod tests {
     #[test]
     fn normalize_query_string_with_opening_slash() {
         assert_eq!(normalize("/?foo=bar", false), "?foo=bar");
+    }
+
+    #[test]
+    fn normalize_retain_trailing_slash() {
+        assert_eq!(normalize("foo/bar/", false), "/foo/bar/");
+    }
+
+    #[test]
+    fn normalize_dedup_trailing_slashes() {
+        assert_eq!(normalize("foo/bar/////", false), "/foo/bar/");
     }
 }


### PR DESCRIPTION
This addresses client-side part of #2154 leaving path matching trailing slash insensitive (to be compatible with current behavior). For example `/*path/` would still match both `foo` and `foo/`. But when clicking on a link `foo/`, trailing slash would be retained.

I think it's sensible to keep matching compatible until server-side for this is figured out.

Since path resolution implementation in router is copied from solidjs router and that one retains trailing slashes, I just fixed regexp recreations in rust code to fully match ones from solidjs router:
https://github.com/solidjs/solid-router/blob/main/src/utils.ts#L5:
```js
const trimPathRegex = /^\/+|(\/)\/+$/g;
//
export function normalizePath(path: string, omitSlash: boolean = false) {
  const s = path.replace(trimPathRegex, "$1");
  //
}
```
(note that trailing slash is retained (match group `$1`) but excessive trailing slashes are trimmed)
https://github.com/solidjs/solid-router/blob/main/src/utils.ts#L37:
```js
export function joinPaths(from: string, to: string): string {
  return normalizePath(from).replace(/\/*(\*.*)?$/g, "") + normalizePath(to);
}
```
(matches wildcard pattern optionally from right and removes it along with all trailing slashes in `from` path)

