### PR TITLE
Bumping config to 0.14.

### DIFF
--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -9,7 +9,7 @@ description = "Configuration for the Leptos web framework."
 readme = "../README.md"
 
 [dependencies]
-config = { version = "0.13.3", default-features = false, features = ["toml"] }
+config = { version = "0.14", default-features = false, features = ["toml"] }
 regex = "1.7.0"
 serde = { version = "1.0.151", features = ["derive"] }
 thiserror = "1.0.38"


### PR DESCRIPTION
Removed 7 modules from the list produced by 

```Cargo outdated```

```
leptos_config
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
async-trait    0.1.77   ---     Removed  Normal  ---
config         0.13.4   ---     0.14.0   Normal  ---
proc-macro2    1.0.78   ---     Removed  Normal  ---
quote          1.0.35   ---     Removed  Normal  ---
syn            2.0.48   ---     Removed  Normal  ---
toml           0.5.11   ---     0.8.10   Normal  ---
unicode-ident  1.0.12   ---     Removed  Normal  ---
```
