### PR TITLE
Fix nested routing/related issues

### DIFF
--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -364,6 +364,15 @@ where
     state: <HtmlElement<E, At, Ch, Dom> as Render<Dom>>::State,
 }
 
+impl<E, At, Ch> Drop for RegisteredMetaTagState<E, At, Ch>
+where
+    HtmlElement<E, At, Ch, Dom>: Render<Dom>,
+{
+    fn drop(&mut self) {
+        self.state.unmount();
+    }
+}
+
 fn document_head() -> HtmlHeadElement {
     let document = document();
     document.head().unwrap_or_else(|| {

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -443,20 +443,10 @@ impl<At, Ch, R: Renderer> Deref for ElementState<At, Ch, R> {
 
 impl<At, Ch, R> Mountable<R> for ElementState<At, Ch, R>
 where
-    Ch: Mountable<R>,
     R: Renderer,
 {
     fn unmount(&mut self) {
-        if let Some(children) = self.children.as_mut() {
-            children.unmount_from_parent();
-        }
         R::remove(self.el.as_ref());
-    }
-
-    fn unmount_from_parent(&mut self) {
-        if let Some(children) = self.children.as_mut() {
-            children.unmount_from_parent();
-        }
     }
 
     fn mount(&mut self, parent: &R::Element, marker: Option<&R::Node>) {

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -282,15 +282,6 @@ pub trait Mountable<R: Renderer> {
     /// Detaches the view from the DOM.
     fn unmount(&mut self);
 
-    /// Detaches the view from the DOM, when it is a child of another element that is being
-    /// unmounted.
-    ///
-    /// Most elements do not require any action here, but special view types that have additional
-    /// unmount logic do.
-    fn unmount_from_parent(&mut self) {
-        self.unmount();
-    }
-
     /// Mounts a node to the interface.
     fn mount(&mut self, parent: &R::Element, marker: Option<&R::Node>);
 

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -27,8 +27,6 @@ macro_rules! render_primitive {
 						self.0.unmount()
 					}
 
-                    fn unmount_from_parent(&mut self) {}
-
 					fn mount(
 						&mut self,
 						parent: &<R as Renderer>::Element,

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -131,8 +131,6 @@ where
         self.node.unmount()
     }
 
-    fn unmount_from_parent(&mut self) {}
-
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -234,8 +232,6 @@ impl<R: Renderer> Mountable<R> for StringState<R> {
         self.node.unmount()
     }
 
-    fn unmount_from_parent(&mut self) {}
-
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -327,8 +323,6 @@ impl<R: Renderer> Mountable<R> for RcStrState<R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
-
-    fn unmount_from_parent(&mut self) {}
 
     fn mount(
         &mut self,
@@ -433,8 +427,6 @@ impl<R: Renderer> Mountable<R> for ArcStrState<R> {
         self.node.unmount()
     }
 
-    fn unmount_from_parent(&mut self) {}
-
     fn mount(
         &mut self,
         parent: &<R as Renderer>::Element,
@@ -537,8 +529,6 @@ impl<'a, R: Renderer> Mountable<R> for CowStrState<'a, R> {
     fn unmount(&mut self) {
         self.node.unmount()
     }
-
-    fn unmount_from_parent(&mut self) {}
 
     fn mount(
         &mut self,


### PR DESCRIPTION
951f4a73eef8df1e444f446a9ff3bf8b383a51b3 was misguided, as temporarily unmounting a parent (as in the case of Suspense) should not unmount its children from that parent.

Rather than providing a default implementation for all container types, etc., it is much smarter simply to fix #2832 in a better way: a `Drop` implementation on `RegisteredMetaTagState` that unmounts the meta tags from the head, as they should be.