### PR TITLE
Add missing 'form' attribute for <mo> MathML element

### DIFF
--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -148,7 +148,7 @@ mathml_elements![
     mn [],
     mo [
         accent, fence, lspace, maxsize, minsize, movablelimits,
-        rspace, separator, stretchy, symmetric
+        rspace, separator, stretchy, symmetric, form
     ],
     ms [],
     mspace [height, width],


### PR DESCRIPTION
Although this attribute seems to be missing in the attribute table on [Mozilla Docs for that tag](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mo) ,
it does appear in the compatibility [table lower down](https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mo#browser_compatibility).
This attribute is also frequently used by [temml](https://temml.org/), a common generator for MathML content.

**WARNING: I haven't set up a dev or test env**, and hoping this this can be picked up by somebody else as a quick fix if what I did was incorrect.

Mainly doing this to raise awareness of the issue.