### PR TITLE
fix: serialization error during SSR on ServerFnError

### DIFF
--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -281,7 +281,7 @@ impl Runtime {
                     let source_map = self.node_sources.borrow();
                     for effect in subs.borrow().iter() {
                         if let Some(effect_sources) = source_map.get(*effect) {
-                            effect_sources.borrow_mut().remove(&node);
+                            effect_sources.borrow_mut().swap_remove(&node);
                         }
                     }
                 }
@@ -308,7 +308,7 @@ impl Runtime {
             let subs = self.node_subscribers.borrow();
             for source in sources.borrow().iter() {
                 if let Some(source) = subs.get(*source) {
-                    source.borrow_mut().remove(&node_id);
+                    source.borrow_mut().swap_remove(&node_id);
                 }
             }
         }

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -158,7 +158,7 @@ impl MetaTagsContext {
                     move || {
                         let head = document().head().unwrap_throw();
                         _ = head.remove_child(&el);
-                        els.borrow_mut().remove(&id);
+                        els.borrow_mut().swap_remove(&id);
                     }
                 });
 

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -175,7 +175,6 @@ impl<E> ViaError<E> for WrapError<E> {
 /// This means that other error types can easily be converted into it using the
 /// `?` operator.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub enum ServerFnError<E = NoCustomError> {
     /// A user-defined custom error type, which defaults to [`NoCustomError`].
     WrappedServerError(E),


### PR DESCRIPTION
Having the tag on `ServerFnError` types here caused a runtime panic during SSR if a resource had an initial `Err` value:
```
could not serialize Resource: Serialize(Error("cannot serialize tagged newtype variant ServerFnError::ServerError containing a string", line: 0, column: 0))
```