### PR TITLE
Add support for postcard codec in server_fn

### DIFF
--- a/examples/server_fns_axum/Cargo.toml
+++ b/examples/server_fns_axum/Cargo.toml
@@ -16,6 +16,7 @@ server_fn = { path = "../../server_fn", features = [
   "serde-lite",
   "rkyv",
   "multipart",
+  "postcard",
 ] }
 log = "0.4.22"
 simple_logger = "5.0"

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -47,6 +47,7 @@ serde-lite = { version = "0.5.0", features = ["derive"], optional = true }
 futures = "0.3.30"
 http = { version = "1.1" }
 ciborium = { version = "0.2.2", optional = true }
+postcard = { version = "1", features = ["alloc"], optional = true }
 hyper = { version = "1.4", optional = true }
 bytes = "1.7"
 http-body-util = { version = "0.1.2", optional = true }
@@ -108,6 +109,7 @@ url = ["dep:serde_qs"]
 cbor = ["dep:ciborium"]
 rkyv = ["dep:rkyv"]
 msgpack = ["dep:rmp-serde"]
+postcard = ["dep:postcard"]
 default-tls = ["reqwest?/default-tls"]
 rustls = ["reqwest?/rustls-tls"]
 reqwest = ["dep:reqwest"]

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -198,4 +198,24 @@ skip_feature_sets = [
     "url",
     "serde-lite",
   ],
+  [
+    "postcard",
+    "json",
+  ],
+  [
+    "postcard",
+    "cbor",
+  ],
+  [
+    "postcard",
+    "url",
+  ],
+  [
+    "postcard",
+    "serde-lite",
+  ],
+  [
+    "postcard",
+    "rkyv",
+  ],
 ]

--- a/server_fn/src/codec/mod.rs
+++ b/server_fn/src/codec/mod.rs
@@ -49,6 +49,11 @@ mod msgpack;
 #[cfg(feature = "msgpack")]
 pub use msgpack::*;
 
+#[cfg(feature = "postcard")]
+mod postcard;
+#[cfg(feature = "postcard")]
+pub use postcard::*;
+
 mod stream;
 use crate::error::ServerFnError;
 use futures::Future;

--- a/server_fn/src/codec/postcard.rs
+++ b/server_fn/src/codec/postcard.rs
@@ -1,0 +1,74 @@
+use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
+use crate::{
+    error::ServerFnError,
+    request::{ClientReq, Req},
+    response::{ClientRes, Res},
+};
+use bytes::Bytes;
+use http::Method;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// A codec for Postcard.
+pub struct Postcard;
+
+impl Encoding for Postcard {
+    const CONTENT_TYPE: &'static str = "application/x-postcard";
+    const METHOD: Method = Method::POST;
+}
+
+impl<T, Request, Err> IntoReq<Postcard, Request, Err> for T
+where
+    Request: ClientReq<Err>,
+    T: Serialize,
+{
+    fn into_req(
+        self,
+        path: &str,
+        accepts: &str,
+    ) -> Result<Request, ServerFnError<Err>> {
+        let data = postcard::to_allocvec(&self)
+            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+        Request::try_new_post_bytes(
+            path,
+            Postcard::CONTENT_TYPE,
+            accepts,
+            Bytes::from(data),
+        )
+    }
+}
+
+impl<T, Request, Err> FromReq<Postcard, Request, Err> for T
+where
+    Request: Req<Err> + Send,
+    T: DeserializeOwned,
+{
+    async fn from_req(req: Request) -> Result<Self, ServerFnError<Err>> {
+        let data = req.try_into_bytes().await?;
+        postcard::from_bytes::<T>(&data)
+            .map_err(|e| ServerFnError::Args(e.to_string()))
+    }
+}
+
+impl<T, Response, Err> IntoRes<Postcard, Response, Err> for T
+where
+    Response: Res<Err>,
+    T: Serialize + Send,
+{
+    async fn into_res(self) -> Result<Response, ServerFnError<Err>> {
+        let data = postcard::to_allocvec(&self)
+            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+        Response::try_from_bytes(Postcard::CONTENT_TYPE, Bytes::from(data))
+    }
+}
+
+impl<T, Response, Err> FromRes<Postcard, Response, Err> for T
+where
+    Response: ClientRes<Err> + Send,
+    T: DeserializeOwned,
+{
+    async fn from_res(res: Response) -> Result<Self, ServerFnError<Err>> {
+        let data = res.try_into_bytes().await?;
+        postcard::from_bytes(&data)
+            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+    }
+}


### PR DESCRIPTION
According to the ser/de benchmarks on https://github.com/djkoloski/rust_serialization_benchmark, postcard should be almost as fast as rkyv, while being compatible with serde, which is very convenient.
Postcard also has a significantly smaller serialized size compared to rkyv.

I've implemented the codec in server_fn and it seems to be working well.