### PR TITLE
fix: `.refetch()` should not include any tracked reads

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -2,6 +2,8 @@
 #![forbid(unsafe_code)]
 // to prevent warnings from popping up when a nightly feature is stabilized
 #![allow(stable_features)]
+// FIXME? every use of quote! {} is warning here -- false positive?
+#![allow(private_macro_use)]
 
 #[macro_use]
 extern crate proc_macro_error;

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -3,6 +3,7 @@
 // to prevent warnings from popping up when a nightly feature is stabilized
 #![allow(stable_features)]
 // FIXME? every use of quote! {} is warning here -- false positive?
+#![allow(unknown_lints)]
 #![allow(private_macro_use)]
 
 #[macro_use]

--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -357,7 +357,12 @@ impl<T> SignalWithUntracked for Memo<T> {
     #[inline]
     fn try_with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> Option<O> {
         with_runtime(|runtime| {
-            self.id.try_with_no_subscription(runtime, |v: &T| f(v)).ok()
+            self.id
+                .try_with_no_subscription(runtime, |v: &Option<T>| {
+                    v.as_ref().map(f)
+                })
+                .ok()
+                .flatten()
         })
         .ok()
         .flatten()

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -8,8 +8,8 @@ use crate::{
     signal_prelude::format_signal_warning, spawn::spawn_local,
     suspense::LocalStatus, use_context, GlobalSuspenseContext, Memo,
     ReadSignal, ScopeProperty, Signal, SignalDispose, SignalGet,
-    SignalGetUntracked, SignalSet, SignalUpdate, SignalWith, SuspenseContext,
-    WriteSignal,
+    SignalGetUntracked, SignalSet, SignalUpdate, SignalWith,
+    SignalWithUntracked, SuspenseContext, WriteSignal,
 };
 use std::{
     any::Any,
@@ -1358,7 +1358,7 @@ where
         self.version.set(version);
         self.scheduled.set(false);
 
-        _ = self.source.try_with(|source| {
+        _ = self.source.try_with_untracked(|source| {
             let fut = (self.fetcher)(source.clone());
 
             // `scheduled` is true for the rest of this code only

--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -244,6 +244,7 @@ where
     create_isomorphic_effect({
         let r = Rc::clone(&r);
         move |_| {
+            source.track();
             load_resource(id, r.clone());
         }
     });


### PR DESCRIPTION
`.refetch()` inadvertently took a tracked read on the source memo, which meant that if you refetched inside an effect, it would refetch again if the source changed, which is probably not intended.