### PR TITLE
Make get_configuration sync

### DIFF
--- a/examples/action-form-error-handling/src/main.rs
+++ b/examples/action-form-error-handling/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> std::io::Result<()> {
     use leptos_meta::MetaTags;
 
     // Generate the list of routes in your Leptos App
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
     println!("listening on http://{}", &addr);
 

--- a/examples/counter_isomorphic/src/main.rs
+++ b/examples/counter_isomorphic/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> std::io::Result<()> {
 
     // Setting this to None means we'll be using cargo-leptos and its env vars.
     // when not using cargo-leptos None must be replaced with Some("Cargo.toml")
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
     println!("listening on http://{}", &addr);
 

--- a/examples/errors_axum/src/main.rs
+++ b/examples/errors_axum/src/main.rs
@@ -38,7 +38,7 @@ async fn main() {
     use ssr_imports::*;
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/hackernews/src/main.rs
+++ b/examples/hackernews/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> std::io::Result<()> {
     use leptos_meta::MetaTags;
     use ssr_imports::*;
 
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
 
     HttpServer::new(move || {

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
     use leptos::config::get_configuration;
     use leptos_axum::{generate_route_list, LeptosRoutes};
 
-    let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+    let conf = get_configuration(Some("Cargo.toml")).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/hackernews_islands_axum/src/main.rs
+++ b/examples/hackernews_islands_axum/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
     pub use leptos::config::get_configuration;
     pub use leptos_axum::{generate_route_list, LeptosRoutes};
 
-    let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+    let conf = get_configuration(Some("Cargo.toml")).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/islands/src/main.rs
+++ b/examples/islands/src/main.rs
@@ -6,7 +6,7 @@ use leptos_axum::{generate_route_list, LeptosRoutes};
 #[tokio::main]
 async fn main() {
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/server_fns_axum/src/main.rs
+++ b/examples/server_fns_axum/src/main.rs
@@ -10,7 +10,7 @@ async fn main() {
         .expect("couldn't initialize logging");
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/ssr_modes/src/main.rs
+++ b/examples/ssr_modes/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> std::io::Result<()> {
     use leptos_meta::MetaTags;
     use ssr_modes::app::*;
 
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
 
     HttpServer::new(move || {

--- a/examples/ssr_modes_axum/src/main.rs
+++ b/examples/ssr_modes_axum/src/main.rs
@@ -6,7 +6,7 @@ async fn main() {
     use leptos_axum::{generate_route_list, LeptosRoutes};
     use ssr_modes_axum::app::*;
 
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
     let leptos_options = conf.leptos_options;
     // Generate the list of routes in your Leptos App

--- a/examples/suspense_tests/src/main.rs
+++ b/examples/suspense_tests/src/main.rs
@@ -7,7 +7,7 @@ async fn main() -> std::io::Result<()> {
     use leptos_actix::{generate_route_list, LeptosRoutes};
     use suspense_tests::app::*;
 
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
     println!("listening on http://{}", &addr);
 

--- a/examples/tailwind_actix/src/main.rs
+++ b/examples/tailwind_actix/src/main.rs
@@ -9,7 +9,7 @@ use leptos_meta::MetaTags;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
 
     HttpServer::new(move || {

--- a/examples/tailwind_axum/src/main.rs
+++ b/examples/tailwind_axum/src/main.rs
@@ -6,7 +6,7 @@ use leptos_tailwind::app::{shell, App};
 #[tokio::main]
 async fn main() {
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/examples/todo_app_sqlite/src/main.rs
+++ b/examples/todo_app_sqlite/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> std::io::Result<()> {
         .await
         .expect("could not run SQLx migrations");
 
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
     println!("listening on http://{}", &addr);
 

--- a/examples/todo_app_sqlite_axum/src/main.rs
+++ b/examples/todo_app_sqlite_axum/src/main.rs
@@ -38,7 +38,7 @@ async fn main() {
     }
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(TodoApp);

--- a/examples/todo_app_sqlite_csr/src/main.rs
+++ b/examples/todo_app_sqlite_csr/src/main.rs
@@ -24,7 +24,7 @@ async fn main() {
     let _conn = ssr::db().await.expect("couldn't connect to DB");
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -396,7 +396,7 @@ pub fn handle_server_fns_with_context(
 /// # if false { // don't actually try to run a server in a doctest...
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let addr = conf.leptos_options.site_addr.clone();
 ///     HttpServer::new(move || {
 ///         let leptos_options = &conf.leptos_options;
@@ -464,7 +464,7 @@ where
 /// # if false { // don't actually try to run a server in a doctest...
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let addr = conf.leptos_options.site_addr.clone();
 ///     HttpServer::new(move || {
 ///         let leptos_options = &conf.leptos_options;
@@ -530,7 +530,7 @@ where
 /// # if false { // don't actually try to run a server in a doctest...
 /// #[actix_web::main]
 /// async fn main() -> std::io::Result<()> {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let addr = conf.leptos_options.site_addr.clone();
 ///     HttpServer::new(move || {
 ///         let leptos_options = &conf.leptos_options;

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -400,7 +400,7 @@ pub type PinnedHtmlStream =
 /// #[cfg(feature = "default")]
 /// #[tokio::main]
 /// async fn main() {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let leptos_options = conf.leptos_options;
 ///     let addr = leptos_options.site_addr.clone();
 ///
@@ -488,7 +488,7 @@ where
 /// #[cfg(feature = "default")]
 /// #[tokio::main]
 /// async fn main() {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let leptos_options = conf.leptos_options;
 ///     let addr = leptos_options.site_addr.clone();
 ///
@@ -839,7 +839,7 @@ fn provide_contexts(
 /// #[cfg(feature = "default")]
 /// #[tokio::main]
 /// async fn main() {
-///     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+///     let conf = get_configuration(Some("Cargo.toml")).unwrap();
 ///     let leptos_options = conf.leptos_options;
 ///     let addr = leptos_options.site_addr.clone();
 ///

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -347,11 +347,11 @@ pub fn get_config_from_str(
 /// you'll need to set the options as environment variables or rely on the defaults. This is the preferred
 /// approach for cargo-leptos. If Some("./Cargo.toml") is provided, Leptos will read in the settings itself. This
 /// option currently does not allow dashes in file or folder names, as all dashes become underscores
-pub async fn get_configuration(
+pub fn get_configuration(
     path: Option<&str>,
 ) -> Result<ConfFile, LeptosConfigError> {
     if let Some(path) = path {
-        get_config_from_file(&path).await
+        get_config_from_file(&path)
     } else {
         get_config_from_env()
     }
@@ -359,7 +359,7 @@ pub async fn get_configuration(
 
 /// Loads [LeptosOptions] from a Cargo.toml with layered overrides. Leptos will read in the settings itself. This
 /// option currently does not allow dashes in file or folder names, as all dashes become underscores
-pub async fn get_config_from_file<P: AsRef<Path>>(
+pub fn get_config_from_file<P: AsRef<Path>>(
     path: P,
 ) -> Result<ConfFile, LeptosConfigError> {
     let text = fs::read_to_string(path)

--- a/leptos_config/tests/config.rs
+++ b/leptos_config/tests/config.rs
@@ -48,7 +48,6 @@ async fn get_configuration_from_file_ok() {
         ],
         async {
             get_configuration(Some(&path_s))
-                .await
                 .unwrap()
                 .leptos_options
         },
@@ -75,7 +74,7 @@ async fn get_configuration_from_invalid_file() {
     }
     let path: &Path = cargo_tmp.as_ref();
     let path_s = path.to_string_lossy().to_string();
-    assert!(get_configuration(Some(&path_s)).await.is_err());
+    assert!(get_configuration(Some(&path_s)).is_err());
 }
 
 #[tokio::test]
@@ -87,7 +86,7 @@ async fn get_configuration_from_empty_file() {
     }
     let path: &Path = cargo_tmp.as_ref();
     let path_s = path.to_string_lossy().to_string();
-    assert!(get_configuration(Some(&path_s)).await.is_err());
+    assert!(get_configuration(Some(&path_s)).is_err());
 }
 
 #[tokio::test]
@@ -109,7 +108,6 @@ async fn get_config_from_file_ok() {
         ],
         async {
             get_config_from_file(&cargo_tmp)
-                .await
                 .unwrap()
                 .leptos_options
         },
@@ -134,7 +132,7 @@ async fn get_config_from_file_invalid() {
         let mut output = File::create(&cargo_tmp).unwrap();
         write!(output, "{CARGO_TOML_CONTENT_ERR}").unwrap();
     }
-    assert!(get_config_from_file(&cargo_tmp).await.is_err());
+    assert!(get_config_from_file(&cargo_tmp).is_err());
 }
 
 #[tokio::test]
@@ -144,7 +142,7 @@ async fn get_config_from_file_empty() {
         let mut output = File::create(&cargo_tmp).unwrap();
         write!(output, "").unwrap();
     }
-    assert!(get_config_from_file(&cargo_tmp).await.is_err());
+    assert!(get_config_from_file(&cargo_tmp).is_err());
 }
 
 #[test]
@@ -184,7 +182,7 @@ async fn get_config_from_env() {
             ("LEPTOS_RELOAD_PORT", Some("8080")),
             ("LEPTOS_RELOAD_EXTERNAL_PORT", Some("8080")),
         ],
-        async { get_configuration(None).await.unwrap().leptos_options },
+        async { get_configuration(None).unwrap().leptos_options },
     )
     .await;
 
@@ -208,7 +206,7 @@ async fn get_config_from_env() {
             ("LEPTOS_RELOAD_PORT", None::<&str>),
             ("LEPTOS_RELOAD_EXTERNAL_PORT", None::<&str>),
         ],
-        async { get_configuration(None).await.unwrap().leptos_options },
+        async { get_configuration(None).unwrap().leptos_options },
     )
     .await;
 

--- a/projects/meilisearch-searchbar/src/main.rs
+++ b/projects/meilisearch-searchbar/src/main.rs
@@ -60,7 +60,7 @@ async fn main() {
     
     drop(documents);
 
-    let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+    let conf = get_configuration(Some("Cargo.toml")).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/nginx-mpmc/app-1/src/main.rs
+++ b/projects/nginx-mpmc/app-1/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     // <https://github.com/leptos-rs/start-axum#executing-a-server-on-a-remote-machine-without-the-toolchain>
     // Alternately a file can be specified such as Some("Cargo.toml")
     // The file would need to be included with the executable when moved to deployment
-    let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+    let conf = get_configuration(Some("Cargo.toml")).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/nginx-mpmc/app-2/src/main.rs
+++ b/projects/nginx-mpmc/app-2/src/main.rs
@@ -15,7 +15,7 @@ async fn main() {
     // <https://github.com/leptos-rs/start-axum#executing-a-server-on-a-remote-machine-without-the-toolchain>
     // Alternately a file can be specified such as Some("Cargo.toml")
     // The file would need to be included with the executable when moved to deployment
-    let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
+    let conf = get_configuration(Some("Cargo.toml")).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/openapi-openai-api-swagger-ui/src/main.rs
+++ b/projects/openapi-openai-api-swagger-ui/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
     // <https://github.com/leptos-rs/start-axum#executing-a-server-on-a-remote-machine-without-the-toolchain>
     // Alternately a file can be specified such as Some("Cargo.toml")
     // The file would need to be included with the executable when moved to deployment
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/ory-kratos/server/src/main.rs
+++ b/projects/ory-kratos/server/src/main.rs
@@ -43,7 +43,7 @@ async fn main() {
     // <https://github.com/leptos-rs/start-axum#executing-a-server-on-a-remote-machine-without-the-toolchain>
     // Alternately a file can be specified such as Some("Cargo.toml")
     // The file would need to be included with the executable when moved to deployment
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/session_auth_axum/src/main.rs
+++ b/projects/session_auth_axum/src/main.rs
@@ -93,7 +93,7 @@ async fn main() {
     // _ = Foo::register();
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(TodoApp);

--- a/projects/sitemap_axum/src/main.rs
+++ b/projects/sitemap_axum/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
     // <https://github.com/leptos-rs/start-axum#executing-a-server-on-a-remote-machine-without-the-toolchain>
     // Alternately a file can be specified such as Some("Cargo.toml")
     // The file would need to be included with the executable when moved to deployment
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(App);

--- a/projects/sso_auth_axum/src/main.rs
+++ b/projects/sso_auth_axum/src/main.rs
@@ -87,7 +87,7 @@ async fn main() {
         .expect("could not run SQLx migrations");
 
     // Setting this to None means we'll be using cargo-leptos and its env vars
-    let conf = get_configuration(None).await.unwrap();
+    let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
     let addr = leptos_options.site_addr;
     let routes = generate_route_list(sso_auth_axum::App);


### PR DESCRIPTION
I noticed get_configuration() in leptos_config doesn't need to be async, and I have an integration where that makes things a bit easier