### PR TITLE
chore(ci): fix failing CI by removing deprecation note

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -91,7 +91,9 @@ denylist = [
   "rustls",
   "default-tls",
   "wasm-bindgen",
-  "trace-component-props"
+  "trace-component-props",
+  "spin",
+  "experimental-islands"
 ]
 skip_feature_sets = [
   [

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -869,7 +869,7 @@ pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// You can provide any combination of the following named arguments:
 /// - `name`: sets the identifier for the server function’s type, which is a struct created
 ///    to hold the arguments (defaults to the function identifier in PascalCase)
-/// - `prefix`: a prefix at which the server function handler will be mounted (defaults to `/api`) 
+/// - `prefix`: a prefix at which the server function handler will be mounted (defaults to `/api`)
 ///    your prefix must begin with `/`. Otherwise your function won't be found.
 /// - `endpoint`: specifies the exact path at which the server function handler will be mounted,
 ///   relative to the prefix (defaults to the function name followed by unique hash)

--- a/leptos_reactive/src/oco.rs
+++ b/leptos_reactive/src/oco.rs
@@ -440,9 +440,6 @@ impl<'a> From<Oco<'a, str>> for Oco<'a, [u8]> {
     }
 }
 
-#[deprecated(note = "This error was intended for a `TryFrom` implementation \
-                     for `Oco`. `Oco` will likely move to its own crate \
-                     after 0.7 so this type will be removed in the future")]
 /// Error returned from `Oco::try_from` for unsuccessful
 /// conversion from `Oco<'_, [u8]>` to `Oco<'_, str>`.
 #[derive(Debug, Clone, thiserror::Error)]


### PR DESCRIPTION
#2318 adds a deprecation note on an unused error enum. Unfortunately adding deprecation warnings breaks CI that fails on clippy warnings, including our own, so has caused CI on all subsequent PRs to break.