### PR TITLE
fix: correctly report whether a stored_value is disposed

### DIFF
--- a/reactive_graph/src/owner/stored_value.rs
+++ b/reactive_graph/src/owner/stored_value.rs
@@ -325,7 +325,7 @@ impl<T, S: Storage<T>> StoredValue<T, S> {
 
 impl<T, S> IsDisposed for StoredValue<T, S> {
     fn is_disposed(&self) -> bool {
-        Arena::with(|arena| arena.contains_key(self.node))
+        Arena::with(|arena| !arena.contains_key(self.node))
     }
 }
 


### PR DESCRIPTION
`StoredValue::is_disposed` should return true when it has been removed from the arena.