### PR TITLE
fix: make TextProp's IntoView and IntoAttribute impls reactive

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -251,7 +251,7 @@ where
 
 impl IntoView for TextProp {
     fn into_view(self) -> View {
-        self.get().into_view()
+        (move || self.get()).into_view()
     }
 }
 

--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -227,7 +227,7 @@ impl IntoAttribute for Option<Box<dyn IntoAttribute>> {
 
 impl IntoAttribute for TextProp {
     fn into_attribute(self) -> Attribute {
-        self.get().into_attribute()
+        (move || self.get()).into_attribute()
     }
 
     impl_into_attr_boxed! {}


### PR DESCRIPTION
This makes passing a `TextProp` directly into an attribute behave as one would expect.
