### PR TITLE
chore: temprorarily disable `hackernews-js-fetch` example

### DIFF
--- a/examples/Makefile.toml
+++ b/examples/Makefile.toml
@@ -19,7 +19,8 @@ CARGO_MAKE_CRATE_WORKSPACE_MEMBERS = [
   "hackernews",
   "hackernews_axum",
   "hackernews_islands_axum",
-  "hackernews_js_fetch",
+  # TODO: reenable the example on the axum-js-fetch and gloo-net new release
+  # "hackernews_js_fetch",
   "js-framework-benchmark",
   "login_with_token_csr_only",
   "parent_child",


### PR DESCRIPTION
The `axum-js-fetch` crate has not been successful in updating in the long run and prevents the `hackernews-js-fetch` example and CI from succeeding. Disabling it as part of the workflow helps manage PRs and merges.