### PR TITLE
doc: more details on how redirect works (#2789)

### DIFF
--- a/examples/ssr_modes_axum/src/app.rs
+++ b/examples/ssr_modes_axum/src/app.rs
@@ -42,23 +42,6 @@ pub async fn is_admin() -> Result<bool, ServerFnError> {
 #[server]
 pub async fn set_is_admin(is_admin: bool) -> Result<(), ServerFnError> {
     IS_ADMIN.store(is_admin, Ordering::Relaxed);
-    leptos_axum::redirect("/toggle");
-    Ok(())
-}
-
-#[server]
-pub async fn redirect1() -> Result<(), ServerFnError> {
-    leptos_axum::redirect("/1");
-    Ok(())
-}
-#[server]
-pub async fn redirect2() -> Result<(), ServerFnError> {
-    leptos_axum::redirect("/2");
-    Ok(())
-}
-#[server]
-pub async fn redirect3() -> Result<(), ServerFnError> {
-    leptos_axum::redirect("/3");
     Ok(())
 }
 
@@ -70,7 +53,6 @@ pub fn App() -> impl IntoView {
     let toggle_admin = ServerAction::<SetIsAdmin>::new();
     let is_admin =
         Resource::new(move || toggle_admin.version().get(), |_| is_admin());
-    let redirect1 = Resource::new_blocking(|| (), |_| redirect1());
 
     view! {
         <Stylesheet id="leptos" href="/pkg/ssr_modes.css"/>
@@ -80,9 +62,6 @@ pub fn App() -> impl IntoView {
             <nav>
                 <a href="/">"Home"</a>
                 <a href="/admin">"Admin"</a>
-                <button on:click=move |_| spawn_local(async {
-                    _ = redirect2().await;
-                })>"Redirect 2"</button>
                 <Transition>
                     <ActionForm action=toggle_admin>
                         <input

--- a/examples/ssr_modes_axum/src/app.rs
+++ b/examples/ssr_modes_axum/src/app.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use leptos::{prelude::*, spawn::spawn_local};
+use leptos::prelude::*;
 use leptos_meta::MetaTags;
 use leptos_meta::*;
 use leptos_router::{

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -193,6 +193,11 @@ impl ExtendResponse for ActixResponse {
 /// without actually setting the status code. This means that the client will not follow the
 /// redirect, and can therefore return the value of the server function and then handle
 /// the redirect with client-side routing.
+///
+/// Note that server functions using this should be encapsulated inside a [Resource::new_blocking],
+/// as it would ensure the redirect headers are set before they are read and sent to the client.
+/// Failing to do so may result in the headers not being sent at all and thus the redirect call
+/// will have no effect.
 #[tracing::instrument(level = "trace", fields(error), skip_all)]
 pub fn redirect(path: &str) {
     if let (Some(req), Some(res)) =


### PR DESCRIPTION
Include the note about blocking resource for both the actix and axum, and expanded the wording on the axum version.

Note that I did add a `FIXME` note to `leptos_axum::redirect` because I don't know how should this be properly addressed in the documentation (or the code for that matter).

I am open to suggestion to better wording, etc.