### PR TITLE
fix: re-throw errors in delegated event listeners

### DIFF
--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -150,7 +150,10 @@ pub(crate) fn add_delegated_event_listener(
                         if !maybe_handler.is_undefined() {
                             let f = maybe_handler
                                 .unchecked_ref::<js_sys::Function>();
-                            let _ = f.call1(&node, &ev);
+
+                            if let Err(e) = f.call1(&node, &ev) {
+                                wasm_bindgen::throw_val(e);
+                            }
 
                             if ev.cancel_bubble() {
                                 return;


### PR DESCRIPTION
Hi there,

This just re-throws errors that happen in delegated event listeners, it prevents confusion from a panic not showing up anywhere (besides the control flow being interrupted).