### PR TITLE
fix: move lint rules outside of quote_spanned

### DIFF
--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -52,12 +52,10 @@ pub(crate) fn fragment_to_tokens(
                 None,
             )?;
 
-            let node = quote_spanned! {span=>
-                #[allow(unused_braces)] {#node}
-            };
+            let node = quote_spanned!(span => { #node });
 
             Some(quote! {
-                ::leptos::IntoView::into_view(#node)
+                ::leptos::IntoView::into_view(#[allow(unused_braces)] #node)
             })
         })
         .peekable();
@@ -339,9 +337,7 @@ pub(crate) fn element_to_tokens(
             quote! {}
         };
         let ide_helper_close_tag = ide_helper_close_tag.into_iter();
-        Some(quote_spanned! {node.span()=>
-            #[allow(unused_braces)]
-            {
+        let result = quote_spanned! {node.span()=> {
             #(#ide_helper_close_tag)*
             #name
                 #(#attrs)*
@@ -352,7 +348,10 @@ pub(crate) fn element_to_tokens(
                 #(#children)*
                 #view_marker
             }
-        })
+        };
+
+        // We need to move "allow" out of "quote_spanned" because it breaks hovering in rust-analyzer
+        Some(quote!(#[allow(unused_braces)] #result))
     }
 }
 

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -70,12 +70,10 @@ pub(crate) fn component_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned! {value.span()=>
-                #[allow(unused_braces)] {#value}
-            };
+            let value = quote_spanned!(value.span()=> { #value });
 
             quote_spanned! {attr.span()=>
-                .#name(#value)
+                .#name(#[allow(unused_braces)] #value)
             }
         });
 

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -83,12 +83,10 @@ pub(crate) fn fragment_to_tokens_ssr(
     let nodes = nodes.iter().map(|node| {
         let span = node.span();
         let node = root_node_to_tokens_ssr(node, global_class, None);
-        let node = quote_spanned! {span=>
-            #[allow(unused_braces)] {#node}
-        };
+        let node = quote_spanned!(span=> { #node });
 
         quote! {
-            ::leptos::IntoView::into_view(#node)
+            ::leptos::IntoView::into_view(#[allow(unused_braces)] #node)
         }
     });
 

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -61,12 +61,10 @@ pub(crate) fn slot_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned! {value.span()=>
-                #[allow(unused_braces)] {#value}
-            };
+            let value = quote_spanned!(value.span()=> { #value });
 
             quote_spanned! {attr.span()=>
-                .#name(#value)
+                .#name(#[allow(unused_braces)] #value)
             }
         });
 
@@ -187,7 +185,7 @@ pub(crate) fn slot_to_tokens(
     };
 
     let slot = quote_spanned! {node.span()=>
-        #[allow(unused_braces)] {
+        {
             let slot = #component_name::builder()
                 #(#props)*
                 #(#slots)*
@@ -199,6 +197,9 @@ pub(crate) fn slot_to_tokens(
             slot.into()
         },
     };
+
+    // We need to move "allow" out of "quote_spanned" because it breaks hovering in rust-analyzer
+    let slot = quote!(#[allow(unused_braces)] #slot);
 
     parent_slots
         .entry(name)

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__client_template__full_span__counter_component.snap
@@ -145,27 +145,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(51..52),
+                                        span: bytes(37..52),
                                     },
                                 ],
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                         ],
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -195,27 +195,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(70..71),
+                                        span: bytes(65..71),
                                     },
                                 ],
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                         ],
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Brace,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__counter_component.snap
@@ -145,27 +145,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(51..52),
+                                        span: bytes(37..52),
                                     },
                                 ],
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                         ],
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -195,27 +195,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(70..71),
+                                        span: bytes(65..71),
                                     },
                                 ],
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                         ],
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Brace,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__simple_counter.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__csr__full_span__simple_counter.snap
@@ -1,33 +1,27 @@
 ---
 source: leptos_macro/src/view/tests.rs
-assertion_line: 101
 expression: result
 ---
 TokenStream [
     Punct {
         char: '#',
         spacing: Alone,
-        span: bytes(10..331),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 sym: allow,
-                span: bytes(10..331),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         sym: unused_braces,
-                        span: bytes(10..331),
                     },
                 ],
-                span: bytes(10..331),
             },
         ],
-        span: bytes(10..331),
     },
     Group {
         delimiter: Brace,
@@ -153,27 +147,22 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(28..83),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(28..83),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(28..83),
                                     },
                                 ],
-                                span: bytes(28..83),
                             },
                         ],
-                        span: bytes(28..83),
                     },
                     Group {
                         delimiter: Brace,
@@ -404,27 +393,22 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(96..176),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(96..176),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(96..176),
                                     },
                                 ],
-                                span: bytes(96..176),
                             },
                         ],
-                        span: bytes(96..176),
                     },
                     Group {
                         delimiter: Brace,
@@ -697,27 +681,22 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(189..223),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(189..223),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(189..223),
                                     },
                                 ],
-                                span: bytes(189..223),
                             },
                         ],
-                        span: bytes(189..223),
                     },
                     Group {
                         delimiter: Brace,
@@ -902,27 +881,22 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(236..316),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(236..316),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(236..316),
                                     },
                                 ],
-                                span: bytes(236..316),
                             },
                         ],
-                        span: bytes(236..316),
                     },
                     Group {
                         delimiter: Brace,

--- a/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__counter_component.snap
+++ b/leptos_macro/src/view/snapshots/leptos_macro__view__tests__ssr__full_span__counter_component.snap
@@ -145,27 +145,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(51..52),
+                                        span: bytes(37..52),
                                     },
                                 ],
-                                span: bytes(51..52),
+                                span: bytes(37..52),
                             },
                         ],
-                        span: bytes(51..52),
+                        span: bytes(37..52),
                     },
                     Group {
                         delimiter: Brace,
@@ -195,27 +195,27 @@ TokenStream [
                     Punct {
                         char: '#',
                         spacing: Alone,
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Bracket,
                         stream: TokenStream [
                             Ident {
                                 sym: allow,
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         sym: unused_braces,
-                                        span: bytes(70..71),
+                                        span: bytes(65..71),
                                     },
                                 ],
-                                span: bytes(70..71),
+                                span: bytes(65..71),
                             },
                         ],
-                        span: bytes(70..71),
+                        span: bytes(65..71),
                     },
                     Group {
                         delimiter: Brace,


### PR DESCRIPTION
Fixes #2527: DX regressions introduced by Rust Analyzer [2024-03-18 (v0.3.1885)](https://github.com/rust-lang/rust-analyzer/releases/tag/2024-03-18). Specifically:
- **Hover over items used inside view! macro** - fixed in this PR
- **Component's syntax highlighting** - fixed in r-a in recent updates
- **Go to definition** - fixed in r-a in recent updates

Related discussion on Rust Analyzer's Zulip: [t-compiler/rust-analyzer > Leptos macros](https://rust-lang.zulipchat.com/#narrow/stream/185405-t-compiler.2Frust-analyzer/topic/.E2.9C.94.20Leptos.20macros)