### PR TITLE
Create an axum-no-default feature for server_fn and sets leptos_axum to rely on it instead.

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -14,7 +14,7 @@ axum = { version = "0.7", default-features = false, features = [
 futures = "0.3"
 http-body-util = "0.1"
 leptos = { workspace = true, features = ["ssr"] }
-server_fn = { workspace = true, features = ["axum"] }
+server_fn = { workspace = true, features = ["axum-no-default"] }
 leptos_macro = { workspace = true, features = ["axum"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = "1"
 actix-web = { version = "4", optional = true }
 
 # axum
-axum = { version = "0.7", optional = true, features = ["multipart"] }
+axum = { version = "0.7", optional = true, default-features = false, features = ["multipart"] }
 tower = { version = "0.4", optional = true }
 tower-layer = { version = "0.3", optional = true }
 
@@ -75,13 +75,17 @@ url = "2"
 default = ["json", "cbor"]
 form-redirects = []
 actix = ["ssr", "dep:actix-web", "dep:send_wrapper"]
-axum = [
+axum-no-default = [
   "ssr",
   "dep:axum",
   "dep:hyper",
   "dep:http-body-util",
   "dep:tower",
   "dep:tower-layer",
+]
+axum = [
+  "axum/default",
+  "axum-no-default",
 ]
 browser = [
   "dep:gloo-net",

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -117,7 +117,7 @@ pub mod response;
 #[cfg(feature = "actix")]
 #[doc(hidden)]
 pub use ::actix_web as actix_export;
-#[cfg(feature = "axum")]
+#[cfg(feature = "axum-no-default")]
 #[doc(hidden)]
 pub use ::axum as axum_export;
 use client::Client;
@@ -456,7 +456,7 @@ impl<Req: 'static, Res: 'static> inventory::Collect
 }
 
 /// Axum integration.
-#[cfg(feature = "axum")]
+#[cfg(feature = "axum-no-default")]
 pub mod axum {
     use crate::{
         middleware::{BoxedService, Service},

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -26,7 +26,7 @@ pub trait Service<Request, Response> {
     ) -> Pin<Box<dyn Future<Output = Response> + Send>>;
 }
 
-#[cfg(feature = "axum")]
+#[cfg(feature = "axum-no-default")]
 mod axum {
     use super::{BoxedService, Service};
     use crate::{response::Res, ServerFnError};

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, future::Future};
 #[cfg(feature = "actix")]
 pub mod actix;
 /// Request types for Axum.
-#[cfg(feature = "axum")]
+#[cfg(feature = "axum-no-default")]
 pub mod axum;
 /// Request types for the browser.
 #[cfg(feature = "browser")]

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -5,7 +5,7 @@ pub mod actix;
 #[cfg(feature = "browser")]
 pub mod browser;
 /// Response types for Axum.
-#[cfg(feature = "axum")]
+#[cfg(feature = "axum-no-default")]
 pub mod http;
 /// Response types for [`reqwest`].
 #[cfg(feature = "reqwest")]

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -434,7 +434,7 @@ pub fn server_macro_impl(
         quote! {
             #server_fn_path::request::BrowserMockReq
         }
-    } else if cfg!(feature = "axum") {
+    } else if cfg!(feature = "axum-no-default") {
         quote! {
             #server_fn_path::axum_export::http::Request<#server_fn_path::axum_export::body::Body>
         }
@@ -458,7 +458,7 @@ pub fn server_macro_impl(
         quote! {
             #server_fn_path::response::BrowserMockRes
         }
-    } else if cfg!(feature = "axum") {
+    } else if cfg!(feature = "axum-no-default") {
         quote! {
             #server_fn_path::axum_export::http::Response<#server_fn_path::axum_export::body::Body>
         }


### PR DESCRIPTION
This is required to run an axum leptos server in wasm post 0.6.0. Prior 0.6 server_fn didn't rely on axum and now that it does it needs a no-default version because the default axum is not wasm compatible because it brings in tokio. 

leptos_axum doesn't require server_fn to have axum default features so I set it to rely on the new no-default-feature version of server_fn. 

I don't think server_fn requires axum to have default features at all, so instead of adding a no-default feature flag we could just set no-default feature for axum to be the default feature set of server_fn.

This fixes

https://github.com/leptos-community/deployment-deno/pull/2

