### PR TITLE
updated codee version

### DIFF
--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 
 [dependencies]
 base64 = "0.22.1"
-codee = { version = "0.1.2", features = ["json_serde"] }
+codee = { version = "0.2.0", features = ["json_serde"] }
 hydration_context = { workspace = true }
 reactive_graph = { workspace = true, features = ["hydration"] }
 server_fn = { workspace = true }


### PR DESCRIPTION
This shouldn't affect anything in Leptos at all. Just updateing so leptos-use has the same version