### PR TITLE
Fixed several warnings in check pipeline

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -729,10 +729,7 @@ async fn stream_app(
 
     build_stream_response(options, res_options, stream, runtime).await
 }
-#[cfg_attr(
-    any(debug_assertions, feature = "ssr"),
-    instrument(level = "trace", skip_all,)
-)]
+#[cfg_attr(any(debug_assertions), instrument(level = "trace", skip_all,))]
 async fn stream_app_in_order(
     options: &LeptosOptions,
     app: impl FnOnce() -> View + 'static,

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -24,10 +24,7 @@ pub(crate) enum Mode {
 
 impl Default for Mode {
     fn default() -> Self {
-        if cfg!(feature = "hydrate")
-            || cfg!(feature = "csr")
-            || cfg!(feature = "web")
-        {
+        if cfg!(feature = "hydrate") || cfg!(feature = "csr") {
             Mode::Client
         } else {
             Mode::Ssr

--- a/leptos_reactive/src/hydration.rs
+++ b/leptos_reactive/src/hydration.rs
@@ -31,7 +31,7 @@ pub struct SharedContext {
 impl SharedContext {
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn all_resources() -> Vec<ResourceId> {
@@ -41,7 +41,7 @@ impl SharedContext {
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope that are
     /// pending from the server.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn pending_resources() -> Vec<ResourceId> {
@@ -50,7 +50,7 @@ impl SharedContext {
 
     /// Returns IDs for all [`Resource`](crate::Resource)s found on any scope.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn serialization_resolvers(
@@ -62,7 +62,7 @@ impl SharedContext {
     /// Registers the given [`SuspenseContext`](crate::SuspenseContext) with the current scope,
     /// calling the `resolver` when its resources are all resolved.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn register_suspense(
@@ -121,7 +121,7 @@ impl SharedContext {
     /// Returns a tuple of two pinned `Future`s that return content for out-of-order
     /// and in-order streaming, respectively.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn take_pending_fragment(id: &str) -> Option<FragmentData> {
@@ -135,7 +135,7 @@ impl SharedContext {
 
     /// A future that will resolve when all blocking fragments are ready.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn blocking_fragments_ready() -> PinnedFuture<()> {
@@ -162,7 +162,7 @@ impl SharedContext {
     /// The keys are hydration IDs. Values are tuples of two pinned
     /// `Future`s that return content for out-of-order and in-order streaming, respectively.
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn pending_fragments() -> HashMap<String, FragmentData> {
@@ -176,7 +176,7 @@ impl SharedContext {
     /// Registers the given element as an island with the current reactive owner.
     #[cfg(all(feature = "hydrate", feature = "experimental-islands"))]
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn register_island(el: &web_sys::HtmlElement) {
@@ -190,7 +190,7 @@ impl SharedContext {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn fragment_has_local_resources(fragment: &str) -> bool {
@@ -204,7 +204,7 @@ impl SharedContext {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn fragments_with_local_resources() -> HashSet<String> {
@@ -216,7 +216,7 @@ impl SharedContext {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     pub fn register_local_fragment(key: String) {

--- a/leptos_reactive/src/runtime.rs
+++ b/leptos_reactive/src/runtime.rs
@@ -629,7 +629,7 @@ impl Runtime {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[track_caller]
@@ -644,7 +644,7 @@ impl Runtime {
     }
 
     #[cfg_attr(
-        any(debug_assertions, features = "ssr"),
+        any(debug_assertions, feature = "ssr"),
         instrument(level = "trace", skip_all,)
     )]
     #[track_caller]
@@ -1382,7 +1382,7 @@ impl Drop for SetObserverOnDrop {
 ///
 /// To avoid panicking under any circumstances, use [`try_batch`].
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 #[inline(always)]
@@ -1398,7 +1398,7 @@ pub fn batch<T>(f: impl FnOnce() -> T) -> T {
 ///
 /// Unlike [`batch`], this will not panic if the runtime has been disposed.
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 #[inline(always)]
@@ -1447,7 +1447,7 @@ pub fn on_cleanup(cleanup_fn: impl FnOnce() + 'static) {
 }
 
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 fn push_cleanup(cleanup_fn: Box<dyn FnOnce()>) {
@@ -1509,7 +1509,7 @@ impl ScopeProperty {
 /// # runtime.dispose();
 /// ```
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 #[inline(always)]
@@ -1519,7 +1519,7 @@ pub fn untrack<T>(f: impl FnOnce() -> T) -> T {
 
 #[doc(hidden)]
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 #[inline(always)]

--- a/leptos_reactive/src/signal.rs
+++ b/leptos_reactive/src/signal.rs
@@ -332,7 +332,7 @@ pub trait SignalDispose {
 /// #
 /// ```
 #[cfg_attr(
- any(debug_assertions, features="ssr"),
+    any(debug_assertions, feature="ssr"),
     instrument(
         level = "trace",
         skip_all,
@@ -354,7 +354,7 @@ pub fn create_signal<T>(value: T) -> (ReadSignal<T>, WriteSignal<T>) {
 /// **Note**: If used on the server side during server rendering, this will return `None`
 /// immediately and not begin driving the stream.
 #[cfg_attr(
-    any(debug_assertions, features = "ssr"),
+    any(debug_assertions, feature = "ssr"),
     instrument(level = "trace", skip_all,)
 )]
 pub fn create_signal_from_stream<T>(
@@ -1143,7 +1143,7 @@ impl<T> Hash for WriteSignal<T> {
 /// #
 /// ```
 #[cfg_attr(
- any(debug_assertions, features="ssr"),
+ any(debug_assertions, feature="ssr"),
     instrument(
         level = "trace",
         skip_all,
@@ -1432,17 +1432,17 @@ impl<T> SignalSetUntracked<T> for RwSignal<T> {
 
 impl<T> SignalUpdateUntracked<T> for RwSignal<T> {
     #[cfg_attr(
- any(debug_assertions, features="ssr"),
-    instrument(
-        level = "trace",
-        name = "RwSignal::update_untracked()",
-        skip_all,
-        fields(
-            id = ?self.id,
-            defined_at = %self.defined_at,
-            ty = %std::any::type_name::<T>()
+        any(debug_assertions, feature="ssr"),
+        instrument(
+            level = "trace",
+            name = "RwSignal::update_untracked()",
+            skip_all,
+            fields(
+                id = ?self.id,
+                defined_at = %self.defined_at,
+                ty = %std::any::type_name::<T>()
+            )
         )
-    )
     )]
     #[inline(always)]
     fn update_untracked(&self, f: impl FnOnce(&mut T)) {

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -117,7 +117,7 @@ impl core::fmt::Debug for MetaTagsContext {
 
 impl MetaTagsContext {
     /// Converts metadata tags into an HTML string.
-    #[cfg(any(feature = "ssr", docs))]
+    #[cfg(any(feature = "ssr", doc))]
     pub fn as_string(&self) -> String {
         self.els
             .borrow()

--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -13,8 +13,6 @@ use leptos::{
     },
     *,
 };
-#[cfg(feature = "transition")]
-use leptos_reactive::use_transition;
 use send_wrapper::SendWrapper;
 use std::{cell::RefCell, rc::Rc};
 use thiserror::Error;
@@ -188,10 +186,6 @@ impl RouterContext {
         // the current History.state
         let (state, set_state) =
             create_signal(source.with_untracked(|s| s.state.clone()));
-
-        // we'll use this transition to wait for async resources to load when navigating to a new route
-        #[cfg(feature = "transition")]
-        let transition = use_transition();
 
         // Each field of `location` reactively represents a different part of the current location
         let location = create_location(reference, state);


### PR DESCRIPTION
While running checks described in [CONTRIBUTING.md](https://github.com/leptos-rs/leptos/blob/main/CONTRIBUTING.md) I've noticed quite some warnings. Some of them reference to obsolete features, some of them origin in misspelling of attributes. Current PR addressed these issues