### PR TITLE
StaticRouteGenerator's generate wait for initial fs write

### DIFF
--- a/router/src/static_routes.rs
+++ b/router/src/static_routes.rs
@@ -313,7 +313,6 @@ impl ResolvedStaticPath {
                     // awaiting the Future
                     _ = tx.send((owner.clone(), Some(html)));
                 } else {
-                    _ = tx.send((owner.clone(), None));
                     if let Err(e) = writer(&self, &owner, html).await {
                         #[cfg(feature = "tracing")]
                         tracing::warn!("{e}");
@@ -321,6 +320,7 @@ impl ResolvedStaticPath {
                         #[cfg(not(feature = "tracing"))]
                         eprintln!("{e}");
                     }
+                    _ = tx.send((owner.clone(), None));
                 }
 
                 // if there's a regeneration function, keep looping


### PR DESCRIPTION
I'm not sure if this was intended behaviour but I was trying to use leptos as Static site generator, so main with something like

```rust
#[tokio::main]
async fn main() {
    let conf = get_configuration(None).unwrap();
    let addr = conf.leptos_options.site_addr;
    let leptos_options = conf.leptos_options;

    let (_, static_routes) = generate_route_list_with_ssg({
        let leptos_options = leptos_options.clone();
        move || shell(leptos_options.clone())
    });

    static_routes.generate(&leptos_options).await;
}
```

this didn't worked but if I added a `tokio::sleep` for a few seconds before exiting it worked, which is not how I think should be the default behaviour.

I noticed the oneshot send was being called before writer was called and so it was not being awaited in sync, this moves tx.send after writer. Now generate().await works without additional waits, I'm not sure if this affects anything else, i.e SSR or something as I'm just using leptos as I'm just using it as SSG