### PR TITLE
fix: support complex struct form submits without JS (closes #2790)

### DIFF
--- a/server_fn/src/codec/url.rs
+++ b/server_fn/src/codec/url.rs
@@ -40,7 +40,8 @@ where
 {
     async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
         let string_data = req.as_query().unwrap_or_default();
-        let args = serde_qs::from_str::<Self>(string_data)
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(string_data)
             .map_err(|e| ServerFnError::Args(e.to_string()))?;
         Ok(args)
     }
@@ -74,7 +75,8 @@ where
 {
     async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
         let string_data = req.try_into_string().await?;
-        let args = serde_qs::from_str::<Self>(&string_data)
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(&string_data)
             .map_err(|e| ServerFnError::Args(e.to_string()))?;
         Ok(args)
     }


### PR DESCRIPTION
`serde-qs` ["strict mode"](https://docs.rs/serde_qs/latest/serde_qs/struct.Config.html), which is enabled by default, doesn't accept URL-encoded `[` and `]` as part of field names, which the browser sends automatically. Disabling strict mode when deserializing allows complex structs to work when sent directly from the browser. `serde-qs` docs note that "Strict mode is more accurate for cases where it a field may contain square brackets" so there is a potential trade-off, but I am not sure exactly the cases in which this would apply.