### PR TITLE
Provide deprecated `watch` function

### DIFF
--- a/reactive_graph/src/effect/effect.rs
+++ b/reactive_graph/src/effect/effect.rs
@@ -72,6 +72,7 @@ use std::{
 ///    this with a web framework, this generally means that effects **do not run on the server**.
 ///    and you can call browser-specific APIs within the effect function without causing issues.
 ///    If you need an effect to run on the server, use [`Effect::new_isomorphic`].
+#[derive(Debug, Clone, Copy)]
 pub struct Effect<S> {
     inner: Option<StoredValue<StoredEffect, S>>,
 }
@@ -514,4 +515,23 @@ where
     T: 'static,
 {
     Effect::new(fun)
+}
+
+/// Creates an [`Effect`], equivalent to [Effect::watch].
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust \
+                idioms. Please use `Effect::watch()` instead."]
+pub fn watch<W, T>(
+    deps: impl Fn() -> W + 'static,
+    callback: impl Fn(&W, Option<&W>, Option<T>) -> T + Clone + 'static,
+    immediate: bool,
+) -> impl Fn() + Clone
+where
+    W: Clone + 'static,
+    T: 'static,
+{
+    let watch = Effect::watch(deps, callback, immediate);
+
+    move || watch.stop()
 }


### PR DESCRIPTION
This PR provides a deprecated `watch` function, similar to `create_effect`. This should ease migration.

In order for `watch` to maintain the same signature as 0.6, `Effect` must be at least `Clone`. I provided both `Clone` _and_ `Copy`. Since the underlying type is always `Copy`, I think it makes sense to allow easy ergonomic access to `Effect::stop`, even if this may result in `stop` being called more than once. As noted [in this message](https://discord.com/channels/1031524867910148188/1263897766929764363/1269441434222592000), multiple calls to `stop` aren't a correctness problem; they're simply redundant.

I also provided a single test to ensure it runs properly. Since `watch` is a very light wrapper around `Effect::watch`, this can be argued to be redundant.