### PR TITLE
fix: error rather than panicking if unable to send response in Axum integration

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -332,7 +332,9 @@ async fn handle_server_fns_inner(
     rx.await.unwrap_or_else(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            ServerFnError::<NoCustomError>::ServerError(e.to_string()).ser(),
+            ServerFnError::<NoCustomError>::ServerError(e.to_string())
+                .ser()
+                .unwrap_or_default(),
         )
             .into_response()
     })

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -54,7 +54,7 @@ use leptos_meta::{generate_head_metadata_separated, MetaContext};
 use leptos_router::*;
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
-use server_fn::redirect::REDIRECT_HEADER;
+use server_fn::{error::NoCustomError, redirect::REDIRECT_HEADER};
 use std::{fmt::Debug, io, pin::Pin, sync::Arc, thread::available_parallelism};
 use tokio_util::task::LocalPoolHandle;
 use tracing::Instrument;
@@ -329,7 +329,13 @@ async fn handle_server_fns_inner(
         _ = tx.send(res);
     });
 
-    rx.await.unwrap()
+    rx.await.unwrap_or_else(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ServerFnError::<NoCustomError>::ServerError(e.to_string()).ser(),
+        )
+            .into_response()
+    })
 }
 
 pub type PinnedHtmlStream =


### PR DESCRIPTION
Because of the awkward setup of spawning into a pinned thread, the Axum integration tries to send its response through a channel (due to the weird Send/Sync workaround currently in place) and unwraps awaiting the receiver
https://github.com/leptos-rs/leptos/blob/0ff1e279a2774730ab01f28d2c794217de35a19d/integrations/axum/src/lib.rs#L332

Panicking here (or anywhere in these handlers) is a bad idea, and can cause difficult-to-reproduce issues.

I'm wondering if replacing all these with something like this might be a good idea.
