### PR TITLE
remove unused dependencies leptos_axum and leptos_router

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -16,8 +16,6 @@ axum = { version = "0.7.5", default-features = false, features = [
 ] }
 dashmap = "6"
 futures = "0.3.30"
-http = "1.1"
-http-body-util = "0.1.2"
 leptos = { workspace = true, features = ["nonce", "ssr"] }
 server_fn = { workspace = true, features = ["axum-no-default"] }
 leptos_macro = { workspace = true, features = ["axum"] }
@@ -26,7 +24,6 @@ leptos_router = { workspace = true, features = ["ssr"] }
 leptos_integration_utils = { workspace = true }
 once_cell = "1"
 parking_lot = "0.12.3"
-serde_json = "1.0"
 tokio = { version = "1.39", default-features = false }
 tower = "0.4.13"
 tower-http = "0.5.2"

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -606,9 +606,9 @@ where
 /// use axum::{
 ///     body::Body,
 ///     extract::Path,
+///     http::Request,
 ///     response::{IntoResponse, Response},
 /// };
-/// use http::Request;
 /// use leptos::{config::LeptosOptions, context::provide_context, prelude::*};
 ///
 /// async fn custom_handler(
@@ -806,9 +806,9 @@ where
 /// use axum::{
 ///     body::Body,
 ///     extract::Path,
+///     http::Request,
 ///     response::{IntoResponse, Response},
 /// };
-/// use http::Request;
 /// use leptos::context::provide_context;
 ///
 /// async fn custom_handler(
@@ -1025,9 +1025,9 @@ where
 /// use axum::{
 ///     body::Body,
 ///     extract::Path,
+///     http::Request,
 ///     response::{IntoResponse, Response},
 /// };
-/// use http::Request;
 /// use leptos::context::provide_context;
 ///
 /// async fn custom_handler(
@@ -1093,9 +1093,9 @@ where
 /// use axum::{
 ///     body::Body,
 ///     extract::Path,
+///     http::Request,
 ///     response::{IntoResponse, Response},
 /// };
-/// use http::Request;
 /// use leptos::context::provide_context;
 ///
 /// async fn custom_handler(
@@ -1932,7 +1932,7 @@ where
 ///
 /// #[server]
 /// pub async fn request_method() -> Result<String, ServerFnError> {
-///     use http::Method;
+///     use axum::http::Method;
 ///     use leptos_axum::extract;
 ///
 ///     // you can extract anything that a regular Axum extractor can extract

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -33,14 +33,13 @@
 //! directory in the Leptos repository.
 
 #[cfg(feature = "default")]
-use axum::http::Uri;
 use axum::{
     body::{Body, Bytes},
     extract::{FromRef, FromRequestParts, MatchedPath, State},
     http::{
         header::{self, HeaderName, HeaderValue, ACCEPT, LOCATION, REFERER},
         request::Parts,
-        HeaderMap, Method, Request, Response, StatusCode,
+        HeaderMap, Method, Request, Response, StatusCode, Uri,
     },
     response::IntoResponse,
     routing::{delete, get, patch, post, put},
@@ -1343,7 +1342,7 @@ where
             // stub out a path for now
             provide_context(RequestUrl::new(""));
             let (mock_parts, _) =
-                http::Request::new(Body::from("")).into_parts();
+                Request::new(Body::from("")).into_parts();
             let (mock_meta, _) = ServerMetaContext::new();
             provide_contexts("", &mock_meta, mock_parts, Default::default());
             additional_context();
@@ -1402,8 +1401,8 @@ impl StaticRouteGenerator {
             let add_context = additional_context.clone();
             move || {
                 let full_path = format!("http://leptos.dev{path}");
-                let mock_req = http::Request::builder()
-                    .method(http::Method::GET)
+                let mock_req = Request::builder()
+                    .method(Method::GET)
                     .header("Accept", "text/html")
                     .body(Body::empty())
                     .unwrap();

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -33,13 +33,14 @@
 //! directory in the Leptos repository.
 
 #[cfg(feature = "default")]
+use axum::http::Uri;
 use axum::{
     body::{Body, Bytes},
     extract::{FromRef, FromRequestParts, MatchedPath, State},
     http::{
         header::{self, HeaderName, HeaderValue, ACCEPT, LOCATION, REFERER},
         request::Parts,
-        HeaderMap, Method, Request, Response, StatusCode, Uri,
+        HeaderMap, Method, Request, Response, StatusCode,
     },
     response::IntoResponse,
     routing::{delete, get, patch, post, put},

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1341,8 +1341,7 @@ where
         .with(|| {
             // stub out a path for now
             provide_context(RequestUrl::new(""));
-            let (mock_parts, _) =
-                Request::new(Body::from("")).into_parts();
+            let (mock_parts, _) = Request::new(Body::from("")).into_parts();
             let (mock_meta, _) = ServerMetaContext::new();
             provide_contexts("", &mock_meta, mock_parts, Default::default());
             additional_context();

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -22,13 +22,11 @@ url = "2.5"
 js-sys = { version = "0.3.69" }
 wasm-bindgen = { version = "0.2.93" }
 tracing = { version = "0.1.40", optional = true }
-paste = "1.0"
 once_cell = "1.19"
 send_wrapper = "0.6.0"
 thiserror = "1.0"
 percent-encoding = { version = "2.3", optional = true }
 gloo-net = "0.6.0"
-serde = { version = "1", features = ["derive"] }
 
 [dependencies.web-sys]
 version = "0.3.70"


### PR DESCRIPTION
In the process of preparing for 0.7 (atleast for leptos_axum), some dependencies were added but unnecessary as axum re-exports them.