### PR TITLE
docs: generate link to definition

### DIFF
--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -27,3 +27,6 @@ tokio = { version = "1", features = ["rt", "fs"] }
 [features]
 nonce = ["leptos/nonce"]
 experimental-islands = ["leptos_integration_utils/experimental-islands"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -37,3 +37,6 @@ nonce = ["leptos/nonce"]
 wasm = []
 default = ["tokio/fs", "tokio/sync"]
 experimental-islands = ["leptos_integration_utils/experimental-islands"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -18,3 +18,6 @@ tracing = "0.1.37"
 
 [features]
 experimental-islands = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -141,3 +141,6 @@ skip_feature_sets = [
     "rustls",
   ],
 ]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -20,3 +20,6 @@ typed-builder = "0.18"
 tokio = { version = "1", features = ["rt", "macros"] }
 tempfile = "3"
 temp-env = { version = "0.3.6", features = ["async_closure"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -178,3 +178,6 @@ trace-component-props = []
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "trace-component-props"]
 skip_feature_sets = [["web", "ssr"]]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -51,3 +51,6 @@ axum = ["server_fn_macro/axum"]
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "tracing", "trace-component-props"]
 skip_feature_sets = [["csr", "hydrate"], ["hydrate", "csr"], ["hydrate", "ssr"]]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_reactive/Cargo.toml
+++ b/leptos_reactive/Cargo.toml
@@ -121,3 +121,6 @@ skip_feature_sets = [
     "rkyv",
   ],
 ]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -32,3 +32,6 @@ nightly = ["leptos_reactive/nightly"]
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -29,3 +29,6 @@ nightly = ["leptos/nightly"]
 [package.metadata.cargo-all-features]
 denylist = ["nightly"]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -78,3 +78,6 @@ nightly = ["leptos/nightly"]
 # No need to test optional dependencies as they are enabled by the ssr feature
 denylist = ["url", "regex", "nightly"]
 skip_feature_sets = [["csr", "ssr"], ["csr", "hydrate"], ["ssr", "hydrate"]]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -111,6 +111,7 @@ ssr = ["inventory"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 # disables some feature combos for testing in CI
 [package.metadata.cargo-all-features]

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -22,3 +22,6 @@ ssr = []
 actix = []
 axum = []
 reqwest = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--generate-link-to-definition"]


### PR DESCRIPTION
Need to make sure the CI passes for this but it should allow for links within the docs rs source code.

This was mentioned in discord a while back and I am just getting around to it.

Tried to get all of the major crates as putting this config in the workspace did not seem to work.
