### PR TITLE
chore(ci): upgrade actions to node 20

### DIFF
--- a/.github/workflows/get-examples-matrix.yml
+++ b/.github/workflows/get-examples-matrix.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install JQ Tool
-        uses: mbround18/install-jq@v1
+      - name: Install jq
+        run: sudo apt-get install jq
 
       - name: Set Matrix
         id: set-matrix

--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -54,9 +54,7 @@ jobs:
         run: cargo binstall cargo-leptos --no-confirm
 
       - name: Install Trunk
-        uses: jetli/trunk-action@v0.4.0
-        with:
-          version: "latest"
+        run: cargo binstall trunk --no-confirm
 
       - name: Print Trunk Version
         run: trunk --version

--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v3
         name: Install pnpm
         id: pnpm-install
         with:
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}

--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -27,11 +27,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.toolchain }}
-          override: true
-          components: rustfmt
 
       - name: Add wasm32-unknown-unknown
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install
         with:

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -206,5 +206,3 @@ fn ssr_option() {
 
     runtime.dispose();
 }
-
-// TODO: simulate change to trigger ci examples

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -206,3 +206,5 @@ fn ssr_option() {
 
     runtime.dispose();
 }
+
+// TODO: simulate change to trigger ci examples


### PR DESCRIPTION

Resolve node warnings from the following actions:

- mbround18/install-jq@v1
- actions-rs/toolchain@v1
- jetli/trunk-action@v0.4.0
- actions/cache@v3