### PR TITLE
Chore: cargo outdated, bump rustc-hash to version 2.0.0, no additional fixups

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -26,7 +26,7 @@ or_poisoned = { workspace = true }
 paste = "1"
 rand = { version = "0.8", optional = true }
 reactive_graph = { workspace = true, features = ["serde"] }
-rustc-hash = "1"
+rustc-hash = "2"
 tachys = { workspace = true, features = ["reactive_graph", "oco"] }
 thiserror = "1"
 tracing = "0.1"

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -15,7 +15,7 @@ or_poisoned = { workspace = true }
 futures = "0.3"
 hydration_context = { workspace = true, optional = true }
 pin-project-lite = "0.2"
-rustc-hash = "1.1.0"
+rustc-hash = "2"
 serde = { version = "1", features = ["derive"], optional = true }
 slotmap = "1"
 thiserror = "1"

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -149,7 +149,7 @@ web-sys = { version = "0.3", features = [
 ] }
 drain_filter_polyfill = "0.1"
 indexmap = "2"
-rustc-hash = "1"
+rustc-hash = "2"
 futures = "0.3"
 parking_lot = "0.12"
 itertools = "0.12"


### PR DESCRIPTION
This is a small thing, but I find without constant small PRs keeping the list of things reported by "cargo outdated" small ....

Well the thing blows up into a UGLY spaghetti monster which is impossible to unpick 

On this branch here is output of "cargo outdated"

On the target list for the next PR hmmm..   ahash, log, iter-tools, libc, bitflags , cfg-if



```
any_spawner
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
gio-sys        0.19.8   ---     0.20.0   Normal  ---
glib           0.19.9   ---     0.20.0   Normal  ---
glib-macros    0.19.9   ---     0.20.0   Normal  ---
glib-sys       0.19.8   ---     0.20.0   Normal  ---
gobject-sys    0.19.8   ---     0.20.0   Normal  ---
proc-macro2    1.0.86   ---     Removed  Normal  ---
quote          1.0.36   ---     Removed  Normal  ---
serde          1.0.204  ---     Removed  Normal  ---
serde_derive   1.0.204  ---     Removed  Normal  ---
syn            2.0.72   ---     Removed  Normal  ---
system-deps    6.2.2    ---     7.0.1    Build   ---
unicode-ident  1.0.12   ---     Removed  Normal  ---

leptos
================
Name                    Project                        Compat  Latest   Kind    Platform
----                    -------                        ------  ------   ----    --------
ahash                   0.8.11                         ---     Removed  Normal  ---
allocator-api2          0.2.18                         ---     Removed  Normal  ---
anyhow                  1.0.86                         ---     Removed  Normal  ---
async-trait             0.1.81                         ---     Removed  Normal  ---
autocfg                 1.3.0                          ---     Removed  Build   ---
bitflags                2.6.0                          ---     Removed  Normal  ---
byteorder               1.5.0                          ---     Removed  Normal  ---
bytes                   1.7.1                          ---     Removed  Normal  ---
cfg-if                  1.0.0                          ---     Removed  Normal  ---
equivalent              1.0.1                          ---     Removed  Normal  ---
fnv                     1.0.7                          ---     Removed  Normal  ---
form_urlencoded         1.2.1                          ---     Removed  Normal  ---
futures                 0.3.30                         ---     Removed  Normal  ---
futures-channel         0.3.30                         ---     Removed  Normal  ---
futures-core            0.3.30                         ---     Removed  Normal  ---
futures-executor        0.3.30                         ---     Removed  Normal  ---
futures-io              0.3.30                         ---     Removed  Normal  ---
futures-macro           0.3.30                         ---     Removed  Normal  ---
futures-sink            0.3.30                         ---     Removed  Normal  ---
futures-task            0.3.30                         ---     Removed  Normal  ---
futures-util            0.3.30                         ---     Removed  Normal  ---
getrandom               0.2.15                         ---     Removed  Normal  ---
hashbrown               0.14.5                         ---     Removed  Normal  ---
heck                    0.4.1                          ---     Removed  Normal  ---
hermit-abi              0.3.9                          ---     Removed  Normal  cfg(target_os = "hermit")
http                    0.2.12                         ---     Removed  Normal  ---
id-arena                2.2.1                          ---     Removed  Normal  ---
indexmap                2.3.0                          ---     Removed  Normal  ---
itoa                    1.0.11                         ---     Removed  Normal  ---
leb128                  0.2.5                          ---     Removed  Normal  ---
leptos-spin-macro       0.1.0                          ---     0.2.0    Normal  ---
libc                    0.2.155                        ---     Removed  Normal  cfg(not(windows))
libc                    0.2.155                        ---     Removed  Normal  cfg(unix)
log                     0.4.22                         ---     Removed  Normal  ---
memchr                  2.7.4                          ---     Removed  Normal  ---
num_cpus                1.16.0                         ---     Removed  Normal  ---
once_cell               1.19.0                         ---     Removed  Normal  ---
once_cell               1.19.0                         ---     Removed  Normal  cfg(not(all(target_arch = "arm", target_os = "none")))
percent-encoding        2.3.1                          ---     Removed  Normal  ---
pin-project-lite        0.2.14                         ---     Removed  Normal  ---
pin-utils               0.1.0                          ---     Removed  Normal  ---
proc-macro2             1.0.86                         ---     Removed  Normal  ---
quote                   1.0.36                         ---     Removed  Normal  ---
routefinder             0.5.4                          ---     Removed  Normal  ---
ryu                     1.0.18                         ---     Removed  Normal  ---
semver                  1.0.23                         ---     Removed  Normal  ---
serde                   1.0.204                        ---     Removed  Normal  ---
serde_derive            1.0.204                        ---     Removed  Normal  ---
serde_json              1.0.122                        ---     Removed  Normal  ---
serde_qs                0.12.0                         ---     0.13.0   Normal  ---
slab                    0.4.9                          ---     Removed  Normal  ---
smallvec                1.13.2                         ---     Removed  Normal  ---
smartcow                0.2.1                          ---     Removed  Normal  ---
smartstring             1.0.1                          ---     Removed  Normal  ---
spdx                    0.10.6                         ---     Removed  Normal  ---
spin-macro              2.2.0                          ---     Removed  Normal  ---
spin-sdk                2.2.0                          ---     Removed  Normal  ---
static_assertions       1.1.0                          ---     Removed  Normal  ---
syn                     1.0.109                        ---     Removed  Normal  ---
syn                     2.0.72                         ---     Removed  Normal  ---
thiserror               1.0.63                         ---     Removed  Normal  ---
thiserror-impl          1.0.63                         ---     Removed  Normal  ---
typed-builder           0.18.2                         ---     0.19.1   Normal  ---
typed-builder-macro     0.18.2                         ---     0.19.1   Normal  ---
unicode-ident           1.0.12                         ---     Removed  Normal  ---
unicode-segmentation    1.11.0                         ---     Removed  Normal  ---
unicode-xid             0.2.4                          ---     Removed  Normal  ---
version_check           0.9.5                          ---     Removed  Build   ---
wasi                    0.11.0+wasi-snapshot-preview1  ---     Removed  Normal  cfg(target_os = "wasi")
wasm-encoder            0.36.2                         ---     Removed  Normal  ---
wasm-encoder            0.41.2                         ---     Removed  Normal  ---
wasm-metadata           0.10.20                        ---     Removed  Normal  ---
wasmparser              0.116.1                        ---     Removed  Normal  ---
wasmparser              0.121.2                        ---     Removed  Normal  ---
wit-bindgen             0.13.1                         ---     Removed  Normal  ---
wit-bindgen-core        0.13.1                         ---     Removed  Normal  ---
wit-bindgen-rust        0.13.2                         ---     Removed  Normal  ---
wit-bindgen-rust-macro  0.13.1                         ---     Removed  Normal  ---
wit-component           0.17.0                         ---     Removed  Normal  ---
wit-parser              0.12.2                         ---     Removed  Normal  ---
zerocopy                0.7.35                         ---     Removed  Normal  ---
zerocopy-derive         0.7.35                         ---     Removed  Normal  ---

leptos_config
================
Name                 Project  Compat  Latest   Kind    Platform
----                 -------  ------  ------   ----    --------
proc-macro2          1.0.86   ---     Removed  Normal  ---
quote                1.0.36   ---     Removed  Normal  ---
serde                1.0.204  ---     Removed  Normal  ---
serde_derive         1.0.204  ---     Removed  Normal  ---
syn                  2.0.72   ---     Removed  Normal  ---
typed-builder        0.18.2   ---     0.19.1   Normal  ---
typed-builder-macro  0.18.2   ---     0.19.1   Normal  ---
unicode-ident        1.0.12   ---     Removed  Normal  ---

tachys
================
Name                        Project  Compat  Latest   Kind    Platform
----                        -------  ------  ------   ----    --------
itertools                   0.12.1   ---     0.13.0   Normal  ---
proc-macro2                 1.0.86   ---     Removed  Normal  ---
quote                       1.0.36   ---     Removed  Normal  ---
serde                       1.0.204  ---     Removed  Normal  ---
serde_derive                1.0.204  ---     Removed  Normal  ---
sledgehammer_bindgen        0.4.0    ---     0.5.0    Normal  ---
sledgehammer_bindgen_macro  0.4.0    ---     0.5.1    Normal  ---
syn                         2.0.72   ---     Removed  Normal  ---
unicode-ident               1.0.12   ---     Removed  Normal  ---

leptos_macro
================
Name                 Project  Compat  Latest   Kind         Platform
----                 -------  ------  ------   ----         --------
itertools            0.12.1   ---     0.13.0   Normal       ---
proc-macro2          1.0.86   ---     Removed  Normal       ---
quote                1.0.36   ---     Removed  Normal       ---
rstml                0.11.2   ---     0.12.0   Normal       ---
serde                1.0.204  ---     Removed  Normal       ---
serde_derive         1.0.204  ---     Removed  Normal       ---
syn                  2.0.72   ---     Removed  Normal       ---
typed-builder        0.18.2   ---     0.19.1   Development  ---
typed-builder-macro  0.18.2   ---     0.19.1   Normal       ---
unicode-ident        1.0.12   ---     Removed  Normal       ---

leptos_hot_reload
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
proc-macro2    1.0.86   ---     Removed  Normal  ---
quote          1.0.36   ---     Removed  Normal  ---
rstml          0.11.2   ---     0.12.0   Normal  ---
serde          1.0.204  ---     Removed  Normal  ---
serde_derive   1.0.204  ---     Removed  Normal  ---
syn            2.0.72   ---     Removed  Normal  ---
unicode-ident  1.0.12   ---     Removed  Normal  ---

server_fn
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
dashmap        5.5.3    ---     6.0.1    Normal  ---
proc-macro2    1.0.86   ---     Removed  Normal  ---
quote          1.0.36   ---     Removed  Normal  ---
serde          1.0.204  ---     Removed  Normal  ---
serde_derive   1.0.204  ---     Removed  Normal  ---
serde_qs       0.12.0   ---     0.13.0   Normal  ---
syn            2.0.72   ---     Removed  Normal  ---
unicode-ident  1.0.12   ---     Removed  Normal  ---

leptos_actix
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
proc-macro2    1.0.86   ---     Removed  Normal  ---
quote          1.0.36   ---     Removed  Normal  ---
serde          1.0.204  ---     Removed  Normal  ---
serde_derive   1.0.204  ---     Removed  Normal  ---
syn            2.0.72   ---     Removed  Normal  ---
unicode-ident  1.0.12   ---     Removed  Normal  ---

leptos_meta
================
Name           Project  Compat  Latest   Kind    Platform
----           -------  ------  ------   ----    --------
proc-macro2    1.0.86   ---     Removed  Normal  ---
quote          1.0.36   ---     Removed  Normal  ---
serde          1.0.204  ---     Removed  Normal  ---
serde_derive   1.0.204  ---     Removed  Normal  ---
syn            2.0.72   ---     Removed  Normal  ---
unicode-ident  1.0.12   ---     Removed  Normal  ---

leptos_router
================
Name      Project  Compat  Latest  Kind    Platform
----      -------  ------  ------  ----    --------
gloo-net  0.5.0    ---     0.6.0   Normal  ---
http      0.2.12   ---     1.1.0   Normal  ---
```

