### PR TITLE
Handle boolean attributes correctly

### DIFF
--- a/leptos_dom/src/macro_helpers/into_attribute.rs
+++ b/leptos_dom/src/macro_helpers/into_attribute.rs
@@ -47,7 +47,17 @@ impl Attribute {
                 .map(|value| format!("{attr_name}=\"{value}\"").into())
                 .unwrap_or_default(),
             Attribute::Bool(include) => {
-                Oco::Borrowed(if *include { attr_name } else { "" })
+                Oco::Borrowed(if attr_name.starts_with("aria-") {
+                    if *include {
+                        "true"
+                    } else {
+                        "false"
+                    }
+                } else if *include {
+                    attr_name
+                } else {
+                    ""
+                })
             }
         }
     }


### PR DESCRIPTION
Closes #2605.

This PR only gets the process started. The [`as_nameless_value_string`](https://github.com/leptos-rs/leptos/blob/8bd3c6f2012bd742974ea528fefa5bbbdabbfab4/leptos_dom/src/macro_helpers/into_attribute.rs#L65-L87) function presents a challenge because the attribute name is not available in the function. I think would be best to get input from people more familiar with this codebase before tackling this further. I will unmark this as draft when it is ready to merge.