### PR TITLE
fix(meta): provide meta context missing in example

### DIFF
--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -16,6 +16,9 @@
 //!
 //! #[component]
 //! fn MyApp() -> impl IntoView {
+//!     // Provides a [`MetaContext`], if there is not already one provided.
+//!     provide_meta_context();
+//!
 //!     let (name, set_name) = create_signal("Alice".to_string());
 //!
 //!     view! {


### PR DESCRIPTION
Otherwise user gets:

```
use_head() is being called without a MetaContext being provided. We'll automatically create and provide one, but if this is being called in a child route it may cause bugs. To be safe, you should provide_meta_context() somewhere in the root of the app.
```