### PR TITLE
docs: remove unnecessary type parameter and trait bound in component macro 'bad' example

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -489,7 +489,7 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 /// use leptos::html::Div;
 ///
 /// #[component]
-/// fn MyComponent<T: Fn() -> HtmlElement<Div>>(render_prop: impl Fn() -> HtmlElement<Div>) -> impl IntoView {
+/// fn MyComponent(render_prop: impl Fn() -> HtmlElement<Div>) -> impl IntoView {
 /// }
 /// ```
 ///


### PR DESCRIPTION
the removed type parameter is redundant to the 'bad' example, and is confusing with it being one of the 'valid' options 