### PR TITLE
Replace proc-macro-error with proc-macro-error2

### DIFF
--- a/reactive_stores_macro/Cargo.toml
+++ b/reactive_stores_macro/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 
 [dependencies]
 convert_case = "0.6"
-proc-macro-error = "1.0"
+proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -1,6 +1,6 @@
 use convert_case::{Case, Casing};
 use proc_macro2::{Span, TokenStream};
-use proc_macro_error::{abort, abort_call_site, proc_macro_error};
+use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream, Parser},

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro-error = { version = "1.0", default-features = false }
+proc-macro-error2 = { version = "2.0", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
 

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::Span;
-use proc_macro_error::abort;
+use proc_macro_error2::abort;
 use quote::{quote, ToTokens};
 
 const RFC3986_UNRESERVED: [char; 4] = ['-', '.', '_', '~'];
@@ -25,7 +25,7 @@ const RFC3986_PCHAR_OTHER: [char; 1] = ['@'];
 ///
 /// assert_eq!(path, output);
 /// ```
-#[proc_macro_error::proc_macro_error]
+#[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 pub fn path(tokens: TokenStream) -> TokenStream {
     let mut parser = SegmentParser::new(tokens);


### PR DESCRIPTION
I ran cargo-audit on a project of mine that uses Leptos and got a warning that Leptos is using an unmaintained library: `proc-macro-error`. This PR replaces it with `proc-macro-error2`, a drop-in replacement. Interestingly, `leptos-macro` is already using the newer library.