### PR TITLE
I have been looking the "github actions" build warnings.

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
         name: Install pnpm
         id: pnpm-install
         with:


### PR DESCRIPTION
I think the solution is to bump the version numbers of two actions.

```
CI (leptos_config) / Run ci (nightly-2024-01-29)
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: actions-rs/toolchain@v1, davidB/rust-cargo-make@v1, jetli/trunk-action@v0.4.0, pnpm/action-setup@v2, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```