### PR TITLE
fix: set aria-current `<A>` while percent decoding the url

### DIFF
--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -1,4 +1,4 @@
-use crate::{use_location, use_resolved_path, State};
+use crate::{unescape, use_location, use_resolved_path, State};
 use leptos::{leptos_dom::IntoView, *};
 use std::borrow::Cow;
 
@@ -135,10 +135,11 @@ where
                     let path = to
                         .split(['?', '#'])
                         .next()
+                        .map(unescape)
                         .unwrap_or_default()
                         .to_lowercase();
                     location.pathname.with(|loc| {
-                        let loc = loc.to_lowercase();
+                        let loc = unescape(&loc.to_lowercase());
                         if exact {
                             loc == path
                         } else {


### PR DESCRIPTION
I'm not incredibly happy with this solution, nor am I sure this is something worth fixing, but this makes aria-current for `<A>` tags work whether the `href` property is url percent encoded or not.