### PR TITLE
WIP added generic types for server fns

### DIFF
--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -12,12 +12,12 @@ use server_fn::{
     request::{browser::BrowserRequest, ClientReq, Req},
     response::{browser::BrowserResponse, ClientRes, Res},
 };
-use std::future::Future;
 #[cfg(feature = "ssr")]
 use std::sync::{
     atomic::{AtomicU8, Ordering},
     Mutex,
 };
+use std::{fmt::Display, future::Future};
 use strum::{Display, EnumString};
 use wasm_bindgen::JsCast;
 use web_sys::{FormData, HtmlFormElement, SubmitEvent};
@@ -781,6 +781,19 @@ where
 pub struct WhyNotResult {
     original: String,
     modified: String,
+}
+
+#[server]
+pub async fn test_fn<S>(
+    first: S,
+    second: S,
+) -> Result<WhyNotResult, ServerFnError>
+where
+    S: Display + Send + DeserializeOwned + Serialize + 'static,
+{
+    let original = first.to_string();
+    let modified = format!("{original}{second}");
+    Ok(WhyNotResult { original, modified })
 }
 
 #[server(

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -242,6 +242,11 @@ pub fn server_macro_impl(
                 #server_fn_path::codec::Json
             }
         });
+
+    let (impl_generics, ty_generics, where_clause) =
+        body.generics.split_for_impl();
+    let turbofish_ty_generics = ty_generics.as_turbofish();
+
     // default to PascalCase version of function name if no struct name given
     let struct_name = struct_name.unwrap_or_else(|| {
         let upper_camel_case_name = Converter::new()
@@ -253,15 +258,15 @@ pub fn server_macro_impl(
 
     // struct name, wrapped in any custom-encoding newtype wrapper
     let wrapped_struct_name = if let Some(wrapper) = custom_wrapper.as_ref() {
-        quote! { #wrapper<#struct_name> }
+        quote! { #wrapper::<#struct_name #ty_generics> }
     } else {
-        quote! { #struct_name }
+        quote! { #struct_name #ty_generics }
     };
     let wrapped_struct_name_turbofish =
         if let Some(wrapper) = custom_wrapper.as_ref() {
-            quote! { #wrapper::<#struct_name> }
+            quote! { #wrapper::<#struct_name #ty_generics> }
         } else {
-            quote! { #struct_name }
+            quote! { #struct_name #ty_generics }
         };
 
     // build struct for type
@@ -301,16 +306,16 @@ pub fn server_macro_impl(
             let field = first_field.unwrap();
             let (name, ty) = field;
             quote! {
-                impl From<#struct_name> for #ty {
-                    fn from(value: #struct_name) -> Self {
-                        let #struct_name { #name } = value;
+                impl #impl_generics From<#struct_name #ty_generics> for #ty #where_clause {
+                    fn from(value: #struct_name #ty_generics) -> Self {
+                        let #struct_name #turbofish_ty_generics { #name } = value;
                         #name
                     }
                 }
 
-                impl From<#ty> for #struct_name {
+                impl #impl_generics From<#ty> for #struct_name #ty_generics #where_clause {
                     fn from(#name: #ty) -> Self {
-                        #struct_name { #name }
+                        #struct_name #turbofish_ty_generics { #name }
                     }
                 }
             }
@@ -386,11 +391,11 @@ pub fn server_macro_impl(
     let run_body = if cfg!(feature = "ssr") {
         let destructure = if let Some(wrapper) = custom_wrapper.as_ref() {
             quote! {
-                let #wrapper(#struct_name { #(#field_names),* }) = self;
+                let #wrapper(#struct_name #turbofish_ty_generics { #(#field_names),* }) = self;
             }
         } else {
             quote! {
-                let #struct_name { #(#field_names),* } = self;
+                let #struct_name #turbofish_ty_generics { #(#field_names),* } = self;
             }
         };
 
@@ -439,7 +444,7 @@ pub fn server_macro_impl(
         quote! {
             #docs
             #(#attrs)*
-            #vis async fn #fn_name(#(#fn_args),*) #output_arrow #return_ty {
+            #vis async fn #fn_name #ty_generics (#(#fn_args),*) #output_arrow #return_ty #where_clause {
                 #dummy_name(#(#field_names),*).await
             }
         }
@@ -447,18 +452,18 @@ pub fn server_macro_impl(
         let restructure = if let Some(custom_wrapper) = custom_wrapper.as_ref()
         {
             quote! {
-                let data = #custom_wrapper(#struct_name { #(#field_names),* });
+                let data = #custom_wrapper(#struct_name #turbofish_ty_generics { #(#field_names),* });
             }
         } else {
             quote! {
-                let data = #struct_name { #(#field_names),* };
+                let data = #struct_name #turbofish_ty_generics { #(#field_names),* };
             }
         };
         quote! {
             #docs
             #(#attrs)*
             #[allow(unused_variables)]
-            #vis async fn #fn_name(#(#fn_args),*) #output_arrow #return_ty {
+            #vis async fn #fn_name #ty_generics (#(#fn_args),*) #output_arrow #return_ty #where_clause {
                 use #server_fn_path::ServerFn;
                 #restructure
                 data.run_on_client().await
@@ -625,18 +630,18 @@ pub fn server_macro_impl(
         quote! { vec![] }
     };
 
-    Ok(quote::quote! {
+    let quote = quote::quote! {
         #args_docs
         #docs
         #[derive(Debug, #derives)]
         #addl_path
-        pub struct #struct_name {
+        pub struct #struct_name #ty_generics #where_clause {
             #(#fields),*
         }
 
         #from_impl
 
-        impl #server_fn_path::ServerFn for #wrapped_struct_name {
+        impl #impl_generics #server_fn_path::ServerFn for #wrapped_struct_name #where_clause {
             const PATH: &'static str = #path;
 
             type Client = #client;
@@ -659,7 +664,13 @@ pub fn server_macro_impl(
         #func
 
         #dummy
-    })
+    };
+
+    if !ty_generics.into_token_stream().is_empty() {
+        println!("{}", quote);
+    }
+
+    Ok(quote)
 }
 
 fn type_from_ident(ident: Ident) -> Type {
@@ -1042,7 +1053,7 @@ impl Parse for ServerFnBody {
 
         let fn_token = input.parse()?;
         let ident = input.parse()?;
-        let generics: Generics = input.parse()?;
+        let mut generics = input.parse::<Generics>()?;
 
         let content;
         let _paren_token = syn::parenthesized!(content in input);
@@ -1051,6 +1062,7 @@ impl Parse for ServerFnBody {
 
         let output_arrow = input.parse()?;
         let return_ty = input.parse()?;
+        generics.where_clause = input.parse()?;
 
         let block = input.parse()?;
 


### PR DESCRIPTION
I'm still getting the following error when compiling `server_fn_axum`:

```
error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'_>`
   --> src/app.rs:787:14
    |
787 | pub async fn test_fn<S>(
    |              ^^^^^^^^^^
    |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'_>` found
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
...
792 |     S: Display + Send + DeserializeOwned + Serialize + 'static,
    |                         ^^^^^^^^^^^^^^^^
note: required for `TestFn<S>` to implement `app::_::_serde::Deserialize<'de>`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^--------
    | |
    | unsatisfied trait bound introduced here
787 | pub async fn test_fn<S>(
    |              ^^^^^^^^^^
    = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` which comes from the expansion of the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'de>`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
    |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'de>` found
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
...
792 |     S: Display + Send + DeserializeOwned + Serialize + 'static,
    |                         ^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'_>`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
    |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'_>` found
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
...
792 |     S: Display + Send + DeserializeOwned + Serialize + 'static,
    |                         ^^^^^^^^^^^^^^^^
note: required for `app::_::<impl app::_::_serde::Deserialize<'de> for TestFn<S>>::deserialize::__Visitor<'de, S>` to implement `Visitor<'de>`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'_>`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
    |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'_>` found
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^
...
792 |     S: Display + Send + DeserializeOwned + Serialize + 'static,
    |                         ^^^^^^^^^^^^^^^^
note: required by a bound in `app::_::<impl app::_::_serde::Deserialize<'de> for TestFn<S>>::deserialize::__Visitor`
   --> src/app.rs:786:1
    |
786 | #[server]
    | ^^^^^^^^^ required by this bound in `__Visitor`
    = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'_>`
    --> src/app.rs:788:12
     |
788  |     first: S,
     |            ^
     |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'_>` found
    --> src/app.rs:786:1
     |
786  | #[server]
     | ^^^^^^^^^
...
792  |     S: Display + Send + DeserializeOwned + Serialize + 'static,
     |                         ^^^^^^^^^^^^^^^^
note: required by a bound in `next_element`
    --> /Users/rakshith/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.209/src/de/mod.rs:1733:12
     |
1731 |     fn next_element<T>(&mut self) -> Result<Option<T>, Self::Error>
     |        ------------ required by a bound in this associated function
1732 |     where
1733 |         T: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `SeqAccess::next_element`
     = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0283]: type annotations needed: cannot satisfy `S: app::_::_serde::Deserialize<'_>`
    --> src/app.rs:788:12
     |
788  |     first: S,
     |            ^
     |
note: multiple `impl`s or `where` clauses satisfying `S: app::_::_serde::Deserialize<'_>` found
    --> src/app.rs:786:1
     |
786  | #[server]
     | ^^^^^^^^^
...
792  |     S: Display + Send + DeserializeOwned + Serialize + 'static,
     |                         ^^^^^^^^^^^^^^^^
note: required by a bound in `next_value`
    --> /Users/rakshith/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.209/src/de/mod.rs:1872:12
     |
1870 |     fn next_value<V>(&mut self) -> Result<V, Self::Error>
     |        ---------- required by a bound in this associated function
1871 |     where
1872 |         V: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `MapAccess::next_value`
     = note: this error originates in the derive macro `::leptos::server_fn::serde::Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0283`.
error: could not compile `server_fns_axum` (lib) due to 9 previous errors
Error: Failed to build server_fns_axum

Stack backtrace:
   0: std::backtrace::Backtrace::create
   1: anyhow::error::<impl anyhow::Error>::msg
   2: cargo_leptos::run::{{closure}}
   3: tokio::runtime::park::CachedParkThread::block_on
   4: tokio::runtime::context::runtime::enter_runtime
   5: cargo_leptos::main
   6: std::sys::backtrace::__rust_begin_short_backtrace
   7: std::rt::lang_start::{{closure}}
   8: std::rt::lang_start_internal
   9: _main
Error while executing command, exit code: 1
```

For context, `test_fn` expands to this:

```
#[doc = "Serialized arguments for the [`test_fn`] server function.\n\n"]
#[derive(
    Debug,
    Clone,
    ::leptos::server_fn::serde::Serialize,
    ::leptos::server_fn::serde::Deserialize,
)]
#[serde(crate = "leptos::server_fn::serde")]
pub struct TestFn<S>
where
    S: Display + Send + DeserializeOwned + Serialize + 'static,
{
    pub first: S,
    pub second: S,
}
impl<S> ::leptos::server_fn::ServerFn for TestFn<S>
where
    S: Display + Send + DeserializeOwned + Serialize + 'static,
{
    const PATH: &'static str = if "".is_empty() {
        ::leptos::server_fn::const_format::concatcp!(
            "/api",
            "/",
            "test_fn",
            ::leptos::server_fn::xxhash_rust::const_xxh64::xxh64(
                concat!(
                    env!("CARGO_MANIFEST_DIR"),
                    ":",
                    file!(),
                    ":",
                    line!(),
                    ":",
                    column!()
                )
                .as_bytes(),
                0
            )
        )
    } else {
        ::leptos::server_fn::const_format::concatcp!("/api", "")
    };
    type Client = ::leptos::server_fn::client::browser::BrowserClient;
    type ServerRequest = ::leptos::server_fn::request::BrowserMockReq;
    type ServerResponse = ::leptos::server_fn::response::BrowserMockRes;
    type Output = WhyNotResult;
    type InputEncoding = ::leptos::server_fn::codec::PostUrl;
    type OutputEncoding = ::leptos::server_fn::codec::Json;
    type Error = ::leptos::server_fn::error::NoCustomError;
    fn middlewares() -> Vec<
        std::sync::Arc<
            dyn ::leptos::server_fn::middleware::Layer<
                ::leptos::server_fn::request::BrowserMockReq,
                ::leptos::server_fn::response::BrowserMockRes,
            >,
        >,
    > {
        vec![]
    }
    #[allow(unused_variables)]
    async fn run_body(self) -> Result<WhyNotResult, ServerFnError> {
        unreachable!()
    }
}
#[allow(unused_variables)]
pub async fn test_fn<S>(
    first: S,
    second: S,
) -> Result<WhyNotResult, ServerFnError>
where
    S: Display + Send + DeserializeOwned + Serialize + 'static,
{
    use ::leptos::server_fn::ServerFn;
    let data = TestFn::<S> { first, second };
    data.run_on_client().await
}
```

Not sure why this is happening. Any help on this would be appreciated