### PR TITLE
Add repository field to server_fn_macro

### DIFF
--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = "2021"
 authors = ["Greg Johnston"]
 license = "MIT"
+repository = "https://github.com/leptos-rs/leptos"
 description = "RPC for any web framework."
 readme = "../README.md"
 


### PR DESCRIPTION
Hi! While scraping crates.io I've found `server_fn_macro` to be missing the `repository` field. This fixes it.