### PR TITLE
fix(ci): address clippy issue

### DIFF
--- a/.github/workflows/ci-changed-examples.yml
+++ b/.github/workflows/ci-changed-examples.yml
@@ -29,4 +29,4 @@ jobs:
     with:
       directory: ${{ matrix.directory }}
       cargo_make_task: "ci"
-      toolchain: nightly
+      toolchain: nightly-2024-01-29

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -24,4 +24,4 @@ jobs:
     with:
       directory: ${{ matrix.directory }}
       cargo_make_task: "ci"
-      toolchain: nightly
+      toolchain: nightly-2024-01-29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
     with:
       directory: ${{ matrix.directory }}
       cargo_make_task: "ci"
-      toolchain: nightly
+      toolchain: nightly-2024-01-29

--- a/cargo-make/check.toml
+++ b/cargo-make/check.toml
@@ -3,5 +3,5 @@ alias = "check-all"
 
 [tasks.check-all]
 command = "cargo"
-args = ["+nightly", "check-all-features"]
+args = ["+nightly-2024-01-29", "check-all-features"]
 install_crate = "cargo-all-features"

--- a/cargo-make/test.toml
+++ b/cargo-make/test.toml
@@ -3,5 +3,5 @@ alias = "test-all"
 
 [tasks.test-all]
 command = "cargo"
-args = ["+nightly", "test-all-features"]
+args = ["+nightly-2024-01-29", "test-all-features"]
 install_crate = "cargo-all-features"

--- a/examples/cargo-make/cargo-leptos.toml
+++ b/examples/cargo-make/cargo-leptos.toml
@@ -15,13 +15,13 @@ clear = true
 dependencies = ["check-debug", "check-release"]
 
 [tasks.check-debug]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["check-all-features"]
 install_crate = "cargo-all-features"
 
 [tasks.check-release]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["check-all-features", "--release"]
 install_crate = "cargo-all-features"

--- a/examples/cargo-make/compile.toml
+++ b/examples/cargo-make/compile.toml
@@ -1,11 +1,11 @@
 [tasks.build]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["build-all-features"]
 install_crate = "cargo-all-features"
 
 [tasks.check]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["check-all-features"]
 install_crate = "cargo-all-features"

--- a/examples/cargo-make/lint.toml
+++ b/examples/cargo-make/lint.toml
@@ -1,5 +1,5 @@
 [tasks.pre-clippy]
-env = { CARGO_MAKE_CLIPPY_ARGS = "--all-targets --all-features -- -D warnings" }
+env = { CARGO_MAKE_CLIPPY_ARGS = "--no-deps --all-targets --all-features -- -D warnings" }
 
 [tasks.check-style]
 dependencies = ["check-format-flow", "clippy-flow"]

--- a/examples/counter/rust-toolchain.toml
+++ b/examples/counter/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/counter_url_query/rust-toolchain.toml
+++ b/examples/counter_url_query/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/counters/rust-toolchain.toml
+++ b/examples/counters/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/directives/rust-toolchain.toml
+++ b/examples/directives/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/error_boundary/rust-toolchain.toml
+++ b/examples/error_boundary/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/errors_axum/rust-toolchain.toml
+++ b/examples/errors_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/fetch/rust-toolchain.toml
+++ b/examples/fetch/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/hackernews/rust-toolchain.toml
+++ b/examples/hackernews/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/hackernews_axum/rust-toolchain.toml
+++ b/examples/hackernews_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/hackernews_islands_axum/rust-toolchain.toml
+++ b/examples/hackernews_islands_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/js-framework-benchmark/Makefile.toml
+++ b/examples/js-framework-benchmark/Makefile.toml
@@ -5,13 +5,13 @@ extend = [
 ]
 
 [tasks.build]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["build-all-features", "--target", "wasm32-unknown-unknown"]
 install_crate = "cargo-all-features"
 
 [tasks.check]
-toolchain = "nightly"
+toolchain = "nightly-2024-01-29"
 command = "cargo"
 args = ["check-all-features", "--target", "wasm32-unknown-unknown"]
 install_crate = "cargo-all-features"

--- a/examples/js-framework-benchmark/rust-toolchain.toml
+++ b/examples/js-framework-benchmark/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/parent_child/rust-toolchain.toml
+++ b/examples/parent_child/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/portal/rust-toolchain.toml
+++ b/examples/portal/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/router/rust-toolchain.toml
+++ b/examples/router/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/server_fns_axum/rust-toolchain.toml
+++ b/examples/server_fns_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/session_auth_axum/rust-toolchain.toml
+++ b/examples/session_auth_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/slots/rust-toolchain.toml
+++ b/examples/slots/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/ssr_modes/rust-toolchain.toml
+++ b/examples/ssr_modes/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/ssr_modes_axum/rust-toolchain.toml
+++ b/examples/ssr_modes_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/tailwind_actix/rust-toolchain.toml
+++ b/examples/tailwind_actix/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/tailwind_axum/rust-toolchain.toml
+++ b/examples/tailwind_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/tailwind_csr/rust-toolchain.toml
+++ b/examples/tailwind_csr/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/timer/rust-toolchain.toml
+++ b/examples/timer/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/todo_app_sqlite/rust-toolchain.toml
+++ b/examples/todo_app_sqlite/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/todo_app_sqlite_axum/rust-toolchain.toml
+++ b/examples/todo_app_sqlite_axum/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/todo_app_sqlite_csr/rust-toolchain.toml
+++ b/examples/todo_app_sqlite_csr/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/examples/todomvc/rust-toolchain.toml
+++ b/examples/todomvc/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-01-29"

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -206,3 +206,5 @@ fn ssr_option() {
 
     runtime.dispose();
 }
+
+// TODO: remove simulated change

--- a/leptos_macro/Makefile.toml
+++ b/leptos_macro/Makefile.toml
@@ -11,13 +11,13 @@ dependencies = [
 [tasks.test-leptos_macro-example]
 description = "Tests the leptos_macro/example to check if macro handles doc comments correctly"
 command = "cargo"
-args = ["+nightly", "test", "--doc"]
+args = ["+nightly-2024-01-29", "test", "--doc"]
 cwd = "example"
 install_crate = false
 
 [tasks.doc-leptos_macro-example]
 description = "Docs the leptos_macro/example to check if macro handles doc comments correctly"
 command = "cargo"
-args = ["+nightly", "doc"]
+args = ["+nightly-2024-01-29", "doc"]
 cwd = "example"
 install_crate = false


### PR DESCRIPTION
Addresses #2272

## Changes

- Pin _nightly_ to a version that resolves the clippy issue.
- Do not lint the dependencies of example crates

## Notes

- I have not found a way to skip dependency linting with `cargo hack`
- Pinning _nightly_ also suports the [cargo-semver-checks](https://lib.rs/crates/cargo-semver-checks#readme-what-rust-versions-does-cargo-semver-checks-support) Rust version recommendation.

## Unsuccessful Checks

- **CI / CI (leptos)** - Cancelled

- **CI / CI (leptos_reactive)** - Cancelled

- **CI / CI (server_fn)** - No ci output this time. Ran out of space in the previous run.

- **CI Examples / CI (examples/counter_isomorphic)** -  Compile Error

- **CI Examples / CI (examples/server_fns_axum)** - Compile Error

- **CI Examples / CI (examples/todo_app_sqlite_axum)** - Internal Error in `server_fn`

```
Feature: Delete Todo
  Scenario: Should not see the deleted todo
    > Given I see the app
   ✔> Given I see the app
      Given I add a todo as Buy Yogurt
thread '<unnamed>' panicked at /home/joseph/gh/leptos/server_fn/src/request/mod.rs:128:9:
internal error: entered unreachable code
```

- **CI Examples / CI (examples/todo_app_sqlite_csr)** - Internal Error in `server_fn`

```
Feature: Delete Todo
  Scenario: Should not see the deleted todo
   ✔> Given I see the app
      Given I add a todo as Buy Yogurt
thread '<unnamed>' panicked at /home/joseph/gh/leptos/server_fn/src/request/mod.rs:128:9:
internal error: entered unreachable code
```