### PR TITLE
[0.6] fix: Rust-Analyzer hover information / redundant spans

### DIFF
--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -332,16 +332,17 @@ pub(crate) fn element_to_tokens(
             quote! {}
         };
         let ide_helper_close_tag = ide_helper_close_tag.into_iter();
-        let result = quote_spanned! {node.span()=> {
-            #(#ide_helper_close_tag)*
-            #name
-                #(#attrs)*
-                #(#bindings)*
-                #(#class_attrs)*
-                #(#style_attrs)*
-                #global_class_expr
-                #(#children)*
-                #view_marker
+        let result = quote! {
+            {
+                #(#ide_helper_close_tag)*
+                #name
+                    #(#attrs)*
+                    #(#bindings)*
+                    #(#class_attrs)*
+                    #(#style_attrs)*
+                    #global_class_expr
+                    #(#children)*
+                    #view_marker
             }
         };
 

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -43,7 +43,6 @@ pub(crate) fn fragment_to_tokens(
     let mut nodes = nodes
         .iter()
         .filter_map(|node| {
-            let span = node.span();
             let node = node_to_tokens(
                 node,
                 parent_type,
@@ -52,10 +51,8 @@ pub(crate) fn fragment_to_tokens(
                 None,
             )?;
 
-            let node = quote_spanned!(span => { #node });
-
             Some(quote! {
-                ::leptos::IntoView::into_view(#[allow(unused_braces)] #node)
+                ::leptos::IntoView::into_view(#[allow(unused_braces)] { #node })
             })
         })
         .peekable();
@@ -406,18 +403,14 @@ pub(crate) fn attribute_to_tokens(
         let event_type = if is_custom {
             event_type
         } else if let Some(ev_name) = event_name_ident {
-            quote_spanned! {
-                ev_name.span()=> #ev_name
-            }
+            quote! { #ev_name }
         } else {
             event_type
         };
 
         let event_type = if is_force_undelegated {
             let undelegated = if let Some(undelegated) = undelegated_ident {
-                quote_spanned! {
-                    undelegated.span()=> #undelegated
-                }
+                quote! { #undelegated }
             } else {
                 quote! { undelegated }
             };

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -303,9 +303,7 @@ pub(crate) fn element_to_tokens(
                         global_class,
                         None,
                     )
-                    .unwrap_or(quote_spanned! {
-                        Span::call_site()=> ::leptos::leptos_dom::Unit
-                    }),
+                    .unwrap_or(quote! { ::leptos::leptos_dom::Unit }),
                 ),
                 Node::Text(node) => Some(quote! { #node }),
                 Node::RawText(node) => {

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -100,7 +100,13 @@ pub(crate) fn component_to_tokens(
         .filter(|attr| attr.key.to_string().starts_with("on:"))
         .map(|attr| {
             let (event_type, handler) = event_from_attribute_node(attr, true);
-            let on = quote_spanned!(attr.key.span()=> on);
+            // HACK(chrisp60): rstml and leptos has a different definition on attribute keys.
+            // This retains precise span information for the "on" in "on:some_event_name".
+            //
+            // A similar hack is done in `event_from_attribute_node` to retain the precise
+            // event name span.
+            let on = attr.key.to_token_stream().into_iter().next();
+
             quote! {
                 .#on(#event_type, #handler)
             }

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -81,16 +81,14 @@ pub(crate) fn fragment_to_tokens_ssr(
     };
 
     let nodes = nodes.iter().map(|node| {
-        let span = node.span();
         let node = root_node_to_tokens_ssr(node, global_class, None);
-        let node = quote_spanned!(span=> { #node });
 
         quote! {
-            ::leptos::IntoView::into_view(#[allow(unused_braces)] #node)
+            ::leptos::IntoView::into_view(#[allow(unused_braces)] { #node })
         }
     });
 
-    quote_spanned! {original_span=>
+    quote! {
         {
             ::leptos::Fragment::lazy(|| ::std::vec![
                 #(#nodes),*

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -61,10 +61,8 @@ pub(crate) fn slot_to_tokens(
                 })
                 .unwrap_or_else(|| quote! { #name });
 
-            let value = quote_spanned!(value.span()=> { #value });
-
-            quote_spanned! {attr.span()=>
-                .#name(#[allow(unused_braces)] #value)
+            quote! {
+                .#name(#[allow(unused_braces)] { #value })
             }
         });
 
@@ -168,7 +166,7 @@ pub(crate) fn slot_to_tokens(
             .span();
         let slot = Ident::new(&slot, span);
         let value = if values.len() > 1 {
-            quote_spanned! {span=>
+            quote! {
                 ::std::vec![
                     #(#values)*
                 ]


### PR DESCRIPTION
These changes hope to achieve the same result as #2836 but for the current stable version.

Everything stated in that PR is also applicable here. This works on my machine but other people may need to chime in and say if anything doesn't look correct

All images taken using `rust-analyzer@2024-08-12`

## Semantic Highlights

### Before
![image](https://github.com/user-attachments/assets/5ce8c617-0248-43cc-a71c-de294376d020)

### After
Notice `on:click`
![image](https://github.com/user-attachments/assets/23cb99c7-95d5-4d4f-8e4a-02b57c96c5d4)

## Hover Information

### Before
![image](https://github.com/user-attachments/assets/0e1ddc87-361e-4121-b126-2d57e03ee609)

### After
![image](https://github.com/user-attachments/assets/fb460fd5-33c7-425f-abc7-9bb6d5b86a23)

Correct hover information is provided for each individual section of `on:event` handlers as well.
