### PR TITLE
Percent Decode Url Parameters

### DIFF
--- a/router/src/history/params.rs
+++ b/router/src/history/params.rs
@@ -30,6 +30,8 @@ impl ParamsMap {
     /// Inserts a value into the map.
     #[inline(always)]
     pub fn insert(&mut self, key: String, value: String) -> Option<String> {
+        use crate::history::url::unescape;
+        let value = unescape(&value);
         self.0.insert(key, value)
     }
 
@@ -76,12 +78,14 @@ impl Default for ParamsMap {
 ///
 /// ```
 /// # use leptos_router::params_map;
+/// # #[cfg(feature = "ssr")] {
 /// let map = params_map! {
 ///     "crate" => "leptos",
 ///     42 => true, // where key & val: core::fmt::Display
 /// };
 /// assert_eq!(map.get("crate"), Some(&"leptos".to_string()));
 /// assert_eq!(map.get("42"), Some(&true.to_string()))
+/// # }
 /// ```
 // Original implementation included the below credits.
 //

--- a/router/src/history/url.rs
+++ b/router/src/history/url.rs
@@ -15,6 +15,14 @@ pub struct Url {
     pub hash: String,
 }
 
+#[cfg(feature = "ssr")]
+pub fn unescape(s: &str) -> String {
+    percent_encoding::percent_decode_str(s)
+        .decode_utf8()
+        .unwrap()
+        .to_string()
+}
+
 #[cfg(not(feature = "ssr"))]
 pub fn unescape(s: &str) -> String {
     js_sys::decode_uri(s).unwrap().into()

--- a/router/tests/matcher.rs
+++ b/router/tests/matcher.rs
@@ -43,6 +43,21 @@ cfg_if! {
         }
 
         #[test]
+        fn create_matcher_should_build_params_collection_and_decode() {
+            let matcher = Matcher::new("/foo/:id");
+            let matched = matcher.test("/foo/%E2%89%A1abc%20123");
+            assert_eq!(
+                matched,
+                Some(PathMatch {
+                    path: "/foo/%E2%89%A1abc%20123".into(),
+                    params: params_map!(
+                        "id" => "≡abc 123"
+                    )
+                })
+            );
+        }
+
+        #[test]
         fn create_matcher_should_match_past_end_when_ending_in_asterisk() {
             let matcher = Matcher::new("/foo/bar/*");
             let matched = matcher.test("/foo/bar/baz");


### PR DESCRIPTION
In my application I have some routes with parameters that can be user defined and often include spaces. This means that there usually is a %20 instead of a space in the parameter which is unexpected from a dev perspective. This makes sure that when building the parameter map we percent decode the parameter.

This breaks a doc test and I have a proposed fix for it since it now requires the "ssr" feature to work. The test now only runs when the ssr feature is enabled.