### PR TITLE
docs: remove duplicated code block in example of For

### DIFF
--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -34,18 +34,6 @@ use std::hash::Hash;
 ///           }
 ///         }
 ///       />
-///       <For
-///         // a function that returns the items we're iterating over; a signal is fine
-///         each=move || counters.get()
-///         // a unique key for each item
-///         key=|counter| counter.id
-///         // renders each item to a view
-///         children=move |counter: Counter| {
-///           view! {
-///             <button>"Value: " {move || counter.count.get()}</button>
-///           }
-///         }
-///       />
 ///     </div>
 ///   }
 /// }


### PR DESCRIPTION
This code block is added twice to the example.