### PR TITLE
test: does erasing types of components improve compile times?

### DIFF
--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -64,7 +64,7 @@ pub fn RouterExample() -> impl IntoView {
 
 // You can define other routes in their own component.
 // Routes implement the MatchNestedRoutes
-#[component]
+#[component(transparent)]
 pub fn ContactRoutes() -> impl MatchNestedRoutes + Clone {
     view! {
         <ParentRoute path=path!("") view=ContactList>

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -92,7 +92,6 @@ trace-component-props = [
   "leptos_dom/trace-component-props"
 ]
 delegation = ["tachys/delegation"]
-erase_types = ["leptos_macro/erase_types"]
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -92,6 +92,7 @@ trace-component-props = [
   "leptos_dom/trace-component-props"
 ]
 delegation = ["tachys/delegation"]
+no_erase = ["leptos_macro/no_erase"]
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -92,7 +92,7 @@ trace-component-props = [
   "leptos_dom/trace-component-props"
 ]
 delegation = ["tachys/delegation"]
-no_erase = ["leptos_macro/no_erase"]
+erase_types = ["leptos_macro/erase_types"]
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/leptos/src/await_.rs
+++ b/leptos/src/await_.rs
@@ -87,7 +87,7 @@ where
     T: Send + Sync + Serialize + DeserializeOwned + 'static,
     Fut: std::future::Future<Output = T> + Send + 'static,
     Chil: FnOnce(&T) -> V + Send + 'static,
-    V: IntoView,
+    V: IntoView + 'static,
 {
     let res = ArcOnceResource::<T>::new_with_options(future, blocking);
     let ready = res.ready();

--- a/leptos/src/provider.rs
+++ b/leptos/src/provider.rs
@@ -35,7 +35,7 @@ pub fn Provider<T, Chil>(
 ) -> impl IntoView
 where
     T: Send + Sync + 'static,
-    Chil: IntoView,
+    Chil: IntoView + 'static,
 {
     let owner = Owner::current()
         .expect("no current reactive Owner found")

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -1,5 +1,6 @@
 use leptos::html::HtmlElement;
 
+#[cfg(feature = "ssr")]
 #[test]
 fn simple_ssr_test() {
     use leptos::prelude::*;
@@ -20,6 +21,7 @@ fn simple_ssr_test() {
     );
 }
 
+#[cfg(feature = "ssr")]
 #[test]
 fn ssr_test_with_components() {
     use leptos::prelude::*;
@@ -51,6 +53,7 @@ fn ssr_test_with_components() {
     );
 }
 
+#[cfg(feature = "ssr")]
 #[test]
 fn ssr_test_with_snake_case_components() {
     use leptos::prelude::*;
@@ -81,6 +84,7 @@ fn ssr_test_with_snake_case_components() {
     );
 }
 
+#[cfg(feature = "ssr")]
 #[test]
 fn test_classes() {
     use leptos::prelude::*;
@@ -98,6 +102,7 @@ fn test_classes() {
     assert_eq!(rendered.to_html(), "<div class=\"my big  red car\"></div>");
 }
 
+#[cfg(feature = "ssr")]
 #[test]
 fn ssr_with_styles() {
     use leptos::prelude::*;
@@ -119,6 +124,7 @@ fn ssr_with_styles() {
     );
 }
 
+#[cfg(feature = "ssr")]
 #[test]
 fn ssr_option() {
     use leptos::prelude::*;

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "ssr")]
 use leptos::html::HtmlElement;
 
 #[cfg(feature = "ssr")]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -60,3 +60,6 @@ skip_feature_sets = [
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(erase_components)'] }

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -48,7 +48,7 @@ experimental-islands = []
 trace-component-props = []
 actix = ["server_fn_macro/actix"]
 axum = ["server_fn_macro/axum"]
-no_erase = []
+erase_types = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "tracing", "trace-component-props"]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -48,7 +48,6 @@ experimental-islands = []
 trace-component-props = []
 actix = ["server_fn_macro/actix"]
 axum = ["server_fn_macro/axum"]
-erase_types = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "tracing", "trace-component-props"]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -56,3 +56,11 @@ skip_feature_sets = [["csr", "hydrate"], ["hydrate", "csr"], ["hydrate", "ssr"]]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
+
+[package.metadata.cargo-all-features]
+skip_feature_sets = [
+  ["csr", "ssr"],
+  ["csr", "hydrate"],
+  ["ssr", "hydrate"],
+  ["actix", "axum"]
+]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -52,15 +52,12 @@ erase_types = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "tracing", "trace-component-props"]
-skip_feature_sets = [["csr", "hydrate"], ["hydrate", "csr"], ["hydrate", "ssr"]]
+skip_feature_sets = [
+	["csr", "hydrate"],
+	["hydrate", "csr"],
+	["hydrate", "ssr"],
+	["actix", "axum"]
+]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]
-
-[package.metadata.cargo-all-features]
-skip_feature_sets = [
-  ["csr", "ssr"],
-  ["csr", "hydrate"],
-  ["ssr", "hydrate"],
-  ["actix", "axum"]
-]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -48,6 +48,7 @@ experimental-islands = []
 trace-component-props = []
 actix = ["server_fn_macro/actix"]
 axum = ["server_fn_macro/axum"]
+no_erase = []
 
 [package.metadata.cargo-all-features]
 denylist = ["nightly", "tracing", "trace-component-props"]

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -286,7 +286,7 @@ impl ToTokens for Model {
             }
         } else {
             quote! {
-                ::leptos::reactive_graph::untrack(
+                ::leptos::prelude::untrack(
                     move || {
                         #tracing_guard_expr
                         #tracing_props_expr

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -272,7 +272,7 @@ impl ToTokens for Model {
 
         let component = if *is_transparent {
             body_expr
-        } else if cfg!(feature = "erase_types") {
+        } else if cfg!(erase_components) {
             quote! {
                 ::leptos::prelude::IntoAny::into_any(
                     ::leptos::prelude::untrack(

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -272,6 +272,16 @@ impl ToTokens for Model {
 
         let component = if *is_transparent {
             body_expr
+        } else if cfg!(feature = "no_erase") {
+            quote! {
+                ::leptos::reactive_graph::untrack(
+                    move || {
+                        #tracing_guard_expr
+                        #tracing_props_expr
+                        #body_expr
+                    }
+                    )
+            }
         } else {
             quote! {
                 ::leptos::prelude::IntoAny::into_any(
@@ -281,8 +291,8 @@ impl ToTokens for Model {
                             #tracing_props_expr
                             #body_expr
                         }
+                        )
                     )
-                )
             }
         };
 

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -272,17 +272,7 @@ impl ToTokens for Model {
 
         let component = if *is_transparent {
             body_expr
-        } else if cfg!(feature = "no_erase") {
-            quote! {
-                ::leptos::reactive_graph::untrack(
-                    move || {
-                        #tracing_guard_expr
-                        #tracing_props_expr
-                        #body_expr
-                    }
-                    )
-            }
-        } else {
+        } else if cfg!(feature = "erase_types") {
             quote! {
                 ::leptos::prelude::IntoAny::into_any(
                     ::leptos::prelude::untrack(
@@ -291,8 +281,18 @@ impl ToTokens for Model {
                             #tracing_props_expr
                             #body_expr
                         }
-                        )
                     )
+                )
+            }
+        } else {
+            quote! {
+                ::leptos::reactive_graph::untrack(
+                    move || {
+                        #tracing_guard_expr
+                        #tracing_props_expr
+                        #body_expr
+                    }
+                )
             }
         };
 

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -535,11 +535,24 @@ pub fn include_view(tokens: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
-pub fn component(
-    _args: proc_macro::TokenStream,
-    s: TokenStream,
-) -> TokenStream {
-    component_macro(s, None)
+pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
+    let is_transparent = if !args.is_empty() {
+        let transparent = parse_macro_input!(args as syn::Ident);
+
+        if transparent != "transparent" {
+            abort!(
+                transparent,
+                "only `transparent` is supported";
+                help = "try `#[component(transparent)]` or `#[component]`"
+            );
+        }
+
+        true
+    } else {
+        false
+    };
+
+    component_macro(s, is_transparent, None)
 }
 
 /// Defines a component as an interactive island when you are using the
@@ -615,17 +628,37 @@ pub fn component(
 /// ```
 #[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
-pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
+pub fn island(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
+    let is_transparent = if !args.is_empty() {
+        let transparent = parse_macro_input!(args as syn::Ident);
+
+        if transparent != "transparent" {
+            abort!(
+                transparent,
+                "only `transparent` is supported";
+                help = "try `#[component(transparent)]` or `#[component]`"
+            );
+        }
+
+        true
+    } else {
+        false
+    };
+
     let island_src = s.to_string();
-    component_macro(s, Some(island_src))
+    component_macro(s, is_transparent, Some(island_src))
 }
 
-fn component_macro(s: TokenStream, island: Option<String>) -> TokenStream {
+fn component_macro(
+    s: TokenStream,
+    is_transparent: bool,
+    island: Option<String>,
+) -> TokenStream {
     let mut dummy = syn::parse::<DummyModel>(s.clone());
     let parse_result = syn::parse::<component::Model>(s);
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
-        let expanded = model.with_island(island).into_token_stream();
+        let expanded = model.is_transparent(is_transparent).with_island(island).into_token_stream();
         if !matches!(unexpanded.vis, Visibility::Public(_)) {
             unexpanded.vis = Visibility::Public(Pub {
                 span: unexpanded.vis.span(),

--- a/leptos_macro/tests/ui.rs
+++ b/leptos_macro/tests/ui.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "erase_types"))]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/leptos_macro/tests/ui.rs
+++ b/leptos_macro/tests/ui.rs
@@ -1,4 +1,4 @@
-#[cfg(not(feature = "erase_types"))]
+#[cfg(not(erase_components))]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-#[component]
+#[component(transparent)]
 pub fn Router<Chil>(
     /// The base URL for the router. Defaults to `""`.
     #[prop(optional, into)]
@@ -204,7 +204,7 @@ where
     }
 }*/
 
-#[component]
+#[component(transparent)]
 pub fn Routes<Defs, FallbackFn, Fallback>(
     fallback: FallbackFn,
     children: RouteChildren<Defs>,
@@ -247,7 +247,7 @@ where
     }
 }
 
-#[component]
+#[component(transparent)]
 pub fn FlatRoutes<Defs, FallbackFn, Fallback>(
     fallback: FallbackFn,
     children: RouteChildren<Defs>,
@@ -294,7 +294,7 @@ where
     }
 }
 
-#[component]
+#[component(transparent)]
 pub fn Route<Segments, View>(
     path: Segments,
     view: View,
@@ -306,7 +306,7 @@ where
     NestedRoute::new(path, view).ssr_mode(ssr)
 }
 
-#[component]
+#[component(transparent)]
 pub fn ParentRoute<Segments, View, Children>(
     path: Segments,
     view: View,
@@ -320,7 +320,7 @@ where
     NestedRoute::new(path, view).ssr_mode(ssr).child(children)
 }
 
-#[component]
+#[component(transparent)]
 pub fn ProtectedRoute<Segments, ViewFn, View, C, PathFn, P>(
     path: Segments,
     view: ViewFn,
@@ -362,7 +362,7 @@ where
     NestedRoute::new(path, view).ssr_mode(ssr)
 }
 
-#[component]
+#[component(transparent)]
 pub fn ProtectedParentRoute<Segments, ViewFn, View, C, PathFn, P, Children>(
     path: Segments,
     view: ViewFn,
@@ -424,7 +424,7 @@ where
 ///
 /// [`leptos_actix`]: <https://docs.rs/leptos_actix/>
 /// [`leptos_axum`]: <https://docs.rs/leptos_axum/>
-#[component]
+#[component(transparent)]
 pub fn Redirect<P>(
     /// The relative path to which the user should be redirected.
     path: P,

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -35,7 +35,7 @@ pub struct AnyView {
 
     build: fn(Box<dyn Any>) -> AnyViewState,
     rebuild: fn(TypeId, Box<dyn Any>, &mut AnyViewState),
-    add_any_attr: fn(Box<dyn Any>, AnyAttribute) -> AnyView,
+    add_attr: fn(Box<dyn Any>, AnyAttribute) -> AnyView,
     // The fields below are cfg-gated so they will not be included in WASM bundles if not needed.
     // Ordinarily, the compiler can simply omit this dead code because the methods are not called.
     // With this type-erased wrapper, however, the compiler is not *always* able to correctly
@@ -144,11 +144,11 @@ where
 
         let value = Box::new(self) as Box<dyn Any + Send>;
 
-        let add_any_attr = |value: Box<dyn Any>, attr: AnyAttribute| {
+        let add_attr = |value: Box<dyn Any>, attr: AnyAttribute| {
             let value = value
                 .downcast::<T>()
-                .expect("AnyView::add_any_attr could not be downcast");
-            value.add_any_attr(attr).into_any()
+                .expect("AnyView::add_attr could not be downcast");
+            (*value).add_any_attr(attr).into_any()
         };
 
         #[cfg(feature = "ssr")]
@@ -287,7 +287,7 @@ where
             value,
             build,
             rebuild,
-            add_any_attr,
+            add_attr,
             #[cfg(feature = "ssr")]
             resolve,
             #[cfg(feature = "ssr")]
@@ -329,7 +329,7 @@ impl AddAnyAttr for AnyView {
         Self::Output<NewAttr>: RenderHtml,
     {
         let attr = attr.into_cloneable_owned();
-        (self.add_any_attr)(self.value, attr.into_any_attr())
+        (self.add_attr)(self.value, attr.into_any_attr())
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -144,164 +144,180 @@ where
 
         let value = Box::new(self) as Box<dyn Any + Send>;
 
-        let add_attr = |value: Box<dyn Any>, attr: AnyAttribute| {
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::add_attr could not be downcast");
-            (*value).add_any_attr(attr).into_any()
-        };
+        match value.downcast::<AnyView>() {
+            // if it's already an AnyView, we don't need to double-wrap it
+            Ok(any_view) => *any_view,
+            Err(value) => {
+                let add_attr = |value: Box<dyn Any>, attr: AnyAttribute| {
+                    let value = value
+                        .downcast::<T>()
+                        .expect("AnyView::add_attr could not be downcast");
+                    (*value).add_any_attr(attr).into_any()
+                };
 
-        #[cfg(feature = "ssr")]
-        let dry_resolve = |value: &mut Box<dyn Any + Send>| {
-            let value = value
-                .downcast_mut::<T>()
-                .expect("AnyView::resolve could not be downcast");
-            value.dry_resolve();
-        };
+                #[cfg(feature = "ssr")]
+                let dry_resolve = |value: &mut Box<dyn Any + Send>| {
+                    let value = value
+                        .downcast_mut::<T>()
+                        .expect("AnyView::resolve could not be downcast");
+                    value.dry_resolve();
+                };
 
-        #[cfg(feature = "ssr")]
-        let resolve = |value: Box<dyn Any>| {
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::resolve could not be downcast");
-            Box::pin(async move { value.resolve().await.into_any() })
-                as Pin<Box<dyn Future<Output = AnyView> + Send>>
-        };
-        #[cfg(feature = "ssr")]
-        let to_html = |value: Box<dyn Any>,
-                       buf: &mut String,
-                       position: &mut Position,
-                       escape: bool,
-                       mark_branches: bool| {
-            let type_id = mark_branches
-                .then(|| format!("{:?}", TypeId::of::<T>()))
-                .unwrap_or_default();
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::to_html could not be downcast");
-            if mark_branches {
-                buf.open_branch(&type_id);
-            }
-            value.to_html_with_buf(buf, position, escape, mark_branches);
-            if mark_branches {
-                buf.close_branch(&type_id);
-            }
-        };
-        #[cfg(feature = "ssr")]
-        let to_html_async = |value: Box<dyn Any>,
-                             buf: &mut StreamBuilder,
-                             position: &mut Position,
-                             escape: bool,
-                             mark_branches: bool| {
-            let type_id = mark_branches
-                .then(|| format!("{:?}", TypeId::of::<T>()))
-                .unwrap_or_default();
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::to_html could not be downcast");
-            if mark_branches {
-                buf.open_branch(&type_id);
-            }
-            value.to_html_async_with_buf::<false>(
-                buf,
-                position,
-                escape,
-                mark_branches,
-            );
-            if mark_branches {
-                buf.close_branch(&type_id);
-            }
-        };
-        #[cfg(feature = "ssr")]
-        let to_html_async_ooo =
-            |value: Box<dyn Any>,
-             buf: &mut StreamBuilder,
-             position: &mut Position,
-             escape: bool,
-             mark_branches: bool| {
-                let value = value
-                    .downcast::<T>()
-                    .expect("AnyView::to_html could not be downcast");
-                value.to_html_async_with_buf::<true>(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                );
-            };
-        let build = |value: Box<dyn Any>| {
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::build couldn't downcast");
-            let state = Box::new(value.build());
+                #[cfg(feature = "ssr")]
+                let resolve = |value: Box<dyn Any>| {
+                    let value = value
+                        .downcast::<T>()
+                        .expect("AnyView::resolve could not be downcast");
+                    Box::pin(async move { value.resolve().await.into_any() })
+                        as Pin<Box<dyn Future<Output = AnyView> + Send>>
+                };
+                #[cfg(feature = "ssr")]
+                let to_html =
+                    |value: Box<dyn Any>,
+                     buf: &mut String,
+                     position: &mut Position,
+                     escape: bool,
+                     mark_branches: bool| {
+                        let type_id = mark_branches
+                            .then(|| format!("{:?}", TypeId::of::<T>()))
+                            .unwrap_or_default();
+                        let value = value
+                            .downcast::<T>()
+                            .expect("AnyView::to_html could not be downcast");
+                        if mark_branches {
+                            buf.open_branch(&type_id);
+                        }
+                        value.to_html_with_buf(
+                            buf,
+                            position,
+                            escape,
+                            mark_branches,
+                        );
+                        if mark_branches {
+                            buf.close_branch(&type_id);
+                        }
+                    };
+                #[cfg(feature = "ssr")]
+                let to_html_async =
+                    |value: Box<dyn Any>,
+                     buf: &mut StreamBuilder,
+                     position: &mut Position,
+                     escape: bool,
+                     mark_branches: bool| {
+                        let type_id = mark_branches
+                            .then(|| format!("{:?}", TypeId::of::<T>()))
+                            .unwrap_or_default();
+                        let value = value
+                            .downcast::<T>()
+                            .expect("AnyView::to_html could not be downcast");
+                        if mark_branches {
+                            buf.open_branch(&type_id);
+                        }
+                        value.to_html_async_with_buf::<false>(
+                            buf,
+                            position,
+                            escape,
+                            mark_branches,
+                        );
+                        if mark_branches {
+                            buf.close_branch(&type_id);
+                        }
+                    };
+                #[cfg(feature = "ssr")]
+                let to_html_async_ooo =
+                    |value: Box<dyn Any>,
+                     buf: &mut StreamBuilder,
+                     position: &mut Position,
+                     escape: bool,
+                     mark_branches: bool| {
+                        let value = value
+                            .downcast::<T>()
+                            .expect("AnyView::to_html could not be downcast");
+                        value.to_html_async_with_buf::<true>(
+                            buf,
+                            position,
+                            escape,
+                            mark_branches,
+                        );
+                    };
+                let build = |value: Box<dyn Any>| {
+                    let value = value
+                        .downcast::<T>()
+                        .expect("AnyView::build couldn't downcast");
+                    let state = Box::new(value.build());
 
-            AnyViewState {
-                type_id: TypeId::of::<T>(),
-                state,
+                    AnyViewState {
+                        type_id: TypeId::of::<T>(),
+                        state,
 
-                mount: mount_any::<T>,
-                unmount: unmount_any::<T>,
-                insert_before_this: insert_before_this::<T>,
-            }
-        };
-        #[cfg(feature = "hydrate")]
-        let hydrate_from_server =
-            |value: Box<dyn Any>, cursor: &Cursor, position: &PositionState| {
-                let value = value
-                    .downcast::<T>()
-                    .expect("AnyView::hydrate_from_server couldn't downcast");
-                let state = Box::new(value.hydrate::<true>(cursor, position));
+                        mount: mount_any::<T>,
+                        unmount: unmount_any::<T>,
+                        insert_before_this: insert_before_this::<T>,
+                    }
+                };
+                #[cfg(feature = "hydrate")]
+                let hydrate_from_server =
+                    |value: Box<dyn Any>,
+                     cursor: &Cursor,
+                     position: &PositionState| {
+                        let value = value.downcast::<T>().expect(
+                            "AnyView::hydrate_from_server couldn't downcast",
+                        );
+                        let state =
+                            Box::new(value.hydrate::<true>(cursor, position));
 
-                AnyViewState {
+                        AnyViewState {
+                            type_id: TypeId::of::<T>(),
+                            state,
+
+                            mount: mount_any::<T>,
+                            unmount: unmount_any::<T>,
+                            insert_before_this: insert_before_this::<T>,
+                        }
+                    };
+
+                let rebuild =
+                    |new_type_id: TypeId,
+                     value: Box<dyn Any>,
+                     state: &mut AnyViewState| {
+                        let value = value
+                            .downcast::<T>()
+                            .expect("AnyView::rebuild couldn't downcast value");
+                        if new_type_id == state.type_id {
+                            let state = state.state.downcast_mut().expect(
+                                "AnyView::rebuild couldn't downcast state",
+                            );
+                            value.rebuild(state);
+                        } else {
+                            let mut new = value.into_any().build();
+                            state.insert_before_this(&mut new);
+                            state.unmount();
+                            *state = new;
+                        }
+                    };
+
+                AnyView {
                     type_id: TypeId::of::<T>(),
-                    state,
-
-                    mount: mount_any::<T>,
-                    unmount: unmount_any::<T>,
-                    insert_before_this: insert_before_this::<T>,
+                    value,
+                    build,
+                    rebuild,
+                    add_attr,
+                    #[cfg(feature = "ssr")]
+                    resolve,
+                    #[cfg(feature = "ssr")]
+                    dry_resolve,
+                    #[cfg(feature = "ssr")]
+                    html_len,
+                    #[cfg(feature = "ssr")]
+                    to_html,
+                    #[cfg(feature = "ssr")]
+                    to_html_async,
+                    #[cfg(feature = "ssr")]
+                    to_html_async_ooo,
+                    #[cfg(feature = "hydrate")]
+                    hydrate_from_server,
                 }
-            };
-
-        let rebuild = |new_type_id: TypeId,
-                       value: Box<dyn Any>,
-                       state: &mut AnyViewState| {
-            let value = value
-                .downcast::<T>()
-                .expect("AnyView::rebuild couldn't downcast value");
-            if new_type_id == state.type_id {
-                let state = state
-                    .state
-                    .downcast_mut()
-                    .expect("AnyView::rebuild couldn't downcast state");
-                value.rebuild(state);
-            } else {
-                let mut new = value.into_any().build();
-                state.insert_before_this(&mut new);
-                state.unmount();
-                *state = new;
             }
-        };
-
-        AnyView {
-            type_id: TypeId::of::<T>(),
-            value,
-            build,
-            rebuild,
-            add_attr,
-            #[cfg(feature = "ssr")]
-            resolve,
-            #[cfg(feature = "ssr")]
-            dry_resolve,
-            #[cfg(feature = "ssr")]
-            html_len,
-            #[cfg(feature = "ssr")]
-            to_html,
-            #[cfg(feature = "ssr")]
-            to_html_async,
-            #[cfg(feature = "ssr")]
-            to_html_async_ooo,
-            #[cfg(feature = "hydrate")]
-            hydrate_from_server,
         }
     }
 }


### PR DESCRIPTION
Related to #2902. There is a genuine trade-off between compile time and WASM binary size: there seems to be some exponential compile time growth (and occasional recursion limits!) as we build a larger and larger statically-typed view tree, but it does allow the compiler to eliminate unused code much more effectively.

**`hackernews`**
`cargo build --timings --features=ssr`: 19.67s (main) => 6.65s (branch)
WASM size: 544kb (main) => 583kb (branch)

**`todo_app_sqlite_axum`**
`cargo build --timings --features=ssr`: 5.74s (main) => 2.62s (branch)
WASM size: 535kb (main) => 566kb (branch)