### PR TITLE
remove unnecessary `PartialEq` trait bounds

### DIFF
--- a/reactive_graph/src/computed/arc_memo.rs
+++ b/reactive_graph/src/computed/arc_memo.rs
@@ -132,10 +132,7 @@ where
     pub fn new_with_compare(
         fun: impl Fn(Option<&T>) -> T + Send + Sync + 'static,
         changed: fn(Option<&T>, Option<&T>) -> bool,
-    ) -> Self
-    where
-        T: PartialEq,
-    {
+    ) -> Self {
         Self::new_owning(move |prev: Option<T>| {
             let new_value = fun(prev.as_ref());
             let changed = changed(prev.as_ref(), Some(&new_value));
@@ -157,10 +154,7 @@ where
     )]
     pub fn new_owning(
         fun: impl Fn(Option<T>) -> (T, bool) + Send + Sync + 'static,
-    ) -> Self
-    where
-        T: PartialEq,
-    {
+    ) -> Self {
         let inner = Arc::new_cyclic(|weak| {
             let subscriber = AnySubscriber(
                 weak.as_ptr() as usize,

--- a/reactive_graph/src/computed/memo.rs
+++ b/reactive_graph/src/computed/memo.rs
@@ -195,10 +195,7 @@ where
     pub fn new_with_compare(
         fun: impl Fn(Option<&T>) -> T + Send + Sync + 'static,
         changed: fn(Option<&T>, Option<&T>) -> bool,
-    ) -> Self
-    where
-        T: PartialEq,
-    {
+    ) -> Self {
         Self {
             #[cfg(debug_assertions)]
             defined_at: Location::caller(),
@@ -222,10 +219,7 @@ where
     )]
     pub fn new_owning(
         fun: impl Fn(Option<T>) -> (T, bool) + Send + Sync + 'static,
-    ) -> Self
-    where
-        T: PartialEq,
-    {
+    ) -> Self {
         Self {
             #[cfg(debug_assertions)]
             defined_at: Location::caller(),


### PR DESCRIPTION
This MR removes certain `PartialEq` bounds which are not required when creating a new Memo