### PR TITLE
feat: print inner value in `Debug` impls

### DIFF
--- a/leptos_reactive/src/memo.rs
+++ b/leptos_reactive/src/memo.rs
@@ -369,11 +369,10 @@ where
 
 impl<T> Copy for Memo<T> {}
 
-impl<T> fmt::Debug for Memo<T> {
+impl<T: fmt::Debug> fmt::Debug for Memo<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("Memo");
-        s.field("id", &self.id);
-        s.field("ty", &self.ty);
+        self.with_untracked(|v| s.field("inner", v));
         #[cfg(any(debug_assertions, feature = "ssr"))]
         s.field("defined_at", &self.defined_at);
         s.finish()

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -772,11 +772,10 @@ impl<T> Clone for ReadSignal<T> {
 
 impl<T> Copy for ReadSignal<T> {}
 
-impl<T> fmt::Debug for ReadSignal<T> {
+impl<T: fmt::Debug> fmt::Debug for ReadSignal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("ReadSignal");
-        s.field("id", &self.id);
-        s.field("ty", &self.ty);
+        self.with_untracked(|v| s.field("inner", v));
         #[cfg(any(debug_assertions, feature = "ssr"))]
         s.field("defined_at", &self.defined_at);
         s.finish()
@@ -1224,11 +1223,10 @@ impl<T> Clone for RwSignal<T> {
 
 impl<T> Copy for RwSignal<T> {}
 
-impl<T> fmt::Debug for RwSignal<T> {
+impl<T: fmt::Debug> fmt::Debug for RwSignal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("RwSignal");
-        s.field("id", &self.id);
-        s.field("ty", &self.ty);
+        self.with_untracked(|v| s.field("inner", v));
         #[cfg(any(debug_assertions, feature = "ssr"))]
         s.field("defined_at", &self.defined_at);
         s.finish()

--- a/leptos_reactive/src/signal_wrappers_read.rs
+++ b/leptos_reactive/src/signal_wrappers_read.rs
@@ -91,7 +91,7 @@ impl<T> Clone for Signal<T> {
 
 impl<T> Copy for Signal<T> {}
 
-impl<T> core::fmt::Debug for Signal<T> {
+impl<T: core::fmt::Debug> core::fmt::Debug for Signal<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut s = f.debug_struct("Signal");
         s.field("inner", &self.inner);
@@ -458,14 +458,14 @@ impl<T> Clone for SignalTypes<T> {
 
 impl<T> Copy for SignalTypes<T> {}
 
-impl<T> core::fmt::Debug for SignalTypes<T> {
+impl<T: core::fmt::Debug> core::fmt::Debug for SignalTypes<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Self::ReadSignal(arg0) => {
-                f.debug_tuple("ReadSignal").field(arg0).finish()
-            }
-            Self::Memo(arg0) => f.debug_tuple("Memo").field(arg0).finish(),
-            Self::DerivedSignal(_) => f.debug_tuple("DerivedSignal").finish(),
+            Self::ReadSignal(arg0) => arg0.fmt(f),
+            Self::Memo(arg0) => arg0.fmt(f),
+            Self::DerivedSignal(get) => get.with_value(|get| {
+                f.debug_tuple("DerivedSignal").field(&untrack(get)).finish()
+            }),
         }
     }
 }

--- a/leptos_reactive/src/stored_value.rs
+++ b/leptos_reactive/src/stored_value.rs
@@ -43,12 +43,11 @@ impl<T> Clone for StoredValue<T> {
 
 impl<T> Copy for StoredValue<T> {}
 
-impl<T> fmt::Debug for StoredValue<T> {
+impl<T: fmt::Debug> fmt::Debug for StoredValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StoredValue")
-            .field("id", &self.id)
-            .field("ty", &self.ty)
-            .finish()
+        self.with_value(|v| {
+            f.debug_struct("StoredValue").field("inner", v).finish()
+        })
     }
 }
 


### PR DESCRIPTION
When developing websites in `leptos` it's very useful to be able to quickly debug-print various signals and see what's inside them. Accessing them is already an option, but it's verbose during a critical point in the iteration cycle and doesn't work well for nested signals.

No subscription happens when debug-printing.

The main issue here is that this means that debug-printing can panic if the signal is disposed of. We can partially work around that by using the `try_` versions of the access methods, but we can't work around it for signals accessed within derived signals as far as I can tell.

We didn't expect this to be a problem, so internally we opted for consistency (every signal panics when accessed after disposal), but I can change it if preferred.

Finally, the added bounds are a breaking change. We didn't have any issues, but depending on the plan for future versions it might make sense to just close this and consider it in the future reactive system.