### PR TITLE
Optimize inert HTML elements

### DIFF
--- a/examples/js-framework-benchmark/src/lib.rs
+++ b/examples/js-framework-benchmark/src/lib.rs
@@ -162,22 +162,24 @@ pub fn App() -> impl IntoView {
             <table class="table table-hover table-striped test-data">
                 <tbody>
                     <For
-                        each={move || data.get()}
-                        key={|row| row.id}
+                        each=move || data.get()
+                        key=|row| row.id
                         children=move |row: RowData| {
                             let row_id = row.id;
                             let label = row.label;
                             let is_selected = is_selected.clone();
-                            ViewTemplate::new(view! {
-                                <tr class:danger={move || is_selected.selected(Some(row_id))}>
-                                    <td class="col-md-1">{row_id.to_string()}</td>
-                                    <td class="col-md-4"><a on:click=move |_| set_selected.set(Some(row_id))>{move || label.get()}</a></td>
-                                    <td class="col-md-1"><a on:click=move |_| remove(row_id)><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a></td>
-                                    <td class="col-md-6"/>
-                                </tr>
-                            })
+                            template! {
+                                < tr class : danger = { move || is_selected.selected(Some(row_id)) }
+                                > < td class = "col-md-1" > { row_id.to_string() } </ td > < td
+                                class = "col-md-4" >< a on : click = move | _ | set_selected
+                                .set(Some(row_id)) > { move || label.get() } </ a ></ td > < td
+                                class = "col-md-1" >< a on : click = move | _ | remove(row_id) ><
+                                span class = "glyphicon glyphicon-remove" aria - hidden = "true" ></
+                                span ></ a ></ td > < td class = "col-md-6" /> </ tr >
+                            }
                         }
                     />
+
                 </tbody>
             </table>
             <span class="preloadicon glyphicon glyphicon-remove" aria-hidden="true"></span>

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -12,6 +12,7 @@ use syn::{spanned::Spanned, Expr, ExprPath, ExprRange, RangeLimits, Stmt};
 pub(crate) fn component_to_tokens(
     node: &mut NodeElement<impl CustomNode>,
     global_class: Option<&TokenTree>,
+    disable_inert_html: bool,
 ) -> TokenStream {
     #[allow(unused)] // TODO this is used by hot-reloading
     #[cfg(debug_assertions)]
@@ -191,6 +192,7 @@ pub(crate) fn component_to_tokens(
             Some(&mut slots),
             global_class,
             None,
+            disable_inert_html,
         );
 
         // TODO view marker for hot-reloading

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -173,12 +173,12 @@ impl<'a> ToTokens for InertElementBuilder<'a> {
         match self {
             InertElementBuilder::GlobalClass { strs, .. } => {
                 tokens.extend(quote! {
-                    std::borrow::Cow::Owned([#(#strs),*].join(""))
+                    [#(#strs),*].join("")
                 });
             }
             InertElementBuilder::NoGlobalClass { buffer } => {
                 tokens.extend(quote! {
-                    std::borrow::Cow::Borrowed(#buffer)
+                    #buffer
                 })
             }
         }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -173,12 +173,12 @@ impl<'a> ToTokens for InertElementBuilder<'a> {
         match self {
             InertElementBuilder::GlobalClass { strs, .. } => {
                 tokens.extend(quote! {
-                    || std::borrow::Cow::Owned([#(#strs),*].join(""))
+                    std::borrow::Cow::Owned([#(#strs),*].join(""))
                 });
             }
             InertElementBuilder::NoGlobalClass { buffer } => {
                 tokens.extend(quote! {
-                    || std::borrow::Cow::Borrowed(#buffer)
+                    std::borrow::Cow::Borrowed(#buffer)
                 })
             }
         }
@@ -263,7 +263,6 @@ impl<'a> InertElementBuilder<'a> {
 }
 
 fn inert_element_to_tokens(
-    el_name: String,
     node: &Node<impl CustomNode>,
     global_class: Option<&TokenTree>,
 ) -> Option<TokenStream> {
@@ -345,7 +344,7 @@ fn inert_element_to_tokens(
     html.finish();
 
     Some(quote! {
-        ::leptos::tachys::html::InertElement::new(#el_name, #html)
+        ::leptos::tachys::html::InertElement::new(#html)
     })
 }
 
@@ -516,11 +515,7 @@ fn node_to_tokens(
         }
         Node::Element(el_node) => {
             if !top_level && is_inert {
-                inert_element_to_tokens(
-                    el_node.name().to_string(),
-                    node,
-                    global_class,
-                )
+                inert_element_to_tokens(node, global_class)
             } else {
                 element_to_tokens(
                     el_node,

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -93,6 +93,18 @@ pub fn render_view(
 }
 
 fn is_inert_element(orig_node: &Node<impl CustomNode>) -> bool {
+    // do not use this if the top-level node is not an Element,
+    // or if it's an element with no children and no attrs
+    match orig_node {
+        Node::Element(el) => {
+            if el.attributes().is_empty() && el.children.is_empty() {
+                return false;
+            }
+        }
+        _ => return false,
+    }
+
+    // otherwise, walk over all the nodes to make sure everything is inert
     let mut nodes = VecDeque::from([orig_node]);
 
     while let Some(current_element) = nodes.pop_front() {

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -307,20 +307,17 @@ fn inert_element_to_tokens(
                                 if let Some(value) =
                                     attr.possible_value.to_value()
                                 {
-                                    if let KVAttributeValue::Expr(expr) =
-                                        &value.value
+                                    if let KVAttributeValue::Expr(Expr::Lit(
+                                        lit,
+                                    )) = &value.value
                                     {
-                                        if let Expr::Lit(lit) = expr {
-                                            if let Lit::Str(txt) = &lit.lit {
-                                                if attr_name == "class" {
-                                                    html.push_class(
-                                                        &txt.value(),
-                                                    );
-                                                } else {
-                                                    html.push_str("=\"");
-                                                    html.push_str(&txt.value());
-                                                    html.push('"');
-                                                }
+                                        if let Lit::Str(txt) = &lit.lit {
+                                            if attr_name == "class" {
+                                                html.push_class(&txt.value());
+                                            } else {
+                                                html.push_str("=\"");
+                                                html.push_str(&txt.value());
+                                                html.push('"');
                                             }
                                         }
                                     }

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -11,6 +11,7 @@ pub(crate) fn slot_to_tokens(
     slot: &KeyedAttribute,
     parent_slots: Option<&mut HashMap<String, Vec<TokenStream>>>,
     global_class: Option<&TokenTree>,
+    disable_inert_html: bool,
 ) {
     let name = slot.key.to_string();
     let name = name.trim();
@@ -118,6 +119,7 @@ pub(crate) fn slot_to_tokens(
             Some(&mut slots),
             global_class,
             None,
+            disable_inert_html,
         );
 
         // TODO view markers for hot-reloading

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -87,17 +87,13 @@ where
 
 /// An element that contains no interactivity, and whose contents can be known at compile time.
 pub struct InertElement {
-    tag: &'static str,
     html: Cow<'static, str>,
 }
 
 impl InertElement {
     /// Creates a new inert element.
-    pub fn new(
-        tag: &'static str,
-        html: impl FnOnce() -> Cow<'static, str>,
-    ) -> Self {
-        Self { tag, html: html() }
+    pub fn new(html: Cow<'static, str>) -> Self {
+        Self { html }
     }
 }
 

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -108,9 +108,7 @@ where
     type State = Rndr::Element;
 
     fn build(self) -> Self::State {
-        let el = Rndr::create_element_with_tag_name(self.tag);
-        Rndr::set_inner_html(&el, &self.html);
-        el
+        Rndr::create_element_from_html(&self.html)
     }
 
     fn rebuild(self, _state: &mut Self::State) {}

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -1,7 +1,10 @@
+use self::attribute::Attribute;
 use crate::{
+    hydration::Cursor,
     no_attrs,
-    renderer::Renderer,
-    view::{Position, Render, RenderHtml},
+    prelude::AddAnyAttr,
+    renderer::{CastFrom, Renderer},
+    view::{Position, PositionState, Render, RenderHtml},
 };
 use std::marker::PhantomData;
 
@@ -76,8 +79,100 @@ where
 
     fn hydrate<const FROM_SERVER: bool>(
         self,
-        _cursor: &crate::hydration::Cursor<R>,
-        _position: &crate::view::PositionState,
+        _cursor: &Cursor<R>,
+        _position: &PositionState,
     ) -> Self::State {
+    }
+}
+
+/// An element that contains no interactivity, and whose contents can be known at compile time.
+pub struct InertElement {
+    tag: &'static str,
+    html: &'static str,
+}
+
+impl InertElement {
+    /// Creates a new inert element.
+    pub fn new(tag: &'static str, html: &'static str) -> Self {
+        Self { tag, html }
+    }
+}
+
+impl<Rndr> Render<Rndr> for InertElement
+where
+    Rndr: Renderer,
+{
+    type State = Rndr::Element;
+
+    fn build(self) -> Self::State {
+        todo!()
+    }
+
+    fn rebuild(self, _state: &mut Self::State) {}
+}
+
+impl<Rndr> AddAnyAttr<Rndr> for InertElement
+where
+    Rndr: Renderer,
+{
+    type Output<SomeNewAttr: Attribute<Rndr>> = Self;
+
+    fn add_any_attr<NewAttr: Attribute<Rndr>>(
+        self,
+        _attr: NewAttr,
+    ) -> Self::Output<NewAttr>
+    where
+        Self::Output<NewAttr>: RenderHtml<Rndr>,
+    {
+        panic!(
+            "InertElement does not support adding attributes. It should only \
+             be used as a child, and not returned at the top level."
+        )
+    }
+}
+
+impl<Rndr> RenderHtml<Rndr> for InertElement
+where
+    Rndr: Renderer,
+{
+    type AsyncOutput = Self;
+
+    const MIN_LENGTH: usize = 0;
+
+    fn html_len(&self) -> usize {
+        self.html.len()
+    }
+
+    fn dry_resolve(&mut self) {}
+
+    async fn resolve(self) -> Self {
+        self
+    }
+
+    fn to_html_with_buf(
+        self,
+        buf: &mut String,
+        position: &mut Position,
+        _escape: bool,
+        _mark_branches: bool,
+    ) {
+        buf.push_str(self.html);
+        *position = Position::NextChild;
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        cursor: &Cursor<Rndr>,
+        position: &PositionState,
+    ) -> Self::State {
+        let curr_position = position.get();
+        if curr_position == Position::FirstChild {
+            cursor.child();
+        } else if curr_position != Position::Current {
+            cursor.sibling();
+        }
+        let el = Rndr::Element::cast_from(cursor.current()).unwrap();
+        position.set(Position::NextChild);
+        el
     }
 }

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -92,8 +92,8 @@ pub struct InertElement {
 
 impl InertElement {
     /// Creates a new inert element.
-    pub fn new(html: Cow<'static, str>) -> Self {
-        Self { html }
+    pub fn new(html: impl Into<Cow<'static, str>>) -> Self {
+        Self { html: html.into() }
     }
 }
 

--- a/tachys/src/renderer/dom.rs
+++ b/tachys/src/renderer/dom.rs
@@ -391,8 +391,11 @@ impl DomRenderer for Dom {
             .unchecked_into()
     }
 
-    fn create_element_with_tag_name(name: &str) -> Self::Element {
-        document().create_element(name).unwrap()
+    fn create_element_from_html(html: &str) -> Self::Element {
+        // TODO can be optimized to cache HTML strings or cache <template>?
+        let tpl = document().create_element("template").unwrap();
+        tpl.set_inner_html(html);
+        Self::clone_template(tpl.unchecked_ref())
     }
 }
 

--- a/tachys/src/renderer/dom.rs
+++ b/tachys/src/renderer/dom.rs
@@ -390,6 +390,10 @@ impl DomRenderer for Dom {
             .unwrap()
             .unchecked_into()
     }
+
+    fn create_element_with_tag_name(name: &str) -> Self::Element {
+        document().create_element(name).unwrap()
+    }
 }
 
 impl Mountable<Dom> for Node {

--- a/tachys/src/renderer/mock_dom.rs
+++ b/tachys/src/renderer/mock_dom.rs
@@ -300,6 +300,10 @@ impl DomRenderer for MockDom {
     fn clone_template(tpl: &Self::TemplateElement) -> Self::Element {
         todo!()
     }
+
+    fn create_element_with_tag_name(name: &str) -> Self::Element {
+        document().create_element(name)
+    }
 }
 
 impl Default for Document {

--- a/tachys/src/renderer/mock_dom.rs
+++ b/tachys/src/renderer/mock_dom.rs
@@ -301,8 +301,8 @@ impl DomRenderer for MockDom {
         todo!()
     }
 
-    fn create_element_with_tag_name(name: &str) -> Self::Element {
-        document().create_element(name)
+    fn create_element_from_html(html: &str) -> Self::Element {
+        todo!()
     }
 }
 

--- a/tachys/src/renderer/mod.rs
+++ b/tachys/src/renderer/mod.rs
@@ -206,6 +206,9 @@ pub trait DomRenderer: Renderer {
         value: &str,
     );
 
+    /// Creates an element from the given tag name.
+    fn create_element_with_tag_name(name: &str) -> Self::Element;
+
     /// Sets the `innerHTML` of a DOM element, without escaping any values.
     fn set_inner_html(el: &Self::Element, html: &str);
 
@@ -213,6 +216,7 @@ pub trait DomRenderer: Renderer {
     fn get_template<V>() -> Self::TemplateElement
     where
         V: ToTemplate + 'static;
+
     /// Deeply clones a template.
     fn clone_template(tpl: &Self::TemplateElement) -> Self::Element;
 }

--- a/tachys/src/renderer/mod.rs
+++ b/tachys/src/renderer/mod.rs
@@ -206,9 +206,6 @@ pub trait DomRenderer: Renderer {
         value: &str,
     );
 
-    /// Creates an element from the given tag name.
-    fn create_element_with_tag_name(name: &str) -> Self::Element;
-
     /// Sets the `innerHTML` of a DOM element, without escaping any values.
     fn set_inner_html(el: &Self::Element, html: &str);
 
@@ -219,6 +216,9 @@ pub trait DomRenderer: Renderer {
 
     /// Deeply clones a template.
     fn clone_template(tpl: &Self::TemplateElement) -> Self::Element;
+
+    /// Creates a single element from a string of HTML.
+    fn create_element_from_html(html: &str) -> Self::Element;
 }
 
 /// Attempts to cast from one type to another.

--- a/tachys/src/renderer/sledgehammer.rs
+++ b/tachys/src/renderer/sledgehammer.rs
@@ -560,6 +560,10 @@ impl DomRenderer for Sledgehammer {
         });
         node
     }
+
+    fn create_element_with_tag_name(name: &str) -> Self::Element {
+        todo!()
+    }
 }
 
 impl Mountable<Sledgehammer> for SNode {

--- a/tachys/src/renderer/sledgehammer.rs
+++ b/tachys/src/renderer/sledgehammer.rs
@@ -561,7 +561,7 @@ impl DomRenderer for Sledgehammer {
         node
     }
 
-    fn create_element_with_tag_name(name: &str) -> Self::Element {
+    fn create_element_from_html(html: &str) -> Self::Element {
         todo!()
     }
 }


### PR DESCRIPTION
One of the main architectural shifts between Leptos 0.1-0.6 and 0.7 is the shift from a type-erased `View` enum to a fully-typed view tree. This enables the compiler to generate much more efficient code, because it knows (for example) that `move || something.get().to_string()` can *only ever* generate `String` text nodes, and never any other kind of view: so it does not need to emit code to handle swapping one branch of the old `View` enum for another. This has led to significant binary-size reductions on the order of 20-30% in many example applications.

On the other hand, creating deeply-nested generic types seems to have catastrophic effects on compile times. In particular, representing a big tree of static HTML with many nested components as a tree of `HtmlElement<El, Attributes, Children, Renderer>` structs creates massive slowdowns in rustc as that tree becomes larger. 0.7 uses the Rust *language* in a perfectly reasonable way to compose behavior, but in a way that the Rust *compiler* cannot actually handle very well in terms of its own performance.

This PR optimizes a specific case: Within the `view` macro, it replaces children that consist entirely of plain, static HTML with no dynamic attributes or dynamic children with a single `InertElement` type, compiling that segment of the tree into a static string.

This has several benefits:
- decrease compile times slightly in the general, relatively-dynamic case by optimizing the inert (non-dynamic) parts of the page
- decrease compile times massively for applications with large static portions of HTML in the view macro, because the proc-macro code to generate the static HTML is significantly faster than the trait-based approach for these cases
- increases server rendering performance marginally by pushing one big static string rather than many small static strings, which on average will reduce reallocations slightly
- reduces WASM binary sizes by some amount by shipping inert portions of client-rendered apps as a single static str and a pair of `createElement`/`innerHTML` calls
- increases hydration speed, because inert elements can simply be skipped over rather than walked through entirely

I can't see any downside to this PR (granted that anything it breaks can and should be fixed.) I'd appreciate feedback from people with real-sized applications who can help test compile time improvements.