### PR TITLE
fix(ci): "needless borrow" error and example never exiting

### DIFF
--- a/examples/cargo-make/playwright-trunk-test.toml
+++ b/examples/cargo-make/playwright-trunk-test.toml
@@ -6,9 +6,17 @@ extend = [
 [tasks.integration-test]
 description = "Run integration test with automated start and stop of processes"
 env = { SPAWN_CLIENT_PROCESS = "1" }
-dependencies = ["start", "wait-one", "test-playwright", "stop"]
+run_task = { name = ["start", "wait-test-stop"], parallel = true }
 
-[tasks.wait-one]
+[tasks.wait-test-stop]
+private = true
+dependencies = ["wait-server", "test-playwright", "stop"]
+
+[tasks.wait-server]
 script = '''
-sleep 1
+for run in {1..6}; do
+    echo "Waiting to ensure server is started..."
+    sleep 10
+done
+echo "Times up, running tests"
 '''

--- a/examples/cargo-make/playwright-trunk-test.toml
+++ b/examples/cargo-make/playwright-trunk-test.toml
@@ -14,7 +14,7 @@ dependencies = ["wait-server", "test-playwright", "stop"]
 
 [tasks.wait-server]
 script = '''
-for run in {1..6}; do
+for run in {1..12}; do
     echo "Waiting to ensure server is started..."
     sleep 10
 done

--- a/examples/error_boundary/Makefile.toml
+++ b/examples/error_boundary/Makefile.toml
@@ -2,7 +2,3 @@ extend = [
     { path = "../cargo-make/main.toml" },
     { path = "../cargo-make/playwright-trunk-test.toml" },
 ]
-
-[env]
-
-CLIENT_PROCESS_NAME = "error_boundary"

--- a/examples/error_boundary/Makefile.toml
+++ b/examples/error_boundary/Makefile.toml
@@ -2,3 +2,7 @@ extend = [
     { path = "../cargo-make/main.toml" },
     { path = "../cargo-make/playwright-trunk-test.toml" },
 ]
+
+[env]
+
+CLIENT_PROCESS_NAME = "error_boundary"

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -104,7 +104,7 @@ pub fn html_parts_separated(
         "() => mod.hydrate()"
     };
 
-    let (js_hash, wasm_hash, css_hash) = get_hashes(&options);
+    let (js_hash, wasm_hash, css_hash) = get_hashes(options);
 
     let head = head.replace(
         &format!("{output_name}.css"),


### PR DESCRIPTION
`options` is already a reference so it was passing a double reference. Looks like this was inadvertently added in the last commit in PR https://github.com/leptos-rs/leptos/pull/2373 while other CI failures were happening so it was missed.

The error_boundary example has been leaving the server running and eventually failing due to timing out. This PR makes the start task run in parallel with the playwright task instead of waiting forever on the server start task to exit it uses a dumb two minute sleep timer to ensure the server has compiled and started. This could probably be improved but might risk being too complex for bash scripts so I left it for now.