### PR TITLE
fix: do not strip query in redirect hook when using client-side navigation

### DIFF
--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -70,7 +70,7 @@ pub fn Router(
             let navigate = navigate.clone();
             // delay by a tick here, so that the Action updates *before* the redirect
             request_animation_frame(move || {
-                navigate(&url.pathname(), Default::default());
+                navigate(&url.href(), Default::default());
             });
             // Use set_href() if the conditions for client-side navigation were not satisfied
         } else if let Err(e) =


### PR DESCRIPTION
Fixes #2374

@jollygreenlaser 