### PR TITLE
fix: automatically break children into tuples of a size the trait system can handle (closes #2863)

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -134,6 +134,19 @@ fn fragment_to_tokens(
         None
     } else if children.len() == 1 {
         children.into_iter().next()
+    } else if children.len() > 16 {
+        // implementations of various traits used in routing and rendering are implemented for
+        // tuples of sizes 0, 1, 2, 3, ... N. N varies but is > 16. The traits are also implemented
+        // for tuples of tuples, so if we have more than 16 items, we can split them out into
+        // multiple tuples.
+        let chunks = children.chunks(16).map(|children| {
+            quote! {
+                (#(#children),*)
+            }
+        });
+        Some(quote! {
+             (#(#chunks),*)
+        })
     } else {
         Some(quote! {
             (#(#children),*)


### PR DESCRIPTION
This automatically transforms any set of > 16 children into multiple tuples of max 16 items, which should avoid any problems due to the fact that rendering and routing traits are only implemented on tuples of up to some N (16, 26, whatever), at least when you are using the view macro.