### PR TITLE
Added missing doc comment and changed the type for as_query() 

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -28,7 +28,7 @@
 //! ## Example
 //!
 //! ```rust
-//! 
+//!
 //! use leptos::*;
 //! use leptos_router::*;
 //!

--- a/server_fn/src/codec/url.rs
+++ b/server_fn/src/codec/url.rs
@@ -40,7 +40,7 @@ where
 {
     async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
         let string_data = req.as_query().unwrap_or_default();
-        let args = serde_qs::from_str::<Self>(string_data)
+        let args = serde_qs::from_str::<Self>(&string_data)
             .map_err(|e| ServerFnError::Args(e.to_string()))?;
         Ok(args)
     }

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -441,6 +441,7 @@ impl<Req, Res> Clone for ServerFnTraitObj<Req, Res> {
 }
 
 #[allow(unused)] // used by server integrations
+/// A neat little type that stores our trait representations of your server functions
 type LazyServerFnMap<Req, Res> =
     Lazy<DashMap<&'static str, ServerFnTraitObj<Req, Res>>>;
 

--- a/server_fn/src/request/actix.rs
+++ b/server_fn/src/request/actix.rs
@@ -37,8 +37,8 @@ impl<CustErr> Req<CustErr> for ActixRequest
 where
     CustErr: 'static,
 {
-    fn as_query(&self) -> Option<&str> {
-        self.0 .0.uri().query()
+    fn as_query(&self) -> Option<Cow<'_, str>> {
+        self.0 .0.uri().query().map(|q| q.into())
     }
 
     fn to_content_type(&self) -> Option<Cow<'_, str>> {

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -12,8 +12,8 @@ impl<CustErr> Req<CustErr> for Request<Body>
 where
     CustErr: 'static,
 {
-    fn as_query(&self) -> Option<&str> {
-        self.uri().query()
+    fn as_query(&self) -> Option<Cow<'_, str>> {
+        self.uri().query().map(|q| q.into())
     }
 
     fn to_content_type(&self) -> Option<Cow<'_, str>> {

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -78,7 +78,7 @@ where
     Self: Sized,
 {
     /// Returns the query string of the request’s URL, starting after the `?`.
-    fn as_query(&self) -> Option<&str>;
+    fn as_query(&self) -> Option<Cow<'_, str>>;
 
     /// Returns the `Content-Type` header, if any.
     fn to_content_type(&self) -> Option<Cow<'_, str>>;
@@ -116,7 +116,7 @@ impl<CustErr> Req<CustErr> for BrowserMockReq
 where
     CustErr: 'static,
 {
-    fn as_query(&self) -> Option<&str> {
+    fn as_query(&self) -> Option<Cow<'_, str>> {
         unreachable!()
     }
 

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -59,15 +59,14 @@ pub fn server_macro_impl(
         .inputs
         .iter_mut()
         .map(|f| {
-            let typed_arg = match f {
-                FnArg::Receiver(_) => {
-                    return Err(syn::Error::new(
+            let typed_arg =
+                match f {
+                    FnArg::Receiver(_) => return Err(syn::Error::new(
                         f.span(),
                         "cannot use receiver types in server function macro",
-                    ))
-                }
-                FnArg::Typed(t) => t,
-            };
+                    )),
+                    FnArg::Typed(t) => t,
+                };
 
             // strip `mut`, which is allowed in fn args but not in struct fields
             if let Pat::Ident(ident) = &mut *typed_arg.pat {


### PR DESCRIPTION
as_query() is unimplementable since it returns Option<&str> and not everyone has a way to get a &str of the Headers, so I transformed it into a Cow<'_, str> like all the other methods