### PR TITLE
Update leptos-spin-macro reference

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -16,7 +16,7 @@ leptos_macro = { workspace = true }
 leptos_reactive = { workspace = true }
 leptos_server = { workspace = true }
 leptos_config = { workspace = true }
-leptos-spin-macro = { version = "0.1", optional = true }
+leptos-spin-macro = { version = "0.2", optional = true }
 tracing = "0.1"
 typed-builder = "0.18"
 typed-builder-macro = "0.18"


### PR DESCRIPTION
The currently referenced `leptos-spin-macro` crate depends on `spin-sdk` v2, which can cause conflicts for users wanting to run Leptos on Spin using `spin-sdk` v3.

This PR updates the reference.  `leptos-spin-macro` 0.2 does not depend on the Spin SDK so should avoid any potential conflicts.
