### PR TITLE
fix: migration syntax and insert query

### DIFF
--- a/projects/sso_auth_axum/migrations/20231217000000_create_tables.sql
+++ b/projects/sso_auth_axum/migrations/20231217000000_create_tables.sql
@@ -21,6 +21,6 @@ CREATE TABLE IF NOT EXISTS google_tokens (
   access_secret TEXT NOT NULL,
   refresh_secret TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (user_id) REFERENCES users(id) CONFLICT REPLACE
+  FOREIGN KEY (user_id) REFERENCES users(id)
 );
 

--- a/projects/sso_auth_axum/src/lib.rs
+++ b/projects/sso_auth_axum/src/lib.rs
@@ -64,7 +64,7 @@ pub async fn refresh_token(email: String) -> Result<u64, ServerFnError> {
         .execute(&pool)
         .await?;
     sqlx::query(
-        "INSERT INTO google_tokens (user_id,access_secret,refresh_secret) \
+        "INSERT OR REPLACE INTO google_tokens (user_id,access_secret,refresh_secret) \
          VALUES (?,?,?)",
     )
     .bind(user.id)

--- a/projects/sso_auth_axum/src/main.rs
+++ b/projects/sso_auth_axum/src/main.rs
@@ -96,7 +96,7 @@ async fn main() {
     let client = oauth2::basic::BasicClient::new(
         oauth2::ClientId::new(
             std::env::var("G_AUTH_CLIENT_ID")
-                .expect("G_AUTH_CLIENT Env var to be set."),
+                .expect("G_AUTH_CLIENT_ID Env var to be set."),
         ),
         Some(oauth2::ClientSecret::new(
             std::env::var("G_AUTH_SECRET")


### PR DESCRIPTION
I noticed that the example was not working because the migration could not run:

```
sqlite> CREATE TABLE IF NOT EXISTS google_tokens (
(x1...>   id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
(x1...>   user_id INTEGER NOT NULL UNIQUE,
(x1...>   access_secret TEXT NOT NULL,
(x1...>   refresh_secret TEXT NOT NULL,
(x1...>   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
(x1...>   FOREIGN KEY (user_id) REFERENCES users(id) CONFLICT REPLACE
(x1...> );
Parse error: near "CONFLICT": syntax error
  AMP,   FOREIGN KEY (user_id) REFERENCES users(id) CONFLICT REPLACE );
                                      error here ---^
sqlite> 
```

Moving that conflict resolution to the insert query seems to work fine.