### PR TITLE
fix(ci): leptos examples fail with bindgen schema error

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -44,6 +44,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install wasm-bindgen
+        run: cargo binstall wasm-bindgen-cli --no-confirm
+
+      - name: Install cargo-leptos
+        run: cargo binstall cargo-leptos --no-confirm
+
       - name: Install Trunk
         uses: jetli/trunk-action@v0.4.0
         with:

--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -25,7 +25,7 @@ leptos_router = { path = "../../router" }
 log = "0.4"
 once_cell = "1.18"
 gloo-net = { git = "https://github.com/rustwasm/gloo" }
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }
 simple_logger = "4.3"
 tracing = { version = "0.1", optional = true }

--- a/examples/counter_without_macros/Cargo.toml
+++ b/examples/counter_without_macros/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen = "0.2.84"
+wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3.34"
 pretty_assertions = "1.3.0"
 rstest = "0.17.0"

--- a/examples/counters_stable/Cargo.toml
+++ b/examples/counters_stable/Cargo.toml
@@ -12,7 +12,7 @@ console_log = "1"
 console_error_panic_hook = "0.1.7"
 
 [dev-dependencies]
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3.37"
 pretty_assertions = "1.4.0"
 

--- a/examples/suspense_tests/Cargo.toml
+++ b/examples/suspense_tests/Cargo.toml
@@ -16,7 +16,7 @@ leptos_actix = { path = "../../integrations/actix", optional = true }
 leptos_router = { path = "../../router" }
 log = "0.4"
 simple_logger = "4"
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2"
 serde = "1.0.159"
 tokio = { version = "1.29", features = ["time", "rt"], optional = true }
 

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -206,5 +206,3 @@ fn ssr_option() {
 
     runtime.dispose();
 }
-
-// TODO: remove simulated change to trigger ci

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -207,4 +207,4 @@ fn ssr_option() {
     runtime.dispose();
 }
 
-// TODO: remove simulated change
+// TODO: remove simulated change to trigger ci


### PR DESCRIPTION
Resolves #2427

Install the latest version of `wasm-bindgen` and `cargo-leptos` as part of the CI environment setup.