### PR TITLE
#2726 (Part1) Drop crate lazy_static, prefer std::sync::LazyLock

### DIFF
--- a/.github/workflows/ci-semver.yml
+++ b/.github/workflows/ci-semver.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     needs: [get-leptos-changed]
     if: needs.get-leptos-changed.outputs.leptos_changed == 'true'
-    name: Run semver check (nightly-2024-04-14)
+    name: Run semver check (nightly-2024-07-26)
     runs-on: ubuntu-latest
 
     steps:
@@ -25,4 +25,4 @@ jobs:
       - name: Semver Checks
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          rust-toolchain: nightly-2024-04-14
+          rust-toolchain: nightly-2024-07-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
     with:
       directory: ${{ matrix.directory }}
       cargo_make_task: "ci"
-      toolchain: nightly-2024-04-14
+      toolchain: nightly-2024-07-26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,9 @@ exclude = ["benchmarks", "examples"]
 
 [workspace.package]
 version = "0.6.13"
-rust-version = "1.75"
+
+# Required by use of std::sync::LazyLock
+rust-version = "1.80"
 
 [workspace.dependencies]
 oco_ref = { path = "./oco", version = "0.1.0" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -23,7 +23,6 @@ miniserde = "0.1"
 gloo = "0.8"
 uuid = { version = "1", features = ["serde", "v4", "wasm-bindgen"] }
 wasm-bindgen = "0.2"
-lazy_static = "1"
 log = "0.4"
 strum = "0.24"
 strum_macros = "0.24"

--- a/benchmarks/src/ssr.rs
+++ b/benchmarks/src/ssr.rs
@@ -18,7 +18,7 @@ fn leptos_ssr_bench(b: &mut Bencher) {
 				}
 			}
 
-			let rendered = view! { 
+			let rendered = view! {
 				<main>
 					<h1>"Welcome to our benchmark page."</h1>
 					<p>"Here's some introductory text."</p>
@@ -58,7 +58,7 @@ fn tachys_ssr_bench(b: &mut Bencher) {
 			}
 		}
 
-		let rendered = view! { 
+		let rendered = view! {
 			<main>
 				<h1>"Welcome to our benchmark page."</h1>
 				<p>"Here's some introductory text."</p>
@@ -77,6 +77,7 @@ fn tachys_ssr_bench(b: &mut Bencher) {
 
 #[bench]
 fn tera_ssr_bench(b: &mut Bencher) {
+    use std::cell::LazyCell;
     use serde::{Deserialize, Serialize};
     use tera::*;
 
@@ -92,13 +93,11 @@ fn tera_ssr_bench(b: &mut Bencher) {
 	{% endfor %}
 	</main>"#;
 
-    lazy_static::lazy_static! {
-        static ref TERA: Tera = {
+        static LazyCell<Tera> = LazyCell::new(|| {
             let mut tera = Tera::default();
             tera.add_raw_templates(vec![("template.html", TEMPLATE)]).unwrap();
             tera
-        };
-    }
+        });
 
     #[derive(Serialize, Deserialize)]
     struct Counter {

--- a/benchmarks/src/todomvc/tera.rs
+++ b/benchmarks/src/todomvc/tera.rs
@@ -55,7 +55,7 @@ static TEMPLATE: &str = r#"<main>
 						{% else %}
 						 <li><a href="/">All</a></li>
 						{% endif %}
-				
+
 						{% if mode_active %}
                         <li><a href="/active" class="selected">Active</a></li>
 						{% else %}
@@ -88,16 +88,16 @@ static TEMPLATE: &str = r#"<main>
 
 #[bench]
 fn tera_todomvc_ssr(b: &mut Bencher) {
+    use std::sync::LazyLock;
     use serde::{Deserialize, Serialize};
     use tera::*;
 
-    lazy_static::lazy_static! {
-        static ref TERA: Tera = {
-            let mut tera = Tera::default();
-            tera.add_raw_templates(vec![("template.html", TEMPLATE)]).unwrap();
-            tera
-        };
-    }
+    static TERA: LazyLock<Tera> = LazyLock::new(|| {
+        let mut tera = Tera::default();
+        tera.add_raw_templates(vec![("template.html", TEMPLATE)]).unwrap();
+        tera
+    });
+
 
     #[derive(Serialize, Deserialize)]
     struct Todo {
@@ -128,16 +128,17 @@ fn tera_todomvc_ssr(b: &mut Bencher) {
 
 #[bench]
 fn tera_todomvc_ssr_1000(b: &mut Bencher) {
+    use std::sync::LazyLock;
     use serde::{Deserialize, Serialize};
     use tera::*;
 
-    lazy_static::lazy_static! {
-        static ref TERA: Tera = {
+
+        static TERA: LazyLock<Tera> = LazyLock::new(|| {
             let mut tera = Tera::default();
             tera.add_raw_templates(vec![("template.html", TEMPLATE)]).unwrap();
             tera
-        };
-    }
+        });
+
 
     #[derive(Serialize, Deserialize)]
     struct Todo {

--- a/examples/counter_isomorphic/src/counters.rs
+++ b/examples/counter_isomorphic/src/counters.rs
@@ -6,15 +6,14 @@ use tracing::instrument;
 
 #[cfg(feature = "ssr")]
 pub mod ssr_imports {
+    pub std::sync::LazyLock;
     pub use broadcaster::BroadcastChannel;
     pub use once_cell::sync::OnceCell;
     pub use std::sync::atomic::{AtomicI32, Ordering};
 
     pub static COUNT: AtomicI32 = AtomicI32::new(0);
 
-    lazy_static::lazy_static! {
-        pub static ref COUNT_CHANNEL: BroadcastChannel<i32> = BroadcastChannel::new();
-    }
+    pub static COUNT_CHANNEL: LazyLock<BroadcastChannel<i32>> = LazyLock::new(|| BroadcastChannel::new());
 
     static LOG_INIT: OnceCell<()> = OnceCell::new();
 

--- a/examples/counter_isomorphic/src/counters.rs
+++ b/examples/counter_isomorphic/src/counters.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 
 #[cfg(feature = "ssr")]
 pub mod ssr_imports {
-    pub std::sync::LazyLock;
+    pub use std::sync::LazyLock;
     pub use broadcaster::BroadcastChannel;
     pub use once_cell::sync::OnceCell;
     pub use std::sync::atomic::{AtomicI32, Ordering};

--- a/examples/spread/rust-toolchain.toml
+++ b/examples/spread/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-01-29"
+channel = "nightly-2024-07-26"

--- a/leptos_macro/Makefile.toml
+++ b/leptos_macro/Makefile.toml
@@ -11,13 +11,13 @@ dependencies = [
 [tasks.test-leptos_macro-example]
 description = "Tests the leptos_macro/example to check if macro handles doc comments correctly"
 command = "cargo"
-args = ["+nightly-2024-04-14", "test", "--doc"]
+args = ["+nightly-2024-07-26", "test", "--doc"]
 cwd = "example"
 install_crate = false
 
 [tasks.doc-leptos_macro-example]
 description = "Docs the leptos_macro/example to check if macro handles doc comments correctly"
 command = "cargo"
-args = ["+nightly-2024-04-14", "doc"]
+args = ["+nightly-2024-07-26", "doc"]
 cwd = "example"
 install_crate = false

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 leptos_reactive = { workspace = true }
 leptos_macro = { workspace = true }
 server_fn = { workspace = true }
-lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -16,7 +16,6 @@ leptos_meta = { workspace = true, optional = true }
 cached = { version = "0.45.0", optional = true }
 cfg-if = "1"
 gloo-net = { version = "0.5", features = ["http"] }
-lazy_static = "1"
 linear-map = { version = "1", features = ["serde_impl"] }
 once_cell = "1.18"
 regex = { version = "1", optional = true }

--- a/router/src/matching/expand_optionals.rs
+++ b/router/src/matching/expand_optionals.rs
@@ -59,12 +59,16 @@ pub fn expand_optionals(pattern: &str) -> Vec<Cow<'_, str>> {
 #[doc(hidden)]
 #[cfg(feature = "ssr")]
 pub fn expand_optionals(pattern: &str) -> Vec<Cow<'_, str>> {
+    use std::sync::LazyLock;
+
     use regex::Regex;
 
-    lazy_static::lazy_static! {
-        pub static ref OPTIONAL_RE: Regex = Regex::new(OPTIONAL).expect("could not compile OPTIONAL_RE");
-        pub static ref OPTIONAL_RE_2: Regex = Regex::new(OPTIONAL_2).expect("could not compile OPTIONAL_RE_2");
-    }
+    static OPTIONAL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(OPTIONAL).expect("could not compile OPTIONAL_RE")
+    });
+    static OPTIONAL_RE_2: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(OPTIONAL_2).expect("could not compile OPTIONAL_RE_2")
+    });
 
     let captures = OPTIONAL_RE.find(pattern);
     match captures {

--- a/router/src/matching/expand_optionals.rs
+++ b/router/src/matching/expand_optionals.rs
@@ -59,9 +59,8 @@ pub fn expand_optionals(pattern: &str) -> Vec<Cow<'_, str>> {
 #[doc(hidden)]
 #[cfg(feature = "ssr")]
 pub fn expand_optionals(pattern: &str) -> Vec<Cow<'_, str>> {
-    use std::sync::LazyLock;
-
     use regex::Regex;
+    use std::sync::LazyLock;
 
     static OPTIONAL_RE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(OPTIONAL).expect("could not compile OPTIONAL_RE")


### PR DESCRIPTION
**MSRV change**

rust-version is now 1.80

This is just the smallest change possible the framework.. 

smallest patch easiest  to review. I want to do this as the implications of the MSRV change need carefull consideration.

There are lots of  bulky changes to the examples/project subdirectories which will need careful testing in themselves .. but that is part 2.