### PR TITLE
Add hash files support to 0.7

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -88,7 +88,7 @@ spin = ["leptos-spin-macro"]
 experimental-islands = ["leptos_macro/experimental-islands", "dep:serde_json"]
 trace-component-props = [
   "leptos_macro/trace-component-props",
-  "leptos_dom/trace-component-props"
+  "leptos_dom/trace-component-props",
 ]
 delegation = ["tachys/delegation"]
 
@@ -100,22 +100,52 @@ denylist = [
   "rustls",
   "default-tls",
   "wasm-bindgen",
-  "rkyv", # was causing clippy issues on nightly
+  "rkyv",                  # was causing clippy issues on nightly
   "trace-component-props",
   "spin",
   "experimental-islands",
 ]
 skip_feature_sets = [
-  ["csr", "ssr"],
-  ["csr", "hydrate"],
-  ["ssr", "hydrate"],
-  ["serde", "serde-lite"],
-  ["serde-lite", "miniserde"],
-  ["serde", "miniserde"],
-  ["serde", "rkyv"],
-  ["miniserde", "rkyv"],
-  ["serde-lite", "rkyv"],
-  ["default-tls", "rustls"],
+  [
+    "csr",
+    "ssr",
+  ],
+  [
+    "csr",
+    "hydrate",
+  ],
+  [
+    "ssr",
+    "hydrate",
+  ],
+  [
+    "serde",
+    "serde-lite",
+  ],
+  [
+    "serde-lite",
+    "miniserde",
+  ],
+  [
+    "serde",
+    "miniserde",
+  ],
+  [
+    "serde",
+    "rkyv",
+  ],
+  [
+    "miniserde",
+    "rkyv",
+  ],
+  [
+    "serde-lite",
+    "rkyv",
+  ],
+  [
+    "default-tls",
+    "rustls",
+  ],
 ]
 
 [package.metadata.docs.rs]

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -88,7 +88,7 @@ spin = ["leptos-spin-macro"]
 experimental-islands = ["leptos_macro/experimental-islands", "dep:serde_json"]
 trace-component-props = [
   "leptos_macro/trace-component-props",
-  "leptos_dom/trace-component-props",
+  "leptos_dom/trace-component-props"
 ]
 delegation = ["tachys/delegation"]
 
@@ -100,52 +100,22 @@ denylist = [
   "rustls",
   "default-tls",
   "wasm-bindgen",
-  "rkyv",                  # was causing clippy issues on nightly
+  "rkyv", # was causing clippy issues on nightly
   "trace-component-props",
   "spin",
   "experimental-islands",
 ]
 skip_feature_sets = [
-  [
-    "csr",
-    "ssr",
-  ],
-  [
-    "csr",
-    "hydrate",
-  ],
-  [
-    "ssr",
-    "hydrate",
-  ],
-  [
-    "serde",
-    "serde-lite",
-  ],
-  [
-    "serde-lite",
-    "miniserde",
-  ],
-  [
-    "serde",
-    "miniserde",
-  ],
-  [
-    "serde",
-    "rkyv",
-  ],
-  [
-    "miniserde",
-    "rkyv",
-  ],
-  [
-    "serde-lite",
-    "rkyv",
-  ],
-  [
-    "default-tls",
-    "rustls",
-  ],
+  ["csr", "ssr"],
+  ["csr", "hydrate"],
+  ["ssr", "hydrate"],
+  ["serde", "serde-lite"],
+  ["serde-lite", "miniserde"],
+  ["serde", "miniserde"],
+  ["serde", "rkyv"],
+  ["miniserde", "rkyv"],
+  ["serde-lite", "rkyv"],
+  ["default-tls", "rustls"],
 ]
 
 [package.metadata.docs.rs]

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -94,6 +94,5 @@ pub fn HydrationScripts(
         <script type="module" nonce=nonce>
             {format!("{script}({pkg_path:?}, {js_file_name:?}, {wasm_file_name:?})")}
         </script>
-    <Stylesheet
     }
 }

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -64,14 +64,11 @@ pub fn HydrationScripts(
                 }
             }
         }
-    }
-    js_file_name.push_str(".js");
-    wasm_file_name.push_str(".wasm");
-
-    let pkg_path = &options.site_pkg_dir;
-    if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
+    } else if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
         wasm_file_name.push_str("_bg");
     }
+
+    let pkg_path = &options.site_pkg_dir;
     #[cfg(feature = "nonce")]
     let nonce = crate::nonce::use_nonce();
     #[cfg(not(feature = "nonce"))]
@@ -95,7 +92,7 @@ pub fn HydrationScripts(
             crossorigin=nonce.clone().unwrap_or_default()
         />
         <script type="module" nonce=nonce>
-            {format!("{script}({pkg_path:?}, {output_name:?}, {wasm_output_name:?})")}
+            {format!("{script}({pkg_path:?}, {js_file_name:?}, {wasm_file_name:?})")}
         </script>
     <Stylesheet
     }

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -51,7 +51,7 @@ pub fn HydrationScripts(
         if hash_path.exists() {
             let hashes = std::fs::read_to_string(&hash_path)
                 .expect("failed to read hash file");
-            for line in hashes.line() {
+            for line in hashes.lines() {
                 let line = line.trim();
                 if !line.is_empty() {
                     if let Some((file, hash)) = line.split_once(':') {
@@ -60,7 +60,6 @@ pub fn HydrationScripts(
                         } else if file == "wasm" {
                             wasm_file_name.push_str(&format!(".{}", hash));
                         }
-                        // TODO: figure out css
                     }
                 }
             }
@@ -98,5 +97,6 @@ pub fn HydrationScripts(
         <script type="module" nonce=nonce>
             {format!("{script}({pkg_path:?}, {output_name:?}, {wasm_output_name:?})")}
         </script>
+    <Stylesheet
     }
 }

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -39,11 +39,39 @@ pub fn HydrationScripts(
     options: LeptosOptions,
     #[prop(optional)] islands: bool,
 ) -> impl IntoView {
+    let js_file_name = &options.output_name;
+    let wasm_file_name = &options.output_name;
+    if options.hash_files {
+        let hash_path = std::env::current_exe()
+            .map(|path| {
+                path.parent().map(|p| p.to_path_buf()).unwrap_or_default()
+            })
+            .unwrap_or_default()
+            .join(&options.hash_file);
+        if hash_path.exists() {
+            let hashes = std::fs::read_to_string(&hash_path)
+                .expect("failed to read hash file");
+            for line in hashes.line() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    if let Some((file, hash)) = line.split_once(':') {
+                        if file == "js" {
+                            js_file_name.push_str(&format!(".{}", hash));
+                        } else if file == "wasm" {
+                            wasm_file_name.push_str(&format!(".{}", hash));
+                        }
+                        // TODO: figure out css
+                    }
+                }
+            }
+        }
+    }
+    js_file_name.push_str(".js");
+    wasm_file_name.push_str(".wasm");
+
     let pkg_path = &options.site_pkg_dir;
-    let output_name = &options.output_name;
-    let mut wasm_output_name = output_name.clone();
     if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
-        wasm_output_name.push_str("_bg");
+        wasm_file_name.push_str("_bg");
     }
     #[cfg(feature = "nonce")]
     let nonce = crate::nonce::use_nonce();
@@ -59,10 +87,10 @@ pub fn HydrationScripts(
     };
 
     view! {
-        <link rel="modulepreload" href=format!("/{pkg_path}/{output_name}.js") nonce=nonce.clone()/>
+        <link rel="modulepreload" href=format!("/{pkg_path}/{js_file_name}.js") nonce=nonce.clone()/>
         <link
             rel="preload"
-            href=format!("/{pkg_path}/{wasm_output_name}.wasm")
+            href=format!("/{pkg_path}/{wasm_file_name}.wasm")
             r#as="fetch"
             r#type="application/wasm"
             crossorigin=nonce.clone().unwrap_or_default()

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -39,8 +39,8 @@ pub fn HydrationScripts(
     options: LeptosOptions,
     #[prop(optional)] islands: bool,
 ) -> impl IntoView {
-    let js_file_name = &options.output_name;
-    let wasm_file_name = &options.output_name;
+    let mut js_file_name = options.output_name.to_string();
+    let mut wasm_file_name = options.output_name.to_string();
     if options.hash_files {
         let hash_path = std::env::current_exe()
             .map(|path| {

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -36,22 +36,6 @@ pub fn Stylesheet(
 }
 
 /// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document head that loads a `cargo-leptos`-hashed stylesheet.
-///
-/// ```no_run
-/// use leptos::prelude::*;
-/// use leptos_meta::*;
-///
-/// #[component]
-/// fn MyApp() -> impl IntoView {
-///     provide_meta_context();
-///
-///     view! {
-///       <main>
-///         <HashedStylesheet options=leptos_options />
-///       </main>
-///     }
-/// }
-/// ```
 #[component]
 pub fn HashedStylesheet(
     /// Leptos options

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -54,12 +54,13 @@ pub fn Stylesheet(
 /// ```
 #[component]
 pub fn HashedStylesheet(
+    /// Leptos options
     options: LeptosOptions,
     /// An ID for the stylesheet.
     #[prop(optional, into)]
     id: Option<String>,
 ) -> impl IntoView {
-    let css_file_name = &options.output_name;
+    let mut css_file_name = options.output_name.to_string();
     if options.hash_files {
         let hash_path = std::env::current_exe()
             .map(|path| {

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -1,7 +1,7 @@
 use crate::register;
 use leptos::{
-    attr::global::GlobalAttributes, component, tachys::html::element::link,
-    IntoView,
+    attr::global::GlobalAttributes, component, prelude::LeptosOptions,
+    tachys::html::element::link, IntoView,
 };
 
 /// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document
@@ -31,6 +31,68 @@ pub fn Stylesheet(
     #[prop(optional, into)]
     id: Option<String>,
 ) -> impl IntoView {
+    // TODO additional attributes
+    register(link().id(id).rel("stylesheet").href(href))
+}
+
+/// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document
+/// head that loads a stylesheet from the URL given by the `href` property. The URL is modified to
+/// include the computed hash from `cargo-leptos`.
+///
+/// ```
+/// use leptos::prelude::*;
+/// use leptos_meta::*;
+///
+/// #[component]
+/// fn MyApp() -> impl IntoView {
+///     provide_meta_context();
+///
+///     view! {
+///       <main>
+///         <HashedStylesheet href="/style.css" options=options />
+///       </main>
+///     }
+/// }
+/// ```
+#[component]
+pub fn HashedStylesheet(
+    /// The URL at which the stylesheet is located.
+    #[prop(into)]
+    href: String,
+    options: LeptosOptions,
+    /// An ID for the stylesheet.
+    #[prop(optional, into)]
+    id: Option<String>,
+) -> impl IntoView {
+    let mut href = href;
+    if options.hash_files {
+        let hash_path = std::env::current_exe()
+            .map(|path| {
+                path.parent().map(|p| p.to_path_buf()).unwrap_or_default()
+            })
+            .unwrap_or_default()
+            .join(&options.hash_file);
+        if hash_path.exists() {
+            let hashes = std::fs::read_to_string(&hash_path)
+                .expect("failed to read hash file");
+            for line in hashes.lines() {
+                let line = line.trim();
+                if !line.is_empty() {
+                    if let Some((file, hash)) = line.split_once(':') {
+                        if file == "css" {
+                            if href.ends_with(".css") {
+                                href =
+                                    href.trim_end_matches(".css").to_string();
+                                href.push_str(&format!(".{}.css", hash));
+                            } else {
+                                href.push_str(&format!(".{}.css", hash));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     // TODO additional attributes
     register(link().id(id).rel("stylesheet").href(href))
 }

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -85,5 +85,10 @@ pub fn HashedStylesheet(
     css_file_name.push_str(".css");
     let pkg_path = &options.site_pkg_dir;
     // TODO additional attributes
-    register(link().id(id).rel("stylesheet").href(format!("/{pkg_path}/{css_file_name}")))
+    register(
+        link()
+            .id(id)
+            .rel("stylesheet")
+            .href(format!("/{pkg_path}/{css_file_name}")),
+    )
 }

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -37,7 +37,7 @@ pub fn Stylesheet(
 
 /// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document head that loads a `cargo-leptos`-hashed stylesheet.
 ///
-/// ```
+/// ```no_run
 /// use leptos::prelude::*;
 /// use leptos_meta::*;
 ///

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -35,9 +35,7 @@ pub fn Stylesheet(
     register(link().id(id).rel("stylesheet").href(href))
 }
 
-/// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document
-/// head that loads a stylesheet from the URL given by the `href` property. The URL is modified to
-/// include the computed hash from `cargo-leptos`.
+/// Injects an [`HTMLLinkElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement) into the document head that loads a `cargo-leptos`-hashed stylesheet.
 ///
 /// ```
 /// use leptos::prelude::*;
@@ -49,22 +47,19 @@ pub fn Stylesheet(
 ///
 ///     view! {
 ///       <main>
-///         <HashedStylesheet href="/style.css" options=options />
+///         <HashedStylesheet options=leptos_options />
 ///       </main>
 ///     }
 /// }
 /// ```
 #[component]
 pub fn HashedStylesheet(
-    /// The URL at which the stylesheet is located.
-    #[prop(into)]
-    href: String,
     options: LeptosOptions,
     /// An ID for the stylesheet.
     #[prop(optional, into)]
     id: Option<String>,
 ) -> impl IntoView {
-    let mut href = href;
+    let css_file_name = &options.output_name;
     if options.hash_files {
         let hash_path = std::env::current_exe()
             .map(|path| {
@@ -80,19 +75,15 @@ pub fn HashedStylesheet(
                 if !line.is_empty() {
                     if let Some((file, hash)) = line.split_once(':') {
                         if file == "css" {
-                            if href.ends_with(".css") {
-                                href =
-                                    href.trim_end_matches(".css").to_string();
-                                href.push_str(&format!(".{}.css", hash));
-                            } else {
-                                href.push_str(&format!(".{}.css", hash));
-                            }
+                            css_file_name.push_str(&format!(".{}", hash));
                         }
                     }
                 }
             }
         }
     }
+    css_file_name.push_str(".css");
+    let pkg_path = &options.site_pkg_dir;
     // TODO additional attributes
-    register(link().id(id).rel("stylesheet").href(href))
+    register(link().id(id).rel("stylesheet").href(format!("/{pkg_path}/{css_file_name}")))
 }


### PR DESCRIPTION
This adds a `<HashedStylesheet />` component for inserting the `cargo-leptos` CSS hashed style sheet, and modifies `<HydrationScripts />` to insert the JS and CSS hashes into the file names.