### PR TITLE
leptos 0.7: Switch to `proc-macro-error2` to address unmaintained security advisory.

### DIFF
--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1.0"
 html-escape = "0.2.13"
 itertools = "0.13.0"
 prettyplease = "0.2.20"
-proc-macro-error = { version = "1.0", default-features = false }
+proc-macro-error2 = { version = "2.0", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -6,7 +6,7 @@ use convert_case::{
 use itertools::Itertools;
 use leptos_hot_reload::parsing::value_to_string;
 use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{format_ident, quote, quote_spanned, ToTokens, TokenStreamExt};
 use std::hash::DefaultHasher;
 use syn::{
@@ -121,7 +121,7 @@ impl ToTokens for Model {
                 _ => None,
             });
         if let Some(semi) = ends_semi {
-            proc_macro_error::emit_error!(
+            proc_macro_error2::emit_error!(
                 semi.span(),
                 "A component that ends with a `view!` macro followed by a \
                  semicolon will return (), an empty view. This is usually an \

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -7,7 +7,7 @@
 #![allow(private_macro_use)]
 
 #[macro_use]
-extern crate proc_macro_error;
+extern crate proc_macro_error2;
 
 use component::DummyModel;
 use proc_macro::TokenStream;
@@ -262,7 +262,7 @@ mod slot;
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
 pub fn view(tokens: TokenStream) -> TokenStream {
@@ -346,7 +346,7 @@ fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
 ///
 /// The file is loaded and parsed during proc-macro execution, and its path is resolved relative to
 /// the crate root rather than relative to the file from which it is called.
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn include_view(tokens: TokenStream) -> TokenStream {
     let file_name = syn::parse::<syn::LitStr>(tokens).unwrap_or_else(|_| {
@@ -509,7 +509,7 @@ pub fn include_view(tokens: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn component(
     _args: proc_macro::TokenStream,
@@ -589,7 +589,7 @@ pub fn component(
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     component_macro(s, true)
@@ -728,7 +728,7 @@ fn component_macro(s: TokenStream, island: bool) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     if !args.is_empty() {

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -7,7 +7,7 @@ use self::{
 use convert_case::{Case::Snake, Casing};
 use leptos_hot_reload::parsing::{is_component_node, value_to_string};
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{quote, quote_spanned, ToTokens};
 use rstml::node::{
     CustomNode, KVAttributeValue, KeyedAttribute, Node, NodeAttribute,
@@ -286,7 +286,7 @@ pub(crate) fn element_to_tokens(
                 name.push_str(&tuple_name);
             }
             if names.contains(&name) {
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     attr.span(),
                     format!("This element already has a `{name}` attribute.")
                 );
@@ -364,7 +364,7 @@ pub(crate) fn element_to_tokens(
             match parent_type {
                 TagType::Unknown => {
                     // We decided this warning was too aggressive, but I'll leave it here in case we want it later
-                    /* proc_macro_error::emit_warning!(name.span(), "The view macro is assuming this is an HTML element, \
+                    /* proc_macro_error2::emit_warning!(name.span(), "The view macro is assuming this is an HTML element, \
                     but it is ambiguous; if it is an SVG or MathML element, prefix with svg:: or math::"); */
                     quote! {
                         ::leptos::tachys::html::element::#name()
@@ -423,7 +423,7 @@ pub(crate) fn element_to_tokens(
         } else {
             if !node.children.is_empty() {
                 let name = node.name();
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     name.span(),
                     format!(
                         "Self-closing elements like <{name}> cannot have \
@@ -562,7 +562,7 @@ fn attribute_to_tokens(
                     && node.value().and_then(value_to_string).is_none()
                 {
                     let span = node.key.span();
-                    proc_macro_error::emit_error!(span, "Combining a global class (view! { class = ... }) \
+                    proc_macro_error2::emit_error!(span, "Combining a global class (view! { class = ... }) \
             and a dynamic `class=` attribute on an element causes runtime inconsistencies. You can \
             toggle individual classes dynamically with the `class:name=value` syntax. \n\nSee this issue \
             for more information and an example: https://github.com/leptos-rs/leptos/issues/773")
@@ -653,7 +653,7 @@ pub(crate) fn attribute_absolute(
                                 quote! { ::leptos::tachys::html::event::#on(#ty, #handler) },
                             )
                         } else {
-                            proc_macro_error::abort!(
+                            proc_macro_error2::abort!(
                                 id.span(),
                                 &format!(
                                     "`{id}:` syntax is not supported on \
@@ -1154,7 +1154,7 @@ pub(crate) fn ident_from_tag_name(tag_name: &NodeName) -> Ident {
             .expect("element needs to have a name"),
         NodeName::Block(_) => {
             let span = tag_name.span();
-            proc_macro_error::emit_error!(
+            proc_macro_error2::emit_error!(
                 span,
                 "blocks not allowed in tag-name position"
             );

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -23,7 +23,7 @@ pub(crate) fn slot_to_tokens(
     let component_name = ident_from_tag_name(node.name());
 
     let Some(parent_slots) = parent_slots else {
-        proc_macro_error::emit_error!(
+        proc_macro_error2::emit_error!(
             node.name().span(),
             "slots cannot be used inside HTML elements"
         );


### PR DESCRIPTION
`proc-macro-error` is unmaintained according to https://github.com/rustsec/advisory-db/pull/2057, and one of my CI checks failed on this.