### PR TITLE
docs: log error on failing to convert form to ServerFn type, in addition to setting action value

### DIFF
--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -478,6 +478,7 @@ where
                     action.dispatch(new_input);
                 }
                 Err(err) => {
+                    error!("Error converting form field into server function arguments: {err:?}");
                     batch(move || {
                         value.set(Some(Err(ServerFnError::Serialization(
                             err.to_string(),

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -478,7 +478,10 @@ where
                     action.dispatch(new_input);
                 }
                 Err(err) => {
-                    error!("Error converting form field into server function arguments: {err:?}");
+                    error!(
+                        "Error converting form field into server function \
+                         arguments: {err:?}"
+                    );
                     batch(move || {
                         value.set(Some(Err(ServerFnError::Serialization(
                             err.to_string(),


### PR DESCRIPTION
Elsewhere, when we hit an error, we both log it as an error and also set the `value` of the action to reflect the error. When converting form fields to the `ServerFn` type, we were only setting the `value`. This made it seem like the `ActionForm` was failing silently if you weren't reading the `action`, and it's super easy to get tripped up by this. This just adds a log.

cc: @benwis 