### PR TITLE
Persist parent span context within resource fetchers

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -1389,6 +1389,7 @@ where
                 }
             }
 
+            let current_span = tracing::Span::current();
             // run the Future
             let serializable = self.serializable;
             spawn_local({
@@ -1397,6 +1398,8 @@ where
                 let set_loading = self.set_loading;
                 let last_version = self.version.clone();
                 async move {
+                    // continue trace context within resource fetcher
+                    let _guard = current_span.enter();
                     let res = fut.await;
 
                     if version == last_version.get() {


### PR DESCRIPTION
This PR fixes a loss in parent span context when fetching resources in SSR. 

Most notably, calling `server_fn` in a resource during SSR currently results in a break in span context, and server_fn  span runs as a 'sibling' instead of entering as a child.
 
With this fix the `server_fn` span will correctly continue as a child of it's caller.