### PR TITLE
fix: Rust-Analyzer hover information / redundant spans

### DIFF
--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -78,10 +78,8 @@ pub(crate) fn component_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned!(value.span()=> { #value });
-
-            quote_spanned! {attr.span()=>
-                .#name(#[allow(unused_braces)] #value)
+            quote! {
+                .#name(#[allow(unused_braces)] { #value })
             }
         });
 
@@ -262,30 +260,18 @@ pub(crate) fn component_to_tokens(
         quote! {}
     };
 
-    let name_ref = quote_spanned! {name.span()=>
-        &#name
-    };
-
-    let build = quote_spanned! {name.span()=>
-        .build()
-    };
-
-    let component_props_builder = quote_spanned! {name.span()=>
-        ::leptos::component::component_props_builder(#name_ref #generics)
-    };
-
     #[allow(unused_mut)] // used in debug
-    let mut component = quote_spanned! {node.span()=>
+    let mut component = quote! {
         {
             #[allow(unreachable_code)]
             ::leptos::component::component_view(
                 #[allow(clippy::needless_borrows_for_generic_args)]
-                #name_ref,
-                #component_props_builder
+                &#name,
+                ::leptos::component::component_props_builder(&#name #generics)
                     #(#props)*
                     #(#slots)*
                     #children
-                    #build
+                    .build()
             )
             #spreads
         }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -673,20 +673,14 @@ pub(crate) fn event_type_and_handler(
     let event_type = if is_custom {
         event_type
     } else if let Some(ev_name) = event_name_ident {
-        let span = ev_name.span();
-        quote_spanned! {
-            span => #ev_name
-        }
+        quote! { #ev_name }
     } else {
         event_type
     };
 
     let event_type = if is_force_undelegated {
         let undelegated = if let Some(undelegated) = undelegated_ident {
-            let span = undelegated.span();
-            quote_spanned! {
-                span => #undelegated
-            }
+            quote! { #undelegated }
         } else {
             quote! { undelegated }
         };

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -59,10 +59,8 @@ pub(crate) fn slot_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned!(value.span()=> { #value });
-
-            quote_spanned! {attr.span()=>
-                .#name(#[allow(unused_braces)] #value)
+            quote! {
+                .#name(#[allow(unused_braces)] { #value })
             }
         });
 
@@ -136,8 +134,9 @@ pub(crate) fn slot_to_tokens(
                 items_to_bind.iter().map(|ident| quote! { #ident, });
 
             let clonables = items_to_clone.iter().map(|ident| {
-                let ident_ref = quote_spanned!(ident.span()=> &#ident);
-                quote! { let #ident = ::core::clone::Clone::clone(#ident_ref); }
+                quote_spanned! {ident.span()=>
+                    let #ident = ::core::clone::Clone::clone(&#ident);
+                }
             });
 
             if bindables.len() > 0 {
@@ -169,7 +168,7 @@ pub(crate) fn slot_to_tokens(
             .span();
         let slot = Ident::new(&slot, span);
         let value = if values.len() > 1 {
-            quote_spanned! {span=>
+            quote! {
                 ::std::vec![
                     #(#values)*
                 ]


### PR DESCRIPTION
These changes hope to improve (I wish I could say fix, but I'm not entirely sure yet) the recent issues that the `view!` and `#[component]` macros had with providing incorrect / extra information through Rust-Analyzer.

In many instances, the procedural macros are spanning tokens with their own span redundantly, while also including lint attributes and unrelated tokens within their spanned interpolation.

I am **far** from an expert on procedural macros and token spans, while this seems to fix the issues on my editor, I just don't know enough to say if it actually fixes everything. From what I can tell, no diagnostic information is lost from these changes.

Additionally, I have no idea how to write a test for this. I am open to doing additional work to research and write tests if needed.
