### PR TITLE
ci: disable semver checks

### DIFF
--- a/.github/workflows/ci-semver.yml
+++ b/.github/workflows/ci-semver.yml
@@ -1,12 +1,6 @@
 name: CI semver
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: workflow_dispatch # Only run this workflow manually
 
 jobs:
   get-leptos-changed:


### PR DESCRIPTION
This resolves #2470.

## Changes

- Allow the **CI semver** workflow to be triggered manually
  - _This provides the option of trying again later_
- Do not trigger the **CI semver** on `push`

## Notes

- The blame for the errors seem to be external to the `leptos` code. Something changed around 03/24/2024 that now causes even previously passing commits to fail.