### PR TITLE
fix: add `leptos_router_macro::path` to public api [`0.7`]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.7.0-beta" }
 leptos_integration_utils = { path = "./integrations/utils", version = "0.7.0-beta" }
 leptos_macro = { path = "./leptos_macro", version = "0.7.0-beta" }
 leptos_router = { path = "./router", version = "0.7.0-beta" }
+leptos_router_macro = { path = "./router_macro", version = "0.7.0-beta" }
 leptos_server = { path = "./leptos_server", version = "0.7.0-beta" }
 leptos_meta = { path = "./meta", version = "0.7.0-beta" }
 next_tuple = { path = "./next_tuple", version = "0.1.0-beta" }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 leptos = { workspace = true }
+leptos_router_macro = { workspace = true }
 any_spawner = { workspace = true }
 either_of = { workspace = true }
 or_poisoned = { workspace = true }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -25,3 +25,4 @@ pub use navigate::*;
 //pub use router::*;
 pub use ssr_mode::*;
 pub use static_route::*;
+pub use leptos_router_macro::path;


### PR DESCRIPTION
Seems like this is currently missing from the public API on v0.7.

I chose to re-export it through `leptos_router`, I am assuming it doesn't
have use outside of that crate. Please let me know if it is preferred to be
through the base `leptos` crate instead.

This macro was mentioned in the release docs for 0.7-beta