### PR TITLE
Minor: Ran cargo clippy --fix

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -705,8 +705,8 @@ impl Docs {
                         {
                             view_code_fence_state = ViewCodeFenceState::Rust;
                             let view = trimmed_doc.find('v').unwrap();
-                            quotes = trimmed_doc[..view].to_owned();
-                            quote_ws = leading_ws.to_owned();
+                            trimmed_doc[..view].clone_into(&mut quotes);
+                            leading_ws.clone_into(&mut quote_ws);
                             let rust_options = &trimmed_doc
                                 [view + "view".len()..]
                                 .trim_start();

--- a/leptos_reactive/src/callback.rs
+++ b/leptos_reactive/src/callback.rs
@@ -238,7 +238,7 @@ mod tests {
     fn clone_callback() {
         let rt = create_runtime();
         let callback = Callback::new(move |_no_clone: NoClone| NoClone {});
-        let _cloned = callback.clone();
+        let _cloned = callback;
         rt.dispose();
     }
 

--- a/leptos_reactive/src/slice.rs
+++ b/leptos_reactive/src/slice.rs
@@ -71,8 +71,8 @@ use crate::{
 #[track_caller]
 pub fn create_slice<T, O, S>(
     signal: RwSignal<T>,
-    getter: impl Fn(&T) -> O + Clone + Copy + 'static,
-    setter: impl Fn(&mut T, S) + Clone + Copy + 'static,
+    getter: impl Fn(&T) -> O + Copy + 'static,
+    setter: impl Fn(&mut T, S) + Copy + 'static,
 ) -> (Signal<O>, SignalSetter<S>)
 where
     O: PartialEq,
@@ -88,7 +88,7 @@ where
 #[track_caller]
 pub fn create_read_slice<T, O>(
     signal: RwSignal<T>,
-    getter: impl Fn(&T) -> O + Clone + Copy + 'static,
+    getter: impl Fn(&T) -> O + Copy + 'static,
 ) -> Signal<O>
 where
     O: PartialEq,
@@ -101,7 +101,7 @@ where
 #[track_caller]
 pub fn create_write_slice<T, O>(
     signal: RwSignal<T>,
-    setter: impl Fn(&mut T, O) + Clone + Copy + 'static,
+    setter: impl Fn(&mut T, O) + Copy + 'static,
 ) -> SignalSetter<O> {
     let setter = move |value| signal.update(|x| setter(x, value));
     setter.into_signal_setter()

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -248,7 +248,7 @@ fn owning_memo_slice() {
     let token = create_owning_memo(move |old_token| {
         state.with(move |state| {
             let is_different = old_token.as_ref() != Some(&state.token);
-            let mut token = old_token.unwrap_or_else(String::new);
+            let mut token = old_token.unwrap_or_default();
 
             if is_different {
                 token.clone_from(&state.token);

--- a/router/src/components/routes.rs
+++ b/router/src/components/routes.rs
@@ -359,7 +359,7 @@ fn inherit_settings(children: &mut [RouteDefinition], router: &RouterContext) {
     ) {
         for child in children {
             if child.trailing_slash.is_none() {
-                child.trailing_slash = inherited.trailing_slash.clone();
+                child.trailing_slash.clone_from(&inherited.trailing_slash);
             }
             route_def_inherit(
                 &mut child.children,

--- a/router/src/extract_routes/test_extract_routes.rs
+++ b/router/src/extract_routes/test_extract_routes.rs
@@ -186,7 +186,7 @@ impl History for TestHistory {
     }
 
     fn navigate(&self, new_loc: &LocationChange) {
-        self.loc.update(|loc| loc.value = new_loc.value.clone())
+        self.loc.update(|loc| loc.value.clone_from(&new_loc.value))
     }
 }
 


### PR DESCRIPTION
I Manually reviewed the changes. All look like reasonable nudges.

A summary :-

In one place removed a redundant call to .clone().

In two places, now using clone_from() which clippy says **MAY** be an optimisation.