### PR TITLE
feat: add `impl_from` argument to `#[server]` proc_macro

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -883,9 +883,11 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///     - `"GetCbor"`: `GET` request with URL-encoded arguments and CBOR response
 /// - `req` and `res` specify the HTTP request and response types to be used on the server (these
 ///   should usually only be necessary if you are integrating with a server other than Actix/Axum)
-/// - `impl_into`: specifies whether to implement trait Into for server function's argument or not,
-///   given that there is only one argument; on making server action dispatch, this allows to call `.into()` on the
-///   server function argument, eliminating the need to fill server function’s type manually (defaults to `true`)
+/// - `impl_from`: specifies whether to implement trait `From` for server function's type or not.
+///   By default, if a server function only has one argument, the macro automatically implements the `From` trait
+///   to convert from the argument type to the server function type, and vice versa, allowing you to convert
+///   between them easily. Setting `impl_from` to `false` disables this, which can be necessary for argument types
+///   for which this would create a conflicting implementation. (defaults to `true`)
 ///
 /// ```rust,ignore
 /// #[server(

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -896,7 +896,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///   endpoint = "my_fn",
 ///   input = Cbor,
 ///   output = Json
-///   impl_into = true
+///   impl_from = true
 /// )]
 /// pub async fn my_wacky_server_fn(input: Vec<String>) -> Result<usize, ServerFnError> {
 ///   todo!()

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -883,6 +883,9 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///     - `"GetCbor"`: `GET` request with URL-encoded arguments and CBOR response
 /// - `req` and `res` specify the HTTP request and response types to be used on the server (these
 ///   should usually only be necessary if you are integrating with a server other than Actix/Axum)
+/// - `impl_into`: specifies whether to implement trait Into for server function's argument or not,
+///   given that there is only one argument; on making server action dispatch, this allows to call `.into()` on the
+///   server function argument, eliminating the need to fill server function’s type manually (defaults to `true`)
 ///
 /// ```rust,ignore
 /// #[server(
@@ -891,6 +894,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///   endpoint = "my_fn",
 ///   input = Cbor,
 ///   output = Json
+///   impl_into = true
 /// )]
 /// pub async fn my_wacky_server_fn(input: Vec<String>) -> Result<usize, ServerFnError> {
 ///   todo!()

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -119,7 +119,7 @@ pub fn server_macro_impl(
         res_ty,
         client,
         custom_wrapper,
-        impl_from: impl_into,
+        impl_from,
     } = args;
     let prefix = prefix.unwrap_or_else(|| Literal::string(default_path));
     let fn_path = fn_path.unwrap_or_else(|| Literal::string(""));
@@ -207,10 +207,10 @@ pub fn server_macro_impl(
         FnArg::Receiver(_) => None,
         FnArg::Typed(t) => Some((&t.pat, &t.ty)),
     });
-    let impl_into = impl_into.map(|v| v.value).unwrap_or(true);
+    let impl_from = impl_from.map(|v| v.value).unwrap_or(true);
     let from_impl = (body.inputs.len() == 1
         && first_field.is_some()
-        && impl_into)
+        && impl_from)
         .then(|| {
             let field = first_field.unwrap();
             let (name, ty) = field;
@@ -698,7 +698,7 @@ impl Parse for ServerFnArgs {
         let mut res_ty: Option<Type> = None;
         let mut client: Option<Type> = None;
         let mut custom_wrapper: Option<Path> = None;
-        let mut impl_into: Option<LitBool> = None;
+        let mut impl_from: Option<LitBool> = None;
 
         let mut use_key_and_value = false;
         let mut arg_pos = 0;
@@ -806,14 +806,14 @@ impl Parse for ServerFnArgs {
                             ));
                         }
                         custom_wrapper = Some(stream.parse()?);
-                    } else if key == "impl_into" {
-                        if impl_into.is_some() {
+                    } else if key == "impl_from" {
+                        if impl_from.is_some() {
                             return Err(syn::Error::new(
                                 key.span(),
-                                "keyword argument repeated: `impl_into`",
+                                "keyword argument repeated: `impl_from`",
                             ));
                         }
-                        impl_into = Some(stream.parse()?);
+                        impl_from = Some(stream.parse()?);
                     } else {
                         return Err(lookahead.error());
                     }
@@ -909,7 +909,7 @@ impl Parse for ServerFnArgs {
             res_ty,
             client,
             custom_wrapper,
-            impl_from: impl_into,
+            impl_from,
         })
     }
 }

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -642,7 +642,7 @@ fn err_type(return_ty: &Type) -> Result<Option<&GenericArgument>> {
                 {
                     if let Some(segment) = pat.path.segments.last() {
                         if segment.ident == "ServerFnError" {
-                            let args = &pat.path.segments[0].arguments;
+                            let args = &segment.arguments;
                             match args {
                                 // Result<T, ServerFnError>
                                 PathArguments::None => return Ok(None),


### PR DESCRIPTION
This PR adds an optional `impl_from` named  argument for `server_fn` proc macro.
This argument defaults to `true` and enables (or disables) the impl of `From` trait for server function argument type.

In cases when the server function has more than one argument, the `impl_from` has no effect on the trait impl generation, as it has been already disabled by function arguments number check.

The related issue has been discussed here: https://discord.com/channels/1031524867910148188/1203001939089035295

TL;DR: orphan rules disable (in some cases) the implementation of `From` trait for conversion between the only server function argument and server function argument type. 

The minimal example of the issue lives here: https://github.com/videobitva/test_server_fn
