### PR TITLE
feat: Add Compression to Hacker News w/ Islands Example

### DIFF
--- a/examples/cargo-make/cargo-leptos-compress.toml
+++ b/examples/cargo-make/cargo-leptos-compress.toml
@@ -1,5 +1,13 @@
+extend = [
+    { path = "./lint.toml" }
+]
+
+[tasks.make-target-site-dir]
+command = "mkdir"
+args = ["-p", "target/site"]
+
 [tasks.install-cargo-leptos]
-install_crate = { crate_name = "cargo-leptos", binary = "cargo-leptos", test_arg = "--help" }
+install_crate = { crate_name = "cargo-leptos", install_command = "cargo install --git https://github.com/leptos-rs/cargo-leptos --locked cargo-leptos",binary = "cargo-leptos", test_arg = "--help" }
 
 [tasks.cargo-leptos-e2e]
 command = "cargo"
@@ -8,6 +16,7 @@ args = ["leptos", "end-to-end"]
 [tasks.build]
 clear = true
 command = "cargo"
+dependencies = ["make-target-site-dir"]
 args = ["leptos", "build", "--release", "-P"]
 
 [tasks.check]
@@ -25,6 +34,9 @@ toolchain = "stable"
 command = "cargo"
 args = ["check-all-features", "--release"]
 install_crate = "cargo-all-features"
+
+[tasks.lint]
+dependencies = ["make-target-site-dir", "check-style"]
 
 [tasks.start-client]
 dependencies = ["install-cargo-leptos"]

--- a/examples/cargo-make/cargo-leptos-compress.toml
+++ b/examples/cargo-make/cargo-leptos-compress.toml
@@ -7,7 +7,7 @@ command = "mkdir"
 args = ["-p", "target/site"]
 
 [tasks.install-cargo-leptos]
-install_crate = { crate_name = "cargo-leptos", install_command = "cargo install --git https://github.com/leptos-rs/cargo-leptos --locked cargo-leptos",binary = "cargo-leptos", test_arg = "--help" }
+install_crate = { crate_name = "cargo-leptos", binary = "cargo-leptos", test_arg = "--help" }
 
 [tasks.cargo-leptos-e2e]
 command = "cargo"

--- a/examples/cargo-make/cargo-leptos-compress.toml
+++ b/examples/cargo-make/cargo-leptos-compress.toml
@@ -1,0 +1,32 @@
+[tasks.install-cargo-leptos]
+install_crate = { crate_name = "cargo-leptos", binary = "cargo-leptos", test_arg = "--help" }
+
+[tasks.cargo-leptos-e2e]
+command = "cargo"
+args = ["leptos", "end-to-end"]
+
+[tasks.build]
+clear = true
+command = "cargo"
+args = ["leptos", "build", "--release", "-P"]
+
+[tasks.check]
+clear = true
+dependencies = ["check-debug", "check-release"]
+
+[tasks.check-debug]
+toolchain = "stable"
+command = "cargo"
+args = ["check-all-features"]
+install_crate = "cargo-all-features"
+
+[tasks.check-release]
+toolchain = "stable"
+command = "cargo"
+args = ["check-all-features", "--release"]
+install_crate = "cargo-all-features"
+
+[tasks.start-client]
+dependencies = ["install-cargo-leptos"]
+command = "cargo"
+args = ["leptos", "watch", "--release", "-P"]

--- a/examples/hackernews_islands_axum/Cargo.toml
+++ b/examples/hackernews_islands_axum/Cargo.toml
@@ -99,6 +99,12 @@ bin-features = ["ssr"]
 # Optional. Defaults to false.
 bin-default-features = false
 
+# This feature will add a hash to the filename of assets.
+# This is useful here because our files are precompressed and use a `Cache-Control` policy to reduce HTTP requests
+#
+# Optional. Defaults to false.
+hash_file = true
+
 # The features to use when compiling the lib target
 #
 # Optional. Can be over-ridden with the command line parameter --lib-features

--- a/examples/hackernews_islands_axum/Cargo.toml
+++ b/examples/hackernews_islands_axum/Cargo.toml
@@ -31,6 +31,7 @@ axum = { version = "0.7", optional = true, features = ["http2"] }
 tower = { version = "0.4", optional = true }
 tower-http = { version = "0.5", features = [
   "fs",
+  "compression-gzip",
   "compression-br",
 ], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
@@ -38,6 +39,8 @@ http = { version = "1.0", optional = true }
 web-sys = { version = "0.3", features = ["AbortController", "AbortSignal"] }
 wasm-bindgen = "0.2"
 lazy_static = "1.4.0"
+rust-embed = { version = "8", features = ["axum", "mime_guess", "tokio"], optional = true  }
+mime_guess = { version = "2.0.4", optional = true }
 
 [features]
 default = []
@@ -49,6 +52,8 @@ ssr = [
   "dep:tower-http",
   "dep:tokio",
   "dep:http",
+  "dep:rust-embed",
+  "dep:mime_guess",
   "leptos/ssr",
   "leptos_axum",
   "leptos_meta/ssr",

--- a/examples/hackernews_islands_axum/Makefile.toml
+++ b/examples/hackernews_islands_axum/Makefile.toml
@@ -1,6 +1,6 @@
 extend = [
     { path = "../cargo-make/main.toml" },
-    { path = "../cargo-make/cargo-leptos.toml" },
+    { path = "../cargo-make/cargo-leptos-compress.toml" },
 ]
 
 [env]

--- a/examples/hackernews_islands_axum/README.md
+++ b/examples/hackernews_islands_axum/README.md
@@ -1,6 +1,11 @@
 # Leptos Hacker News Example with Axum
 
-This example creates a basic clone of the Hacker News site. It showcases Leptos' ability to create both a client-side rendered app, and a server side rendered app with hydration, in a single repository. This repo differs from the main Hacker News example by using Axum as it's server.
+This example creates a basic clone of the Hacker News site. It showcases Leptos' ability to:
+- Create a client-side rendered app
+- Create a server side rendered app with hydration
+- Precompress static assets and bundle those in with the server binary
+
+This repo differs from the main Hacker News example by using Axum as it's server, precompressing and embedding static assets into the binary, and dynamically compressing the generated HTML.
 
 ## Getting Started
 
@@ -8,4 +13,4 @@ See the [Examples README](../README.md) for setup and run instructions.
 
 ## Quick Start
 
-Run `cargo leptos watch` to run this example.
+Run `cargo leptos watch --release -P` to run this example.

--- a/examples/hackernews_islands_axum/build-front.sh
+++ b/examples/hackernews_islands_axum/build-front.sh
@@ -1,8 +1,0 @@
-wasm-pack build --target=web --features=hydrate --release
-cd pkg
-rm *.br
-cp hackernews.js hackernews.unmin.js
-cat hackernews.unmin.js | esbuild > hackernews.js
-brotli hackernews.js
-brotli hackernews_bg.wasm
-brotli style.css

--- a/examples/hackernews_islands_axum/src/fallback.rs
+++ b/examples/hackernews_islands_axum/src/fallback.rs
@@ -2,20 +2,34 @@ use crate::error_template::error_template;
 use axum::{
     body::Body,
     extract::State,
-    http::{Request, Response, StatusCode, Uri},
+    http::{header, Request, Response, StatusCode, Uri},
     response::{IntoResponse, Response as AxumResponse},
 };
 use leptos::LeptosOptions;
-use tower::ServiceExt;
-use tower_http::services::ServeDir;
+use std::borrow::Cow;
+
+#[cfg(not(debug_assertions))]
+const DEV_MODE: bool = false;
+
+#[cfg(debug_assertions)]
+const DEV_MODE: bool = true;
+
+#[derive(rust_embed::RustEmbed)]
+#[folder = "target/site/"]
+struct Assets;
 
 pub async fn file_and_error_handler(
     uri: Uri,
     State(options): State<LeptosOptions>,
     req: Request<Body>,
 ) -> AxumResponse {
-    let root = options.site_root.clone();
-    let res = get_static_file(uri.clone(), &root).await.unwrap();
+    let accept_encoding = req
+        .headers()
+        .get("accept-encoding")
+        .map(|h| h.to_str().unwrap_or("none"))
+        .unwrap_or("none")
+        .to_string();
+    let res = get_static_file(uri.clone(), accept_encoding).await.unwrap();
 
     if res.status() == StatusCode::OK {
         res.into_response()
@@ -30,19 +44,56 @@ pub async fn file_and_error_handler(
 
 async fn get_static_file(
     uri: Uri,
-    root: &str,
+    accept_encoding: String,
 ) -> Result<Response<Body>, (StatusCode, String)> {
-    let req = Request::builder()
-        .uri(uri.clone())
-        .body(Body::empty())
-        .unwrap();
-    // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
-    // This path is relative to the cargo root
-    match ServeDir::new(root).oneshot(req).await {
-        Ok(res) => Ok(res.into_response()),
-        Err(err) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Something went wrong: {}", err),
-        )),
+    let (_, path) = uri.path().split_at(1); // split off the first `/`
+    let mime = mime_guess::from_path(path);
+
+    let (path, encoding) = if DEV_MODE {
+        // during DEV, don't care about the precompression -> faster workflow
+        (Cow::from(path), "none")
+    } else if accept_encoding.contains("br") {
+        (Cow::from(format!("{}.br", path)), "br")
+    } else if accept_encoding.contains("gzip") {
+        (Cow::from(format!("{}.gz", path)), "gzip")
+    } else {
+        (Cow::from(path), "none")
+    };
+
+    match Assets::get(path.as_ref()) {
+        Some(content) => {
+            let body = Body::from(content.data);
+
+            let res = match DEV_MODE {
+                true => Response::builder()
+                    .header(
+                        header::CONTENT_TYPE,
+                        mime.first_or_octet_stream().as_ref(),
+                    )
+                    .header(header::CONTENT_ENCODING, encoding)
+                    .body(body)
+                    .unwrap(),
+                false => Response::builder()
+                    .header(header::CACHE_CONTROL, "max-age=86400")
+                    .header(
+                        header::CONTENT_TYPE,
+                        mime.first_or_octet_stream().as_ref(),
+                    )
+                    .header(header::CONTENT_ENCODING, encoding)
+                    .body(body)
+                    .unwrap(),
+            };
+
+            Ok(res.into_response())
+        }
+
+        None => {
+            eprintln!(">> Asset {} not found", path);
+            for a in Assets::iter() {
+                eprintln!("Available asset: {}", a);
+            }
+
+            Err((StatusCode::NOT_FOUND, format!("Not found")))
+        }
     }
 }

--- a/examples/hackernews_islands_axum/src/fallback.rs
+++ b/examples/hackernews_islands_axum/src/fallback.rs
@@ -93,7 +93,7 @@ async fn get_static_file(
                 eprintln!("Available asset: {}", a);
             }
 
-            Err((StatusCode::NOT_FOUND, format!("Not found")))
+            Err((StatusCode::NOT_FOUND, "Not found".to_string()))
         }
     }
 }

--- a/examples/hackernews_islands_axum/src/main.rs
+++ b/examples/hackernews_islands_axum/src/main.rs
@@ -6,16 +6,35 @@ async fn main() {
     use hackernews_islands::*;
     pub use leptos::get_configuration;
     pub use leptos_axum::{generate_route_list, LeptosRoutes};
+    use tower_http::compression::{
+        predicate::{NotForContentType, SizeAbove},
+        CompressionLayer, CompressionLevel, Predicate,
+    };
 
     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);
 
+    let predicate = 
+    // files smaller than 1501 bytes are not compressed, since the MTU (Maximum Transmission Unit) of a TCP packet is 1500 bytes
+    SizeAbove::new(1500)
+        .and(NotForContentType::GRPC)
+        .and(NotForContentType::IMAGES)
+        // prevent compressing assets that are already statically compressed
+        .and(NotForContentType::const_new("application/javascript"))
+        .and(NotForContentType::const_new("application/wasm"))
+        .and(NotForContentType::const_new("text/css"));
+
     // build our application with a route
     let app = Router::new()
         .route("/favicon.ico", get(file_and_error_handler))
         .leptos_routes(&leptos_options, routes, App)
+        .layer(
+            CompressionLayer::new()
+                .quality(CompressionLevel::Fastest)
+                .compress_when(predicate),
+        )
         .fallback(file_and_error_handler)
         .with_state(leptos_options);
 

--- a/examples/hackernews_islands_axum/src/main.rs
+++ b/examples/hackernews_islands_axum/src/main.rs
@@ -16,9 +16,7 @@ async fn main() {
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);
 
-    let predicate = 
-    // files smaller than 1501 bytes are not compressed, since the MTU (Maximum Transmission Unit) of a TCP packet is 1500 bytes
-    SizeAbove::new(1500)
+    let predicate = SizeAbove::new(1500) // files smaller than 1501 bytes are not compressed, since the MTU (Maximum Transmission Unit) of a TCP packet is 1500 bytes
         .and(NotForContentType::GRPC)
         .and(NotForContentType::IMAGES)
         // prevent compressing assets that are already statically compressed


### PR DESCRIPTION
One of the things I love about leptos is how easy it is to ship a small frontend. 

Leptos provides islands that reduce the amount of total HTML generated and it's build tool minifies CSS with `lightningcss`, soon will be minifying javascript with `swc`, and it can even precompress these static assets. That last of which I think may be the most important because web assembly compress fairly well and it allows the user to ship their entire app as 1 static binary (with musl). 

Since precompression was added as a feature in `cargo-leptos` I haven't seen it mentioned a whole lot so I wanted to help people see how to use it. I have also seen a couple question about setting up compression in general so I added that too.

I've updated the `hackernews_islands_axum` example to serve all static assets precompressed with `cargo-leptos` and to dynamically compress the HTML.

The type of compression sent will depend on what the client supports.

The resulting network usage

| Asset | No Compression | Compression | Difference |
| :---- | :------------- | :---------- | :--------- |
| HTML  | 16.25 kB       | 4.80 kB     | - 70.46%   |    
| CSS   | 3.84 kB        | 1.17 kB     | - 69.53%   |        
| JS    | 16.86 kB       | 4.63 kB     | - 72.53%   |         
| WASM  | 200.15 kB      | 69.93 kB    | - 65.06%   |       
| ICON  | 15.54 kB       | 3.29 kB     | - 78.83%   |
|       |                |             |            |
| **TOTAL** | **252.64 kB** | **83.82 kB** | **- 66.82%** |
