### PR TITLE
fix: impl `Copy` for `Callback`

### DIFF
--- a/leptos/src/callback.rs
+++ b/leptos/src/callback.rs
@@ -197,6 +197,8 @@ impl<In, Out> Clone for Callback<In, Out> {
     }
 }
 
+impl<In, Out> Copy for Callback<In, Out> {}
+
 impl<In: 'static, Out: 'static> Callback<In, Out> {
     /// Creates a new callback from the given function.
     pub fn new<F>(fun: F) -> Self

--- a/leptos/src/callback.rs
+++ b/leptos/src/callback.rs
@@ -193,7 +193,7 @@ impl<In, Out> Callable<In, Out> for Callback<In, Out> {
 
 impl<In, Out> Clone for Callback<In, Out> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 


### PR DESCRIPTION
I suppose it's an oversight rather than an intentional change compared to v0.6?