### PR TITLE
Add MessagePack codec

### DIFF
--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -53,6 +53,7 @@ rkyv = { version = "0.7", features = [
   "uuid",
   "strict",
 ], optional = true }
+rmp-serde = { version = "1.1", optional = true }
 
 # client
 gloo-net = { version = "0.5", optional = true }
@@ -101,6 +102,7 @@ multipart = ["browser", "dep:multer"]
 url = ["dep:serde_qs"]
 cbor = ["dep:ciborium"]
 rkyv = ["dep:rkyv"]
+msgpack = ["dep:rmp-serde"]
 default-tls = ["reqwest?/default-tls"]
 rustls = ["reqwest?/rustls-tls"]
 reqwest = ["dep:reqwest"]

--- a/server_fn/src/codec/mod.rs
+++ b/server_fn/src/codec/mod.rs
@@ -44,6 +44,11 @@ mod multipart;
 #[cfg(feature = "multipart")]
 pub use multipart::*;
 
+#[cfg(feature = "msgpack")]
+mod msgpack;
+#[cfg(feature = "msgpack")]
+pub use msgpack::*;
+
 mod stream;
 use crate::error::ServerFnError;
 use futures::Future;

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -1,0 +1,74 @@
+use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
+use crate::{
+    error::ServerFnError,
+    request::{ClientReq, Req},
+    response::{ClientRes, Res},
+};
+use bytes::Bytes;
+use http::Method;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// A codec for MessagePack.
+pub struct MsgPack;
+
+impl Encoding for MsgPack {
+    const CONTENT_TYPE: &'static str = "application/msgpack";
+    const METHOD: Method = Method::POST;
+}
+
+impl<T, Request, Err> IntoReq<MsgPack, Request, Err> for T
+where
+    Request: ClientReq<Err>,
+    T: Serialize,
+{
+    fn into_req(
+        self,
+        path: &str,
+        accepts: &str,
+    ) -> Result<Request, ServerFnError<Err>> {
+        let data = rmp_serde::to_vec(&self)
+            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+        Request::try_new_post_bytes(
+            path,
+            MsgPack::CONTENT_TYPE,
+            accepts,
+            Bytes::from(data),
+        )
+    }
+}
+
+impl<T, Request, Err> FromReq<MsgPack, Request, Err> for T
+where
+    Request: Req<Err> + Send,
+    T: DeserializeOwned,
+{
+    async fn from_req(req: Request) -> Result<Self, ServerFnError<Err>> {
+        let string_data = req.try_into_string().await?;
+        rmp_serde::from_slice::<T>(string_data.as_bytes())
+            .map_err(|e| ServerFnError::Args(e.to_string()))
+    }
+}
+
+impl<T, Response, Err> IntoRes<MsgPack, Response, Err> for T
+where
+    Response: Res<Err>,
+    T: Serialize + Send,
+{
+    async fn into_res(self) -> Result<Response, ServerFnError<Err>> {
+        let data = rmp_serde::to_vec(&self)
+            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+        Response::try_from_bytes(MsgPack::CONTENT_TYPE, Bytes::from(data))
+    }
+}
+
+impl<T, Response, Err> FromRes<MsgPack, Response, Err> for T
+where
+    Response: ClientRes<Err> + Send,
+    T: DeserializeOwned,
+{
+    async fn from_res(res: Response) -> Result<Self, ServerFnError<Err>> {
+        let data = res.try_into_string().await?;
+        rmp_serde::from_slice(data.as_bytes())
+            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+    }
+}

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -43,8 +43,8 @@ where
     T: DeserializeOwned,
 {
     async fn from_req(req: Request) -> Result<Self, ServerFnError<Err>> {
-        let string_data = req.try_into_string().await?;
-        rmp_serde::from_slice::<T>(string_data.as_bytes())
+        let data = req.try_into_bytes().await?;
+        rmp_serde::from_slice::<T>(&data)
             .map_err(|e| ServerFnError::Args(e.to_string()))
     }
 }
@@ -67,8 +67,8 @@ where
     T: DeserializeOwned,
 {
     async fn from_res(res: Response) -> Result<Self, ServerFnError<Err>> {
-        let data = res.try_into_string().await?;
-        rmp_serde::from_slice(data.as_bytes())
+        let data = res.try_into_bytes().await?;
+        rmp_serde::from_slice(&data)
             .map_err(|e| ServerFnError::Deserialization(e.to_string()))
     }
 }


### PR DESCRIPTION
This adds [MessagePack](https://msgpack.org/) codec support.

To quote MessagePack, "it's like JSON but fast and small". I was wanting to make a param payload that included a decently-sized byte array inline, and JSON is pretty inefficient at that, so I added MessagePack support.

The CI hasn't finished running on my machine but I decided to go ahead and submit it anyways because the change is so isolated.