### PR TITLE
fix: make directive `.into()` calls consistent

### DIFF
--- a/examples/directives/src/lib.rs
+++ b/examples/directives/src/lib.rs
@@ -1,5 +1,6 @@
 use leptos::{ev::click, html::AnyElement, *};
 
+// no extra parameter
 pub fn highlight(el: HtmlElement<AnyElement>) {
     let mut highlighted = false;
 
@@ -14,6 +15,7 @@ pub fn highlight(el: HtmlElement<AnyElement>) {
     });
 }
 
+// one extra parameter
 pub fn copy_to_clipboard(el: HtmlElement<AnyElement>, content: &str) {
     let content = content.to_string();
 
@@ -31,6 +33,35 @@ pub fn copy_to_clipboard(el: HtmlElement<AnyElement>, content: &str) {
     });
 }
 
+// custom parameter
+
+#[derive(Clone)]
+pub struct Amount(usize);
+
+impl From<usize> for Amount {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+// a 'default' value if no value is passed in
+impl From<()> for Amount {
+    fn from(_: ()) -> Self {
+        Self(1)
+    }
+}
+
+// .into() will automatically be called on the parameter
+pub fn add_dot(el: HtmlElement<AnyElement>, amount: Amount) {
+    _ = el.clone().on(click, move |_| {
+        el.set_inner_text(&format!(
+            "{}{}",
+            el.inner_text(),
+            ".".repeat(amount.0)
+        ))
+    })
+}
+
 #[component]
 pub fn SomeComponent() -> impl IntoView {
     view! {
@@ -46,6 +77,11 @@ pub fn App() -> impl IntoView {
 
     view! {
         <a href="#" use:copy_to_clipboard=data>"Copy \"" {data} "\" to clipboard"</a>
+        // automatically applies the directive to every root element in `SomeComponent`
         <SomeComponent use:highlight />
+        // no value will default to `().into()`
+        <button use:add_dot>"Add a dot"</button>
+        // `5.into()` automatically called
+        <button use:add_dot=5>"Add 5 dots"</button>
     }
 }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -1,7 +1,7 @@
 use crate::{attribute_value, Mode};
 use convert_case::{Case::Snake, Casing};
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use quote::{format_ident, quote, quote_spanned};
+use quote::{quote, quote_spanned};
 use rstml::node::{KeyedAttribute, Node, NodeElement, NodeName};
 use syn::{spanned::Spanned, Expr, Expr::Tuple, ExprLit, ExprPath, Lit};
 
@@ -534,12 +534,12 @@ pub(crate) fn directive_call_from_attribute_node(
     attr: &KeyedAttribute,
     directive_name: &str,
 ) -> TokenStream {
-    let handler = format_ident!("{directive_name}", span = attr.key.span());
+    let handler = syn::Ident::new(directive_name, attr.key.span());
 
     let param = if let Some(value) = attr.value() {
-        quote! { #value.into() }
+        quote! { ::std::convert::Into::into(#value) }
     } else {
-        quote! { () }
+        quote! { ().into() }
     };
 
     quote! { .directive(#handler, #param) }


### PR DESCRIPTION
fixes #2248 

added to the directive examples as well.