### PR TITLE
docs: `leptos_router_macro::path`

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -19,6 +19,7 @@ mod ssr_mode;
 mod static_route;
 
 pub use generate_route_list::*;
+#[doc(inline)]
 pub use leptos_router_macro::path;
 pub use matching::*;
 pub use method::*;

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -6,6 +6,25 @@ use quote::{quote, ToTokens};
 const RFC3986_UNRESERVED: [char; 4] = ['-', '.', '_', '~'];
 const RFC3986_PCHAR_OTHER: [char; 1] = ['@'];
 
+/// Constructs a path for use in a [`leptos_router::Route`] definition.
+///
+/// Note that this is an optional convenience. Manually defining route segments
+/// is equivalent.
+///
+/// # Examples
+///
+/// ```rust
+/// use leptos_router::{path, ParamSegment, StaticSegment, WildcardSegment};
+///
+/// let path = path!("/foo/:bar/*any");
+/// let output = (
+///     StaticSegment("foo"),
+///     ParamSegment("bar"),
+///     WildcardSegment("any"),
+/// );
+///
+/// assert_eq!(path, output);
+/// ```
 #[proc_macro_error::proc_macro_error]
 #[proc_macro]
 pub fn path(tokens: TokenStream) -> TokenStream {


### PR DESCRIPTION
Provides documentation for `leptos_router_macro::path!` and a small example.
