### PR TITLE
Enable CDN support for assets

### DIFF
--- a/leptos/src/hydration/hydration_script.js
+++ b/leptos/src/hydration/hydration_script.js
@@ -1,5 +1,5 @@
-(function (pkg_path, output_name, wasm_output_name) {
-	import(`/${pkg_path}/${output_name}.js`)
+(function (root, pkg_path, output_name, wasm_output_name) {
+	import(`${root}/${pkg_path}/${output_name}.js`)
 		.then(mod => {
 			mod.default(`/${pkg_path}/${wasm_output_name}.wasm`).then(() => {
 				mod.hydrate();

--- a/leptos/src/hydration/island_script.js
+++ b/leptos/src/hydration/island_script.js
@@ -1,4 +1,4 @@
-((pkg_path, output_name, wasm_output_name) => {
+((root, pkg_path, output_name, wasm_output_name) => {
 	function idle(c) {
 		if ("requestIdleCallback" in window) {
 			window.requestIdleCallback(c);
@@ -50,9 +50,9 @@
 		}
 	}
 	idle(() => {
-		import(`/${pkg_path}/${output_name}.js`)
+		import(`${root}/${pkg_path}/${output_name}.js`)
 			.then(mod => {
-				mod.default(`/${pkg_path}/${wasm_output_name}.wasm`).then(() => {
+				mod.default(`${root}/${pkg_path}/${wasm_output_name}.wasm`).then(() => {
 					mod.hydrate();
 					hydrateIslands(islandTree(document.body, null), mod);
 				});

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -38,6 +38,9 @@ pub fn AutoReload(
 pub fn HydrationScripts(
     options: LeptosOptions,
     #[prop(optional)] islands: bool,
+    /// A base url, not including a trailing slash
+    #[prop(optional, into)]
+    root: Option<String>,
 ) -> impl IntoView {
     let mut js_file_name = options.output_name.to_string();
     let mut wasm_file_name = options.output_name.to_string();
@@ -82,17 +85,18 @@ pub fn HydrationScripts(
         include_str!("./hydration_script.js")
     };
 
+    let root = root.unwrap_or_default();
     view! {
-        <link rel="modulepreload" href=format!("/{pkg_path}/{js_file_name}.js") nonce=nonce.clone()/>
+        <link rel="modulepreload" href=format!("{root}/{pkg_path}/{js_file_name}.js") nonce=nonce.clone()/>
         <link
             rel="preload"
-            href=format!("/{pkg_path}/{wasm_file_name}.wasm")
+            href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
             r#as="fetch"
             r#type="application/wasm"
             crossorigin=nonce.clone().unwrap_or_default()
         />
         <script type="module" nonce=nonce>
-            {format!("{script}({pkg_path:?}, {js_file_name:?}, {wasm_file_name:?})")}
+            {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?})")}
         </script>
     }
 }

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -45,7 +45,7 @@ pub fn HashedStylesheet(
     id: Option<String>,
     /// A base url, not including a trailing slash
     #[prop(optional, into)]
-    root: Option<String>
+    root: Option<String>,
 ) -> impl IntoView {
     let mut css_file_name = options.output_name.to_string();
     if options.hash_files {

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -43,6 +43,9 @@ pub fn HashedStylesheet(
     /// An ID for the stylesheet.
     #[prop(optional, into)]
     id: Option<String>,
+    /// A base url, not including a trailing slash
+    #[prop(optional, into)]
+    root: Option<String>
 ) -> impl IntoView {
     let mut css_file_name = options.output_name.to_string();
     if options.hash_files {
@@ -69,11 +72,12 @@ pub fn HashedStylesheet(
     }
     css_file_name.push_str(".css");
     let pkg_path = &options.site_pkg_dir;
+    let root = root.unwrap_or_default();
     // TODO additional attributes
     register(
         link()
             .id(id)
             .rel("stylesheet")
-            .href(format!("/{pkg_path}/{css_file_name}")),
+            .href(format!("{root}/{pkg_path}/{css_file_name}")),
     )
 }


### PR DESCRIPTION
This enables setting a root for a url, especially relating to generated .wasm, .js, and .css files.

This allows using a CDN for static assets by virtue of being able to pass in an https:// root.

```rust
pub fn shell(options: LeptosOptions) -> impl IntoView {
    let root = std::env::var("CDN_PATH").unwrap();
    view! {
        <!DOCTYPE html>
        <html lang="en">
            <head>
                <HydrationScripts options=options.clone() root=root.clone() islands=true/>
                <HashedStylesheet options=options root=root />
            </head>
            <body>
                <App/>
            </body>
        </html>
    }
}
```