### PR TITLE
fix: correctly handle empty `view! {}` in hot-reloading code (closes #2421)

### DIFF
--- a/leptos_hot_reload/src/lib.rs
+++ b/leptos_hot_reload/src/lib.rs
@@ -78,12 +78,20 @@ impl ViewMacros {
         for view in visitor.views {
             let span = view.span();
             let id = span_to_stable_id(path, span.start().line);
-            let tokens = view.tokens.clone().into_iter();
-            // TODO handle class = ...
-            let rsx =
-                rstml::parse2(tokens.collect::<proc_macro2::TokenStream>())?;
-            let template = LNode::parse_view(rsx)?;
-            views.push(MacroInvocation { id, template });
+            if view.tokens.is_empty() {
+                views.push(MacroInvocation {
+                    id,
+                    template: LNode::Fragment(Vec::new()),
+                });
+            } else {
+                let tokens = view.tokens.clone().into_iter();
+                // TODO handle class = ...
+                let rsx = rstml::parse2(
+                    tokens.collect::<proc_macro2::TokenStream>(),
+                )?;
+                let template = LNode::parse_view(rsx)?;
+                views.push(MacroInvocation { id, template });
+            }
         }
         Ok(views)
     }


### PR DESCRIPTION
This will close #2421, once it is merged and released and a new version of cargo-leptos is released that includes it.

It does not necessarily make hot-reloading *work* correctly for these empty `view! {}` cases, because there's nothing "in" the DOM to be replaced by a new view. (It might be possible to change this.) But it at least allows the process to continue working correctly rather than bailing out with an error.