### PR TITLE
fix: ensure stability of hydration IDs on client and server, when using partial hydration (closes #2920)

### DIFF
--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3.30"
 
 any_spawner = { workspace = true }
 tachys = { workspace = true, optional = true, features = ["reactive_graph"] }
+send_wrapper = "0.6"
 
 # serialization formats
 serde = { version = "1.0" }

--- a/leptos_server/src/local_resource.rs
+++ b/leptos_server/src/local_resource.rs
@@ -7,10 +7,11 @@ use reactive_graph::{
         AnySource, AnySubscriber, ReactiveNode, Source, Subscriber,
         ToAnySource, ToAnySubscriber,
     },
-    owner::{use_context, LocalStorage},
+    owner::use_context,
     signal::guards::{AsyncPlain, ReadGuard},
     traits::{DefinedAt, ReadUntracked},
 };
+use send_wrapper::SendWrapper;
 use std::{
     future::{pending, Future, IntoFuture},
     panic::Location,
@@ -175,7 +176,7 @@ impl<T> Subscriber for ArcLocalResource<T> {
 }
 
 pub struct LocalResource<T> {
-    data: AsyncDerived<T, LocalStorage>,
+    data: AsyncDerived<SendWrapper<T>>,
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
 }
@@ -217,9 +218,13 @@ impl<T> LocalResource<T> {
 
         Self {
             data: if cfg!(feature = "ssr") {
-                AsyncDerived::new_mock_unsync(fetcher)
+                AsyncDerived::new_mock(fetcher)
             } else {
-                AsyncDerived::new_unsync(fetcher)
+                let fetcher = SendWrapper::new(fetcher);
+                AsyncDerived::new(move || {
+                    let fut = fetcher();
+                    async move { SendWrapper::new(fut.await) }
+                })
             },
             #[cfg(debug_assertions)]
             defined_at: Location::caller(),
@@ -232,9 +237,14 @@ where
     T: Clone + 'static,
 {
     type Output = T;
-    type IntoFuture = AsyncDerivedFuture<T>;
+    type IntoFuture = futures::future::Map<
+        AsyncDerivedFuture<SendWrapper<T>>,
+        fn(SendWrapper<T>) -> T,
+    >;
 
     fn into_future(self) -> Self::IntoFuture {
+        use futures::FutureExt;
+
         if let Some(mut notifier) = use_context::<LocalResourceNotifier>() {
             notifier.notify();
         } else if cfg!(feature = "ssr") {
@@ -244,7 +254,7 @@ where
                  always pending on the server."
             );
         }
-        self.data.into_future()
+        self.data.into_future().map(|value| (*value).clone())
     }
 }
 
@@ -265,7 +275,8 @@ impl<T> ReadUntracked for LocalResource<T>
 where
     T: Send + Sync + 'static,
 {
-    type Value = ReadGuard<Option<T>, AsyncPlain<Option<T>>>;
+    type Value =
+        ReadGuard<Option<SendWrapper<T>>, AsyncPlain<Option<SendWrapper<T>>>>;
 
     fn try_read_untracked(&self) -> Option<Self::Value> {
         if let Some(mut notifier) = use_context::<LocalResourceNotifier>() {

--- a/reactive_graph/src/signal/guards.rs
+++ b/reactive_graph/src/signal/guards.rs
@@ -31,6 +31,11 @@ impl<T, Inner> ReadGuard<T, Inner> {
             ty: PhantomData,
         }
     }
+
+    /// Returns the inner guard type.
+    pub fn into_inner(self) -> Inner {
+        self.inner
+    }
 }
 
 impl<T, Inner> Clone for ReadGuard<T, Inner>


### PR DESCRIPTION
See #2920. This was an interesting bug. 

Basically, each resource and each Suspense/Transition gets a unique ID, which is created just by incrementing a counter in the shared context.

However, there is an issue when you have code that runs on the server (incrementing that counter) but not on the client (where it doesn't increment the counter). In this case, it caused the server-only Transition used by ProtectedParentRoute to take the ID 1, so it went 0 (resource), 1 (Transition), 2 (resource), while the client did not run the ProtectedParentRoute because it was not an island, so it went 0 (resource), 1 (resource). It did not find a serialized resource for 1, so loaded the resource again, but it thought the value hadn't loaded yet, so attempted to hydrate as if it was not there, hence the hydration issues. (The HTML was, in fact, there!)

This would result from *any* situation in which you had a different number of resources on the client and the server, so would inevitably happen when using Resource with islands if you had a mix of Resources that were created in islands (and so got IDs on both server and client) and in non-islands (and so only got IDs on the server).

This simply creates a separate set of IDs for things that happen outside islands, so the "IDs for things with islands" count is the same between server and client, and the "IDs for things outside islands" count does not interfere.

These IDs will only begin to collide if you have a total of `usize` Resources/Suspenses in response to a single request, in which case something has already gone horribly wrong. 

===

The second commit fixes an (unrelated) problem mentioned in the same issue in which creating a LocalResource created a `SendWrapper<None<T>>`, which still causes problems when dropped from a different thread, even though `T` is never constructed, meaning a panic if it is used in Suspense under load. This has been an issue in various places unfortunately. This commit should fix that issue for local resources.