### PR TITLE
Fix stores

### DIFF
--- a/reactive_stores/src/arc_field.rs
+++ b/reactive_stores/src/arc_field.rs
@@ -78,7 +78,6 @@ impl<T> StoreField for ArcField<T> {
     type Value = T;
     type Reader = StoreFieldReader<T>;
     type Writer = StoreFieldWriter<T>;
-    type UntrackedWriter = StoreFieldWriter<T>;
 
     fn get_trigger(&self, path: StorePath) -> ArcTrigger {
         (self.get_trigger)(path)
@@ -94,12 +93,6 @@ impl<T> StoreField for ArcField<T> {
 
     fn writer(&self) -> Option<Self::Writer> {
         (self.write)().map(StoreFieldWriter::new)
-    }
-
-    fn untracked_writer(&self) -> Option<Self::UntrackedWriter> {
-        let mut writer = (self.write)().map(StoreFieldWriter::new)?;
-        writer.untrack();
-        Some(writer)
     }
 
     fn keys(&self) -> Option<KeyMap> {

--- a/reactive_stores/src/arc_field.rs
+++ b/reactive_stores/src/arc_field.rs
@@ -1,12 +1,10 @@
 use crate::{
     path::{StorePath, StorePathSegment},
-    AtIndex, AtKeyed, KeyMap, KeyedSubfield, StoreField, Subfield,
+    AtIndex, AtKeyed, KeyMap, KeyedSubfield, StoreField, StoreFieldTrigger,
+    Subfield,
 };
-use reactive_graph::{
-    signal::ArcTrigger,
-    traits::{
-        DefinedAt, IsDisposed, Notify, ReadUntracked, Track, UntrackableGuard,
-    },
+use reactive_graph::traits::{
+    DefinedAt, IsDisposed, Notify, ReadUntracked, Track, UntrackableGuard,
 };
 use std::{
     fmt::Debug,
@@ -23,8 +21,8 @@ where
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
     path: StorePath,
-    trigger: ArcTrigger,
-    get_trigger: Arc<dyn Fn(StorePath) -> ArcTrigger + Send + Sync>,
+    trigger: StoreFieldTrigger,
+    get_trigger: Arc<dyn Fn(StorePath) -> StoreFieldTrigger + Send + Sync>,
     read: Arc<dyn Fn() -> Option<StoreFieldReader<T>> + Send + Sync>,
     write: Arc<dyn Fn() -> Option<StoreFieldWriter<T>> + Send + Sync>,
     keys: Arc<dyn Fn() -> Option<KeyMap> + Send + Sync>,
@@ -79,7 +77,7 @@ impl<T> StoreField for ArcField<T> {
     type Reader = StoreFieldReader<T>;
     type Writer = StoreFieldWriter<T>;
 
-    fn get_trigger(&self, path: StorePath) -> ArcTrigger {
+    fn get_trigger(&self, path: StorePath) -> StoreFieldTrigger {
         (self.get_trigger)(path)
     }
 
@@ -236,13 +234,14 @@ impl<T> DefinedAt for ArcField<T> {
 
 impl<T> Notify for ArcField<T> {
     fn notify(&self) {
-        self.trigger.notify();
+        self.trigger.this.notify();
     }
 }
 
 impl<T> Track for ArcField<T> {
     fn track(&self) {
-        self.trigger.track();
+        self.trigger.this.track();
+        self.trigger.children.track();
     }
 }
 

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -1,11 +1,11 @@
 use crate::{
     arc_field::{StoreFieldReader, StoreFieldWriter},
     path::{StorePath, StorePathSegment},
-    ArcField, AtIndex, AtKeyed, KeyMap, KeyedSubfield, StoreField, Subfield,
+    ArcField, AtIndex, AtKeyed, KeyMap, KeyedSubfield, StoreField,
+    StoreFieldTrigger, Subfield,
 };
 use reactive_graph::{
     owner::{Storage, StoredValue, SyncStorage},
-    signal::ArcTrigger,
     traits::{DefinedAt, IsDisposed, Notify, ReadUntracked, Track},
     unwrap_signal,
 };
@@ -28,7 +28,7 @@ where
     type Reader = StoreFieldReader<T>;
     type Writer = StoreFieldWriter<T>;
 
-    fn get_trigger(&self, path: StorePath) -> ArcTrigger {
+    fn get_trigger(&self, path: StorePath) -> StoreFieldTrigger {
         self.inner
             .try_get_value()
             .map(|inner| inner.get_trigger(path))

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -27,7 +27,6 @@ where
     type Value = T;
     type Reader = StoreFieldReader<T>;
     type Writer = StoreFieldWriter<T>;
-    type UntrackedWriter = StoreFieldWriter<T>;
 
     fn get_trigger(&self, path: StorePath) -> ArcTrigger {
         self.inner
@@ -49,12 +48,6 @@ where
 
     fn writer(&self) -> Option<Self::Writer> {
         self.inner.try_get_value().and_then(|inner| inner.writer())
-    }
-
-    fn untracked_writer(&self) -> Option<Self::UntrackedWriter> {
-        self.inner
-            .try_get_value()
-            .and_then(|inner| inner.untracked_writer())
     }
 
     fn keys(&self) -> Option<KeyMap> {

--- a/reactive_stores/src/iter.rs
+++ b/reactive_stores/src/iter.rs
@@ -69,8 +69,6 @@ where
     type Reader = MappedMutArc<Inner::Reader, Prev::Output>;
     type Writer =
         MappedMutArc<WriteGuard<ArcTrigger, Inner::Writer>, Prev::Output>;
-    type UntrackedWriter =
-        MappedMutArc<WriteGuard<ArcTrigger, Inner::Writer>, Prev::Output>;
 
     fn path(&self) -> impl IntoIterator<Item = StorePathSegment> {
         self.inner
@@ -102,12 +100,6 @@ where
             move |n| &n[index],
             move |n| &mut n[index],
         ))
-    }
-
-    fn untracked_writer(&self) -> Option<Self::UntrackedWriter> {
-        let mut guard = self.writer()?;
-        guard.untrack();
-        Some(guard)
     }
 
     #[inline(always)]

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -38,21 +38,33 @@ pub use store_field::{StoreField, Then};
 pub use subfield::Subfield;
 
 #[derive(Debug, Default)]
-struct TriggerMap(FxHashMap<StorePath, ArcTrigger>);
+struct TriggerMap(FxHashMap<StorePath, StoreFieldTrigger>);
+
+#[derive(Debug, Clone, Default)]
+pub struct StoreFieldTrigger {
+    pub this: ArcTrigger,
+    pub children: ArcTrigger,
+}
+
+impl StoreFieldTrigger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 
 impl TriggerMap {
-    fn get_or_insert(&mut self, key: StorePath) -> ArcTrigger {
+    fn get_or_insert(&mut self, key: StorePath) -> StoreFieldTrigger {
         if let Some(trigger) = self.0.get(&key) {
             trigger.clone()
         } else {
-            let new = ArcTrigger::new();
+            let new = StoreFieldTrigger::new();
             self.0.insert(key, new.clone());
             new
         }
     }
 
     #[allow(unused)]
-    fn remove(&mut self, key: &StorePath) -> Option<ArcTrigger> {
+    fn remove(&mut self, key: &StorePath) -> Option<StoreFieldTrigger> {
         self.0.remove(key)
     }
 }
@@ -240,13 +252,17 @@ where
 
 impl<T: 'static> Track for ArcStore<T> {
     fn track(&self) {
-        self.get_trigger(Default::default()).track();
+        let trigger = self.get_trigger(Default::default());
+        trigger.this.track();
+        trigger.children.track();
     }
 }
 
 impl<T: 'static> Notify for ArcStore<T> {
     fn notify(&self) {
-        self.get_trigger(self.path().into_iter().collect()).notify();
+        self.get_trigger(self.path().into_iter().collect())
+            .this
+            .notify();
     }
 }
 

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -482,9 +482,8 @@ mod tests {
         tick().await;
         store.user().update(|name| name.push_str("!!!"));
         tick().await;
-        // TODO known to be broken, I just need to fix CI for now
-        // the effect reads from `user`, so it should trigger every time
-        //assert_eq!(combined_count.load(Ordering::Relaxed), 1);
+        // the effect reads from `todos`, so it shouldn't trigger every time
+        assert_eq!(combined_count.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]

--- a/reactive_stores/src/patch.rs
+++ b/reactive_stores/src/patch.rs
@@ -32,7 +32,7 @@ where
             // don't track the writer for the whole store
             writer.untrack();
             let mut notify = |path: &StorePath| {
-                self.get_trigger(path.to_owned()).notify();
+                self.get_trigger(path.to_owned()).this.notify();
             };
             writer.patch_field(new, &path, &mut notify);
         }

--- a/reactive_stores/src/subfield.rs
+++ b/reactive_stores/src/subfield.rs
@@ -73,8 +73,6 @@ where
     type Value = T;
     type Reader = Mapped<Inner::Reader, T>;
     type Writer = MappedMut<WriteGuard<ArcTrigger, Inner::Writer>, T>;
-    type UntrackedWriter =
-        MappedMut<WriteGuard<ArcTrigger, Inner::UntrackedWriter>, T>;
 
     fn path(&self) -> impl IntoIterator<Item = StorePathSegment> {
         self.inner
@@ -95,12 +93,6 @@ where
     fn writer(&self) -> Option<Self::Writer> {
         let trigger = self.get_trigger(self.path().into_iter().collect());
         let inner = WriteGuard::new(trigger, self.inner.writer()?);
-        Some(MappedMut::new(inner, self.read, self.write))
-    }
-
-    fn untracked_writer(&self) -> Option<Self::UntrackedWriter> {
-        let trigger = self.get_trigger(self.path().into_iter().collect());
-        let inner = WriteGuard::new(trigger, self.inner.untracked_writer()?);
         Some(MappedMut::new(inner, self.read, self.write))
     }
 

--- a/reactive_stores/src/subfield.rs
+++ b/reactive_stores/src/subfield.rs
@@ -1,7 +1,7 @@
 use crate::{
     path::{StorePath, StorePathSegment},
     store_field::StoreField,
-    KeyMap,
+    KeyMap, StoreFieldTrigger,
 };
 use reactive_graph::{
     signal::{
@@ -81,7 +81,7 @@ where
             .chain(iter::once(self.path_segment))
     }
 
-    fn get_trigger(&self, path: StorePath) -> ArcTrigger {
+    fn get_trigger(&self, path: StorePath) -> StoreFieldTrigger {
         self.inner.get_trigger(path)
     }
 
@@ -92,7 +92,7 @@ where
 
     fn writer(&self) -> Option<Self::Writer> {
         let trigger = self.get_trigger(self.path().into_iter().collect());
-        let inner = WriteGuard::new(trigger, self.inner.writer()?);
+        let inner = WriteGuard::new(trigger.children, self.inner.writer()?);
         Some(MappedMut::new(inner, self.read, self.write))
     }
 
@@ -134,7 +134,7 @@ where
 {
     fn notify(&self) {
         let trigger = self.get_trigger(self.path().into_iter().collect());
-        trigger.notify();
+        trigger.this.notify();
     }
 }
 
@@ -145,9 +145,9 @@ where
     T: 'static,
 {
     fn track(&self) {
-        self.inner.track();
         let trigger = self.get_trigger(self.path().into_iter().collect());
-        trigger.track();
+        trigger.this.track();
+        trigger.children.track();
     }
 }
 


### PR DESCRIPTION
The current implementation has some issues when trying to manage 
a) triggering parents when a child changes, and
b) triggering children when a parent changes, without
c) triggering siblings (because child changed > triggers parent > triggers all other children)

Separating this out into two separate sets of triggers, one for "notify me and my parents" and one for "notify me and my children," seems to get the test cases into the correct shape. (Demo app also continues to work fine.)