### PR TITLE
Allow slice! macro to index tuples

### DIFF
--- a/leptos_macro/src/slice.rs
+++ b/leptos_macro/src/slice.rs
@@ -11,7 +11,7 @@ use syn::{
 
 struct SliceMacroInput {
     root: syn::Ident,
-    path: Punctuated<syn::Ident, Token![.]>,
+    path: Punctuated<syn::Member, Token![.]>,
 }
 
 impl Parse for SliceMacroInput {
@@ -19,7 +19,7 @@ impl Parse for SliceMacroInput {
         let root: syn::Ident = input.parse()?;
         input.parse::<Token![.]>()?;
         // do not accept trailing punctuation
-        let path: Punctuated<syn::Ident, Token![.]> =
+        let path: Punctuated<syn::Member, Token![.]> =
             Punctuated::parse_separated_nonempty(input)?;
 
         if path.is_empty() {

--- a/leptos_macro/tests/slice.rs
+++ b/leptos_macro/tests/slice.rs
@@ -10,8 +10,11 @@ pub struct OuterState {
 #[derive(Clone, PartialEq, Default)]
 pub struct InnerState {
     inner_count: i32,
-    inner_name: String,
+    inner_tuple: InnerTuple,
 }
+
+#[derive(Clone, PartialEq, Default)]
+pub struct InnerTuple(String);
 
 #[test]
 fn green() {
@@ -22,7 +25,7 @@ fn green() {
     let (_, _) = slice!(outer_signal.count);
 
     let (_, _) = slice!(outer_signal.inner.inner_count);
-    let (_, _) = slice!(outer_signal.inner.inner_name);
+    let (_, _) = slice!(outer_signal.inner.inner_tuple.0);
 }
 
 #[test]

--- a/leptos_macro/tests/slice/red.stderr
+++ b/leptos_macro/tests/slice/red.stderr
@@ -14,7 +14,7 @@ error: expected `.`
    |
    = note: this error originates in the macro `slice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected end of input, expected identifier
+error: unexpected end of input, expected identifier or integer
   --> tests/slice/red.rs:25:18
    |
 25 |     let (_, _) = slice!(outer_signal.);
@@ -22,7 +22,7 @@ error: unexpected end of input, expected identifier
    |
    = note: this error originates in the macro `slice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: unexpected end of input, expected identifier
+error: unexpected end of input, expected identifier or integer
   --> tests/slice/red.rs:27:18
    |
 27 |     let (_, _) = slice!(outer_signal.inner.);

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -1,18 +1,20 @@
 error: return type is incorrect
+
+         = help: return signature must be `-> impl IntoView`
+
  --> tests/ui/component.rs:4:1
   |
 4 | fn missing_scope() {}
   | ^^^^^^^^^^^^^^^^^^
-  |
-  = help: return signature must be `-> impl IntoView`
 
 error: return type is incorrect
+
+         = help: return signature must be `-> impl IntoView`
+
  --> tests/ui/component.rs:7:1
   |
 7 | fn missing_return_type() {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: return signature must be `-> impl IntoView`
 
 error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into` and `attrs`
   --> tests/ui/component.rs:10:31
@@ -24,19 +26,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component.rs:16:12
    |
 16 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:23:12
    |
 23 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:30:12
    |
 30 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 

--- a/leptos_macro/tests/ui/component_absolute.stderr
+++ b/leptos_macro/tests/ui/component_absolute.stderr
@@ -1,10 +1,11 @@
 error: return type is incorrect
+
+         = help: return signature must be `-> impl IntoView`
+
  --> tests/ui/component_absolute.rs:2:1
   |
 2 | fn missing_return_type() {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = help: return signature must be `-> impl IntoView`
 
 error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into` and `attrs`
  --> tests/ui/component_absolute.rs:5:31
@@ -16,19 +17,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component_absolute.rs:11:12
    |
 11 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:18:12
    |
 18 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:25:12
    |
 25 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 


### PR DESCRIPTION
Currently, the `slice!` macro breaks when trying to index a tuple. Example:

```rust
use leptos::*;

#[derive(Clone, PartialEq, Eq)]
struct PostView {
    pub post: Post,
    pub creator: String
}

#[derive(Clone, PartialEq, Eq)]
struct Post {
    pub body: String,
    pub id: PostId
}

#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
struct PostId(pub i32);

let post = RwSignal::new(
    PostView {
        creator: "Bob".to_owned(),
        post: Post {
            body: "Hello World!!!".to_owned(),
            id: PostId(42)
        }
    }
);

let id = slice!(post.post.id.0); // Does not compile!
```

This change allows both identifiers and tuple indices to be used.