### PR TITLE
fix: try_with should not panic on disposed resources (closes #2620)

### DIFF
--- a/leptos_reactive/src/resource.rs
+++ b/leptos_reactive/src/resource.rs
@@ -798,9 +798,11 @@ where
     fn try_with<O>(&self, f: impl FnOnce(&Option<T>) -> O) -> Option<O> {
         let location = std::panic::Location::caller();
         with_runtime(|runtime| {
-            runtime.resource(self.id, |resource: &ResourceState<S, T>| {
-                resource.with_maybe(f, location, self.id)
-            })
+            runtime
+                .try_resource(self.id, |resource: &ResourceState<S, T>| {
+                    resource.with_maybe(f, location, self.id)
+                })
+                .flatten()
         })
         .ok()
         .flatten()


### PR DESCRIPTION
With this change, the following code:
```
...
Some(existing_resource) => {
    let signal_alive = existing_resource.try_with(|r| {});
    match signal_alive {
        Some(()) => *existing_resource,
        None => {
            let r = self.create_resource(&id);
            self.resource_cache.insert(id, r);
            r
        },
    }
}
...
```
can be used to check whether the cached resource is still usable (in an implementation of resource cache as described in https://github.com/leptos-rs/leptos/discussions/1162).