### PR TITLE
Fix: Small fix for location hash/fragment

### DIFF
--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -39,7 +39,10 @@ pub fn location_hash() -> Option<String> {
     if is_server() {
         None
     } else {
-        location().hash().ok().map(|hash| hash.replace('#', ""))
+        location().hash().ok().map(|hash| match hash.chars().next() {
+            Some('#') => hash[1..].to_string(),
+            _ => hash,
+        })
     }
 }
 


### PR DESCRIPTION
The current location hash implementation will replace all `#` chars in the fragment, which shouldn't be the case.
While, according to spec, `#` is not allowed in the fragment portion of the URL, browsers tend to be lenient towards enforcing this. Opening a URL in your browser (be it Chrome or Firefox) with `#` in the fragment will get accepted and returned in your location hash.

Consider [https://github.com/leptos-rs/leptos/#test#bar](https://github.com/leptos-rs/leptos/#test#bar). Your location hash will return (in Javascript) `#test#bar`.
The current implementation in Leptos will return `testbar` while the new implementation will return `test#bar`, which fits the docs better of the function:
```
/// Current [`window.location.hash`](https://developer.mozilla.org/en-US/docs/Web/API/Window/location)
/// without the beginning #.
```

---

A small side-note: I've contemplated simply always removing the first char of the fragment (since this should always be `#` anyways). Like so: `if s.is_empty() { s } else { s[1..].to_string() }`. I've decided against it, but if you (the reviewer) prefers this implementation, please let me know and I'll update it.