### PR TITLE
Fix doc comment for `spawn_local` function

### DIFF
--- a/leptos_reactive/src/spawn.rs
+++ b/leptos_reactive/src/spawn.rs
@@ -56,7 +56,7 @@ use std::future::Future;
 ///             // handles the error from the resource
 ///             <ErrorBoundary fallback=|_| {view! {<p>"Something went wrong"</p>}}>
 ///                 {move || {
-///                     user.read().map(move |x| {
+///                     user.get().map(move |x| {
 ///                         // the resource has a result
 ///                         x.map(move |y| {
 ///                             // successful call from the server fn


### PR DESCRIPTION
Hi,
I'm using Leptos for my projects and it's great! I can say it's a wonderful framework.
I noticed a small mistake in the `spawn_local` function doc comment today. The `.read` method is deprecated:
![image](https://github.com/user-attachments/assets/06b92652-39c7-4510-bf72-f08ff02aef26)
I've changed it to the `.get` method.