### PR TITLE
fix: stable hashes across different client and server builds for islands (closes #2978)

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -515,7 +515,7 @@ pub fn component(
     _args: proc_macro::TokenStream,
     s: TokenStream,
 ) -> TokenStream {
-    component_macro(s, false)
+    component_macro(s, None)
 }
 
 /// Defines a component as an interactive island when you are using the
@@ -592,15 +592,16 @@ pub fn component(
 #[proc_macro_error2::proc_macro_error]
 #[proc_macro_attribute]
 pub fn island(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
-    component_macro(s, true)
+    let island_src = s.to_string();
+    component_macro(s, Some(island_src))
 }
 
-fn component_macro(s: TokenStream, island: bool) -> TokenStream {
+fn component_macro(s: TokenStream, island: Option<String>) -> TokenStream {
     let mut dummy = syn::parse::<DummyModel>(s.clone());
     let parse_result = syn::parse::<component::Model>(s);
 
     if let (Ok(ref mut unexpanded), Ok(model)) = (&mut dummy, parse_result) {
-        let expanded = model.is_island(island).into_token_stream();
+        let expanded = model.with_island(island).into_token_stream();
         if !matches!(unexpanded.vis, Visibility::Public(_)) {
             unexpanded.vis = Visibility::Public(Pub {
                 span: unexpanded.vis.span(),


### PR DESCRIPTION
I think this is kind of a ridiculous solution, but unfortunately most of the useful methods on `Span` are nightly-only, and it is otherwise pretty hard to distinguish between proc-macro invocations.

We *can't* do the same thing here that we do with server fn macros and use a compile-time hash of the file, line number, etc. because `wasm-bindgen` requires a literal and won't accept this expanded macro.