### PR TITLE
fix: StoredValue and Resource panic during cleanup

### DIFF
--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -294,10 +294,12 @@ impl Runtime {
                 drop(node);
             }
             ScopeProperty::Resource(id) => {
-                self.resources.borrow_mut().remove(id);
+                let value = self.resources.borrow_mut().remove(id);
+                drop(value);
             }
             ScopeProperty::StoredValue(id) => {
-                self.stored_values.borrow_mut().remove(id);
+                let value = self.stored_values.borrow_mut().remove(id);
+                drop(value);
             }
         }
     }


### PR DESCRIPTION
If the value inside a `StoredValue` implements the drop trait, and that drop causes another read, update or dispose on another StoredValue, we'd get a cryptic panic with `already mutably borrowed: BorrowError`. 
I encountered this issue with a `StoredValue<Disposer>` with the disposer type returned by `as_child_of_current_owner()`. Because the Disposer cleans up a reactive sub-scope on Drop, it will try to mutably borrow `Runtime::stored_values` while it is still mutably borrowed by the function that drops it.