### PR TITLE
Allow CDN_PKG_PATH at runtime.

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -56,9 +56,16 @@ pub fn html_parts_separated(
     options: &LeptosOptions,
     meta: Option<&MetaContext>,
 ) -> (String, &'static str) {
-    let pkg_path = option_env!("CDN_PKG_PATH")
-        .map(Cow::from)
-        .unwrap_or_else(|| format!("/{}", options.site_pkg_dir).into());
+    // First check runtime env, then build time, then default:
+    let pkg_path = match std::env::var("CDN_PKG_PATH").ok().map(Cow::from) {
+        Some(path) => path,
+        None => {
+            match option_env!("CDN_PKG_PATH").map(Cow::from) {
+                Some(path) => path,
+                None => format!("/{}", options.site_pkg_dir).into(),
+            }
+        }
+    };
     let output_name = &options.output_name;
     let nonce = use_nonce();
     let nonce = nonce


### PR DESCRIPTION
This PR implements runtime support for CDN_PKG_PATH, preferring it when available.
Beforehand, only build time would be read.

## Why
In my case, my cdn path is categorised as a sensitive key, therefore only available at runtime later than the build stage.