### PR TITLE
Implement `IntoView` for `Arc<str>`

### DIFF
--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -1211,6 +1211,17 @@ impl IntoView for Rc<str> {
     }
 }
 
+impl IntoView for std::sync::Arc<str> {
+    #[cfg_attr(
+        any(debug_assertions, feature = "ssr"),
+        instrument(level = "trace", name = "#text", skip_all)
+    )]
+    #[inline(always)]
+    fn into_view(self) -> View {
+        View::Text(Text::new(self.into()))
+    }
+}
+
 impl IntoView for Oco<'static, str> {
     #[cfg_attr(
         any(debug_assertions, feature = "ssr"),


### PR DESCRIPTION
0.7 will be much harder to work with Rc, so this adds the Arc support in 0.6 to make it possible to transition away from Rc before taking the already-large step to 0.7.