### PR TITLE
Provide deprecated create_node_ref

### DIFF
--- a/tachys/src/reactive_graph/node_ref.rs
+++ b/tachys/src/reactive_graph/node_ref.rs
@@ -103,3 +103,16 @@ where
         self.0.track();
     }
 }
+
+/// Create a [NodeRef].
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `NodeRef::new()` instead."]
+pub fn create_node_ref<E>() -> NodeRef<E>
+where
+    E: ElementType,
+    E::Output: 'static,
+{
+    NodeRef::new()
+}


### PR DESCRIPTION
This PR provides a deprecated `create_node_ref` function as a part of #2771.