### PR TITLE
feat: `#[component]` now handles `impl Trait` by converting to generic type params, fix #2274

### DIFF
--- a/leptos_macro/tests/component.rs
+++ b/leptos_macro/tests/component.rs
@@ -8,20 +8,27 @@ fn Component(
     #[prop(strip_option)] strip_option: Option<u8>,
     #[prop(default = NonZeroUsize::new(10).unwrap())] default: NonZeroUsize,
     #[prop(into)] into: String,
+    impl_trait: impl Fn() -> i32 + 'static,
 ) -> impl IntoView {
     _ = optional;
     _ = optional_no_strip;
     _ = strip_option;
     _ = default;
     _ = into;
+    _ = impl_trait;
 }
 
 #[test]
 fn component() {
-    let cp = ComponentProps::builder().into("").strip_option(9).build();
+    let cp = ComponentProps::builder()
+        .into("")
+        .strip_option(9)
+        .impl_trait(|| 42)
+        .build();
     assert!(!cp.optional);
     assert_eq!(cp.optional_no_strip, None);
     assert_eq!(cp.strip_option, Some(9));
     assert_eq!(cp.default, NonZeroUsize::new(10).unwrap());
     assert_eq!(cp.into, "");
+    assert_eq!((cp.impl_trait)(), 42);
 }


### PR DESCRIPTION
Fix #2274 (for real)

Currently the `Ident`s generated are just in the form `__ImplTrait0`, `__ImplTrait1`, etc. Maybe could base it off of the argument names, to improve error messages if there are bugs.

Book needs to be updated to remove this line:
https://github.com/leptos-rs/book/blob/35c380ffc8f7d2e50ef21db97943138b3dba2728/src/view/03_components.md?plain=1#L233