### PR TITLE
Destructuring `let` (0.7)

### DIFF
--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -20,7 +20,7 @@ syn = { version = "2", features = [
 	"printing",
 ] }
 quote = "1"
-rstml = "0.11.0"
+rstml = "0.11.2"
 proc-macro2 = { version = "1", features = ["span-locations", "nightly"] }
 parking_lot = "0.12"
 walkdir = "2"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -22,7 +22,7 @@ proc-macro-error = { version = "1", default-features = false }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
-rstml = "0.11.0"
+rstml = "0.11.2"
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
 convert_case = "0.6.0"

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -2,9 +2,9 @@ use super::{fragment_to_tokens, TagType};
 use crate::view::attribute_absolute;
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::{format_ident, quote, quote_spanned};
-use rstml::node::{NodeAttribute, NodeBlock, NodeElement};
+use rstml::node::{KeyedAttributeValue, NodeAttribute, NodeBlock, NodeElement, NodeName};
 use std::collections::HashMap;
-use syn::{spanned::Spanned, Expr, ExprRange, RangeLimits, Stmt};
+use syn::{spanned::Spanned, Expr, ExprRange, RangeLimits, Stmt, ExprPath};
 
 pub(crate) fn component_to_tokens(
     node: &NodeElement,
@@ -56,7 +56,7 @@ pub(crate) fn component_to_tokens(
         .filter(|(idx, attr)| {
             idx < &spread_marker && {
                 let attr_key = attr.key.to_string();
-                !attr_key.starts_with("let:")
+                !is_attr_let(&attr.key)
                     && !attr_key.starts_with("clone:")
                     && !attr_key.starts_with("class:")
                     && !attr_key.starts_with("style:")
@@ -88,10 +88,20 @@ pub(crate) fn component_to_tokens(
     let items_to_bind = attrs
         .clone()
         .filter_map(|attr| {
-            attr.key
-                .to_string()
-                .strip_prefix("let:")
-                .map(|ident| format_ident!("{ident}", span = attr.key.span()))
+            if !is_attr_let(&attr.key) {
+                return None;
+            }
+
+            let KeyedAttributeValue::Binding(binding) = &attr.possible_value else {
+                if let Some(ident) = attr.key.to_string().strip_prefix("let:") {
+                    let ident1 = format_ident!("{ident}", span = attr.key.span());
+                    return Some(quote! { #ident1 });
+                } else {
+                    return None;
+                }
+            };
+            let inputs = &binding.inputs;
+            Some(quote! { #inputs })
         })
         .collect::<Vec<_>>();
 
@@ -287,4 +297,14 @@ pub(crate) fn component_to_tokens(
     IdeTagHelper::add_component_completion(&mut component, node); */
 
     component
+}
+
+fn is_attr_let(key: &NodeName) -> bool {
+    if key.to_string().starts_with("let:") {
+        true
+    } else if let NodeName::Path(ExprPath { path, .. }) = key {
+        path.segments.len() == 1 && path.segments[0].ident == "let"
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
This PR adds a new `let()` syntax to components, while also keeping `let:` alive for backwards compatibility.

Example usage:
```rust
view! {
    <For
        each=move || data.get()
        key=|n| *n
        // stores the item in each row in a variable named `data`
        let(data)
    >
        <p>{data}</p>
    </For>
}
```

This also allows for destructuring of tuples and structs, as it's just directly embedded in the children function's arguments.
```rust
view! {
    <For
        each=move || data.get()
        key=|n| *n
        // stores the item in each row in a variable named `data`
        let((tup1, tup2)) // note the extra parentheses for destructuring
    >
        <p>{tup1} {tup2}</p>
    </For>
}
```

I haven't gone through all the examples and changed the usage as I wasn't sure what you wanted to present as the default. Would you like me to do that?