### PR TITLE
Properties with into and default attribute calls into() in proc macro

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -844,8 +844,12 @@ impl TypedBuilderOpts {
 impl TypedBuilderOpts {
     fn to_serde_tokens(&self) -> TokenStream {
         let default = if let Some(v) = &self.default_with_value {
-            let v = v.to_token_stream().to_string();
-            quote! { default=#v, }
+            let mut v = v.to_token_stream();
+            if self.into {
+                v.append_all(quote!{.into()} );
+            } 
+            let v = v.to_string();
+            quote! { default_code=#v, }
         } else if self.default {
             quote! { default, }
         } else {
@@ -863,7 +867,11 @@ impl TypedBuilderOpts {
 impl ToTokens for TypedBuilderOpts {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let default = if let Some(v) = &self.default_with_value {
-            let v = v.to_token_stream().to_string();
+            let mut v = v.to_token_stream();
+            if self.into {
+                v.append_all(quote!{.into()} );
+            } 
+            let v = v.to_string();
             quote! { default_code=#v, }
         } else if self.default {
             quote! { default, }

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -165,7 +165,11 @@ impl TypedBuilderOpts {
 impl ToTokens for TypedBuilderOpts {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let default = if let Some(v) = &self.default_with_value {
-            let v = v.to_token_stream().to_string();
+            let mut v = v.to_token_stream();
+            if self.into {
+                v.append_all(quote!{.into()} );
+            } 
+            let v = v.to_string();
             quote! { default_code=#v, }
         } else if self.default {
             quote! { default, }

--- a/leptos_macro/tests/component.rs
+++ b/leptos_macro/tests/component.rs
@@ -8,12 +8,16 @@ fn Component(
     #[prop(strip_option)] strip_option: Option<u8>,
     #[prop(default = NonZeroUsize::new(10).unwrap())] default: NonZeroUsize,
     #[prop(into)] into: String,
+    #[prop(into, default = "Default value")] into_default: String,
+    #[prop(into, default = NonZeroUsize::new(11).unwrap())] into_default_expr: NonZeroUsize,
 ) -> impl IntoView {
     _ = optional;
     _ = optional_no_strip;
     _ = strip_option;
     _ = default;
     _ = into;
+    _ = into_default;
+    _ = into_default_expr;
 }
 
 #[test]
@@ -24,4 +28,6 @@ fn component() {
     assert_eq!(cp.strip_option, Some(9));
     assert_eq!(cp.default, NonZeroUsize::new(10).unwrap());
     assert_eq!(cp.into, "");
+    assert_eq!(cp.into_default, "Default value");
+    assert_eq!(cp.into_default_expr, NonZeroUsize::new(11).unwrap());
 }


### PR DESCRIPTION
resolves #2386 

Into() is added to the default_code when the prop is into and there's a default expression