### PR TITLE
chore: minimize features activated with `leptos_axum`'s default feature (#1846)

### DIFF
--- a/examples/ssr_modes_axum/Cargo.toml
+++ b/examples/ssr_modes_axum/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1"
 axum = { version = "0.7", optional = true }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
-tokio = { version = "1", features = ["time"], optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"], optional = true }
 wasm-bindgen = "0.2"
 
 [features]

--- a/examples/tailwind_axum/Cargo.toml
+++ b/examples/tailwind_axum/Cargo.toml
@@ -16,7 +16,7 @@ leptos_axum = { path = "../../integrations/axum", optional = true }
 leptos_router = { path = "../../router", features = ["nightly"] }
 log = "0.4.17"
 simple_logger = "4"
-tokio = { version = "1", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
 wasm-bindgen = "0.2"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -34,5 +34,5 @@ tokio = { version = "1", features = ["net"] }
 [features]
 nonce = ["leptos/nonce"]
 wasm = []
-default = ["tokio/full", "axum/macros"]
+default = ["tokio/fs", "tokio/sync"]
 experimental-islands = ["leptos_integration_utils/experimental-islands"]


### PR DESCRIPTION
- `leptos_axum` default feature:
  - remove `tokio/full`, `axum/macros`
  - add `tokio/fs`, `tokio/sync`
- example `leptos-tailwind-axum`:
  - enable `tokio`'s `rt-multi-thread` and `macros` features
- example `ssr_modes_axum`:
  - enable `tokio`'s `rt-multi-thread` and `macros` features