### PR TITLE
router: Fix router forgetting about state (fixes #2164)

### DIFF
--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -37,13 +37,19 @@ pub struct BrowserIntegration {}
 impl BrowserIntegration {
     fn current() -> LocationChange {
         let loc = leptos_dom::helpers::location();
+        let state = window()
+            .history()
+            .and_then(|h| h.state())
+            .ok()
+            .and_then(|s| (!s.is_null()).then_some(s));
+
         LocationChange {
             value: loc.pathname().unwrap_or_default()
                 + loc.search().unwrap_or_default().as_str()
                 + loc.hash().unwrap_or_default().as_str(),
             replace: true,
             scroll: true,
-            state: State(window().history().and_then(|h| h.state()).ok()),
+            state: State(state),
         }
     }
 }

--- a/router/src/history/mod.rs
+++ b/router/src/history/mod.rs
@@ -43,7 +43,7 @@ impl BrowserIntegration {
                 + loc.hash().unwrap_or_default().as_str(),
             replace: true,
             scroll: true,
-            state: State(None),
+            state: State(window().history().and_then(|h| h.state()).ok()),
         }
     }
 }

--- a/router/src/history/state.rs
+++ b/router/src/history/state.rs
@@ -7,7 +7,7 @@ impl State {
     pub fn to_js_value(&self) -> JsValue {
         match &self.0 {
             Some(v) => v.clone(),
-            None => JsValue::UNDEFINED,
+            None => JsValue::NULL,
         }
     }
 }


### PR DESCRIPTION
I am pulling the "State" field in a similar manner to the other location fields within `BrowserIntegration::current()`. I also changed the State serialization for `None` from `UNDEFINED` to `NULL` as the latter is the default in browsers and should be more consistent. I am not sure what the reason was to originally use `undefined` and `State(None)`.