### PR TITLE
fix: prevent setting the same event listener twice

### DIFF
--- a/leptos_dom/src/events.rs
+++ b/leptos_dom/src/events.rs
@@ -70,6 +70,12 @@ pub fn add_event_listener<E>(
 
     let cb = Closure::wrap(cb as Box<dyn FnMut(E)>).into_js_value();
     let key = intern(&key);
+    debug_assert_eq!(
+        Ok(false),
+        js_sys::Reflect::has(target, &JsValue::from_str(&key)),
+        "Error while adding {key} event listener, a listener of type {key} \
+         already present."
+    );
     _ = js_sys::Reflect::set(target, &JsValue::from_str(&key), &cb);
     add_delegated_event_listener(&key, event_name, options);
 }


### PR DESCRIPTION
Delegated event listeners do not support adding more than one event listener of the same type. This can cause confusion if two listeners are added, as one is silently dropped.

Here I just assert that the value does not exist yet, which was what we decided to go with internally (it seems good practice to avoid double listeners, if possible).

Alternatives:
- Switch to a warning.
- Combine the two event listeners.