### PR TITLE
Added missing generics to convert into server_fn Error

### DIFF
--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -54,7 +54,7 @@ where
 }
 
 impl<Err> From<ServerFnError<Err>> for Error {
-    fn from(e: ServerFnError<String>) -> Self {
+    fn from(e: ServerFnError<Err>) -> Self {
         Error(Arc::new(ServerFnErrorErr::from(e)))
     }
 }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -53,8 +53,8 @@ where
     }
 }
 
-impl From<ServerFnError> for Error {
-    fn from(e: ServerFnError) -> Self {
+impl<Err> From<ServerFnError<Err>> for Error {
+    fn from(e: ServerFnError<String>) -> Self {
         Error(Arc::new(ServerFnErrorErr::from(e)))
     }
 }


### PR DESCRIPTION
Without this `IntoView` is not implemented for `Result<View, ServerFnError<String>>` for example.

This is related to https://discord.com/channels/1031524867910148188/1207174766289748048