### PR TITLE
Update counter example's signal usage

### DIFF
--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -14,7 +14,7 @@ pub fn SimpleCounter(
 
     view! {
         <div>
-            <button on:click=move |_| set_value(0)>"Clear"</button>
+            <button on:click=move |_| set_value.set(0)>"Clear"</button>
             <button on:click=move |_| set_value.update(|value| *value -= step)>"-1"</button>
             <span>"Value: " {value} "!"</span>
             <button on:click=move |_| set_value.update(|value| *value += step)>"+1"</button>


### PR DESCRIPTION
Seems we're missing `.set()`