### PR TITLE
leptos 0.7: remove FromRef LeptosOptions in `LeptosRoutes` axum integration

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1462,7 +1462,6 @@ impl AxumPath for &[PathSegment] {
 /// to those paths to Leptos's renderer.
 impl<S> LeptosRoutes<S> for axum::Router<S>
 where
-    LeptosOptions: FromRef<S>,
     S: Clone + Send + Sync + 'static,
 {
     #[tracing::instrument(level = "trace", fields(error), skip_all)]


### PR DESCRIPTION
Hi im trying out leptos for SSR template rendering and saw in the new version LeptosOptions was no longer needed for routes generation.

Maybe this line should be removed o maybe it was left there on purpose 😄 and this should just be closed