### PR TITLE
fix: Transition in hydrate mode that isn't initially created (closes #2279)

### DIFF
--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -155,7 +155,9 @@ fn is_first_run(
     first_run: RwSignal<bool>,
     suspense_context: &SuspenseContext,
 ) -> bool {
-    if cfg!(feature = "csr") {
+    if cfg!(feature = "csr")
+        || (cfg!(feature = "hydrate") && !HydrationCtx::is_hydrating())
+    {
         false
     } else {
         match (


### PR DESCRIPTION
If a Transition is created in hydrate mode, but after hydration, it should be treated the same way a CSR transition is.