### PR TITLE
fix: ensure everything is disposed of consistently

### DIFF
--- a/leptos_reactive/src/node.rs
+++ b/leptos_reactive/src/node.rs
@@ -13,10 +13,7 @@ pub struct Disposer(pub(crate) NodeId);
 impl Drop for Disposer {
     fn drop(&mut self) {
         let id = self.0;
-        _ = with_runtime(|runtime| {
-            runtime.cleanup_node(id);
-            runtime.dispose_node(id);
-        });
+        _ = with_runtime(|runtime| runtime.dispose_node(id));
     }
 }
 

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -262,9 +262,12 @@ impl Runtime {
             | ScopeProperty::Effect(node) => {
                 // run all cleanups for this node
                 let cleanups = { self.on_cleanups.borrow_mut().remove(node) };
+                // untrack around all cleanups
+                let prev_observer = self.observer.take();
                 for cleanup in cleanups.into_iter().flatten() {
                     cleanup();
                 }
+                self.observer.set(prev_observer);
 
                 // clean up all children
                 let properties =

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -206,7 +206,7 @@ impl Runtime {
         let properties = { self.node_properties.borrow_mut().remove(node_id) };
         if let Some(properties) = properties {
             for property in properties {
-                self.cleanup_property(property);
+                self.dispose_property(property);
             }
         }
     }
@@ -254,7 +254,7 @@ impl Runtime {
         }
     }
 
-    pub(crate) fn cleanup_property(&self, property: ScopeProperty) {
+    fn dispose_property(&self, property: ScopeProperty) {
         // for signals, triggers, memos, effects, shared node cleanup
         match property {
             ScopeProperty::Signal(node)
@@ -270,7 +270,7 @@ impl Runtime {
                 let properties =
                     { self.node_properties.borrow_mut().remove(node) };
                 for property in properties.into_iter().flatten() {
-                    self.cleanup_property(property);
+                    self.dispose_property(property);
                 }
 
                 // each of the subs needs to remove the node from its dependencies

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -1175,11 +1175,7 @@ impl RuntimeId {
         );
 
         (id, move || {
-            with_runtime(|runtime| {
-                runtime.nodes.borrow_mut().remove(id);
-                runtime.node_sources.borrow_mut().remove(id);
-            })
-            .expect(
+            with_runtime(|runtime| runtime.dispose_node(id)).expect(
                 "tried to stop a watch in a runtime that has been disposed",
             );
         })

--- a/leptos_reactive/tests/cleanup.rs
+++ b/leptos_reactive/tests/cleanup.rs
@@ -43,3 +43,66 @@ fn cleanup() {
 
     runtime.dispose();
 }
+
+#[test]
+fn cleanup_on_dispose() {
+    use leptos_reactive::{
+        create_memo, create_runtime, create_trigger, on_cleanup, SignalDispose,
+        SignalGetUntracked,
+    };
+
+    struct ExecuteOnDrop(Option<Box<dyn FnOnce()>>);
+    impl ExecuteOnDrop {
+        fn new(f: impl FnOnce() + 'static) -> Self {
+            Self(Some(Box::new(f)))
+        }
+    }
+    impl Drop for ExecuteOnDrop {
+        fn drop(&mut self) {
+            self.0.take().unwrap()();
+        }
+    }
+
+    let runtime = create_runtime();
+
+    let trigger = create_trigger();
+
+    println!("STARTING");
+
+    let memo = create_memo(move |_| {
+        trigger.track();
+
+        // An example of why you might want to do this is that
+        // when something goes out of reactive scope you want it to be cleaned up.
+        // The cleaning up might have side effects, and those side effects might cause
+        // re-renders where new `on_cleanup` are registered.
+        let on_drop = ExecuteOnDrop::new(|| {
+            on_cleanup(|| println!("Nested cleanup in progress."))
+        });
+
+        on_cleanup(move || {
+            println!("Cleanup in progress.");
+            drop(on_drop)
+        });
+    });
+    println!("Memo 1: {:?}", memo);
+    let _ = memo.get_untracked(); // First cleanup registered.
+
+    memo.dispose(); // Cleanup not run here.
+
+    println!("Cleanup should have been executed.");
+
+    let memo = create_memo(move |_| {
+        // New cleanup registered. It'll panic here.
+        on_cleanup(move || println!("Test passed."));
+    });
+    println!("Memo 2: {:?}", memo);
+    println!("^ Note how the memos have the same key (different versions).");
+    let _ = memo.get_untracked(); // First cleanup registered.
+
+    println!("Test passed.");
+
+    memo.dispose();
+
+    runtime.dispose();
+}

--- a/leptos_reactive/tests/memo.rs
+++ b/leptos_reactive/tests/memo.rs
@@ -293,3 +293,29 @@ fn owning_memo_slice() {
 
     runtime.dispose();
 }
+
+#[test]
+fn leak_on_dispose() {
+    use std::rc::Rc;
+
+    let runtime = create_runtime();
+
+    let trigger = create_trigger();
+
+    let value = Rc::new(());
+    let weak = Rc::downgrade(&value);
+
+    let memo = create_memo(move |_| {
+        trigger.track();
+
+        create_rw_signal(value.clone());
+    });
+
+    memo.get_untracked();
+
+    memo.dispose();
+
+    assert!(weak.upgrade().is_none()); // Should have been dropped.
+
+    runtime.dispose();
+}


### PR DESCRIPTION
Hi there!

This one popped up for us as a `BorrowMut` error on the `on_cleanups` secondary map, here's what I think was going on:
- `dispose_node` was removing nodeA from the reactive graph, but not running the cleanups.
- The slot in the `slotmap` was reused by nodeB, and nodeB used `on_cleanup`.
- The old cleanups were still there, so, when inserting the new cleanup, the old ones were dropped since the slot is the same but has a higher version.
- The old cleanups contained `Drop` impls that triggered some work, which were triggered [inside `slotmap`](https://github.com/orlp/slotmap/blob/c905b6ced490551476cb7c37778eb8128bdea7ba/src/sparse_secondary.rs#L291).
- If any of the triggered work used `on_cleanup`, we recurse and panic.

With this patch I tried to simplify and make it more obvious what cleaning up a node and disposing of it means, hopefully my understanding of what's going on here is correct.

The commits are meant to be easy to audit individually, and `refactor` commits are meant to match the original behaviour exactly.

And as always, thank you for `leptos`, it has been great!