### PR TITLE
fix(ci): "needless borrow" error and example never exiting

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -104,7 +104,7 @@ pub fn html_parts_separated(
         "() => mod.hydrate()"
     };
 
-    let (js_hash, wasm_hash, css_hash) = get_hashes(&options);
+    let (js_hash, wasm_hash, css_hash) = get_hashes(options);
 
     let head = head.replace(
         &format!("{output_name}.css"),


### PR DESCRIPTION
`options` is already a reference so it was passing a double reference.

Looks like this was inadvertently added in the last commit in PR https://github.com/leptos-rs/leptos/pull/2373 while other CI failures were happening so it was missed.