### PR TITLE
feat: allow #[prop(attrs)] on slots

### DIFF
--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -65,14 +65,49 @@ impl ToTokens for Model {
             body,
         } = self;
 
-        let (_, generics, where_clause) = body.generics.split_for_impl();
+        let (impl_generics, generics, where_clause) =
+            body.generics.split_for_impl();
 
+        let builder_name = quote::format_ident!("{name}Builder");
         let prop_builder_fields = prop_builder_fields(vis, props);
         let prop_docs = generate_prop_docs(props);
         let builder_name_doc = LitStr::new(
             &format!("Props for the [`{name}`] slot."),
             name.span(),
         );
+
+        let count = props
+            .iter()
+            .filter(
+                |Prop {
+                     prop_opts: PropOpt { attrs, .. },
+                     ..
+                 }| *attrs,
+            )
+            .count();
+
+        let dyn_attrs_props = props
+            .iter()
+            .filter(
+                |Prop {
+                     prop_opts: PropOpt { attrs, .. },
+                     ..
+                 }| *attrs,
+            )
+            .enumerate()
+            .map(|(idx, Prop { name, .. })| {
+                let ident = &name;
+                if idx < count - 1 {
+                    quote! {
+                        self.#ident = v.clone().into();
+                    }
+                } else {
+                    quote! {
+                        self.#ident = v.into();
+                    }
+                }
+            })
+            .collect::<TokenStream>();
 
         let output = quote! {
             #[doc = #builder_name_doc]
@@ -88,6 +123,20 @@ impl ToTokens for Model {
             impl #generics From<#name #generics> for Vec<#name #generics> #where_clause {
                 fn from(value: #name #generics) -> Self {
                     vec![value]
+                }
+            }
+
+            impl #impl_generics ::leptos::Props for #name #generics #where_clause {
+                type Builder = #builder_name #generics;
+                fn builder() -> Self::Builder {
+                    #name::builder()
+                }
+            }
+
+            impl #impl_generics ::leptos::DynAttrs for #name #generics #where_clause {
+                fn dyn_attrs(mut self, v: Vec<(&'static str, ::leptos::Attribute)>) -> Self {
+                    #dyn_attrs_props
+                    self
                 }
             }
         };
@@ -142,6 +191,7 @@ struct PropOpt {
     #[attribute(example = "5 * 10")]
     pub default: Option<syn::Expr>,
     pub into: bool,
+    pub attrs: bool,
 }
 
 struct TypedBuilderOpts {
@@ -154,7 +204,7 @@ struct TypedBuilderOpts {
 impl TypedBuilderOpts {
     pub fn from_opts(opts: &PropOpt, is_ty_option: bool) -> Self {
         Self {
-            default: opts.optional || opts.optional_no_strip,
+            default: opts.optional || opts.optional_no_strip || opts.attrs,
             default_with_value: opts.default.clone(),
             strip_option: opts.strip_option || opts.optional && is_ty_option,
             into: opts.into,

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -50,6 +50,7 @@ pub(crate) fn slot_to_tokens(
         .filter(|attr| {
             !attr.key.to_string().starts_with("let:")
                 && !attr.key.to_string().starts_with("clone:")
+                && !attr.key.to_string().starts_with("attr:")
         })
         .map(|attr| {
             let name = &attr.key;
@@ -85,6 +86,24 @@ pub(crate) fn slot_to_tokens(
                 .map(|ident| format_ident!("{ident}", span = attr.key.span()))
         })
         .collect::<Vec<_>>();
+
+    let dyn_attrs = attrs
+        .filter(|attr| attr.key.to_string().starts_with("attr:"))
+        .filter_map(|attr| {
+            let name = &attr.key.to_string();
+            let name = name.strip_prefix("attr:");
+            let value = attr.value().map(|v| {
+                quote! { #v }
+            })?;
+            Some(quote! { (#name, ::leptos::IntoAttribute::into_attribute(#value)) })
+        })
+        .collect::<Vec<_>>();
+
+    let dyn_attrs = if dyn_attrs.is_empty() {
+        quote! {}
+    } else {
+        quote! { .dyn_attrs(vec![#(#dyn_attrs),*]) }
+    };
 
     let mut slots = HashMap::new();
     let children = if node.children.is_empty() {
@@ -159,6 +178,7 @@ pub(crate) fn slot_to_tokens(
             #(#slots)*
             #children
             .build()
+            #dyn_attrs
             .into(),
     };
 


### PR DESCRIPTION
Saw somebody in the Discord server ask for the ability to do
```rs
#[slot]
struct Slot {
  #[prop(attrs)]
  attributes: Vec<(&'static str, Attribute)>
}
```
Which currently is not implemented, so I just extended the existing options and slapped in the impls and methods in `leptos_macro/slot.rs` and `leptos_macro/slot_helper.rs`