### PR TITLE
fix: only serialize Resources if we're in a part of the tree that needs hydration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,36 +40,36 @@ members = [
 exclude = ["benchmarks", "examples", "projects"]
 
 [workspace.package]
-version = "0.7.0-beta2"
+version = "0.7.0-beta4"
 edition = "2021"
 rust-version = "1.76"
 
 [workspace.dependencies]
-throw_error = { path = "./any_error/", version = "0.2.0-beta2" }
+throw_error = { path = "./any_error/", version = "0.2.0-beta4" }
 any_spawner = { path = "./any_spawner/", version = "0.1.0" }
 const_str_slice_concat = { path = "./const_str_slice_concat", version = "0.1.0" }
 either_of = { path = "./either_of/", version = "0.1.0" }
-hydration_context = { path = "./hydration_context", version = "0.2.0-beta2" }
-leptos = { path = "./leptos", version = "0.7.0-beta2" }
-leptos_config = { path = "./leptos_config", version = "0.7.0-beta2" }
-leptos_dom = { path = "./leptos_dom", version = "0.7.0-beta2" }
-leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.7.0-beta2" }
-leptos_integration_utils = { path = "./integrations/utils", version = "0.7.0-beta2" }
-leptos_macro = { path = "./leptos_macro", version = "0.7.0-beta2" }
-leptos_router = { path = "./router", version = "0.7.0-beta2" }
-leptos_router_macro = { path = "./router_macro", version = "0.7.0-beta2" }
-leptos_server = { path = "./leptos_server", version = "0.7.0-beta2" }
-leptos_meta = { path = "./meta", version = "0.7.0-beta2" }
-next_tuple = { path = "./next_tuple", version = "0.1.0-beta2" }
+hydration_context = { path = "./hydration_context", version = "0.2.0-beta4" }
+leptos = { path = "./leptos", version = "0.7.0-beta4" }
+leptos_config = { path = "./leptos_config", version = "0.7.0-beta4" }
+leptos_dom = { path = "./leptos_dom", version = "0.7.0-beta4" }
+leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.7.0-beta4" }
+leptos_integration_utils = { path = "./integrations/utils", version = "0.7.0-beta4" }
+leptos_macro = { path = "./leptos_macro", version = "0.7.0-beta4" }
+leptos_router = { path = "./router", version = "0.7.0-beta4" }
+leptos_router_macro = { path = "./router_macro", version = "0.7.0-beta4" }
+leptos_server = { path = "./leptos_server", version = "0.7.0-beta4" }
+leptos_meta = { path = "./meta", version = "0.7.0-beta4" }
+next_tuple = { path = "./next_tuple", version = "0.1.0-beta4" }
 oco_ref = { path = "./oco", version = "0.2.0" }
 or_poisoned = { path = "./or_poisoned", version = "0.1.0" }
-reactive_graph = { path = "./reactive_graph", version = "0.1.0-beta2" }
-reactive_stores = { path = "./reactive_stores", version = "0.1.0-beta2" }
-reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.1.0-beta2" }
-server_fn = { path = "./server_fn", version = "0.7.0-beta2" }
-server_fn_macro = { path = "./server_fn_macro", version = "0.7.0-beta2" }
-server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.7.0-beta2" }
-tachys = { path = "./tachys", version = "0.1.0-beta2" }
+reactive_graph = { path = "./reactive_graph", version = "0.1.0-beta4" }
+reactive_stores = { path = "./reactive_stores", version = "0.1.0-beta4" }
+reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.1.0-beta4" }
+server_fn = { path = "./server_fn", version = "0.7.0-beta4" }
+server_fn_macro = { path = "./server_fn_macro", version = "0.7.0-beta4" }
+server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.7.0-beta4" }
+tachys = { path = "./tachys", version = "0.1.0-beta4" }
 
 [profile.release]
 codegen-units = 1

--- a/any_error/Cargo.toml
+++ b/any_error/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "throw_error"
-version = "0.2.0-beta2"
+version = "0.2.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/hydration_context/Cargo.toml
+++ b/hydration_context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hydration_context"
-version = "0.2.0-beta2"
+version = "0.2.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_macro"
-version = "0.7.0-beta2"
+version = "0.7.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -107,19 +107,21 @@ where
                 shared_context.defer_stream(Box::pin(data.ready()));
             }
 
-            shared_context.write_async(
-                id,
-                Box::pin(async move {
-                    ready_fut.await;
-                    value.with_untracked(|data| match &data {
-                        // TODO handle serialization errors
-                        Some(val) => {
-                            Ser::encode(val).unwrap().into_encoded_string()
-                        }
-                        _ => unreachable!(),
-                    })
-                }),
-            );
+            if shared_context.get_is_hydrating() {
+                shared_context.write_async(
+                    id,
+                    Box::pin(async move {
+                        ready_fut.await;
+                        value.with_untracked(|data| match &data {
+                            // TODO handle serialization errors
+                            Some(val) => {
+                                Ser::encode(val).unwrap().into_encoded_string()
+                            }
+                            _ => unreachable!(),
+                        })
+                    }),
+                );
+            }
         }
 
         ArcResource {

--- a/leptos_server/src/shared.rs
+++ b/leptos_server/src/shared.rs
@@ -191,16 +191,19 @@ where
                 let init = initial();
                 #[cfg(feature = "ssr")]
                 if let Some(sc) = sc {
-                    match Ser::encode(&init)
-                        .map(IntoEncodedString::into_encoded_string)
-                    {
-                        Ok(value) => {
-                            sc.write_async(id, Box::pin(async move { value }))
-                        }
-                        #[allow(unused_variables)] // used in tracing
-                        Err(e) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::error!("couldn't serialize: {e:?}");
+                    if sc.get_is_hydrating() {
+                        match Ser::encode(&init)
+                            .map(IntoEncodedString::into_encoded_string)
+                        {
+                            Ok(value) => sc.write_async(
+                                id,
+                                Box::pin(async move { value }),
+                            ),
+                            #[allow(unused_variables)] // used in tracing
+                            Err(e) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!("couldn't serialize: {e:?}");
+                            }
                         }
                     }
                 }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_meta"
-version = "0.7.0-beta3"
+version = "0.7.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/next_tuple/Cargo.toml
+++ b/next_tuple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next_tuple"
-version = "0.1.0-beta2"
+version = "0.1.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_graph"
-version = "0.1.0-beta2"
+version = "0.1.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_graph/src/owner/stored_value.rs
+++ b/reactive_graph/src/owner/stored_value.rs
@@ -580,7 +580,7 @@ impl<T, S> Dispose for StoredValue<T, S> {
 #[inline(always)]
 #[track_caller]
 #[deprecated(
-    since = "0.7.0-beta2",
+    since = "0.7.0-beta4",
     note = "This function is being removed to conform to Rust idioms. Please \
             use `StoredValue::new()` or `StoredValue::new_local()` instead."
 )]

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores"
-version = "0.1.0-beta2"
+version = "0.1.0-beta4"
 rust-version.workspace = true
 edition.workspace = true
 

--- a/reactive_stores_macro/Cargo.toml
+++ b/reactive_stores_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores_macro"
-version = "0.1.0-beta2"
+version = "0.1.0-beta4"
 rust-version.workspace = true
 edition.workspace = true
 

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router"
-version = "0.7.0-beta2"
+version = "0.7.0-beta4"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro2 = "1.0"
 quote = "1.0"
 
 [dev-dependencies]
-leptos_router = { workspace = true }
+leptos_router = { version = "0.7.0-beta" }

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router_macro"
-version = "0.7.0-beta2"
+version = "0.7.0-beta4"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tachys"
-version = "0.1.0-beta3"
+version = "0.1.0-beta4"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"


### PR DESCRIPTION
In full hydration mode, you need to serialize all resources so they can be deserialized in the client. In partial hydration/islands mode, you only need to serialize a Resource if it was created in an island, because a Resource will either be:
1) created in an island, and therefore need its data when the island is being hydrated
2) created in a non-island, and therefore rendered to HTML on the server but without needing hydration, or
3) created in a non-island, and passed to an island -- but it will be passed either as props (and therefore serialized with props) or pass as part of the children (and therefore serialized as HTML)

This brings 0.7 in line with 0.6 by preventing the serialization of resources created outside islands, when you are in islands mode.