### PR TITLE
Add beginner tip to ErrorBoundary

### DIFF
--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -58,7 +58,7 @@ use leptos_reactive::{
 /// So, for instance, if you pass a `Result<T,String>` where `T` implements [IntoView](https://docs.rs/leptos/latest/leptos/trait.IntoView.html)
 /// and attempt to render the error for the purposes of `ErrorBoundary` you'll get a compiler error like this.
 ///
-/// ```
+/// ```rust,ignore
 /// error[E0599]: the method `into_view` exists for enum `Result<ViewableLoginFlow, String>`, but its trait bounds were not satisfied
 ///    --> src/login.rs:229:32
 ///     |

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -71,10 +71,8 @@ use leptos_reactive::{
 ///    ... more notes here ...
 /// ```
 ///
-/// For more information about how to easily implement Errors see
+/// For more information about how to easily implement `Error` see
 /// [thiserror](https://docs.rs/thiserror/latest/thiserror/)
-/// and [anyhow](https://docs.rs/anyhow/latest/anyhow/)
-/// 
 #[component]
 pub fn ErrorBoundary<F, IV>(
     /// The components inside the tag which will get rendered

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -58,7 +58,7 @@ use leptos_reactive::{
 /// So, for instance, if you pass a Result<T,String> where T implements IntoView
 /// and attempt to render the error for the purposes of `ErrorBoundary` you'll get a compiler error like this.
 ///
-/// ```rust,ignore
+/// ```
 /// error[E0599]: the method `into_view` exists for enum `Result<ViewableLoginFlow, String>`, but its trait bounds were not satisfied
 ///    --> src/login.rs:229:32
 ///     |

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -52,10 +52,10 @@ use leptos_reactive::{
 ///   /* etc. */
 /// ```
 ///
-/// ## Beginner's Tip: ErrorBoundary Requires Your Error To Implement std::core::Error.
-/// ErrorBoundary requires your `Result<T,E>` to implement `IntoView`.
-/// `Result<T,E>` only implements `IntoView` if E implements `std::core::Error`.
-/// So, for instance, if you pass a Result<T,String> where T implements IntoView
+/// ## Beginner's Tip: ErrorBoundary Requires Your Error To Implement std::error::Error.
+/// `ErrorBoundary` requires your `Result<T,E>` to implement [IntoView](https://docs.rs/leptos/latest/leptos/trait.IntoView.html).
+/// `Result<T,E>` only implements `IntoView` if `E` implements [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html).
+/// So, for instance, if you pass a `Result<T,String>` where `T` implements [IntoView](https://docs.rs/leptos/latest/leptos/trait.IntoView.html)
 /// and attempt to render the error for the purposes of `ErrorBoundary` you'll get a compiler error like this.
 ///
 /// ```

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -51,6 +51,30 @@ use leptos_reactive::{
 ///       {move || {
 ///   /* etc. */
 /// ```
+///
+/// ## Beginner's Tip: ErrorBoundary Requires Your Error To Implement std::core::Error.
+/// ErrorBoundary requires your `Result<T,E>` to implement `IntoView`.
+/// `Result<T,E>` only implements `IntoView` if E implements `std::core::Error`.
+/// So, for instance, if you pass a Result<T,String> where T implements IntoView
+/// and attempt to render the error for the purposes of `ErrorBoundary` you'll get a compiler error like this.
+///
+/// ```rust,ignore
+/// error[E0599]: the method `into_view` exists for enum `Result<ViewableLoginFlow, String>`, but its trait bounds were not satisfied
+///    --> src/login.rs:229:32
+///     |
+/// 229 |                     err => err.into_view(),
+///     |                                ^^^^^^^^^ method cannot be called on `Result<ViewableLoginFlow, String>` due to unsatisfied trait bounds
+///     |
+///     = note: the following trait bounds were not satisfied:
+///             `<&Result<ViewableLoginFlow, std::string::String> as FnOnce<()>>::Output = _`
+///             which is required by `&Result<ViewableLoginFlow, std::string::String>: leptos::IntoView`
+///    ... more notes here ...
+/// ```
+///
+/// For more information about how to easily implement Errors see
+/// [thiserror](https://docs.rs/thiserror/latest/thiserror/)
+/// and [anyhow](https://docs.rs/anyhow/latest/anyhow/)
+/// 
 #[component]
 pub fn ErrorBoundary<F, IV>(
     /// The components inside the tag which will get rendered


### PR DESCRIPTION
This might seem simple, but the nuances of types and traits confuse many people learning the language.