### PR TITLE
Fixed href path in tailwind_csr example

### DIFF
--- a/examples/tailwind_csr/src/app.rs
+++ b/examples/tailwind_csr/src/app.rs
@@ -8,7 +8,7 @@ pub fn App() -> impl IntoView {
 
     view! {
 
-        <Stylesheet id="leptos" href="/pkg/tailwind.css"/>
+        <Stylesheet id="leptos" href="/style/output.css"/>
         <Link rel="shortcut icon" type_="image/ico" href="/favicon.ico"/>
         <Router>
             <Routes>


### PR DESCRIPTION
Fix for #2327 
Updated `href` path in `Stylesheet` tag to `output.css`