### PR TITLE
feat: Ensure services in axum `#[middleware()]` macro Implement Clone

### DIFF
--- a/examples/server_fns_axum/src/middleware.rs
+++ b/examples/server_fns_axum/src/middleware.rs
@@ -18,6 +18,7 @@ impl<S> Layer<S> for LoggingLayer {
     }
 }
 
+#[derive(Clone)]
 pub struct LoggingService<T> {
     inner: T,
 }


### PR DESCRIPTION
This change requires that services utilized within the `#[middleware()]` macro for server functions to implement `Clone`. This ensures that the service being wrapped by the middleware layer can also be cloned, useful for moving a clone of the service into a boxed future to be polled next:

```rust
fn call(&mut self, req: Request) -> Self::Future {
    let not_ready_inner = self.inner.clone();
    let ready_inner = std::mem::replace(&mut self.inner, not_ready_inner);

    let future = Box::pin(async move {
        /*
            Async operations
        */
        let inner = ServiceBuilder::new()
            .boxed_clone()
            .map_response(IntoResponse::into_response)
            .service(ready_inner);
        let next = Next { inner };
    };
    
    ResponseFuture {
        inner: future
    }
}
```
```rust
fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
    let inner = self.inner.clone();
    let authorization = Box::pin(async move {
        /* Query the DB and authorize this user */
    });

    ResponseFuture {
        authorization,
        inner,
    }
}
```