### PR TITLE
fix: increase MSRV to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ exclude = ["benchmarks", "examples"]
 [workspace.package]
 version = "0.7.0-beta"
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.76"
 
 [workspace.dependencies]
 throw_error = { path = "./any_error/", version = "0.2.0-beta" }


### PR DESCRIPTION
```
warning: current MSRV (Minimum Supported Rust Version) is `1.75.0` but this item is stable since `1.76.0`
   --> tachys/src/view/keyed.rs:574:14
    |
574 |             .inspect(|(set_index, _)| set_index(*to));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `#[warn(clippy::incompatible_msrv)]` on by default
```