### PR TITLE
fix: allow component to use span prop when tracing feature is enabled

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -204,11 +204,11 @@ impl ToTokens for Model {
                         )]
                     },
                     quote! {
-                        let span = ::leptos::tracing::Span::current();
+                        let __span = ::leptos::tracing::Span::current();
                     },
                     quote! {
                         #[cfg(debug_assertions)]
-                        let _guard = span.entered();
+                        let _guard = __span.entered();
                     },
                     if no_props || !cfg!(feature = "trace-component-props") {
                         quote!()


### PR DESCRIPTION
![76d081ca-1eea-447b-90ec-11930c0eebfb](https://github.com/user-attachments/assets/ac1ec9aa-cd57-4e8b-95c3-e631b5ee43cf)
