### PR TITLE
fix: do not unescape / and other route characters when following a link

### DIFF
--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -435,7 +435,7 @@ impl RouterContextInner {
             }
 
             let url = Url::try_from(href.as_str()).unwrap();
-            let path_name = unescape(&url.pathname);
+            let path_name = crate::history::unescape_minimal(&url.pathname);
 
             // let browser handle this event if it leaves our domain
             // or our base path

--- a/router/src/history/url.rs
+++ b/router/src/history/url.rs
@@ -28,6 +28,11 @@ pub fn unescape(s: &str) -> String {
     js_sys::decode_uri_component(s).unwrap().into()
 }
 
+#[cfg(not(feature = "ssr"))]
+pub fn unescape_minimal(s: &str) -> String {
+    js_sys::decode_uri(s).unwrap().into()
+}
+
 #[cfg(feature = "ssr")]
 pub fn escape(s: &str) -> String {
     percent_encoding::utf8_percent_encode(s, percent_encoding::NON_ALPHANUMERIC)


### PR DESCRIPTION
Resolves the need for both #2602 and the following to work:

```
#[component]
pub fn App() -> impl IntoView {
    view! {
      <Router>
        <nav>
          <a href="/file/demo">This link matches</a><br/>
          <a href="/file/demo%2Ftest">"This link doesn't match"</a>
        </nav>
        <main>
          <Routes>
            <Route path="/" view=|| view!{ <h1>Home</h1> }/>
            <Route path="/file/:id" view=|| view!{<h1>File match!</h1>}/>
            <Route path="/*any" view=|| view! { <h1>Any</h1> }/>
          </Routes>
        </main>
      </Router>
    }
}
```