### PR TITLE
Allowing effect functions without parameters for DX boost

### DIFF
--- a/reactive_graph/src/effect.rs
+++ b/reactive_graph/src/effect.rs
@@ -2,7 +2,10 @@
 
 #[allow(clippy::module_inception)]
 mod effect;
+mod effect_function;
 mod inner;
 mod render_effect;
+
 pub use effect::*;
+pub use effect_function::*;
 pub use render_effect::*;

--- a/reactive_graph/src/effect/effect.rs
+++ b/reactive_graph/src/effect/effect.rs
@@ -1,6 +1,6 @@
 use crate::{
     channel::{channel, Receiver},
-    effect::inner::EffectInner,
+    effect::{inner::EffectInner, EffectFunction},
     graph::{
         AnySubscriber, ReactiveNode, SourceSet, Subscriber, ToAnySubscriber,
         WithObserver,
@@ -112,7 +112,7 @@ impl Effect {
     /// This spawns a task on the local thread using
     /// [`spawn_local`](any_spawner::Executor::spawn_local). For an effect that can be spawned on
     /// any thread, use [`new_sync`](Effect::new_sync).
-    pub fn new<T>(mut fun: impl FnMut(Option<T>) -> T + 'static) -> Self
+    pub fn new<T, M>(mut fun: impl EffectFunction<T, M> + 'static) -> Self
     where
         T: 'static,
     {
@@ -138,7 +138,7 @@ impl Effect {
                             let old_value =
                                 mem::take(&mut *value.write().or_poisoned());
                             let new_value = owner.with_cleanup(|| {
-                                subscriber.with_observer(|| fun(old_value))
+                                subscriber.with_observer(|| fun.run(old_value))
                             });
                             *value.write().or_poisoned() = Some(new_value);
                         }
@@ -157,8 +157,8 @@ impl Effect {
     ///
     /// This spawns a task that can be run on any thread. For an effect that will be spawned on
     /// the current thread, use [`new`](Effect::new).
-    pub fn new_sync<T>(
-        mut fun: impl FnMut(Option<T>) -> T + Send + Sync + 'static,
+    pub fn new_sync<T, M>(
+        mut fun: impl EffectFunction<T, M> + Send + Sync + 'static,
     ) -> Self
     where
         T: Send + Sync + 'static,
@@ -185,7 +185,7 @@ impl Effect {
                             let old_value =
                                 mem::take(&mut *value.write().or_poisoned());
                             let new_value = owner.with_cleanup(|| {
-                                subscriber.with_observer(|| fun(old_value))
+                                subscriber.with_observer(|| fun.run(old_value))
                             });
                             *value.write().or_poisoned() = Some(new_value);
                         }
@@ -203,8 +203,8 @@ impl Effect {
     /// that are read inside it change.
     ///
     /// This will run whether the `effects` feature is enabled or not.
-    pub fn new_isomorphic<T>(
-        mut fun: impl FnMut(Option<T>) -> T + Send + Sync + 'static,
+    pub fn new_isomorphic<T, M>(
+        mut fun: impl EffectFunction<T, M> + Send + Sync + 'static,
     ) -> Self
     where
         T: Send + Sync + 'static,
@@ -229,7 +229,7 @@ impl Effect {
                         let old_value =
                             mem::take(&mut *value.write().or_poisoned());
                         let new_value = owner.with_cleanup(|| {
-                            subscriber.with_observer(|| fun(old_value))
+                            subscriber.with_observer(|| fun.run(old_value))
                         });
                         *value.write().or_poisoned() = Some(new_value);
                     }
@@ -256,8 +256,8 @@ impl ToAnySubscriber for Effect {
 /// Creates an [`Effect`].
 #[inline(always)]
 #[track_caller]
-#[deprecated = "This function is being removed to conform to Rust \
-                idioms.Please use `Effect::new()` instead."]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `Effect::new()` instead."]
 pub fn create_effect<T>(fun: impl FnMut(Option<T>) -> T + 'static) -> Effect
 where
     T: 'static,

--- a/reactive_graph/src/effect/effect_function.rs
+++ b/reactive_graph/src/effect/effect_function.rs
@@ -1,0 +1,31 @@
+/// Trait to enable effect functions that have zero or one parameter
+pub trait EffectFunction<T, M> {
+    /// Call this to execute the function. In case the actual function has no parameters
+    /// the parameter `p` will simply be ignored.
+    fn run(&mut self, p: Option<T>) -> T;
+}
+
+/// Marker for single parameter functions
+pub struct SingleParam;
+/// Marker for no parameter functions
+pub struct NoParam;
+
+impl<Func, T> EffectFunction<T, SingleParam> for Func
+where
+    Func: FnMut(Option<T>) -> T,
+{
+    #[inline(always)]
+    fn run(&mut self, p: Option<T>) -> T {
+        (self)(p)
+    }
+}
+
+impl<Func> EffectFunction<(), NoParam> for Func
+where
+    Func: FnMut(),
+{
+    #[inline(always)]
+    fn run(&mut self, _: Option<()>) {
+        self()
+    }
+}

--- a/reactive_graph/tests/effect.rs
+++ b/reactive_graph/tests/effect.rs
@@ -1,13 +1,17 @@
+#[cfg(feature = "effects")]
 use any_spawner::Executor;
+#[cfg(feature = "effects")]
 use reactive_graph::{
     effect::{Effect, RenderEffect},
     prelude::*,
     signal::RwSignal,
 };
+#[cfg(feature = "effects")]
 use std::{
     mem,
     sync::{Arc, RwLock},
 };
+#[cfg(feature = "effects")]
 use tokio::task;
 
 #[cfg(feature = "effects")]
@@ -57,7 +61,7 @@ async fn effect_runs() {
 
             Effect::new({
                 let b = b.clone();
-                move |_| {
+                move || {
                     let formatted = format!("Value is {}", a.get());
                     *b.write().unwrap() = formatted;
                 }
@@ -90,7 +94,7 @@ async fn dynamic_dependencies() {
 
             mem::forget(RenderEffect::new({
                 let combined_count = Arc::clone(&combined_count);
-                move |_| {
+                move || {
                     *combined_count.write().unwrap() += 1;
                     if use_last.get() {
                         println!("{} {}", first.get(), last.get());

--- a/reactive_graph/tests/memo.rs
+++ b/reactive_graph/tests/memo.rs
@@ -1,14 +1,16 @@
+#[cfg(feature = "effects")]
 use any_spawner::Executor;
+#[cfg(feature = "effects")]
+use reactive_graph::effect::{Effect, RenderEffect};
 use reactive_graph::{
     computed::{ArcMemo, Memo},
-    effect::{Effect, RenderEffect},
     prelude::*,
     signal::RwSignal,
 };
-use std::{
-    mem,
-    sync::{Arc, RwLock},
-};
+#[cfg(feature = "effects")]
+use std::mem;
+use std::sync::{Arc, RwLock};
+#[cfg(feature = "effects")]
 use tokio::task;
 
 #[test]


### PR DESCRIPTION
It has long bothered me (much more than is reasonable) that you always had to provide a param to the effect functions while you almost never need it. This is in no small part due to the fact that on my keyboard layout typing the combination `|_|` is really awkward.

Now it's possible to do

```rust
Effect::new(move || { 
    // do sth
});
```

as well as

```rust
Effect::new(move |prev| {
    // do sth

    value
});
```