### PR TITLE
Adds ability to use multiple classes in view macro using array syntax.

### DIFF
--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -321,19 +321,14 @@ fn attr_to_tokens(
     // Classes
     else if let Some(name) = name.strip_prefix("class:") {
         let value = attribute_value(node);
-        match value {
-            syn::Expr::Lit(value) => {
-                todo!();
-            }
 
-            _ => expressions.push(quote_spanned! {
-                span=> ::leptos::leptos_dom::class_helper(
-                    ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
-                    #name.into(),
-                    ::leptos::IntoClass::into_class(#value),
-                )
-            }),
-        };
+        expressions.push(quote_spanned! {
+            span=> ::leptos::leptos_dom::class_helper(
+                ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
+                #name.into(),
+                ::leptos::IntoClass::into_class(#value),
+            )
+        });
     }
     // Attributes
     else {

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -321,14 +321,19 @@ fn attr_to_tokens(
     // Classes
     else if let Some(name) = name.strip_prefix("class:") {
         let value = attribute_value(node);
+        match value {
+            syn::Expr::Lit(value) => {
+                todo!();
+            }
 
-        expressions.push(quote_spanned! {
-            span=> ::leptos::leptos_dom::class_helper(
-                ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
-                #name.into(),
-                ::leptos::IntoClass::into_class(#value),
-            )
-        });
+            _ => expressions.push(quote_spanned! {
+                span=> ::leptos::leptos_dom::class_helper(
+                    ::leptos::wasm_bindgen::JsCast::unchecked_ref(&#el_id),
+                    #name.into(),
+                    ::leptos::IntoClass::into_class(#value),
+                )
+            }),
+        };
     }
     // Attributes
     else {


### PR DESCRIPTION
Adds array syntax to the `fancy class name` syntax in the `view` macro for multiple classes to be controlled by the same `class` attribute.
e.g.
```rust
#[component]
fn App() -> impl IntoView {
  let (classes, set_classes) = create_signal(true);

  view! {
    <div
      class=(["class-1", "class-2"], classes)
    >
      <button
        on:click=move |_| set_classes(!classes)
      >
        Toggle
      </button>
    </div>
  }
}
```
Compared to the current style which requires creating a new `class` attribute for each class.
e.g.
```rust
#[component]
fn App() -> impl IntoView {
  let (classes, set_classes) = create_signal(true);

  view! {
    <div
      class=("class-1", classes)
      class=("class-2", classes)
    >
      <button
        on:click=move |_| set_classes(!classes)
      >
        Toggle
      </button>
    </div>
  }
}
``` 
This can be especially useful when using styling systems like Tailwind.

This was discussed in #2522.