### PR TITLE
feat: `StoredValue::default` implementation

### DIFF
--- a/reactive_graph/src/owner/stored_value.rs
+++ b/reactive_graph/src/owner/stored_value.rs
@@ -238,6 +238,17 @@ where
     }
 }
 
+impl<T, S> Default for StoredValue<T, S>
+where
+    T: Default + 'static,
+    S: Storage<T>,
+{
+    #[track_caller] // Default trait is not annotated with #[track_caller]
+    fn default() -> Self {
+        Self::new_with_storage(Default::default())
+    }
+}
+
 impl<T> StoredValue<T>
 where
     T: Send + Sync + 'static,


### PR DESCRIPTION
I am not entirely familiar with `#[track_caller]`. But, I believe it is only inherited through traits in cases where the trait method is marked as such. [see here](https://rustc-dev-guide.rust-lang.org/backend/implicit-caller-location.html#traits).

I followed the same bounds as `StoredValue::new_with_storage`, please correct me if that is wrong