### PR TITLE
ci(examples): configure leptos examples to build with cargo-leptos when possible

### DIFF
--- a/.github/workflows/get-changed-examples-matrix.yml
+++ b/.github/workflows/get-changed-examples-matrix.yml
@@ -32,9 +32,9 @@ jobs:
           dir_names_max_depth: "2"
           files: |
             examples/**
-            !examples/cargo-make
-            !examples/gtk
-            !examples/hackernews_js_fetch
+            !examples/cargo-make/**
+            !examples/gtk/**
+            !examples/hackernews_js_fetch/**
             !examples/Makefile.toml
             !examples/*.md
           json: true

--- a/.github/workflows/get-example-changed.yml
+++ b/.github/workflows/get-example-changed.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           files: |
             examples/**
-            !examples/cargo-make
-            !examples/gtk
+            !examples/cargo-make/**
+            !examples/gtk/**
             !examples/Makefile.toml
             !examples/*.md
 

--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -51,5 +51,5 @@ echo "CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = $examples"
 
 [tasks.test-report]
 workspace = false
-description = "show the cargo-make configuration for web examples"
+description = "show the cargo-make configuration for web examples [web|all|help]"
 script = { file = "./cargo-make/scripts/web-report.sh" }

--- a/examples/cargo-make/scripts/web-report.sh
+++ b/examples/cargo-make/scripts/web-report.sh
@@ -4,7 +4,8 @@ set -emu
 
 BOLD="\e[1m"
 ITALIC="\e[3m"
-YELLOW="\e[0;33m"
+YELLOW="\e[1;33m"
+RED="\e[1;36m"
 RESET="\e[0m"
 
 function web { #task: only include examples with web cargo-make configuration
@@ -46,6 +47,9 @@ function print_crate_tags {
                 ;;
             *"fantoccini"*)
                 crate_tags=$crate_tags"F"
+                ;;
+            *"package.metadata.leptos"*)
+                crate_tags=$crate_tags"M"
                 ;;
             esac
         done <"./Cargo.toml"
@@ -90,11 +94,21 @@ function print_crate_tags {
         local sorted_crate_symbols
         sorted_crate_symbols=$(echo "$crate_tags" | grep -o . | sort | tr -d "\n")
 
+        # Find leptos projects that are not configured to build with cargo-leptos
+        sorted_crate_symbols=${sorted_crate_symbols//"LM"/"L"}
+
         # Maybe print line
         local crate_line=$path
 
         if [ -n "$crate_tags" ]; then
-            crate_line="$crate_line ➤ ${YELLOW}$sorted_crate_symbols${RESET}"
+            local color=$YELLOW
+            case $sorted_crate_symbols in
+            *"M"*)
+                color=$RED
+                ;;
+            esac
+
+            crate_line="$crate_line ➤ ${color}$sorted_crate_symbols${RESET}"
             echo -e "$crate_line"
         elif [ "$#" -gt 0 ]; then
             crate_line="${BOLD}$crate_line${RESET}"
@@ -117,13 +131,14 @@ function print_footer {
     c="${BOLD}${YELLOW}C${RESET} = Cucumber Test Runner"
     d="${BOLD}${YELLOW}F${RESET} = Fantoccini WebDriver"
     l="${BOLD}${YELLOW}L${RESET} = Cargo Leptos"
+    m="${BOLD}${RED}M${RESET} = Cargo Leptos Medata Only (${ITALIC}ci is not configured to build with cargo-leptos${RESET})"
     n="${BOLD}${YELLOW}N${RESET} = Node"
     p="${BOLD}${YELLOW}P${RESET} = Playwright Test"
     t="${BOLD}${YELLOW}T${RESET} = Trunk"
     w="${BOLD}${YELLOW}W${RESET} = WASM Test"
 
     echo
-    echo -e "${ITALIC}Technology Keys:${RESET}\n $c\n $d\n $l\n $n\n $p\n $t\n $w"
+    echo -e "${ITALIC}Report Keys:${RESET}\n $c\n $d\n $l\n $m\n $n\n $p\n $t\n $w"
     echo
 }
 

--- a/examples/hackernews_islands_axum/Makefile.toml
+++ b/examples/hackernews_islands_axum/Makefile.toml
@@ -1,1 +1,8 @@
-extend = [{ path = "../cargo-make/main.toml" }]
+extend = [
+    { path = "../cargo-make/main.toml" },
+    { path = "../cargo-make/cargo-leptos.toml" },
+]
+
+[env]
+
+CLIENT_PROCESS_NAME = "hackernews_islands"


### PR DESCRIPTION
Closes #2293 

## Changes

- Running `cargo make test-report` now shows leptos crates that are not configured to build with `cargo-leptos`
- Add `ci` leptos configuration for **hackernews_islands_axum** example

## Notes

- **hackernews_js_fetch** is intentionally not configured to build with `cargo-leptos`. It uses a custom build.