### PR TITLE
Fix: Environment variables do not overwrite Config.toml options

### DIFF
--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -19,3 +19,4 @@ typed-builder = "0.18"
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 tempfile = "3"
+temp-env = { version = "0.3.6", features = ["async_closure"] }

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 rust-version.workspace = true
 
 [dependencies]
-config = { version = "0.14", default-features = false, features = ["toml"] }
+config = { version = "0.14", default-features = false, features = ["toml", "convert-case"] }
 regex = "1.7.0"
 serde = { version = "1.0.151", features = ["derive"] }
 thiserror = "1.0.38"

--- a/leptos_config/src/tests.rs
+++ b/leptos_config/src/tests.rs
@@ -30,44 +30,53 @@ fn ws_from_str_test() {
 
 #[test]
 fn env_w_default_test() {
-    std::env::set_var("LEPTOS_CONFIG_ENV_TEST", "custom");
-    assert_eq!(
-        env_w_default("LEPTOS_CONFIG_ENV_TEST", "default").unwrap(),
-        String::from("custom")
-    );
-    std::env::remove_var("LEPTOS_CONFIG_ENV_TEST");
-    assert_eq!(
-        env_w_default("LEPTOS_CONFIG_ENV_TEST", "default").unwrap(),
-        String::from("default")
-    );
+    _ = temp_env::with_var("LEPTOS_CONFIG_ENV_TEST", Some("custom"), || {
+        assert_eq!(
+            env_w_default("LEPTOS_CONFIG_ENV_TEST", "default").unwrap(),
+            String::from("custom")
+        );
+    });
+
+    _ = temp_env::with_var_unset("LEPTOS_CONFIG_ENV_TEST", || {
+        assert_eq!(
+            env_w_default("LEPTOS_CONFIG_ENV_TEST", "default").unwrap(),
+            String::from("default")
+        );
+    });
 }
 
 #[test]
 fn env_wo_default_test() {
-    std::env::set_var("LEPTOS_CONFIG_ENV_TEST", "custom");
-    assert_eq!(
-        env_wo_default("LEPTOS_CONFIG_ENV_TEST").unwrap(),
-        Some(String::from("custom"))
-    );
-    std::env::remove_var("LEPTOS_CONFIG_ENV_TEST");
-    assert_eq!(env_wo_default("LEPTOS_CONFIG_ENV_TEST").unwrap(), None);
+    _ = temp_env::with_var("LEPTOS_CONFIG_ENV_TEST", Some("custom"), || {
+        assert_eq!(
+            env_wo_default("LEPTOS_CONFIG_ENV_TEST").unwrap(),
+            Some(String::from("custom"))
+        );
+    });
+
+    _ = temp_env::with_var_unset("LEPTOS_CONFIG_ENV_TEST", || {
+        assert_eq!(env_wo_default("LEPTOS_CONFIG_ENV_TEST").unwrap(), None);
+    });
 }
 
 #[test]
 fn try_from_env_test() {
     // Test config values from environment variables
-    std::env::set_var("LEPTOS_OUTPUT_NAME", "app_test");
-    std::env::set_var("LEPTOS_SITE_ROOT", "my_target/site");
-    std::env::set_var("LEPTOS_SITE_PKG_DIR", "my_pkg");
-    std::env::set_var("LEPTOS_SITE_ADDR", "0.0.0.0:80");
-    std::env::set_var("LEPTOS_RELOAD_PORT", "8080");
-    std::env::set_var("LEPTOS_RELOAD_EXTERNAL_PORT", "8080");
-    std::env::set_var("LEPTOS_ENV", "PROD");
-    std::env::set_var("LEPTOS_RELOAD_WS_PROTOCOL", "WSS");
+    let config = temp_env::with_vars(
+        [
+            ("LEPTOS_OUTPUT_NAME", Some("app_test")),
+            ("LEPTOS_SITE_ROOT", Some("my_target/site")),
+            ("LEPTOS_SITE_PKG_DIR", Some("my_pkg")),
+            ("LEPTOS_SITE_ADDR", Some("0.0.0.0:80")),
+            ("LEPTOS_RELOAD_PORT", Some("8080")),
+            ("LEPTOS_RELOAD_EXTERNAL_PORT", Some("8080")),
+            ("LEPTOS_ENV", Some("PROD")),
+            ("LEPTOS_RELOAD_WS_PROTOCOL", Some("WSS")),
+        ],
+        || LeptosOptions::try_from_env().unwrap(),
+    );
 
-    let config = LeptosOptions::try_from_env().unwrap();
     assert_eq!(config.output_name, "app_test");
-
     assert_eq!(config.site_root, "my_target/site");
     assert_eq!(config.site_pkg_dir, "my_pkg");
     assert_eq!(

--- a/leptos_config/tests/config.rs
+++ b/leptos_config/tests/config.rs
@@ -236,3 +236,52 @@ fn leptos_options_builder_default() {
     assert_eq!(conf.reload_port, 3001);
     assert_eq!(conf.reload_external_port, None);
 }
+
+#[test]
+fn environment_variable_override() {
+    // first check without variables set
+    let config = temp_env::with_vars_unset(
+        [
+            "LEPTOS_OUTPUT_NAME",
+            "LEPTOS_SITE_ROOT",
+            "LEPTOS_SITE_PKG_DIR",
+            "LEPTOS_SITE_ADDR",
+            "LEPTOS_RELOAD_PORT",
+            "LEPTOS_RELOAD_EXTERNAL_PORT",
+        ],
+        || get_config_from_str(CARGO_TOML_CONTENT_OK).unwrap(),
+    );
+
+    assert_eq!(config.output_name, "app-test");
+    assert_eq!(config.site_root, "my_target/site");
+    assert_eq!(config.site_pkg_dir, "my_pkg");
+    assert_eq!(
+        config.site_addr,
+        SocketAddr::from_str("0.0.0.0:80").unwrap()
+    );
+    assert_eq!(config.reload_port, 8080);
+    assert_eq!(config.reload_external_port, Some(8080));
+
+    // check the override
+    let config = temp_env::with_vars(
+        [
+            ("LEPTOS_OUTPUT_NAME", Some("app-test2")),
+            ("LEPTOS_SITE_ROOT", Some("my_target/site2")),
+            ("LEPTOS_SITE_PKG_DIR", Some("my_pkg2")),
+            ("LEPTOS_SITE_ADDR", Some("0.0.0.0:82")),
+            ("LEPTOS_RELOAD_PORT", Some("8082")),
+            ("LEPTOS_RELOAD_EXTERNAL_PORT", Some("8082")),
+        ],
+        || get_config_from_str(CARGO_TOML_CONTENT_OK).unwrap(),
+    );
+
+    assert_eq!(config.output_name, "app-test2");
+    assert_eq!(config.site_root, "my_target/site2");
+    assert_eq!(config.site_pkg_dir, "my_pkg2");
+    assert_eq!(
+        config.site_addr,
+        SocketAddr::from_str("0.0.0.0:82").unwrap()
+    );
+    assert_eq!(config.reload_port, 8082);
+    assert_eq!(config.reload_external_port, Some(8082));
+}


### PR DESCRIPTION
Closes #2429 

This is my first PR on this project and it turned out a bit bigger than expected. So I am not sure about some of the decisions I made.

- Removed `separator("_")` from the Environment source setup, because this is intended for nested structures.
- Added  `convert_case(Case::Kebab)` to the Environment source setup to match the casing serde expects.
- Removed `"[leptos-options]"` from toml string to let the settings be parsed as root level, otherwise the settings from the file and the ones set by the environment variables would be considered in different structures, therefore not affecting each other. Because of this `get_config_from_str()` now returns a `LeptosOptions` object instead of a `ConfFile`.

The test cases gave me some troubles as I had some inconsistent results. I assume (because tests are executed in parallel) that sometimes variables set in one test could interfere with a test that does not expect them (now that they could actually overwrite settings originated from a file source).
I added `temp-env` as a dev dependency to address my issues. Afterwards the tests were working consistently again and I added a new test to explicitly test the override functionality.

Because I changed the parsing from `ConfFile` to `LeptosOptions`, I think the `serde::Deserialize` trait could actually be removed from the `ConfFile` struct. Any opinions on that?