### PR TITLE
Allow changing SSR meta tags outside components

### DIFF
--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -167,14 +167,14 @@ impl Default for MetaContext {
 #[derive(Clone, Debug)]
 pub struct ServerMetaContext {
     /// Metadata associated with the `<title>` element.
-    pub(crate) title: TitleContext,
+    pub title: TitleContext,
     /// Attributes for the `<html>` element.
-    pub(crate) html: Sender<String>,
+    pub html: Sender<String>,
     /// Attributes for the `<body>` element.
-    pub(crate) body: Sender<String>,
+    pub body: Sender<String>,
     /// Arbitrary elements to be added to the `<head>` as HTML.
     #[allow(unused)] // used in SSR
-    pub(crate) elements: Sender<String>,
+    pub elements: Sender<String>,
 }
 
 /// Allows you to access `<head>` content that was inserted via [`ServerMetaContext`].


### PR DESCRIPTION
This is just a really naive proposal and I'm not sure about the implications of the change. Any help will be appreciated.

My problem is that I need to change `<html>` attributes on SSR before being rendered to the DOM. I know that I can use the `<Html/>` component, something like:

```rust
view! {
    <Html lang="es" dir="auto"/>
}
```

But that forces me to be inside a `view!` or `-> impl IntoView`. I don't have access to the view.

With the change included in this PR, I can do this:

```rust
provide_meta_context();

let meta = leptos::prelude::expect_context::<leptos_meta::ServerMetaContext>();
_ = meta.html.send(format!(" lang=\"es\" dir=\"auto\""));
```

Which sucks but works.

There is an alternative? Is the updating of meta tags forbidden outside the view of a component for some reason or the API has not been built ever? Thanks in advance.