### PR TITLE
Add MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ exclude = ["benchmarks", "examples"]
 
 [workspace.package]
 version = "0.6.6"
+rust-version = "1.75"
 
 [workspace.dependencies]
 leptos = { path = "./leptos", version = "0.6.5" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,6 +2,7 @@
 name = "benchmarks"
 version = "0.1.0"
 edition = "2021"
+rust-version.workspace = true
 
 [dependencies]
 l0410 = { package = "leptos", version = "0.4.10", features = [

--- a/examples/counter_without_macros/Cargo.toml
+++ b/examples/counter_without_macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "counter_without_macros"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.75"
 
 [profile.release]
 codegen-units = 1

--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -2,6 +2,7 @@
 name = "counters_stable"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.75"
 
 [dependencies]
 leptos = { path = "../../leptos", features = ["csr"] }

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Actix integrations for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 actix-http = "3"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Axum integrations for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 axum = { version = "0.7", default-features = false, features = [

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Utilities to help build server integrations for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 futures = "0.3"

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Leptos is a full-stack, isomorphic Rust web framework leveraging fine-grained reactivity to build declarative user interfaces."
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 cfg-if = "1"

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Configuration for the Leptos web framework."
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 config = { version = "0.14", default-features = false, features = ["toml"] }

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "DOM operations for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 async-recursion = "1"

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Utility types used for dev mode and hot-reloading for the Leptos web framework."
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "view macro for the Leptos web framework."
 readme = "../README.md"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Reactive system for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 slotmap = { version = "1", features = ["serde"] }

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "RPC for the Leptos web framework."
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 leptos_reactive = { workspace = true }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Tools to set HTML metadata in the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 cfg-if = "1"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 readme = "../README.md"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Router for the Leptos web framework."
+rust-version.workspace = true
 
 [dependencies]
 leptos = { workspace = true }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "RPC for any web framework."
 readme = "../README.md"
+rust-version.workspace = true
 
 [dependencies]
 server_fn_macro_default = { workspace = true }


### PR DESCRIPTION
Adds a Minimum Supported Rust Version using the [`rust-version`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) field.

Current motivation for this is we are seeing people try to compile Leptos with older versions of Rust and it's failing with confusing error messages. With this PR it now gives a nice error message letting them know which version to upgrade to.

I simply chose Rust 1.75 because it's the oldest that compiles currently. Lmk if we want to use something newer.

You can test this by running this from the project root:
```
rustup install 1.74
rustup default 1.74
cargo build
```

Which using this PR will now output:

> error: package `leptos_macro v0.6.6 (/home/paul/Projects/Rust/leptos/leptos_macro)` cannot be built because it requires rustc 1.75 or newer, while the currently active rustc version is 1.74.1

I added it to the stable examples as well, the nightly examples already enforce a version in their rust-toolchain.toml files.