### PR TITLE
Add compile error when using comment and doctype tags within the `view!` macro

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -58,7 +58,7 @@ impl Parse for Model {
 
         // Make sure return type is correct
         if !is_valid_into_view_return_type(&item.sig.output) {
-            abort!(
+            proc_macro_error::abort!(
                 item.sig,
                 "return type is incorrect";
                 help = "return signature must be `-> impl IntoView`"
@@ -628,19 +628,19 @@ impl Prop {
         let typed = if let FnArg::Typed(ty) = arg {
             ty
         } else {
-            abort!(arg, "receiver not allowed in `fn`");
+            proc_macro_error::abort!(arg, "receiver not allowed in `fn`");
         };
 
         let prop_opts =
             PropOpt::from_attributes(&typed.attrs).unwrap_or_else(|e| {
                 // TODO: replace with `.unwrap_or_abort()` once https://gitlab.com/CreepySkeleton/proc-macro-error/-/issues/17 is fixed
-                abort!(e.span(), e.to_string());
+                proc_macro_error::abort!(e.span(), e.to_string());
             });
 
         let name = if let Pat::Ident(i) = *typed.pat {
             i
         } else {
-            abort!(
+            proc_macro_error::abort!(
                 typed.pat,
                 "only `prop: bool` style types are allowed within the \
                  `#[component]` macro"
@@ -756,7 +756,7 @@ impl Docs {
                 }
 
                 let Some(val) = value_to_string(&attr.value) else {
-                    abort!(
+                    proc_macro_error::abort!(
                         attr,
                         "expected string literal in value of doc comment"
                     );
@@ -1075,7 +1075,7 @@ pub fn unwrap_option(ty: &Type) -> Type {
         }
     }
 
-    abort!(
+    proc_macro_error::abort!(
         ty,
         "`Option` must be `std::option::Option`";
         help = STD_OPTION_MSG

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -4,10 +4,6 @@
 #![allow(stable_features)]
 // FIXME? every use of quote! {} is warning here -- false positive?
 #![allow(unknown_lints)]
-#![allow(private_macro_use)]
-
-#[macro_use]
-extern crate proc_macro_error;
 
 use component::DummyModel;
 use proc_macro::TokenStream;
@@ -339,7 +335,7 @@ pub fn view(tokens: TokenStream) -> TokenStream {
                     third.clone()
                 }
                 _ => {
-                    abort!(
+                    proc_macro_error::abort!(
                         second, "To create a scope class with the view! macro you must put a comma `,` after the value";
                         help = r#"e.g., view!{ class="my-class", <div>...</div>}"#
                     )
@@ -593,7 +589,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
         let transparent = parse_macro_input!(args as syn::Ident);
 
         if transparent != "transparent" {
-            abort!(
+            proc_macro_error::abort!(
                 transparent,
                 "only `transparent` is supported";
                 help = "try `#[component(transparent)]` or `#[component]`"
@@ -846,7 +842,7 @@ pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     if !args.is_empty() {
-        abort!(
+        proc_macro_error::abort!(
             Span::call_site(),
             "no arguments are supported";
             help = "try just `#[slot]`"
@@ -869,7 +865,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// You can provide any combination of the following named arguments:
 /// - `name`: sets the identifier for the server function’s type, which is a struct created
 ///    to hold the arguments (defaults to the function identifier in PascalCase)
-/// - `prefix`: a prefix at which the server function handler will be mounted (defaults to `/api`) 
+/// - `prefix`: a prefix at which the server function handler will be mounted (defaults to `/api`)
 ///    your prefix must begin with `/`. Otherwise your function won't be found.
 /// - `endpoint`: specifies the exact path at which the server function handler will be mounted,
 ///   relative to the prefix (defaults to the function name followed by unique hash)
@@ -965,7 +961,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///   are unique. You cannot define two server functions with the same URL prefix and endpoint path,
 ///   even if they have different URL encodings, e.g. a POST method at `/api/foo` and a GET method at `/api/foo`.
 #[proc_macro_attribute]
-#[proc_macro_error]
+#[proc_macro_error::proc_macro_error]
 pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     match server_fn_macro::server_macro_impl(
         args.into(),
@@ -995,7 +991,9 @@ pub fn params_derive(
 pub(crate) fn attribute_value(attr: &KeyedAttribute) -> &syn::Expr {
     match attr.value() {
         Some(value) => value,
-        None => abort!(attr.key, "attribute should have value"),
+        None => {
+            proc_macro_error::abort!(attr.key, "attribute should have value")
+        }
     }
 }
 

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -108,13 +108,13 @@ impl Prop {
         let prop_opts =
             PropOpt::from_attributes(&arg.attrs).unwrap_or_else(|e| {
                 // TODO: replace with `.unwrap_or_abort()` once https://gitlab.com/CreepySkeleton/proc-macro-error/-/issues/17 is fixed
-                abort!(e.span(), e.to_string());
+                proc_macro_error::abort!(e.span(), e.to_string());
             });
 
         let name = if let Some(i) = arg.ident {
             i
         } else {
-            abort!(
+            proc_macro_error::abort!(
                 arg.ident,
                 "only `prop: bool` style types are allowed within the \
                  `#[slot]` macro"

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -121,7 +121,7 @@ pub(crate) fn node_to_tokens(
             view_marker,
         ),
         Node::Comment(_) => {
-            proc_macro_error::emit_error!(
+            proc_macro_error::emit_warning!(
                 node,
                 "comment tags do not show up in rendered output\nsupport for \
                  this is coming in leptos 0.7"
@@ -129,7 +129,7 @@ pub(crate) fn node_to_tokens(
             Some(quote! {})
         }
         Node::Doctype(_) => {
-            proc_macro_error::emit_error!(
+            proc_macro_error::emit_warning!(
                 node,
                 "doctype tags do not show up in rendered output\nsupport for \
                  this is coming in leptos 0.7"
@@ -349,7 +349,7 @@ pub(crate) fn element_to_tokens(
                     false,
                 ),
                 Node::Comment(_) => {
-                    proc_macro_error::emit_error!(
+                    proc_macro_error::emit_warning!(
                         node,
                         "comment tags do not show up in rendered \
                          output\nsupport for this is coming in leptos 0.7"
@@ -357,7 +357,7 @@ pub(crate) fn element_to_tokens(
                     (quote! {}, false)
                 }
                 Node::Doctype(_) => {
-                    proc_macro_error::emit_error!(
+                    proc_macro_error::emit_warning!(
                         node,
                         "doctype tags do not show up in rendered \
                          output\nsupport for this is coming in leptos 0.7"

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -120,7 +120,22 @@ pub(crate) fn node_to_tokens(
             global_class,
             view_marker,
         ),
-        Node::Comment(_) | Node::Doctype(_) => Some(quote! {}),
+        Node::Comment(_) => {
+            proc_macro_error::emit_error!(
+                node,
+                "comment tags do not show up in rendered output\nsupport for \
+                 this is coming in leptos 0.7"
+            );
+            Some(quote! {})
+        }
+        Node::Doctype(_) => {
+            proc_macro_error::emit_error!(
+                node,
+                "doctype tags do not show up in rendered output\nsupport for \
+                 this is coming in leptos 0.7"
+            );
+            Some(quote! {})
+        }
         Node::Text(node) => Some(quote! {
             ::leptos::leptos_dom::html::text(#node)
         }),
@@ -333,7 +348,22 @@ pub(crate) fn element_to_tokens(
                     .unwrap_or_default(),
                     false,
                 ),
-                Node::Comment(_) | Node::Doctype(_) => (quote! {}, false),
+                Node::Comment(_) => {
+                    proc_macro_error::emit_error!(
+                        node,
+                        "comment tags do not show up in rendered \
+                         output\nsupport for this is coming in leptos 0.7"
+                    );
+                    (quote! {}, false)
+                }
+                Node::Doctype(_) => {
+                    proc_macro_error::emit_error!(
+                        node,
+                        "doctype tags do not show up in rendered \
+                         output\nsupport for this is coming in leptos 0.7"
+                    );
+                    (quote! {}, false)
+                }
             };
             if is_static {
                 quote! {

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -20,7 +20,10 @@ pub(crate) fn render_template(nodes: &[Node]) -> TokenStream {
             root_element_to_tokens(&template_uid, node)
         }
         _ => {
-            abort!(Span::call_site(), "template! takes a single root element.")
+            proc_macro_error::abort!(
+                Span::call_site(),
+                "template! takes a single root element."
+            )
         }
     }
 }
@@ -201,7 +204,7 @@ fn element_to_tokens(
         let next_sib =
             match next_sibling_node(&node.children, idx + 1, next_el_id) {
                 Ok(next_sib) => next_sib,
-                Err(err) => abort!(span, "{}", err),
+                Err(err) => proc_macro_error::abort!(span, "{}", err),
             };
 
         let curr_id = child_to_tokens(
@@ -292,7 +295,10 @@ fn attr_to_tokens(
 
     // refs
     if name == "ref" {
-        abort!(span, "node_ref not yet supported in template! macro")
+        proc_macro_error::abort!(
+            span,
+            "node_ref not yet supported in template! macro"
+        )
     }
     // Event Handlers
     else if name.starts_with("on:") {
@@ -457,7 +463,10 @@ fn child_to_tokens(
             expressions,
             navigations,
         ),
-        _ => abort!(Span::call_site(), "unexpected child node type"),
+        _ => proc_macro_error::abort!(
+            Span::call_site(),
+            "unexpected child node type"
+        ),
     }
 }
 

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -210,7 +210,7 @@ pub(crate) fn parse_event_name(name: &str) -> (TokenStream, bool, bool) {
         .unwrap_or((CUSTOM_EVENT, true));
 
     let Ok(event_type) = event_type.parse::<TokenStream>() else {
-        abort!(event_type, "couldn't parse event name");
+        proc_macro_error::abort!(event_type, "couldn't parse event name");
     };
 
     let event_type = if is_custom {

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -382,7 +382,7 @@ fn element_to_tokens_ssr(
                                 ::leptos::IntoView::into_view(#[allow(unused_braces)] {#block})
                             }));
                         }
-                        Node::Fragment(_) => abort!(
+                        Node::Fragment(_) => proc_macro_error::abort!(
                             Span::call_site(),
                             "You can't nest a fragment inside an element."
                         ),

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -40,7 +40,7 @@ pub(crate) fn root_node_to_tokens_ssr(
             view_marker,
         ),
         Node::Comment(_) => {
-            proc_macro_error::emit_error!(
+            proc_macro_error::emit_warning!(
                 node,
                 "comment tags do not show up in rendered output\nsupport for \
                  this is coming in leptos 0.7"
@@ -48,7 +48,7 @@ pub(crate) fn root_node_to_tokens_ssr(
             quote! {}
         }
         Node::Doctype(_) => {
-            proc_macro_error::emit_error!(
+            proc_macro_error::emit_warning!(
                 node,
                 "doctype tags do not show up in rendered output\nsupport for \
                  this is coming in leptos 0.7"
@@ -402,7 +402,7 @@ fn element_to_tokens_ssr(
                             "You can't nest a fragment inside an element."
                         ),
                         Node::Comment(_) => {
-                            proc_macro_error::emit_error!(
+                            proc_macro_error::emit_warning!(
                                 child,
                                 "comment tags do not show up in rendered \
                                  output\nsupport for this is coming in leptos \
@@ -410,7 +410,7 @@ fn element_to_tokens_ssr(
                             );
                         }
                         Node::Doctype(_) => {
-                            proc_macro_error::emit_error!(
+                            proc_macro_error::emit_warning!(
                                 child,
                                 "doctype tags do not show up in rendered \
                                  output\nsupport for this is coming in leptos \

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -39,7 +39,22 @@ pub(crate) fn root_node_to_tokens_ssr(
             global_class,
             view_marker,
         ),
-        Node::Comment(_) | Node::Doctype(_) => quote! {},
+        Node::Comment(_) => {
+            proc_macro_error::emit_error!(
+                node,
+                "comment tags do not show up in rendered output\nsupport for \
+                 this is coming in leptos 0.7"
+            );
+            quote! {}
+        }
+        Node::Doctype(_) => {
+            proc_macro_error::emit_error!(
+                node,
+                "doctype tags do not show up in rendered output\nsupport for \
+                 this is coming in leptos 0.7"
+            );
+            quote! {}
+        }
         Node::Text(node) => {
             quote! {
                 ::leptos::leptos_dom::html::text(#node)
@@ -386,7 +401,22 @@ fn element_to_tokens_ssr(
                             Span::call_site(),
                             "You can't nest a fragment inside an element."
                         ),
-                        Node::Comment(_) | Node::Doctype(_) => {}
+                        Node::Comment(_) => {
+                            proc_macro_error::emit_error!(
+                                child,
+                                "comment tags do not show up in rendered \
+                                 output\nsupport for this is coming in leptos \
+                                 0.7"
+                            );
+                        }
+                        Node::Doctype(_) => {
+                            proc_macro_error::emit_error!(
+                                child,
+                                "doctype tags do not show up in rendered \
+                                 output\nsupport for this is coming in leptos \
+                                 0.7"
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Discussed in https://github.com/leptos-rs/leptos/issues/2338.

Preview of the error messages:
![image](https://github.com/leptos-rs/leptos/assets/51510921/2aa20328-a74d-4ad8-b7b0-b738ef36628c)

The first commit contains just style changes (using `proc_macro_error::abort!` everywhere instead of just `abort!`, to be consistent with `proc_macro_error::emit_error!`), so it can be reverted if desired.