### PR TITLE
leptos 0.6: Switch to `proc-macro-error2` to address unmaintained security advisory.

### DIFF
--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1"
 html-escape = "0.2"
 itertools = "0.12"
 prettyplease = "0.2.4"
-proc-macro-error = { version = "1", default-features = false }
+proc-macro-error2 = { version = "2", default-features = false }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -128,7 +128,7 @@ impl ToTokens for Model {
                     _ => None,
                 });
             if let Some(semi) = ends_semi {
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     semi.span(),
                     "A component that ends with a `view!` macro followed by a \
                      semicolon will return (), an empty view. This is usually \

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -7,7 +7,7 @@
 #![allow(private_macro_use)]
 
 #[macro_use]
-extern crate proc_macro_error;
+extern crate proc_macro_error2;
 
 use component::DummyModel;
 use proc_macro::TokenStream;
@@ -313,7 +313,7 @@ mod slot;
 /// # ;
 /// # }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 #[cfg_attr(
     any(debug_assertions, feature = "ssr"),
@@ -391,7 +391,7 @@ fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
 /// syntax as the [view!] macro. In hydration or server-side rendering mode,
 /// behaves exactly as the `view` macro. In client-side rendering mode, uses a `<template>`
 /// node to efficiently render the element. Should only be used with a single root element.
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn template(tokens: TokenStream) -> TokenStream {
     if cfg!(feature = "csr") {
@@ -583,7 +583,7 @@ pub fn template(tokens: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let is_transparent = if !args.is_empty() {
@@ -699,7 +699,7 @@ pub fn component(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let Ok(mut dummy) = syn::parse::<DummyModel>(s.clone()) else {
@@ -839,7 +839,7 @@ pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn slot(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     if !args.is_empty() {

--- a/leptos_macro/src/view/client_builder.rs
+++ b/leptos_macro/src/view/client_builder.rs
@@ -132,7 +132,7 @@ pub(crate) fn node_to_tokens(
         Node::RawText(r) => {
             let text = r.to_string_best();
             if text == "cx," {
-                proc_macro_error::abort!(
+                proc_macro_error2::abort!(
                     r.span(),
                     "`cx,` is not used with the `view!` macro in 0.5."
                 )
@@ -185,7 +185,7 @@ pub(crate) fn element_to_tokens(
             match parent_type {
                 TagType::Unknown => {
                     // We decided this warning was too aggressive, but I'll leave it here in case we want it later
-                    /* proc_macro_error::emit_warning!(name.span(), "The view macro is assuming this is an HTML element, \
+                    /* proc_macro_error2::emit_warning!(name.span(), "The view macro is assuming this is an HTML element, \
                     but it is ambiguous; if it is an SVG or MathML element, prefix with svg:: or math::"); */
                     quote! {
                         ::leptos::leptos_dom::html::#name()
@@ -282,7 +282,7 @@ pub(crate) fn element_to_tokens(
         };
 
         if is_self_closing(node) && !node.children.is_empty() {
-            proc_macro_error::abort!(
+            proc_macro_error2::abort!(
                 node.name().span(),
                 format!(
                     "<{tag}> is a self-closing tag and cannot have children."
@@ -470,7 +470,7 @@ pub(crate) fn attribute_to_tokens(
             && node.value().and_then(value_to_string).is_none()
         {
             let span = node.key.span();
-            proc_macro_error::emit_error!(span, "Combining a global class (view! { class = ... }) \
+            proc_macro_error2::emit_error!(span, "Combining a global class (view! { class = ... }) \
             and a dynamic `class=` attribute on an element causes runtime inconsistencies. You can \
             toggle individual classes dynamically with the `class:name=value` syntax. \n\nSee this issue \
             for more information and an example: https://github.com/leptos-rs/leptos/issues/773")

--- a/leptos_macro/src/view/client_template.rs
+++ b/leptos_macro/src/view/client_template.rs
@@ -384,7 +384,7 @@ fn child_to_tokens(
     match node {
         Node::Element(node) => {
             if is_component_node(node) {
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     node.name().span(),
                     "component children not allowed in template!, use view! \
                      instead"

--- a/leptos_macro/src/view/ide_helper.rs
+++ b/leptos_macro/src/view/ide_helper.rs
@@ -25,7 +25,7 @@ impl IdeTagHelper {
     /// Emit warning if tag is component.
     pub fn save_tag_completion(&mut self, name: &NodeName) {
         if is_component_tag_name(name) {
-            proc_macro_error::emit_warning!(
+            proc_macro_error2::emit_warning!(
                 name.span(),
                 "BUG: Component tag is used in regular tag completion."
             );

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -439,7 +439,7 @@ fn fancy_class_name<'a>(
                                 }
 
                                 _ => {
-                                    proc_macro_error::emit_error!(
+                                    proc_macro_error2::emit_error!(
                                         elem.span(),
                                         "class name elements must be string \
                                          literals"
@@ -459,7 +459,7 @@ fn fancy_class_name<'a>(
                     }
 
                     _ => {
-                        proc_macro_error::emit_error!(
+                        proc_macro_error2::emit_error!(
                             class_name.span(),
                             "class name must be a string literal or array of \
                              string literals"
@@ -475,7 +475,7 @@ fn fancy_class_name<'a>(
                     }
                 }
             } else {
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     tuple.span(),
                     "class tuples must have two elements."
                 )
@@ -496,7 +496,7 @@ fn ident_from_tag_name(tag_name: &NodeName) -> Ident {
             .expect("element needs to have a name"),
         NodeName::Block(_) => {
             let span = tag_name.span();
-            proc_macro_error::emit_error!(
+            proc_macro_error2::emit_error!(
                 span,
                 "blocks not allowed in tag-name position"
             );
@@ -529,7 +529,7 @@ fn fancy_style_name<'a>(
                 {
                     s.value()
                 } else {
-                    proc_macro_error::emit_error!(
+                    proc_macro_error2::emit_error!(
                         style_name.span(),
                         "style name must be a string literal"
                     );
@@ -544,7 +544,7 @@ fn fancy_style_name<'a>(
                     value,
                 ));
             } else {
-                proc_macro_error::emit_error!(
+                proc_macro_error2::emit_error!(
                     tuple.span(),
                     "style tuples must have two elements."
                 )

--- a/leptos_macro/src/view/server_template.rs
+++ b/leptos_macro/src/view/server_template.rs
@@ -464,7 +464,7 @@ fn attribute_to_tokens_ssr<'a>(
             && attr.value().and_then(value_to_string).is_none()
         {
             let span = attr.key.span();
-            proc_macro_error::emit_error!(span, "Combining a global class (view! { class = ... }) \
+            proc_macro_error2::emit_error!(span, "Combining a global class (view! { class = ... }) \
             and a dynamic `class=` attribute on an element causes runtime inconsistencies. You can \
             toggle individual classes dynamically with the `class:name=value` syntax. \n\nSee this issue \
             for more information and an example: https://github.com/leptos-rs/leptos/issues/773")

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -25,7 +25,7 @@ pub(crate) fn slot_to_tokens(
     let component_name = ident_from_tag_name(node.name());
 
     let Some(parent_slots) = parent_slots else {
-        proc_macro_error::emit_error!(
+        proc_macro_error2::emit_error!(
             node.name().span(),
             "slots cannot be used inside HTML elements"
         );


### PR DESCRIPTION
`proc-macro-error` is unmaintained according to https://github.com/rustsec/advisory-db/pull/2057, and one of my CI checks failed on this.

I attempted to fix the tests, but they're failing on `leptos_0.6`, and since 0.7 isn't too far away 🤞 I didn't think it's too important to spend effort here.