### PR TITLE
Changes related to stack overflows

### DIFF
--- a/tachys/src/html/element/custom.rs
+++ b/tachys/src/html/element/custom.rs
@@ -17,8 +17,6 @@ where
         rndr: PhantomData,
         attributes: (),
         children: (),
-        #[cfg(debug_assertions)]
-        defined_at: std::panic::Location::caller(),
     }
 }
 

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -35,8 +35,6 @@ macro_rules! html_element_inner {
                     attributes: (),
                     children: (),
                     rndr: PhantomData,
-                    #[cfg(debug_assertions)]
-                    defined_at: std::panic::Location::caller()
                 }
             }
 
@@ -63,17 +61,12 @@ macro_rules! html_element_inner {
                         At: NextTuple,
                         <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V, Rndr>>: Attribute<Rndr>,
                     {
-                        let HtmlElement { tag, rndr, children, attributes,
-                            #[cfg(debug_assertions)]
-                            defined_at
-                        } = self;
+                        let HtmlElement { tag, rndr, children, attributes } = self;
                         HtmlElement {
                             tag,
                             rndr,
                             children,
                             attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
-                            #[cfg(debug_assertions)]
-                            defined_at
                         }
                     }
                 )*
@@ -161,8 +154,6 @@ macro_rules! html_self_closing_elements {
                         children: (),
                         rndr: PhantomData,
                         tag: [<$tag:camel>],
-                        #[cfg(debug_assertions)]
-                        defined_at: std::panic::Location::caller()
                     }
                 }
 
@@ -191,16 +182,12 @@ macro_rules! html_self_closing_elements {
 
                         {
                             let HtmlElement { tag, rndr, children, attributes,
-                                #[cfg(debug_assertions)]
-                                defined_at
                             } = self;
                             HtmlElement {
                                 tag,
                                 rndr,
                                 children,
                                 attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
-                                #[cfg(debug_assertions)]
-                                defined_at
                             }
                         }
                     )*

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -32,8 +32,6 @@ pub struct HtmlElement<E, At, Ch, Rndr> {
     pub(crate) rndr: PhantomData<Rndr>,
     pub(crate) attributes: At,
     pub(crate) children: Ch,
-    #[cfg(debug_assertions)]
-    pub(crate) defined_at: &'static std::panic::Location<'static>,
 }
 
 impl<E: Clone, At: Clone, Ch: Clone, Rndr> Clone
@@ -45,8 +43,6 @@ impl<E: Clone, At: Clone, Ch: Clone, Rndr> Clone
             rndr: PhantomData,
             attributes: self.attributes.clone(),
             children: self.children.clone(),
-            #[cfg(debug_assertions)]
-            defined_at: self.defined_at,
         }
     }
 }
@@ -85,16 +81,12 @@ where
             rndr,
             attributes,
             children,
-            #[cfg(debug_assertions)]
-            defined_at,
         } = self;
         HtmlElement {
             tag,
             rndr,
             attributes,
             children: children.next_tuple(child),
-            #[cfg(debug_assertions)]
-            defined_at,
         }
     }
 }
@@ -122,16 +114,12 @@ where
             attributes,
             children,
             rndr,
-            #[cfg(debug_assertions)]
-            defined_at,
         } = self;
         HtmlElement {
             tag,
             attributes: attributes.add_any_attr(attr),
             children,
             rndr,
-            #[cfg(debug_assertions)]
-            defined_at,
         }
     }
 }
@@ -262,8 +250,6 @@ where
             rndr: PhantomData,
             attributes,
             children,
-            #[cfg(debug_assertions)]
-            defined_at: self.defined_at,
         }
     }
 

--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -26,17 +26,12 @@ macro_rules! mathml_global {
 				At: NextTuple,
 				<At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V, Rndr>>: Attribute<Rndr>,
 			{
-				let HtmlElement { tag, rndr, children, attributes,
-                    #[cfg(debug_assertions)]
-                    defined_at
-                } = self;
+				let HtmlElement { tag, rndr, children, attributes } = self;
 				HtmlElement {
 					tag,
 					rndr,
 					children,
 					attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
-                    #[cfg(debug_assertions)]
-                    defined_at
 				}
 			}
 		}
@@ -59,8 +54,6 @@ macro_rules! mathml_elements {
                         attributes: (),
                         children: (),
                         rndr: PhantomData,
-                        #[cfg(debug_assertions)]
-                        defined_at: std::panic::Location::caller()
                     }
                 }
 
@@ -95,17 +88,12 @@ macro_rules! mathml_elements {
                             At: NextTuple,
                             <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V, Rndr>>: Attribute<Rndr>,
                         {
-                            let HtmlElement { tag, rndr, children, attributes,
-                                #[cfg(debug_assertions)]
-                                defined_at
-                            } = self;
+                            let HtmlElement { tag, rndr, children, attributes } = self;
                             HtmlElement {
                                 tag,
                                 rndr,
                                 children,
                                 attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
-                                #[cfg(debug_assertions)]
-                                defined_at
                             }
                         }
 					)*

--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -27,8 +27,6 @@ macro_rules! svg_elements {
                         attributes: (),
                         children: (),
                         rndr: PhantomData,
-                        #[cfg(debug_assertions)]
-                        defined_at: std::panic::Location::caller()
                     }
                 }
 

--- a/tachys/src/view/add_attr.rs
+++ b/tachys/src/view/add_attr.rs
@@ -1,4 +1,4 @@
-use super::RenderHtml;
+use super::{BoxedView, RenderHtml};
 use crate::{html::attribute::Attribute, renderer::Renderer};
 
 /// Allows adding a new attribute to some type, before it is rendered.
@@ -43,4 +43,23 @@ macro_rules! no_attrs {
             }
         }
     };
+}
+
+impl<T, Rndr> AddAnyAttr<Rndr> for BoxedView<T>
+where
+    T: AddAnyAttr<Rndr>,
+    Rndr: Renderer,
+{
+    type Output<SomeNewAttr: Attribute<Rndr>> =
+        BoxedView<T::Output<SomeNewAttr>>;
+
+    fn add_any_attr<NewAttr: Attribute<Rndr>>(
+        self,
+        attr: NewAttr,
+    ) -> Self::Output<NewAttr>
+    where
+        Self::Output<NewAttr>: RenderHtml<Rndr>,
+    {
+        BoxedView::new(self.into_inner().add_any_attr(attr))
+    }
 }


### PR DESCRIPTION
This branch included some work intended to begin addressing #2971, which was fixed separately by the work in #2989. 

`BoxedView<T>` may be useful in some cases anyway, and the removal of unused debugging fields is probably useful as well.