### PR TITLE
chore: define `edtion = "2021"` in `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 imports_granularity = "Crate"
 max_width = 80
 format_strings = true


### PR DESCRIPTION
See [leptosfmt](https://github.com/bram209/leptosfmt?tab=readme-ov-file#using-with-rust-analyzer) for why this may be needed.

TLDR: when rustfmt is hooked by leptosfmt, you need to specify an edition explicitly.