### PR TITLE
ci(examples/error-boundary): use stable syntax

### DIFF
--- a/examples/error_boundary/Cargo.toml
+++ b/examples/error_boundary/Cargo.toml
@@ -8,7 +8,7 @@ codegen-units = 1
 lto = true
 
 [dependencies]
-leptos = { path = "../../leptos", features = ["csr", "nightly"] }
+leptos = { path = "../../leptos", features = ["csr"] }
 console_log = "1"
 log = "0.4"
 console_error_panic_hook = "0.1.7"

--- a/examples/error_boundary/src/lib.rs
+++ b/examples/error_boundary/src/lib.rs
@@ -5,7 +5,8 @@ pub fn App() -> impl IntoView {
     let (value, set_value) = create_signal(Ok(0));
 
     // when input changes, try to parse a number from the input
-    let on_input = move |ev| set_value(event_target_value(&ev).parse::<i32>());
+    let on_input =
+        move |ev| set_value.set(event_target_value(&ev).parse::<i32>());
 
     view! {
         <h1>"Error Handling"</h1>


### PR DESCRIPTION
WIP - Work in Progress

Supports #2481

## Verification

- `cargo +stable build`

## Notes

- I decided to fix to #2486 here.