### PR TITLE
Error type detection only worked without type path

### DIFF
--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -638,7 +638,7 @@ fn err_type(return_ty: &Type) -> Result<Option<&GenericArgument>> {
                 {
                     if let Some(segment) = pat.path.segments.last() {
                         if segment.ident == "ServerFnError" {
-                            let args = &pat.path.segments[0].arguments;
+                            let args = &segment.arguments;
                             match args {
                                 // Result<T, ServerFnError>
                                 PathArguments::None => return Ok(None),


### PR DESCRIPTION
In most cases when you return `Result<..., ServerFnError<E>>` this worked but when you tried `Result<..., leptos::ServerFnError<E>>` then it didn't.