### PR TITLE
Support dynamic attribuutes in components

### DIFF
--- a/examples/spread/src/lib.rs
+++ b/examples/spread/src/lib.rs
@@ -8,7 +8,7 @@ pub fn SpreadingExample() -> impl IntoView {
     }
 
     let attrs_static_str: Vec<(&'static str, Attribute)> =
-        vec![("data-foo".into(), "42".into_attribute())];
+        vec![("data-foo", "42".into_attribute())];
 
     let attrs_string: Vec<(String, Attribute)> =
         vec![("data-foo".into(), "42".into_attribute())];

--- a/examples/spread/src/lib.rs
+++ b/examples/spread/src/lib.rs
@@ -7,7 +7,10 @@ pub fn SpreadingExample() -> impl IntoView {
         let _ = window().alert_with_message(msg.as_ref());
     }
 
-    let attrs_str: Vec<(&'static str, Attribute)> =
+    let attrs_static_str: Vec<(&'static str, Attribute)> =
+        vec![("data-foo".into(), "42".into_attribute())];
+
+    let attrs_string: Vec<(String, Attribute)> =
         vec![("data-foo".into(), "42".into_attribute())];
 
     let attrs_only: Vec<(Oco<'static, str>, Attribute)> =
@@ -35,8 +38,12 @@ pub fn SpreadingExample() -> impl IntoView {
         }))];
 
     view! {
-        <div {..attrs_str}>
-            "<div {..attrs_str} />"
+        <div {..attrs_static_str}>
+            "<div {..attrs_static_str} />"
+        </div>
+
+        <div {..attrs_string}>
+            "<div {..attrs_string} />"
         </div>
 
         <div {..attrs_only}>
@@ -55,24 +62,10 @@ pub fn SpreadingExample() -> impl IntoView {
             "<div {..partial_attrs} {..partial_event_handlers} />"
         </div>
 
-        <SpreadingAttrsComponent {..attrs_only} />
-
         // Overwriting an event handler, here on:click, will result in a panic in debug builds. In release builds, the initial handler is kept.
         // If spreading is used, prefer manually merging event handlers in the binding list instead.
         //<div {..mixed} on:click=|_e| { alert("I will never be seen..."); }>
         //    "with overwritten click handler"
         //</div>
-    }
-}
-
-#[component]
-pub fn SpreadingAttrsComponent(
-    #[prop(into)]
-    #[prop(optional)]
-    #[prop(attrs)]
-    attrs: Vec<(Oco<'static, str>, Attribute)>,
-) -> impl IntoView {
-    view! {
-        <div {..attrs}>attrs</div>
     }
 }

--- a/examples/spread/src/lib.rs
+++ b/examples/spread/src/lib.rs
@@ -7,8 +7,11 @@ pub fn SpreadingExample() -> impl IntoView {
         let _ = window().alert_with_message(msg.as_ref());
     }
 
-    let attrs_only: Vec<(&'static str, Attribute)> =
-        vec![("data-foo", "42".into_attribute())];
+    let attrs_str: Vec<(&'static str, Attribute)> =
+        vec![("data-foo".into(), "42".into_attribute())];
+
+    let attrs_only: Vec<(Oco<'static, str>, Attribute)> =
+        vec![("data-foo".into(), "42".into_attribute())];
 
     let event_handlers_only: Vec<EventHandlerFn> =
         vec![EventHandlerFn::Click(Box::new(|_e: ev::MouseEvent| {
@@ -32,6 +35,10 @@ pub fn SpreadingExample() -> impl IntoView {
         }))];
 
     view! {
+        <div {..attrs_str}>
+            "<div {..attrs_str} />"
+        </div>
+
         <div {..attrs_only}>
             "<div {..attrs_only} />"
         </div>
@@ -48,10 +55,24 @@ pub fn SpreadingExample() -> impl IntoView {
             "<div {..partial_attrs} {..partial_event_handlers} />"
         </div>
 
+        <SpreadingAttrsComponent {..attrs_only} />
+
         // Overwriting an event handler, here on:click, will result in a panic in debug builds. In release builds, the initial handler is kept.
         // If spreading is used, prefer manually merging event handlers in the binding list instead.
         //<div {..mixed} on:click=|_e| { alert("I will never be seen..."); }>
         //    "with overwritten click handler"
         //</div>
+    }
+}
+
+#[component]
+pub fn SpreadingAttrsComponent(
+    #[prop(into)]
+    #[prop(optional)]
+    #[prop(attrs)]
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
+) -> impl IntoView {
+    view! {
+        <div {..attrs}>attrs</div>
     }
 }

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -275,7 +275,7 @@ pub trait Props {
 
 #[doc(hidden)]
 pub trait DynAttrs {
-    fn dyn_attrs(self, _args: Vec<(&'static str, Attribute)>) -> Self
+    fn dyn_attrs(self, _args: Vec<(Oco<'static, str>, Attribute)>) -> Self
     where
         Self: Sized,
     {

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -275,7 +275,10 @@ pub trait Props {
 
 #[doc(hidden)]
 pub trait DynAttrs {
-    fn dyn_attrs(self, _args: Vec<(Oco<'static, str>, Attribute)>) -> Self
+    fn dyn_attrs(
+        self,
+        _args: impl Into<Vec<(Oco<'static, str>, Attribute)>>,
+    ) -> Self
     where
         Self: Sized,
     {

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -373,7 +373,7 @@ pub enum Binding {
     /// A statically named attribute.
     Attribute {
         /// Name of the attribute.
-        name: &'static str,
+        name: Oco<'static, str>,
         /// Value of the attribute, possibly reactive.
         value: Attribute,
     },
@@ -383,6 +383,15 @@ pub enum Binding {
 
 impl From<(&'static str, Attribute)> for Binding {
     fn from((name, value): (&'static str, Attribute)) -> Self {
+        Self::Attribute {
+            name: name.into(),
+            value,
+        }
+    }
+}
+
+impl From<(Oco<'static, str>, Attribute)> for Binding {
+    fn from((name, value): (Oco<'static, str>, Attribute)) -> Self {
         Self::Attribute { name, value }
     }
 }
@@ -643,7 +652,7 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
         {
             attribute_helper(
                 self.element.as_ref(),
-                name,
+                name.into(),
                 attr.into_attribute(),
             );
             self
@@ -682,7 +691,9 @@ impl<El: ElementDescriptor + 'static> HtmlElement<El> {
     #[track_caller]
     pub fn attrs(
         mut self,
-        attrs: impl std::iter::IntoIterator<Item = (&'static str, Attribute)>,
+        attrs: impl std::iter::IntoIterator<
+            Item = (impl Into<Oco<'static, str>>, Attribute),
+        >,
     ) -> Self {
         for (name, value) in attrs {
             self = self.attr(name, value);

--- a/leptos_dom/src/html.rs
+++ b/leptos_dom/src/html.rs
@@ -390,6 +390,15 @@ impl From<(&'static str, Attribute)> for Binding {
     }
 }
 
+impl From<(String, Attribute)> for Binding {
+    fn from((name, value): (String, Attribute)) -> Self {
+        Self::Attribute {
+            name: name.into(),
+            value,
+        }
+    }
+}
+
 impl From<(Oco<'static, str>, Attribute)> for Binding {
     fn from((name, value): (Oco<'static, str>, Attribute)) -> Self {
         Self::Attribute { name, value }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -537,7 +537,7 @@ impl ToTokens for Model {
             }
 
             impl #impl_generics ::leptos::DynAttrs for #props_name #generics #where_clause {
-                fn dyn_attrs(mut self, v: Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>) -> Self {
+                fn dyn_attrs(mut self, v: impl Into<Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>>) -> Self {
                     #dyn_attrs_props
                     self
                 }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -397,7 +397,7 @@ impl ToTokens for Model {
 
                     if *attrs {
                         Some(quote! {
-                            ::leptos::leptos_dom::html::Binding::Attribute { name, value } => self.#ident.push((name, value)),
+                            ::leptos::leptos_dom::html::Binding::Attribute { name, value } => self.#ident.push((name.into(), value)),
                         })
                     } else {
                         None
@@ -537,7 +537,7 @@ impl ToTokens for Model {
             }
 
             impl #impl_generics ::leptos::DynAttrs for #props_name #generics #where_clause {
-                fn dyn_attrs(mut self, v: Vec<(&'static str, ::leptos::Attribute)>) -> Self {
+                fn dyn_attrs(mut self, v: Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>) -> Self {
                     #dyn_attrs_props
                     self
                 }

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -134,7 +134,7 @@ impl ToTokens for Model {
             }
 
             impl #impl_generics ::leptos::DynAttrs for #name #generics #where_clause {
-                fn dyn_attrs(mut self, v: Vec<(&'static str, ::leptos::Attribute)>) -> Self {
+                fn dyn_attrs(mut self, v: Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>) -> Self {
                     #dyn_attrs_props
                     self
                 }

--- a/leptos_macro/src/slot.rs
+++ b/leptos_macro/src/slot.rs
@@ -134,7 +134,7 @@ impl ToTokens for Model {
             }
 
             impl #impl_generics ::leptos::DynAttrs for #name #generics #where_clause {
-                fn dyn_attrs(mut self, v: Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>) -> Self {
+                fn dyn_attrs(mut self, v: impl Into<Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>>) -> Self {
                     #dyn_attrs_props
                     self
                 }

--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -13,7 +13,7 @@ pub struct BodyContext {
     #[cfg(feature = "ssr")]
     id: Rc<RefCell<Option<TextProp>>>,
     #[cfg(feature = "ssr")]
-    attributes: Rc<RefCell<HashMap<&'static str, Attribute>>>,
+    attributes: Rc<RefCell<HashMap<Oco<'static, str>, Attribute>>>,
 }
 
 impl BodyContext {
@@ -106,7 +106,7 @@ pub fn Body(
     id: Option<TextProp>,
     /// Arbitrary attributes to add to the `<body>`
     #[prop(attrs)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     cfg_if! {
         if #[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))] {

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -15,7 +15,7 @@ pub struct HtmlContext {
     #[cfg(feature = "ssr")]
     class: Rc<RefCell<Option<TextProp>>>,
     #[cfg(feature = "ssr")]
-    attributes: Rc<RefCell<HashMap<&'static str, Attribute>>>,
+    attributes: Rc<RefCell<HashMap<Oco<'static, str>, Attribute>>>,
 }
 
 impl HtmlContext {
@@ -112,7 +112,7 @@ pub fn Html(
     class: Option<TextProp>,
     /// Arbitrary attributes to add to the `<html>`
     #[prop(attrs)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     cfg_if! {
         if #[cfg(all(target_arch = "wasm32", any(feature = "csr", feature = "hydrate")))] {

--- a/meta/src/link.rs
+++ b/meta/src/link.rs
@@ -82,7 +82,7 @@ pub fn Link(
     blocking: Option<Oco<'static, str>>,
     /// Custom attributes.
     #[prop(attrs, optional)]
-    attrs: Vec<(&'static str, Attribute)>,
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     let meta = use_head();
     let next_id = meta.tags.get_next_id();

--- a/meta/src/meta_tags.rs
+++ b/meta/src/meta_tags.rs
@@ -1,5 +1,5 @@
 use crate::{use_head, TextProp};
-use leptos::{component, Attribute, IntoView};
+use leptos::{component, Attribute, IntoView, Oco};
 
 /// Injects an [`HTMLMetaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMetaElement) into the document
 /// head to set metadata
@@ -40,7 +40,7 @@ pub fn Meta(
     content: Option<TextProp>,
     /// Custom attributes.
     #[prop(attrs, optional)]
-    attrs: Vec<(&'static str, Attribute)>,
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     let meta = use_head();
     let next_id = meta.tags.get_next_id();

--- a/meta/src/script.rs
+++ b/meta/src/script.rs
@@ -64,7 +64,7 @@ pub fn Script(
     children: Option<Box<dyn FnOnce() -> Fragment>>,
     /// Custom attributes.
     #[prop(attrs, optional)]
-    attrs: Vec<(&'static str, Attribute)>,
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     let meta = use_head();
     let next_id = meta.tags.get_next_id();

--- a/meta/src/style.rs
+++ b/meta/src/style.rs
@@ -43,7 +43,7 @@ pub fn Style(
     children: Option<Box<dyn FnOnce() -> Fragment>>,
     /// Custom attributes.
     #[prop(attrs, optional)]
-    attrs: Vec<(&'static str, Attribute)>,
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     let meta = use_head();
     let next_id = meta.tags.get_next_id();

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -29,7 +29,7 @@ pub fn Stylesheet(
     id: Option<String>,
     /// Custom attributes.
     #[prop(attrs, optional)]
-    attrs: Vec<(&'static str, Attribute)>,
+    attrs: Vec<(Oco<'static, str>, Attribute)>,
 ) -> impl IntoView {
     if let Some(id) = id {
         view! {

--- a/router/src/components/form.rs
+++ b/router/src/components/form.rs
@@ -73,7 +73,7 @@ pub fn Form<A>(
     /// Arbitrary attributes to add to the `<form>`. Attributes can be added with the
     /// `attr:` syntax in the `view` macro.
     #[prop(attrs)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView
@@ -121,7 +121,7 @@ where
         node_ref: Option<NodeRef<html::Form>>,
         noscroll: bool,
         replace: bool,
-        attributes: Vec<(&'static str, Attribute)>,
+        attributes: Vec<(Oco<'static, str>, Attribute)>,
     ) -> HtmlElement<html::Form> {
         let action_version = version;
         let on_submit = {
@@ -456,7 +456,7 @@ pub fn ActionForm<ServFn>(
     node_ref: Option<NodeRef<html::Form>>,
     /// Arbitrary attributes to add to the `<form>`
     #[prop(attrs, optional)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView
@@ -569,7 +569,7 @@ pub fn MultiActionForm<ServFn>(
     node_ref: Option<NodeRef<html::Form>>,
     /// Arbitrary attributes to add to the `<form>`
     #[prop(attrs, optional)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
     /// Component children; should include the HTML of the form elements.
     children: Children,
 ) -> impl IntoView

--- a/router/src/components/link.rs
+++ b/router/src/components/link.rs
@@ -99,7 +99,7 @@ pub fn A<H>(
     /// Arbitrary attributes to add to the `<a>`. Attributes can be added with the
     /// `attr:` syntax in the `view` macro.
     #[prop(attrs)]
-    attributes: Vec<(&'static str, Attribute)>,
+    attributes: Vec<(Oco<'static, str>, Attribute)>,
     /// The nodes or elements to be shown inside the link.
     children: Children,
 ) -> impl IntoView
@@ -119,7 +119,7 @@ where
         class: Option<AttributeValue>,
         #[allow(unused)] active_class: Option<Oco<'static, str>>,
         id: Option<Oco<'static, str>>,
-        #[allow(unused)] attributes: Vec<(&'static str, Attribute)>,
+        #[allow(unused)] attributes: Vec<(Oco<'static, str>, Attribute)>,
         children: Children,
     ) -> View {
         #[cfg(not(any(feature = "hydrate", feature = "csr")))]


### PR DESCRIPTION
# Overview
I propose an enhancement to allow dynamically generated sets of attributes to be passed to components. Currently, this is limited to predefined attributes because the Binding struct requires field names to be `&'static str`. This proposal aims to address this limitation by enabling components to accept dynamically generated attributes. To support dynamic strings, I suggest updating the Binding struct to use Oco<'static, str> for the name field.

```rust
pub enum Binding {
    /// A statically named attribute.
    Attribute {
        /// Name of the attribute.
        name: Oco<'static, str>,
        /// Value of the attribute, possibly reactive.
        value: Attribute,
    },
    /// A statically typed event handler.
    EventHandler(EventHandlerFn),
}
```

# Technical Details
Leptos components are implemented as structs with a builder macro. This means that the declared `attributes` field in the component is a struct field and it store a passed `Binding`s (i.e. `String`'s), However, it is not possible to store an `Oco::Owned(String)` inside `&'static str`. Therefore, the current attributes field, defined as `Vec<(&'static str, Attribute)>`, should be modified to `Vec<(Oco<'static, str>, Attribute)>` in every component across all projects. This modification will allow the storage of dynamic names from Binding within components. Updating the attribute field signature is essential and it is a breaking change.

```rust
#[component(transparent)]
pub fn FooBar(
	...

    attributes: Vec<(&'static str, Attribute)>,
) -> impl IntoView {
	...
}
```

replaced to 

```rust
#[component(transparent)]
pub fn FooBar(
	...

    attributes: Vec<(Oco<'static, str>, Attribute)>,
) -> impl IntoView {
	...
}
```

and will be expanded to 

```rust
pub struct FooBarProps {
	...

    pub attributes: Vec<(Oco<'static, str>, Attribute)>,
}
```

# Backward Compatibility
Supporting both new and previous syntax while retaining the old component definitions is feasible. However, this might cause potential panics when non-static strings are passed to components that only accept static string attributes. This can lead hidden errors and user frustration. Therefore, it is better to update all components than to introduce a design flaw.

# Usage
The proposed change will allow for the following:

```rust
#[component(transparent)]
pub fn MyComponent(name: String, value: String) -> impl IntoView {
    let attrs: Vec<(Oco<'static, str>, Attribute)> = vec![(name.into(), value.into_attribute())];
    view! {
        <div {..attrs}>foo bar</div>
    }
}

```

This enhancement provides the flexibility to dynamically generate attribute sets, making components more versatile and adaptable to varying use cases.




















# More context

FooBar component will be expanded into this:

```rust
pub struct FooBarProps {
	...

    pub attributes: Vec<(Oco<'static, str>, Attribute)>,
}

...

impl leptos::DynAttrs for FooBarProps {
    fn dyn_attrs(
        mut self,
        v: Vec<(::leptos::Oco<'static, str>, ::leptos::Attribute)>,
    ) -> Self {
        self.attributes = v.into();
        self
    }
}

impl ::leptos::DynBindings for FooBarProps {
    fn dyn_bindings<B: Into<Binding>>(
        mut self,
        bindings: impl std::iter::IntoIterator<Item = B>,
    ) -> Self {
        for binding in bindings.into_iter() {
            let binding: Binding = binding.into();
            match binding {
                Binding::Attribute {
                    name,
                    value,
                } => self.attributes.push((name.into(), value)),
                _ => {}
            }
        }
        self
    }
}

...
```

I believe this enhancement will significantly improve the flexibility and functionality of attribute handling in components. 

This will close #2594