### PR TITLE
feat: spread component attrs

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -365,33 +365,6 @@ impl ToTokens for Model {
             })
             .collect::<TokenStream>();
 
-        let dyn_binding_props = props
-            .iter()
-            .filter(
-                |Prop {
-                     prop_opts: PropOpt { attrs, .. },
-                     ..
-                 }| *attrs,
-            )
-            .filter_map(
-                |Prop {
-                     name,
-                     prop_opts: PropOpt { attrs, .. },
-                     ..
-                 }| {
-                    let ident = &name.ident;
-
-                    if *attrs {
-                        Some(quote! {
-                            ::leptos::leptos_dom::html::Binding::Attribute { name, value } => self.#ident.push((name, value)),
-                        })
-                    } else {
-                        None
-                    }
-                },
-            )
-            .collect::<TokenStream>();
-
         let body = quote! {
             #destructure_props
             #tracing_span_expr
@@ -527,21 +500,6 @@ impl ToTokens for Model {
             impl #impl_generics ::leptos::DynAttrs for #props_name #generics #where_clause {
                 fn dyn_attrs(mut self, v: Vec<(&'static str, ::leptos::Attribute)>) -> Self {
                     #dyn_attrs_props
-                    self
-                }
-            }
-
-            impl #impl_generics #props_name #generics #where_clause {
-                fn dyn_bindings<B: Into<::leptos::leptos_dom::html::Binding>>(mut self, bindings: impl std::iter::IntoIterator<Item = B>) -> Self {
-                    for binding in bindings.into_iter() {
-                        let binding: ::leptos::leptos_dom::html::Binding = binding.into();
-
-                        match binding {
-                            #dyn_binding_props
-                            _ => {}
-                        }
-                    }
-
                     self
                 }
             }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -365,6 +365,33 @@ impl ToTokens for Model {
             })
             .collect::<TokenStream>();
 
+        let dyn_binding_props = props
+            .iter()
+            .filter(
+                |Prop {
+                     prop_opts: PropOpt { attrs, .. },
+                     ..
+                 }| *attrs,
+            )
+            .filter_map(
+                |Prop {
+                     name,
+                     prop_opts: PropOpt { attrs, .. },
+                     ..
+                 }| {
+                    let ident = &name.ident;
+
+                    if *attrs {
+                        Some(quote! {
+                            ::leptos::leptos_dom::html::Binding::Attribute { name, value } => self.#ident.push((name, value)),
+                        })
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect::<TokenStream>();
+
         let body = quote! {
             #destructure_props
             #tracing_span_expr
@@ -500,6 +527,21 @@ impl ToTokens for Model {
             impl #impl_generics ::leptos::DynAttrs for #props_name #generics #where_clause {
                 fn dyn_attrs(mut self, v: Vec<(&'static str, ::leptos::Attribute)>) -> Self {
                     #dyn_attrs_props
+                    self
+                }
+            }
+
+            impl #impl_generics #props_name #generics #where_clause {
+                fn dyn_bindings<B: Into<::leptos::leptos_dom::html::Binding>>(mut self, bindings: impl std::iter::IntoIterator<Item = B>) -> Self {
+                    for binding in bindings.into_iter() {
+                        let binding: ::leptos::leptos_dom::html::Binding = binding.into();
+
+                        match binding {
+                            #dyn_binding_props
+                            _ => {}
+                        }
+                    }
+
                     self
                 }
             }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -27,30 +27,6 @@ pub(crate) fn component_to_tokens(
         }
     });
 
-    let spread_bindings = node.attributes().iter().filter_map(|node| {
-        use rstml::node::NodeBlock;
-        use syn::{Expr, ExprRange, RangeLimits, Stmt};
-
-        if let NodeAttribute::Block(NodeBlock::ValidBlock(block)) = node {
-            match block.stmts.first()? {
-                Stmt::Expr(
-                    Expr::Range(ExprRange {
-                        start: None,
-                        limits: RangeLimits::HalfOpen(_),
-                        end: Some(end),
-                        ..
-                    }),
-                    _,
-                ) => Some(
-                    quote! { .dyn_bindings(#[allow(unused_brace)] {#end}) },
-                ),
-                _ => None,
-            }
-        } else {
-            None
-        }
-    });
-
     let props = attrs
         .clone()
         .filter(|attr| {
@@ -246,8 +222,7 @@ pub(crate) fn component_to_tokens(
             #[allow(clippy::let_unit_value, clippy::unit_arg)]
             let props = props
                 #build
-                #dyn_attrs
-                #(#spread_bindings)*;
+                #dyn_attrs;
 
             #[allow(unreachable_code)]
             ::leptos::component_view(


### PR DESCRIPTION
Solves https://github.com/leptos-rs/leptos/issues/2403

In the following code `Bar` will not inherit attributes from `Foo` when it spreads its attributes
```rs
fn main() {
    let (count, set_count) = create_signal(0);

    mount_to_body(move || {
        view! {
            <Foo
                attr:hello=move || count.get().to_string()
            />

            <button on:click=move|_| { set_count.update(|count| *count += 1) }>"+ count"</button>
        }
    });
}

#[component]
fn Foo(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
    view! {
        <Bar {..attrs} />
    }
}

#[component]
fn Bar(#[prop(attrs)] attrs: Vec<(&'static str, Attribute)>) -> impl IntoView {
    view! {
        <div {..attrs}>"hello world"</div>
    }
}
```

This PR allows for this functionality