### PR TITLE
fix: correctly rebuild reactive attributes to avoid stale signals

### DIFF
--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -57,7 +57,21 @@ where
         })
     }
 
-    fn rebuild(self, _state: &mut Self::State) {}
+    fn rebuild(mut self, state: &mut Self::State) {
+        let prev_value = state.take_value();
+        *state = RenderEffect::new_with_value(
+            move |prev| {
+                let value = self.invoke();
+                if let Some(mut state) = prev {
+                    value.rebuild(&mut state);
+                    state
+                } else {
+                    unreachable!()
+                }
+            },
+            prev_value,
+        );
+    }
 
     fn into_cloneable(self) -> Self::Cloneable {
         self.into_shared()
@@ -127,7 +141,9 @@ mod stable {
                     (move || self.get()).build(el)
                 }
 
-                fn rebuild(self, _state: &mut Self::State) {}
+                fn rebuild(self, state: &mut Self::State) {
+                    (move || self.get()).rebuild(state)
+                }
 
                 fn into_cloneable(self) -> Self::Cloneable {
                     self
@@ -184,7 +200,9 @@ mod stable {
                     (move || self.get()).build(el)
                 }
 
-                fn rebuild(self, _state: &mut Self::State) {}
+                fn rebuild(self, state: &mut Self::State) {
+                    (move || self.get()).rebuild(state)
+                }
 
                 fn into_cloneable(self) -> Self::Cloneable {
                     self


### PR DESCRIPTION
Fixed an issue where `data-count` and `inner_html` were not updated when count was updated. (Refer to https://github.com/leptos-rs/leptos/commit/309a3d504a7ad8e67a7649478bb6dd841d8fe2b0)

```rust
#[component]
pub fn Count() -> impl IntoView {
    let count = RwSignal::new(1);
    let on_click = move |_| {
        count.update(|c| *c += 1);
    };

    view! {
        <div>
            <button on:click=on_click>"+ 1"</button>
            {
                move || {
                    if count.get() != 0 {
                        Either::Left(view!{<CountData data=count/>})
                    } else {
                        Either::Right(())
                    }
                }
            }
        </div>
    }
}

#[component]
pub fn CountData(#[prop(into)] data: MaybeSignal<i32>) -> impl IntoView {
    view! {
        <div data-count=move || data.get() inner_html=move || data.get().to_string()>
        </div>
    }
}
```