### PR TITLE
Remove unnecessary 'static lifetime from argument in Style::as_value_string()

### DIFF
--- a/leptos_dom/src/macro_helpers/into_style.rs
+++ b/leptos_dom/src/macro_helpers/into_style.rs
@@ -176,7 +176,7 @@ impl Style {
     /// Converts the style to its HTML value at that moment so it can be rendered on the server.
     pub fn as_value_string(
         &self,
-        style_name: &'static str,
+        style_name: &str,
     ) -> Option<Oco<'static, str>> {
         match self {
             Style::Value(value) => {


### PR DESCRIPTION

The static lifetime is unnecessary for this argument. It isn't used within the function and only adds an unwarranted constraint. This prevents passing the argument as a regular string.

```rust
    let style = Style::Value("foo".into());

    // Ok
    style.as_value_string("bar");

    // Compilation error: borrowed value does not live long enough
    let bar = "bar".to_string();
    style.as_value_string(&bar); 
```

###  Additional context 

`as_value_string` signature

```rust
impl Style {
    /// Converts the style to its HTML value at that moment so it can be rendered on the server.
    pub fn as_value_string(
        &self,
        style_name: &'static str,
    ) -> Option<Oco<'static, str>> {
        ...
    }
}
```
