### PR TITLE
Debug NodeRef Warning (#2414)

### DIFF
--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -189,10 +189,12 @@ impl<T: ElementDescriptor + 'static> NodeRef<T> {
         self.element.update(|current| {
             if current.is_some() {
                 crate::debug_warn!(
-                    "You are setting a NodeRef that has already been filled. \
+                    "You are setting the NodeRef defined at {}, which has \
+                     already been filled \
                      It’s possible this is intentional, but it’s also \
                      possible that you’re accidentally using the same NodeRef \
-                     for multiple _ref attributes."
+                     for multiple _ref attributes.",
+                    self.defined_at
                 );
             }
             *current = Some(node.clone());

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -218,7 +218,6 @@ impl<T: ElementDescriptor + 'static> NodeRef<T> {
 }
 
 impl<T: ElementDescriptor> Clone for NodeRef<T> {
-    #[track_caller]
     fn clone(&self) -> Self {
         *self
     }

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -2,40 +2,12 @@ use crate::{html::ElementDescriptor, HtmlElement};
 use leptos_reactive::{create_render_effect, signal_prelude::*};
 use std::cell::Cell;
 
-cfg_if::cfg_if!(
+  cfg_if::cfg_if!(
   if #[cfg(debug_assertions)] {
-    /// Contains a shared reference to a DOM node created while using the `view`
-    /// macro to create your UI.
-    ///
-    /// ```
-    /// # use leptos::{*, logging::log};
-    /// use leptos::html::Input;
-    ///
-    /// #[component]
-    /// pub fn MyComponent() -> impl IntoView {
-    ///     let input_ref = create_node_ref::<Input>();
-    ///
-    ///     let on_click = move |_| {
-    ///         let node =
-    ///             input_ref.get().expect("input_ref should be loaded by now");
-    ///         // `node` is strongly typed
-    ///         // it is dereferenced to an `HtmlInputElement` automatically
-    ///         log!("value is {:?}", node.value())
-    ///     };
-    ///
-    ///     view! {
-    ///       <div>
-    ///       // `node_ref` loads the input
-    ///       <input _ref=input_ref type="text"/>
-    ///       // the button consumes it
-    ///       <button on:click=on_click>"Click me"</button>
-    ///       </div>
-    ///     }
-    /// }
-    /// ```
+    #[allow(missing_docs)]
     pub struct NodeRef<T: ElementDescriptor + 'static> {
-      defined_at: &'static std::panic::Location<'static>,
       element: RwSignal<Option<HtmlElement<T>>>,
+      defined_at: &'static std::panic::Location<'static>,
     }
   } else {
     /// Contains a shared reference to a DOM node created while using the `view`

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -2,14 +2,6 @@ use crate::{html::ElementDescriptor, HtmlElement};
 use leptos_reactive::{create_render_effect, signal_prelude::*};
 use std::cell::Cell;
 
-  cfg_if::cfg_if!(
-  if #[cfg(debug_assertions)] {
-    #[allow(missing_docs)]
-    pub struct NodeRef<T: ElementDescriptor + 'static> {
-      element: RwSignal<Option<HtmlElement<T>>>,
-      defined_at: &'static std::panic::Location<'static>,
-    }
-  } else {
     /// Contains a shared reference to a DOM node created while using the `view`
     /// macro to create your UI.
     ///
@@ -39,12 +31,12 @@ use std::cell::Cell;
     ///     }
     /// }
     /// ```
-    #[repr(transparent)]
+    #[cfg_attr(not(debug_assertions), repr(transparent))]
     pub struct NodeRef<T: ElementDescriptor + 'static> {
       element: RwSignal<Option<HtmlElement<T>>>,
+      #[cfg(debug_assertions)]
+      defined_at: &'static std::panic::Location<'static>,
     }
-  }
-);
 
 /// Creates a shared reference to a DOM node created while using the `view`
 /// macro to create your UI.
@@ -79,8 +71,9 @@ use std::cell::Cell;
 #[inline(always)]
 pub fn create_node_ref<T: ElementDescriptor + 'static>() -> NodeRef<T> {
     NodeRef {
-        defined_at: std::panic::Location::caller(),
-        element: create_rw_signal(None),
+      #[cfg(debug_assertions)]
+      defined_at: std::panic::Location::caller(),
+      element: create_rw_signal(None),
     }
 }
 

--- a/leptos_dom/src/node_ref.rs
+++ b/leptos_dom/src/node_ref.rs
@@ -200,7 +200,6 @@ impl<T: ElementDescriptor> Clone for NodeRef<T> {
 impl<T: ElementDescriptor + 'static> Copy for NodeRef<T> {}
 
 impl<T: ElementDescriptor + 'static> Default for NodeRef<T> {
-    #[track_caller]
     fn default() -> Self {
         Self::new()
     }


### PR DESCRIPTION
This is a response to #2414

In production #[repr(transparent)] is use to ensure a compact representation in memory. 
In developement the memory is slightly expanded.

Things I am thinking about 

A) I have introduced a maintence hazard... the documentation block for NodeRef is repeated twice 
So any future PRs will have to make sure things are kept in sync.
I would love to avoid that...

B) I may have been over eager.. ( adding  #[track_caller ] in too many places. ) 
impl<T: ElementDescriptor> Clone for NodeRef<T> {
    #[track_caller]
    fn clone(&self) -> Self {
        *self
    }


