### PR TITLE
chore(ci): temporarily disable semver checks

### DIFF
--- a/.github/workflows/ci-semver.yml
+++ b/.github/workflows/ci-semver.yml
@@ -14,7 +14,7 @@ jobs:
 
   test:
     needs: [get-leptos-changed]
-    if: needs.get-leptos-changed.outputs.leptos_changed == 'true' && github.event.pull_request.labels[0].name != 'breaking'
+    if: github.event.pull_request.labels[0].name == 'semver' # needs.get-leptos-changed.outputs.leptos_changed == 'true' && github.event.pull_request.labels[0].name != 'breaking'
     name: Run semver check (nightly-2024-08-01)
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Now that 0.7 is merged into the main branch, `cargo-semver-checks` is helpfully pointing out that everything is a breaking change relative to 0.6. This will just temporarily disable it until final release.