### PR TITLE
`leptos 0.7` Add allow needless_lifetimes to components macro

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -647,14 +647,14 @@ fn component_macro(s: TokenStream, island: bool) -> TokenStream {
             #expanded
 
             #[doc(hidden)]
-            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
             #unexpanded
         }
     } else if let Ok(mut dummy) = dummy {
         dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
         quote! {
             #[doc(hidden)]
-            #[allow(non_snake_case, dead_code, clippy::too_many_arguments)]
+            #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
             #dummy
         }
     } else {


### PR DESCRIPTION
I was having this warning with clippy, im just copying this #1852 

<img width="992" alt="image" src="https://github.com/user-attachments/assets/53f475a2-acb5-4ff2-83a7-7d051a4f0d49">
