### PR TITLE
fix: run unmount logic for element children (closes #2832)

### DIFF
--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -443,10 +443,20 @@ impl<At, Ch, R: Renderer> Deref for ElementState<At, Ch, R> {
 
 impl<At, Ch, R> Mountable<R> for ElementState<At, Ch, R>
 where
+    Ch: Mountable<R>,
     R: Renderer,
 {
     fn unmount(&mut self) {
+        if let Some(children) = self.children.as_mut() {
+            children.unmount_from_parent();
+        }
         R::remove(self.el.as_ref());
+    }
+
+    fn unmount_from_parent(&mut self) {
+        if let Some(children) = self.children.as_mut() {
+            children.unmount_from_parent();
+        }
     }
 
     fn mount(&mut self, parent: &R::Element, marker: Option<&R::Node>) {

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -282,6 +282,15 @@ pub trait Mountable<R: Renderer> {
     /// Detaches the view from the DOM.
     fn unmount(&mut self);
 
+    /// Detaches the view from the DOM, when it is a child of another element that is being
+    /// unmounted.
+    ///
+    /// Most elements do not require any action here, but special view types that have additional
+    /// unmount logic do.
+    fn unmount_from_parent(&mut self) {
+        self.unmount();
+    }
+
     /// Mounts a node to the interface.
     fn mount(&mut self, parent: &R::Element, marker: Option<&R::Node>);
 

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -27,6 +27,8 @@ macro_rules! render_primitive {
 						self.0.unmount()
 					}
 
+                    fn unmount_from_parent(&mut self) {}
+
 					fn mount(
 						&mut self,
 						parent: &<R as Renderer>::Element,

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -131,6 +131,8 @@ where
         self.node.unmount()
     }
 
+    fn unmount_from_parent(&mut self) {}
+
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -232,6 +234,8 @@ impl<R: Renderer> Mountable<R> for StringState<R> {
         self.node.unmount()
     }
 
+    fn unmount_from_parent(&mut self) {}
+
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -323,6 +327,8 @@ impl<R: Renderer> Mountable<R> for RcStrState<R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
+
+    fn unmount_from_parent(&mut self) {}
 
     fn mount(
         &mut self,
@@ -427,6 +433,8 @@ impl<R: Renderer> Mountable<R> for ArcStrState<R> {
         self.node.unmount()
     }
 
+    fn unmount_from_parent(&mut self) {}
+
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -529,6 +537,8 @@ impl<'a, R: Renderer> Mountable<R> for CowStrState<'a, R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
+
+    fn unmount_from_parent(&mut self) {}
 
     fn mount(
         &mut self,


### PR DESCRIPTION
This was an easy but fun/kind of cool bug.

Every view state type has an `unmount()` method, which is called to remove it from the view. 

For typical view types, this means "remove this from the DOM." The initial implementation for `ElementState` just removes that element, because we know that removing an element from the DOM also removes all its children.

However, this created an issue in situations like
```
<div>
  <Style></Style>
  "Some text"
</div>
```
`Style` is not actually located "under"/as a child of the `<div>` in the DOM: it does have a DOM node to be removed, but it's located in the `<head>`, so removing the `<div>` will not remove it.

The naive solution would just be to run `children.unmount()` in the `ElementState::unmount()` implementation. However, this would be a very bad idea: it would change the cost of unmounting a section of the DOM from `O(1)` to `O(n)` where `n` is the size of that section. For example, navigating away from a page to the next page would do a depth-first removal of each DOM node individually, then remove the root node.

Instead, this PR adds an `unmount_from_parent`, which is called when you are being unmounted because a parent DOM node is unmounting. The default implementation is the same as `unmount()`, so it will run any custom unmount logic. But then there are optimized implementations for actual DOM node types, which do not call any DOM functions, because they know they will be unmounted by the parent being unmounted. This should allow deeply-nested children to call their unmount functions correctly, while not paying the cost of unmounting all the nodes. (And because the view tree is statically typed, the compiler should be able to optimize this reasonably well.)