### PR TITLE
fix: hydration ID mismatch with nested Suspense

### DIFF
--- a/examples/suspense_tests/src/app.rs
+++ b/examples/suspense_tests/src/app.rs
@@ -98,6 +98,7 @@ pub fn App() -> impl IntoView {
                     </Route>
                 </Routes>
             </main>
+            <footer><p>"Does the footer hydrate correctly?"</p></footer>
         </Router>
     }
 }

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -245,6 +245,7 @@ where
 
     HydrationCtx::continue_from(current_id);
     HydrationCtx::next_component();
+    HydrationCtx::next_component();
 
     leptos_dom::View::Suspense(current_id, core_component)
 }


### PR DESCRIPTION
@nicoburniske This does seem to fix the nested Suspense issue in the reproduction case you shared with me (I think) but it also seems like kind of a stupid solution to me, so I'd appreciate it if you could help test it in your initial use case.