### PR TITLE
feat: add `IntoRender` for rendering custom data

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -548,7 +548,9 @@ fn node_to_tokens(
             view_marker,
             disable_inert_html,
         ),
-        Node::Block(block) => Some(quote! { #block }),
+        Node::Block(block) => {
+            Some(quote! { ::leptos::prelude::IntoRender::into_render(#block) })
+        }
         Node::Text(text) => Some(text_to_tokens(&text.value)),
         Node::RawText(raw) => {
             let text = raw.to_string_best();

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -1365,14 +1365,20 @@ fn attribute_value(attr: &KeyedAttribute) -> TokenStream {
                     }
                 }
 
-                quote! {
-                    {#expr}
+                if matches!(expr, Expr::Lit(_)) {
+                    quote! {
+                        #expr
+                    }
+                } else {
+                    quote! {
+                        ::leptos::prelude::IntoAttributeValue::into_attribute_value(#expr)
+                    }
                 }
             }
             // any value in braces: expand as-is to give proper r-a support
             KVAttributeValue::InvalidBraced(block) => {
                 quote! {
-                    #block
+                    ::leptos::prelude::IntoAttributeValue::into_attribute_value(#block)
                 }
             }
         },

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -880,7 +880,7 @@ fn attribute_to_tokens(
                     NodeName::Path(path) => path.path.get_ident(),
                     _ => unreachable!(),
                 };
-                let value = attribute_value(node);
+                let value = attribute_value(node, false);
                 quote! {
                     .#node_ref(#value)
                 }
@@ -930,13 +930,13 @@ fn attribute_to_tokens(
                 // we don't provide statically-checked methods for SVG attributes
                 || (tag_type == TagType::Svg && name != "inner_html")
             {
-                let value = attribute_value(node);
+                let value = attribute_value(node, true);
                 quote! {
                     .attr(#name, #value)
                 }
             } else {
                 let key = attribute_name(&node.key);
-                let value = attribute_value(node);
+                let value = attribute_value(node, true);
 
                 // special case of global_class and class attribute
                 if &node.key.to_string() == "class"
@@ -973,11 +973,11 @@ pub(crate) fn attribute_absolute(
                 let id = &parts[0];
                 match id {
                     NodeNameFragment::Ident(id) => {
-                        let value = attribute_value(node);
                         // ignore `let:` and `clone:`
                         if id == "let" || id == "clone" {
                             None
                         } else if id == "attr" {
+                        let value = attribute_value(node, true);
                             let key = &parts[1];
                             let key_name = key.to_string();
                             if key_name == "class" || key_name == "style" {
@@ -985,6 +985,7 @@ pub(crate) fn attribute_absolute(
                                     quote! { ::leptos::tachys::html::#key::#key(#value) },
                                 )
                             } else if key_name == "aria" {
+                        let value = attribute_value(node, true);
                                 let mut parts_iter = parts.iter();
                                 parts_iter.next();
                                 let fn_name = parts_iter.map(|p| p.to_string()).collect::<Vec<String>>().join("_");
@@ -998,6 +999,7 @@ pub(crate) fn attribute_absolute(
                                 )
                             }
                         } else if id == "use" {
+                        let value = attribute_value(node, false);
                             let key = &parts[1];
                             let param = if let Some(value) = node.value() {
                                 quote!(#value)
@@ -1013,6 +1015,7 @@ pub(crate) fn attribute_absolute(
                                 },
                             )
                         } else if id == "style" || id == "class" {
+                        let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key
                                 .replacen("style:", "", 1)
@@ -1021,12 +1024,14 @@ pub(crate) fn attribute_absolute(
                                 quote! { ::leptos::tachys::html::#id::#id((#key, #value)) },
                             )
                         } else if id == "prop" {
+                        let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key.replacen("prop:", "", 1);
                             Some(
                                 quote! { ::leptos::tachys::html::property::#id(#key, #value) },
                             )
                         } else if id == "on" {
+                        let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key.replacen("on:", "", 1);
                             let (on, ty, handler) =
@@ -1077,7 +1082,7 @@ pub(crate) fn two_way_binding_to_tokens(
     name: &str,
     node: &KeyedAttribute,
 ) -> TokenStream {
-    let value = attribute_value(node);
+    let value = attribute_value(node, false);
 
     let ident =
         format_ident!("{}", name.to_case(UpperCamel), span = node.key.span());
@@ -1102,7 +1107,7 @@ pub(crate) fn event_type_and_handler(
     name: &str,
     node: &KeyedAttribute,
 ) -> (TokenStream, TokenStream, TokenStream) {
-    let handler = attribute_value(node);
+    let handler = attribute_value(node, false);
 
     let (event_type, is_custom, is_force_undelegated, is_targeted) =
         parse_event_name(name);
@@ -1159,7 +1164,7 @@ fn class_to_tokens(
     class: TokenStream,
     class_name: Option<&str>,
 ) -> TokenStream {
-    let value = attribute_value(node);
+    let value = attribute_value(node, false);
     if let Some(class_name) = class_name {
         quote! {
             .#class((#class_name, #value))
@@ -1176,7 +1181,7 @@ fn style_to_tokens(
     style: TokenStream,
     style_name: Option<&str>,
 ) -> TokenStream {
-    let value = attribute_value(node);
+    let value = attribute_value(node, false);
     if let Some(style_name) = style_name {
         quote! {
             .#style((#style_name, #value))
@@ -1193,7 +1198,7 @@ fn prop_to_tokens(
     prop: TokenStream,
     key: &str,
 ) -> TokenStream {
-    let value = attribute_value(node);
+    let value = attribute_value(node, false);
     quote! {
         .#prop(#key, #value)
     }
@@ -1350,7 +1355,10 @@ fn attribute_name(name: &NodeName) -> TokenStream {
     }
 }
 
-fn attribute_value(attr: &KeyedAttribute) -> TokenStream {
+fn attribute_value(
+    attr: &KeyedAttribute,
+    is_attribute_proper: bool,
+) -> TokenStream {
     match attr.possible_value.to_value() {
         None => quote! { true },
         Some(value) => match &value.value {
@@ -1365,7 +1373,7 @@ fn attribute_value(attr: &KeyedAttribute) -> TokenStream {
                     }
                 }
 
-                if matches!(expr, Expr::Lit(_)) {
+                if matches!(expr, Expr::Lit(_)) || !is_attribute_proper {
                     quote! {
                         #expr
                     }
@@ -1377,8 +1385,14 @@ fn attribute_value(attr: &KeyedAttribute) -> TokenStream {
             }
             // any value in braces: expand as-is to give proper r-a support
             KVAttributeValue::InvalidBraced(block) => {
-                quote! {
-                    ::leptos::prelude::IntoAttributeValue::into_attribute_value(#block)
+                if is_attribute_proper {
+                    quote! {
+                        ::leptos::prelude::IntoAttributeValue::into_attribute_value(#block)
+                    }
+                } else {
+                    quote! {
+                        #block
+                    }
                 }
             }
         },

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -985,7 +985,7 @@ pub(crate) fn attribute_absolute(
                                     quote! { ::leptos::tachys::html::#key::#key(#value) },
                                 )
                             } else if key_name == "aria" {
-                        let value = attribute_value(node, true);
+                                let value = attribute_value(node, true);
                                 let mut parts_iter = parts.iter();
                                 parts_iter.next();
                                 let fn_name = parts_iter.map(|p| p.to_string()).collect::<Vec<String>>().join("_");
@@ -999,7 +999,6 @@ pub(crate) fn attribute_absolute(
                                 )
                             }
                         } else if id == "use" {
-                        let value = attribute_value(node, false);
                             let key = &parts[1];
                             let param = if let Some(value) = node.value() {
                                 quote!(#value)
@@ -1015,7 +1014,7 @@ pub(crate) fn attribute_absolute(
                                 },
                             )
                         } else if id == "style" || id == "class" {
-                        let value = attribute_value(node, false);
+                            let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key
                                 .replacen("style:", "", 1)
@@ -1024,14 +1023,13 @@ pub(crate) fn attribute_absolute(
                                 quote! { ::leptos::tachys::html::#id::#id((#key, #value)) },
                             )
                         } else if id == "prop" {
-                        let value = attribute_value(node, false);
+                            let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key.replacen("prop:", "", 1);
                             Some(
                                 quote! { ::leptos::tachys::html::property::#id(#key, #value) },
                             )
                         } else if id == "on" {
-                        let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key.replacen("on:", "", 1);
                             let (on, ty, handler) =

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-/// Declares that can be converted into some other type, which is a valid attribute value.
+/// Declares that this type can be converted into some other type, which is a valid attribute value.
 pub trait IntoAttributeValue {
     /// The attribute value into which this type can be converted.
     type Output;

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -11,6 +11,26 @@ use std::{
     sync::Arc,
 };
 
+/// Declares that can be converted into some other type, which is a valid attribute value.
+pub trait IntoAttributeValue {
+    /// The attribute value into which this type can be converted.
+    type Output;
+
+    /// Consumes this value, transforming it into an attribute value.
+    fn into_attribute_value(self) -> Self::Output;
+}
+
+impl<T> IntoAttributeValue for T
+where
+    T: AttributeValue,
+{
+    type Output = Self;
+
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
 /// A possible value for an HTML attribute.
 pub trait AttributeValue: Send {
     /// The state that should be retained between building and rebuilding.

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -19,6 +19,7 @@ pub mod prelude {
                     OnAttribute, OnTargetAttribute, PropAttribute,
                     StyleAttribute,
                 },
+                IntoAttributeValue,
             },
             directive::DirectiveAttribute,
             element::{ElementChild, ElementExt, InnerHtmlAttribute},

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -26,8 +26,8 @@ pub mod prelude {
         },
         renderer::{dom::Dom, Renderer},
         view::{
-            add_attr::AddAnyAttr, any_view::IntoAny, Mountable, Render,
-            RenderHtml,
+            add_attr::AddAnyAttr, any_view::IntoAny, IntoRender, Mountable,
+            Render, RenderHtml,
         },
     };
 }

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -433,9 +433,12 @@ pub enum Position {
     LastChild,
 }
 
+/// Declares that this type can be converted into some other type, which can be renderered.
 pub trait IntoRender {
+    /// The renderable type into which this type can be converted.
     type Output;
 
+    /// Consumes this value, transforming it into the renderable type.
     fn into_render(self) -> Self::Output;
 }
 

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -432,3 +432,20 @@ pub enum Position {
     /// This is the last child of its parent.
     LastChild,
 }
+
+pub trait IntoRender {
+    type Output;
+
+    fn into_render(self) -> Self::Output;
+}
+
+impl<T> IntoRender for T
+where
+    T: Render,
+{
+    type Output = Self;
+
+    fn into_render(self) -> Self::Output {
+        self
+    }
+}


### PR DESCRIPTION
One of the nice things about 0.6 was that you could implement `IntoView` on arbitrary types pretty easily, by just declaring how they created a type-erased `View`. 0.7 makes this harder by requiring additional method boilerplate. This PR restores a similar functionality by allowing you to implement an `IntoRender` trait on arbitrary types that consists of a single method converting them into an output type, which can either be explicitly named or `AnyView`.

`IntoRender` is blanket implemented for any type that already implements `Render`.

The `view` macro will automatically insert `.into_render()` on all blocks (`{ ... }`) that are in the view. This is because, elements, components, and text nodes already have defined behaviors that we know don't need custom implementations; the only way to use a custom type in `view!` is within a block. If you are outside the view macro (for example, you are mapping over types), you can call `.into_render()` manually.

In the same way, this adds an `IntoAttributeValue` trait that can be used for custom attribute values. `.into_attribute_value()` will automatically be called on any non-literal attribute value in the `view`.

```rust
#[component]
pub fn App() -> impl IntoView {
) -> impl IntoView {
    view! {
        <div>{Foo(42, "test".to_string())} {Bar::A(13)}</div>
        {Foo(37, "outer".to_string())}
        {Baz(101, "more complicated view".to_string())}
    }
}

struct Foo(u8, String);

impl IntoRender for Foo {
    type Output = (&'static str, u8, &'static str, String);

    fn into_render(self) -> Self::Output {
        ("id:", self.0, "message:", self.1)
    }
}

enum Bar {
    A(u8),
    B(String),
}

impl IntoRender for Bar {
    type Output = Either<u8, String>;

    fn into_render(self) -> Self::Output {
        match self {
            Bar::A(id) => Either::Left(id),
            Bar::B(message) => Either::Right(message),
        }
    }
}

struct Baz(u8, String);

impl IntoRender for Baz {
    type Output = AnyView;

    fn into_render(self) -> Self::Output {
        view! {
            <p class="baz">
                <span id=Foo(212, "NY".into())>{self.0}</span>
                <div id=self.1>"Something else"</div>
            </p>
        }
        .into_any()
    }
}

// Implementing attribute values works exactly the same
impl IntoAttributeValue for Foo {
    type Output = String;

    fn into_attribute_value(self) -> Self::Output {
        let Foo(num, text) = self;
        format!("{num}-{text}")
    }
}
```