### PR TITLE
feat: provide several deprecated functions

### DIFF
--- a/reactive_graph/src/computed.rs
+++ b/reactive_graph/src/computed.rs
@@ -141,3 +141,48 @@ where
 {
     Memo::new(fun)
 }
+
+/// Creates a new memo by passing a function that computes the value.
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `Memo::new_owning()` instead."]
+pub fn create_owning_memo<T>(
+    fun: impl Fn(Option<T>) -> (T, bool) + Send + Sync + 'static,
+) -> Memo<T>
+where
+    T: PartialEq + Send + Sync + 'static,
+{
+    Memo::new_owning(fun)
+}
+
+/// A conditional signal that only notifies subscribers when a change
+/// in the source signal’s value changes whether the given function is true.
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `Selector::new()` instead."]
+pub fn create_selector<T>(
+    source: impl Fn() -> T + Clone + 'static,
+) -> Selector<T>
+where
+    T: PartialEq + Eq + Clone + std::hash::Hash + 'static,
+{
+    Selector::new(source)
+}
+
+/// Creates a conditional signal that only notifies subscribers when a change
+/// in the source signal’s value changes whether the given function is true.
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `Selector::new_with_fn()` instead."]
+pub fn create_selector_with_fn<T>(
+    source: impl Fn() -> T + Clone + 'static,
+    f: impl Fn(&T, &T) -> bool + Send + Sync + Clone + 'static,
+) -> Selector<T>
+where
+    T: PartialEq + Eq + Clone + std::hash::Hash + 'static,
+{
+    Selector::new_with_fn(source, f)
+}

--- a/reactive_graph/src/effect.rs
+++ b/reactive_graph/src/effect.rs
@@ -9,3 +9,17 @@ mod render_effect;
 pub use effect::*;
 pub use effect_function::*;
 pub use render_effect::*;
+
+/// Creates a new render effect, which immediately runs `fun`.
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `RenderEffect::new()` instead."]
+pub fn create_render_effect<T>(
+    fun: impl FnMut(Option<T>) -> T + 'static,
+) -> RenderEffect<T>
+where
+    T: 'static,
+{
+    RenderEffect::new(fun)
+}

--- a/reactive_graph/src/signal.rs
+++ b/reactive_graph/src/signal.rs
@@ -181,8 +181,15 @@ pub fn create_signal<T: Send + Sync + 'static>(
 #[track_caller]
 #[deprecated = "This function is being removed to conform to Rust idioms. \
                 Please use `RwSignal::new()` instead."]
-pub fn create_rw_signal<T: Send + Sync + 'static>(
-    value: T,
-) -> RwSignal<T> {
+pub fn create_rw_signal<T: Send + Sync + 'static>(value: T) -> RwSignal<T> {
     RwSignal::new(value)
+}
+
+/// A trigger is a data-less signal with the sole purpose of notifying other reactive code of a change.
+#[inline(always)]
+#[track_caller]
+#[deprecated = "This function is being removed to conform to Rust idioms. \
+                Please use `ArcTrigger::new()` instead."]
+pub fn create_trigger() -> ArcTrigger {
+    ArcTrigger::new()
 }


### PR DESCRIPTION
Contributes to #2771. Adds:

- `create_owning_memo`
- `create_selector`
- `create_selector_with_fn`
- `create_render_effect`
- `create_trigger`