### PR TITLE
Fix Broken Doc links and Deprecate `FromUtf8Error` in `oco.rs`

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -203,7 +203,7 @@ pub fn handle_server_fns() -> Route {
 /// context, allowing you to pass in info about the route or user from Actix, or other info.
 ///
 /// **NOTE**: If your server functions expect a context, make sure to provide it both in
-/// [`handle_server_fns_with_context`] **and** in [`leptos_routes_with_context`] (or whatever
+/// [`handle_server_fns_with_context`] **and** in [`LeptosRoutes::leptos_routes_with_context`] (or whatever
 /// rendering method you are using). During SSR, server functions are called by the rendering
 /// method, while subsequent calls from the client are handled by the server function handler.
 /// The same context needs to be provided to both handlers.

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -900,17 +900,17 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// ## Server Function Encodings
 ///
 /// Server functions are designed to allow a flexible combination of `input` and `output` encodings, the set
-/// of which can be found in the [`server_fn::codec`] module.
+/// of which can be found in the [`server_fn::codec`](../server_fn/codec/index.html) module.
 ///
 /// The serialization/deserialization process for server functions consists of a series of steps,
 /// each of which is represented by a different trait:
-/// 1. [`IntoReq`]: The client serializes the [`ServerFn`] argument type into an HTTP request.
-/// 2. The [`Client`] sends the request to the server.
-/// 3. [`FromReq`]: The server deserializes the HTTP request back into the [`ServerFn`] type.
-/// 4. The server calls calls [`ServerFn::run_body`] on the data.
-/// 5. [`IntoRes`]: The server serializes the [`ServerFn::Output`] type into an HTTP response.
-/// 6. The server integration applies any middleware from [`ServerFn::middlewares`] and responds to the request.
-/// 7. [`FromRes`]: The client deserializes the response back into the [`ServerFn::Output`] type.
+/// 1. [`IntoReq`](../server_fn/codec/trait.IntoReq.html): The client serializes the [`ServerFn`](../server_fn/trait.ServerFn.html) argument type into an HTTP request.
+/// 2. The [`Client`](../server_fn/client/trait.Client.html) sends the request to the server.
+/// 3. [`FromReq`](../server_fn/codec/trait.FromReq.html): The server deserializes the HTTP request back into the [`ServerFn`](../server_fn/client/trait.Client.html) type.
+/// 4. The server calls calls [`ServerFn::run_body`](../server_fn/trait.ServerFn.html#tymethod.run_body) on the data.
+/// 5. [`IntoRes`](../server_fn/codec/trait.IntoRes.html): The server serializes the [`ServerFn::Output`](../server_fn/trait.ServerFn.html#associatedtype.Output) type into an HTTP response.
+/// 6. The server integration applies any middleware from [`ServerFn::middleware`](../server_fn/middleware/index.html) and responds to the request.
+/// 7. [`FromRes`](../server_fn/codec/trait.FromRes.html): The client deserializes the response back into the [`ServerFn::Output`](../server_fn/trait.ServerFn.html#associatedtype.Output) type.
 ///
 /// Whatever encoding is provided to `input` should implement `IntoReq` and `FromReq`. Whatever encoding is provided
 /// to `output` should implement `IntoRes` and `FromRes`.
@@ -932,8 +932,8 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// - **Server functions must return `Result<T, ServerFnError>`.** Even if the work being done
 ///   inside the function body can’t fail, the processes of serialization/deserialization and the
 ///   network call are fallible.
-///     - [`ServerFnError`] can be generic over some custom error type. If so, that type should implement
-///       [`FromStr`] and [`Display`], but does not need to implement [`Error`]. This is so the value
+///     - [`ServerFnError`](../server_fn/error/enum.ServerFnError.html) can be generic over some custom error type. If so, that type should implement
+///       [`FromStr`](std::str::FromStr) and [`Display`](std::fmt::Display), but does not need to implement [`Error`](std::error::Error). This is so the value
 ///       can be easily serialized and deserialized along with the result.
 /// - **Server functions are part of the public API of your application.** A server function is an
 ///   ad hoc HTTP API endpoint, not a magic formula. Any server function can be accessed by any HTTP

--- a/leptos_reactive/src/context.rs
+++ b/leptos_reactive/src/context.rs
@@ -86,7 +86,7 @@ use std::any::{Any, TypeId};
 ///
 /// ### Solution
 ///
-/// If you are using the full Leptos framework, you can use the [`Provider`](leptos::Provider)
+/// If you are using the full Leptos framework, you can use the [`Provider`](../leptos/fn.Provider.html)
 /// component to solve this issue.
 ///
 /// ```rust

--- a/leptos_reactive/src/oco.rs
+++ b/leptos_reactive/src/oco.rs
@@ -440,8 +440,9 @@ impl<'a> From<Oco<'a, str>> for Oco<'a, [u8]> {
     }
 }
 
-#[deprecated(
-    note="This error was intended for a `TryFrom` implementation for `Oco`. `Oco` will likely move to its own crate after 0.7 so this type will be removed in the future")]
+#[deprecated(note = "This error was intended for a `TryFrom` implementation \
+                     for `Oco`. `Oco` will likely move to its own crate \
+                     after 0.7 so this type will be removed in the future")]
 /// Error returned from `Oco::try_from` for unsuccessful
 /// conversion from `Oco<'_, [u8]>` to `Oco<'_, str>`.
 #[derive(Debug, Clone, thiserror::Error)]

--- a/leptos_reactive/src/oco.rs
+++ b/leptos_reactive/src/oco.rs
@@ -440,7 +440,9 @@ impl<'a> From<Oco<'a, str>> for Oco<'a, [u8]> {
     }
 }
 
-/// Error returned from [`Oco::try_from`] for unsuccessful
+#[deprecated(
+    note="This error was intended for a `TryFrom` implementation for `Oco`. `Oco` will likely move to its own crate after 0.7 so this type will be removed in the future")]
+/// Error returned from `Oco::try_from` for unsuccessful
 /// conversion from `Oco<'_, [u8]>` to `Oco<'_, str>`.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("invalid utf-8 sequence: {_0}")]

--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -113,7 +113,7 @@ where
     /// Create an [Action].
     ///
     /// [Action] is a type of [Signal] which represent imperative calls to
-    /// an asynchronous function. Where a [Resource] is driven as a function
+    /// an asynchronous function. Where a [Resource](leptos_reactive::Resource) is driven as a function
     /// of a [Signal], [Action]s are [Action::dispatch]ed by events or handlers.
     ///
     /// ```rust
@@ -242,7 +242,7 @@ impl<I> Action<I, Result<I::Output, ServerFnError<I::Error>>>
 where
     I: ServerFn + 'static,
 {
-    /// Create an [Action] to imperatively call a [server_fn::server] function.
+    /// Create an [Action] to imperatively call a [server](leptos_macro::server) function.
     ///
     /// The struct representing your server function's arguments should be
     /// provided to the [Action]. Unless specified as an argument to the server

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -92,7 +92,7 @@
 //! 6. The server integration applies any middleware from [`ServerFn::middlewares`] and responds to the request.
 //! 7. [`FromRes`]: The client deserializes the response back into the [`ServerFn::Output`] type.
 //!
-//! [server]: <https://docs.rs/server_fn/latest/server_fn/attr.server.html>
+//! [server]: ../leptos/attr.server.html
 //! [`serde_qs`]: <https://docs.rs/serde_qs/latest/serde_qs/>
 //! [`cbor`]: <https://docs.rs/cbor/latest/cbor/>
 


### PR DESCRIPTION
Potentially fixes #859

The relative paths for some doc links comes inspired from what tokio does for its workspace links. See [here](https://docs.rs/tokio-macros/1.6.0/src/tokio_macros/lib.rs.html#28) for an example.