### PR TITLE
fix: Handle trailing slash in routes when building StaticRoute's

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1254,7 +1254,7 @@ where
     generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
 }
 
-/// Builds and outputs each route to the target/site directory. This is useful for static site generation.
+/// Build and output each route to the `./target/site` directory. This is useful for static site generation.
 pub async fn build_static_routes<IV>(
     options: &LeptosOptions,
     app_fn: impl Fn() -> IV + 'static + Send + Clone,

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1278,7 +1278,7 @@ pub async fn build_static_routes<IV>(
         .await
         .expect("could not build static routes")
     });
-    handle.await;
+    let _ = handle.await;
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1254,7 +1254,7 @@ where
     generate_route_list_with_exclusions_and_ssg(app_fn, excluded_routes).0
 }
 
-/// TODO docs
+/// Builds and outputs each route to the target/site directory. This is useful for static site generation.
 pub async fn build_static_routes<IV>(
     options: &LeptosOptions,
     app_fn: impl Fn() -> IV + 'static + Send + Clone,

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1268,7 +1268,7 @@ pub async fn build_static_routes<IV>(
 {
     let options = options.clone();
     let routes = routes.to_owned();
-    spawn_task!(async move {
+    let handle = spawn_task!(async move {
         leptos_router::build_static_routes(
             &options,
             app_fn,
@@ -1278,6 +1278,7 @@ pub async fn build_static_routes<IV>(
         .await
         .expect("could not build static routes")
     });
+    handle.await;
 }
 
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1268,6 +1268,7 @@ pub async fn build_static_routes<IV>(
 {
     let options = options.clone();
     let routes = routes.to_owned();
+    #[allow(unused_variables, clippy::let_unit_value)]
     let handle = spawn_task!(async move {
         leptos_router::build_static_routes(
             &options,
@@ -1278,6 +1279,7 @@ pub async fn build_static_routes<IV>(
         .await
         .expect("could not build static routes")
     });
+    #[cfg(all(not(feature = "wasm"), feature = "default"))]
     let _ = handle.await;
 }
 

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -210,7 +210,13 @@ impl ResolvedStaticPath {
         IV: IntoView + 'static,
     {
         let html = self.build(options, app_fn, additional_context).await;
-        let file_path = static_file_path(options, &self.0);
+        // If the path ends with a trailing slash, we generate the path
+        // as a directory with a index.html file inside.
+        let file_path = if self.0 != "/" && self.0.ends_with("/") {
+            static_file_path(options, &format!("{}index", self.0))
+        } else {
+            static_file_path(options, &self.0)
+        };
         let path = Path::new(&file_path);
         println!("writing static route to: {file_path}");
         if let Some(path) = path.parent() {

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -47,6 +47,7 @@ pub struct StaticPath<'b, 'a: 'b> {
     path: &'a str,
     segments: Vec<StaticPathSegment<'a>>,
     params: LinearMap<&'a str, &'b Vec<String>>,
+    trailing_slash: bool,
 }
 
 #[doc(hidden)]
@@ -72,6 +73,7 @@ impl<'b, 'a: 'b> StaticPath<'b, 'a> {
                 })
                 .collect::<Vec<_>>(),
             params: LinearMap::new(),
+            trailing_slash: path != "/" && path.ends_with("/"),
         }
     }
 

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -205,6 +205,7 @@ impl ResolvedStaticPath {
         let html = self.build(options, app_fn, additional_context).await;
         let file_path = static_file_path(options, &self.0);
         let path = Path::new(&file_path);
+        println!("writing static route to: {file_path}");
         if let Some(path) = path.parent() {
             std::fs::create_dir_all(path)?
         }

--- a/router/src/components/static_render.rs
+++ b/router/src/components/static_render.rs
@@ -122,6 +122,11 @@ impl<'b, 'a: 'b> StaticPath<'b, 'a> {
                 }
             }
         }
+        if let Some(last) = paths.last_mut() {
+            if self.trailing_slash {
+                *last = ResolvedStaticPath(format!("{last}/"));
+            }
+        }
         paths
     }
 


### PR DESCRIPTION
In https://github.com/leptos-rs/leptos/issues/2663 I ran into an issue with hydration for sub-routes. While I was initially a bit off, after @gbj's comment I was able to fix the route I was generating but then ran into another issue with `build_static_routes` not supporting paths ending in a trailing slash (e.g. `another-page/`).

It would instead think these paths had no trailing slash, and when combined with the `TrailingSlash::Exact` setting, you would see output like this

```
building static route: /another-page
Errors: [
    NotFound,
]
building static route:
```

This PR does a couple of things:

- Changes `spawn_task` to return a handle that you can await on
  - This allows `build_static_routes` to return when its done generating the files
  - It then enables the user to do any file manipulation they need in their `main` function after calling `build_static_routes` (previously any attempt to do this would break since the files were generated async and the `.await` on `build_static_routes` wouldn't actually wait for the files to be generated)
- Adds `trailing_slash` to `StaticPath` to track `/` route endings
- Retains the trailing slash when turning the `StaticPath` into a `ResolvedStaticPath`, making sure the correct route gets built
- Changes the file output to be `<route>/index.html` for routes ending with a trailing slash


I've also extended the output a bit, which makes it easier for users to follow along in what route corresponds to what file, written after the current `building static route`:

```
...
building static route: /sub-page/
writing static route to: target/site/sub-page/index.html
building static route: /another-page/
writing static route to: target/site/another-page/index.html
building static route:
writing static route to: target/site/index.html
```

I'm rather new to Rust and especially new to the Leptos codebase, so if there's any improvements I can make I'd love to hear!

I've tested it locally, and it completely fixes https://github.com/leptos-rs/leptos/issues/2663 :) 