### PR TITLE
fix: URL encoding issue (closes #2602)

### DIFF
--- a/router/src/history/params.rs
+++ b/router/src/history/params.rs
@@ -30,8 +30,6 @@ impl ParamsMap {
     /// Inserts a value into the map.
     #[inline(always)]
     pub fn insert(&mut self, key: String, value: String) -> Option<String> {
-        use crate::history::url::unescape;
-        let value = unescape(&value);
         self.0.insert(key, value)
     }
 

--- a/router/src/history/url.rs
+++ b/router/src/history/url.rs
@@ -25,7 +25,7 @@ pub fn unescape(s: &str) -> String {
 
 #[cfg(not(feature = "ssr"))]
 pub fn unescape(s: &str) -> String {
-    js_sys::decode_uri(s).unwrap().into()
+    js_sys::decode_uri_component(s).unwrap().into()
 }
 
 #[cfg(feature = "ssr")]
@@ -36,7 +36,7 @@ pub fn escape(s: &str) -> String {
 
 #[cfg(not(feature = "ssr"))]
 pub fn escape(s: &str) -> String {
-    js_sys::encode_uri(s).as_string().unwrap()
+    js_sys::encode_uri_component(s).as_string().unwrap()
 }
 
 #[cfg(not(feature = "ssr"))]

--- a/router/src/matching/matcher.rs
+++ b/router/src/matching/matcher.rs
@@ -1,7 +1,7 @@
 // Implementation based on Solid Router
 // see <https://github.com/solidjs/solid-router/blob/main/src/utils.ts>
 
-use crate::ParamsMap;
+use crate::{unescape, ParamsMap};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[doc(hidden)]
@@ -68,7 +68,10 @@ impl Matcher {
                 self.segments.iter().zip(loc_segments.iter())
             {
                 if let Some(param_name) = segment.strip_prefix(':') {
-                    params.insert(param_name.into(), (*loc_segment).into());
+                    params.insert(
+                        param_name.into(),
+                        unescape(*loc_segment).into(),
+                    );
                 } else if segment != loc_segment {
                     // if any segment doesn't match and isn't a param, there's no path match
                     return None;


### PR DESCRIPTION
`encode_uri` does not encode URL critical characters like `&` and `+`, for that `encode_uri_component` must be used.
This also revelaed some issues with too much unescaping in several cases. Fixes #2602