### PR TITLE
fixed lifetimes for `PartialPathMatch`

### DIFF
--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -358,7 +358,7 @@ impl<'a, ParamsIter> PartialPathMatch<'a, ParamsIter> {
         self.remaining.is_empty() || self.remaining == "/"
     }
 
-    pub fn remaining(&self) -> &str {
+    pub fn remaining(&self) -> &'a str {
         self.remaining
     }
 
@@ -366,7 +366,7 @@ impl<'a, ParamsIter> PartialPathMatch<'a, ParamsIter> {
         self.params
     }
 
-    pub fn matched(&self) -> &str {
+    pub fn matched(&self) -> &'a str {
         self.matched
     }
 }


### PR DESCRIPTION
`PartialPathMatch` has only one use, be used with `PossibleRouteMatch::test`, where everything is used around the `'a` lifetime, but `remaining` and `matched` being private you need to use the accessors, but they are `fn(&self) -> &str`, so the lifetime is not tied to `'a` but tied to the struct iself. This makes `*Segment::test` unsable in a public API as the result can't be used.

This PR only change the lifetime of the returned str of the accessors to match the `'a` lifetime.

