### PR TITLE
Use the `Track` trait for the `Signal` wrapper.

### DIFF
--- a/reactive_graph/src/serde.rs
+++ b/reactive_graph/src/serde.rs
@@ -75,7 +75,7 @@ impl<T: Serialize + 'static, St: Storage<T>> Serialize for ArcMemo<T, St> {
 
 impl<T, St> Serialize for MaybeSignal<T, St>
 where
-    T: Send + Sync + Serialize,
+    T: Clone + Send + Sync + Serialize,
     St: Storage<SignalTypes<T, St>> + Storage<T>,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/reactive_graph/src/signal/guards.rs
+++ b/reactive_graph/src/signal/guards.rs
@@ -623,3 +623,46 @@ where
         Display::fmt(&**self, f)
     }
 }
+
+/// A wrapper that implements [`Deref`] and [`Borrow`] for itself.
+pub struct Derefable<T>(pub T);
+
+impl<T> Clone for Derefable<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Derefable(self.0.clone())
+    }
+}
+
+impl<T> std::ops::Deref for Derefable<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Borrow<T> for Derefable<T> {
+    fn borrow(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<T> PartialEq<T> for Derefable<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.deref() == other
+    }
+}
+
+impl<T> Display for Derefable<T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}

--- a/reactive_graph/src/traits.rs
+++ b/reactive_graph/src/traits.rs
@@ -171,7 +171,7 @@ pub trait ReadUntracked: Sized + DefinedAt {
 
     /// This is a backdoor to allow overriding the [`Read::try_read`] implementation despite it being auto implemented.
     ///
-    /// If your type containsa [`Signal`](crate::wrappers::read::Signal),
+    /// If your type contains a [`Signal`](crate::wrappers::read::Signal),
     /// call it's [`ReadUntracked::custom_try_read`] here, else return `None`.
     #[track_caller]
     fn custom_try_read(&self) -> Option<Option<Self::Value>> {

--- a/reactive_graph/src/traits.rs
+++ b/reactive_graph/src/traits.rs
@@ -168,11 +168,20 @@ pub trait ReadUntracked: Sized + DefinedAt {
         self.try_read_untracked()
             .unwrap_or_else(unwrap_signal!(self))
     }
+
+    /// This is a backdoor to allow overriding the [`Read::try_read`] implementation despite it being auto implemented.
+    ///
+    /// If your type containsa [`Signal`](crate::wrappers::read::Signal),
+    /// call it's [`ReadUntracked::custom_try_read`] here, else return `None`.
+    #[track_caller]
+    fn custom_try_read(&self) -> Option<Option<Self::Value>> {
+        None
+    }
 }
 
 /// Give read-only access to a signal's value by reference through a guard type,
 /// and subscribes the active reactive observer (an effect or computed) to changes in its value.
-pub trait Read {
+pub trait Read: DefinedAt {
     /// The guard type that will be returned, which can be dereferenced to the value.
     type Value: Deref;
 
@@ -185,7 +194,9 @@ pub trait Read {
     /// # Panics
     /// Panics if you try to access a signal that has been disposed.
     #[track_caller]
-    fn read(&self) -> Self::Value;
+    fn read(&self) -> Self::Value {
+        self.try_read().unwrap_or_else(unwrap_signal!(self))
+    }
 }
 
 impl<T> Read for T
@@ -195,13 +206,18 @@ where
     type Value = T::Value;
 
     fn try_read(&self) -> Option<Self::Value> {
-        self.track();
-        self.try_read_untracked()
-    }
-
-    fn read(&self) -> Self::Value {
-        self.track();
-        self.read_untracked()
+        // The [`Read`] trait is auto implemented for types that implement [`ReadUntracked`] + [`Track`]. The [`Read`] trait then auto implements the [`With`] and [`Get`] traits too.
+        //
+        // This is a problem for e.g. the [`Signal`](crate::wrappers::read::Signal) type,
+        // this type must use a custom [`Read::try_read`] implementation to avoid an unnecessary clone.
+        //
+        // This is a backdoor to allow overriding the [`Read::try_read`] implementation despite it being auto implemented.
+        if let Some(custom) = self.custom_try_read() {
+            custom
+        } else {
+            self.track();
+            self.try_read_untracked()
+        }
     }
 }
 
@@ -307,14 +323,13 @@ pub trait With: DefinedAt {
 
 impl<T> With for T
 where
-    T: WithUntracked + Track,
+    T: Read,
 {
-    type Value = <T as WithUntracked>::Value;
+    type Value = <<T as Read>::Value as Deref>::Target;
 
     #[track_caller]
     fn try_with<U>(&self, fun: impl FnOnce(&Self::Value) -> U) -> Option<U> {
-        self.track();
-        self.try_with_untracked(fun)
+        self.try_read().map(|val| fun(&val))
     }
 }
 

--- a/reactive_graph/src/wrappers.rs
+++ b/reactive_graph/src/wrappers.rs
@@ -15,7 +15,6 @@ pub mod read {
         },
         traits::{
             DefinedAt, Dispose, Get, Read, ReadUntracked, ReadValue, Track,
-            With, WithValue,
         },
         unwrap_signal,
     };
@@ -201,29 +200,6 @@ pub mod read {
         }
     }
 
-    impl<T, S> ArcSignal<T, S>
-    where
-        S: Storage<T>,
-    {
-        /// Subscribes to this signal in the current reactive scope without doing anything with its value.
-        #[track_caller]
-        pub fn track(&self) {
-            match &self.inner {
-                SignalTypes::ReadSignal(i) => {
-                    i.track();
-                }
-                SignalTypes::Memo(i) => {
-                    i.track();
-                }
-                SignalTypes::DerivedSignal(i) => {
-                    i();
-                }
-                // Doesn't change.
-                SignalTypes::Stored(_) => {}
-            }
-        }
-    }
-
     impl<T> Default for ArcSignal<T, SyncStorage>
     where
         T: Default + Send + Sync + 'static,
@@ -285,22 +261,23 @@ pub mod read {
         }
     }
 
-    impl<T, S> With for ArcSignal<T, S>
+    impl<T, S> Track for ArcSignal<T, S>
     where
         S: Storage<T>,
-        T: Clone,
     {
-        type Value = T;
-
-        fn try_with<U>(
-            &self,
-            fun: impl FnOnce(&Self::Value) -> U,
-        ) -> Option<U> {
+        fn track(&self) {
             match &self.inner {
-                SignalTypes::ReadSignal(i) => i.try_with(fun),
-                SignalTypes::Memo(i) => i.try_with(fun),
-                SignalTypes::DerivedSignal(i) => Some(fun(&i())),
-                SignalTypes::Stored(i) => i.try_with_value(fun),
+                SignalTypes::ReadSignal(i) => {
+                    i.track();
+                }
+                SignalTypes::Memo(i) => {
+                    i.track();
+                }
+                SignalTypes::DerivedSignal(i) => {
+                    i();
+                }
+                // Doesn't change.
+                SignalTypes::Stored(_) => {}
             }
         }
     }
@@ -328,32 +305,27 @@ pub mod read {
             }
             .map(ReadGuard::new)
         }
-    }
 
-    impl<T, S> Read for ArcSignal<T, S>
-    where
-        S: Storage<T>,
-    {
-        type Value = ReadGuard<T, SignalReadGuard<T, S>>;
-
-        fn try_read(&self) -> Option<Self::Value> {
-            match &self.inner {
-                SignalTypes::ReadSignal(i) => {
-                    i.try_read().map(SignalReadGuard::Read)
+        /// Overriding the default auto implemented [`Read::try_read`] to combine read and track,
+        /// to avoid 2 clones and just have 1 in the [`SignalTypes::DerivedSignal`].
+        fn custom_try_read(&self) -> Option<Option<Self::Value>> {
+            Some(
+                match &self.inner {
+                    SignalTypes::ReadSignal(i) => {
+                        i.try_read().map(SignalReadGuard::Read)
+                    }
+                    SignalTypes::Memo(i) => {
+                        i.try_read().map(SignalReadGuard::Memo)
+                    }
+                    SignalTypes::DerivedSignal(i) => {
+                        Some(SignalReadGuard::Owned(i()))
+                    }
+                    SignalTypes::Stored(i) => {
+                        i.try_read_value().map(SignalReadGuard::Read)
+                    }
                 }
-                SignalTypes::Memo(i) => i.try_read().map(SignalReadGuard::Memo),
-                SignalTypes::DerivedSignal(i) => {
-                    Some(SignalReadGuard::Owned(i()))
-                }
-                SignalTypes::Stored(i) => {
-                    i.try_read_value().map(SignalReadGuard::Read)
-                }
-            }
-            .map(ReadGuard::new)
-        }
-
-        fn read(&self) -> Self::Value {
-            self.try_read().unwrap_or_else(unwrap_signal!(self))
+                .map(ReadGuard::new),
+            )
         }
     }
 
@@ -432,27 +404,31 @@ pub mod read {
         }
     }
 
-    impl<T, S> With for Signal<T, S>
+    impl<T, S> Track for Signal<T, S>
     where
         T: 'static,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
+        S: Storage<T> + Storage<SignalTypes<T, S>>,
     {
-        type Value = T;
-
-        fn try_with<U>(
-            &self,
-            fun: impl FnOnce(&Self::Value) -> U,
-        ) -> Option<U> {
-            self.inner
+        fn track(&self) {
+            let inner = self
+                .inner
                 // clone the inner Arc type and release the lock
                 // prevents deadlocking if the derived value includes taking a lock on the arena
                 .try_with_value(Clone::clone)
-                .and_then(|inner| match &inner {
-                    SignalTypes::ReadSignal(i) => i.try_with(fun),
-                    SignalTypes::Memo(i) => i.try_with(fun),
-                    SignalTypes::DerivedSignal(i) => Some(fun(&i())),
-                    SignalTypes::Stored(i) => i.try_with_value(fun),
-                })
+                .unwrap_or_else(unwrap_signal!(self));
+            match inner {
+                SignalTypes::ReadSignal(i) => {
+                    i.track();
+                }
+                SignalTypes::Memo(i) => {
+                    i.track();
+                }
+                SignalTypes::DerivedSignal(i) => {
+                    i();
+                }
+                // Doesn't change.
+                SignalTypes::Stored(_) => {}
+            }
         }
     }
 
@@ -486,41 +462,33 @@ pub mod read {
                     .map(ReadGuard::new)
                 })
         }
-    }
 
-    impl<T, S> Read for Signal<T, S>
-    where
-        T: 'static,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
-    {
-        type Value = ReadGuard<T, SignalReadGuard<T, S>>;
-
-        fn try_read(&self) -> Option<Self::Value> {
-            self.inner
-                // clone the inner Arc type and release the lock
-                // prevents deadlocking if the derived value includes taking a lock on the arena
-                .try_with_value(Clone::clone)
-                .and_then(|inner| {
-                    match &inner {
-                        SignalTypes::ReadSignal(i) => {
-                            i.try_read().map(SignalReadGuard::Read)
+        /// Overriding the default auto implemented [`Read::try_read`] to combine read and track,
+        /// to avoid 2 clones and just have 1 in the [`SignalTypes::DerivedSignal`].
+        fn custom_try_read(&self) -> Option<Option<Self::Value>> {
+            Some(
+                self.inner
+                    // clone the inner Arc type and release the lock
+                    // prevents deadlocking if the derived value includes taking a lock on the arena
+                    .try_with_value(Clone::clone)
+                    .and_then(|inner| {
+                        match &inner {
+                            SignalTypes::ReadSignal(i) => {
+                                i.try_read().map(SignalReadGuard::Read)
+                            }
+                            SignalTypes::Memo(i) => {
+                                i.try_read().map(SignalReadGuard::Memo)
+                            }
+                            SignalTypes::DerivedSignal(i) => {
+                                Some(SignalReadGuard::Owned(i()))
+                            }
+                            SignalTypes::Stored(i) => {
+                                i.try_read_value().map(SignalReadGuard::Read)
+                            }
                         }
-                        SignalTypes::Memo(i) => {
-                            i.try_read().map(SignalReadGuard::Memo)
-                        }
-                        SignalTypes::DerivedSignal(i) => {
-                            Some(SignalReadGuard::Owned(i()))
-                        }
-                        SignalTypes::Stored(i) => {
-                            i.try_read_value().map(SignalReadGuard::Read)
-                        }
-                    }
-                    .map(ReadGuard::new)
-                })
-        }
-
-        fn read(&self) -> Self::Value {
-            self.try_read().unwrap_or_else(unwrap_signal!(self))
+                        .map(ReadGuard::new)
+                    }),
+            )
         }
     }
 
@@ -616,36 +584,6 @@ pub mod read {
                 )),
                 #[cfg(debug_assertions)]
                 defined_at: std::panic::Location::caller(),
-            }
-        }
-    }
-
-    impl<T, S> Signal<T, S>
-    where
-        T: 'static,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
-    {
-        /// Subscribes to this signal in the current reactive scope without doing anything with its value.
-        #[track_caller]
-        pub fn track(&self) {
-            let inner = self
-                .inner
-                // clone the inner Arc type and release the lock
-                // prevents deadlocking if the derived value includes taking a lock on the arena
-                .try_with_value(Clone::clone)
-                .unwrap_or_else(unwrap_signal!(self));
-            match inner {
-                SignalTypes::ReadSignal(i) => {
-                    i.track();
-                }
-                SignalTypes::Memo(i) => {
-                    i.track();
-                }
-                SignalTypes::DerivedSignal(i) => {
-                    i();
-                }
-                // Doesn't change.
-                SignalTypes::Stored(_) => {}
             }
         }
     }
@@ -903,20 +841,14 @@ pub mod read {
         }
     }
 
-    impl<T, S> With for MaybeSignal<T, S>
+    impl<T, S> Track for MaybeSignal<T, S>
     where
-        T: Send + Sync + 'static,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
+        S: Storage<T> + Storage<SignalTypes<T, S>>,
     {
-        type Value = T;
-
-        fn try_with<U>(
-            &self,
-            fun: impl FnOnce(&Self::Value) -> U,
-        ) -> Option<U> {
+        fn track(&self) {
             match self {
-                Self::Static(t) => Some(fun(t)),
-                Self::Dynamic(s) => s.try_with(fun),
+                Self::Static(_) => {}
+                Self::Dynamic(signal) => signal.track(),
             }
         }
     }
@@ -936,26 +868,12 @@ pub mod read {
                 Self::Dynamic(s) => s.try_read_untracked(),
             }
         }
-    }
 
-    impl<T, S> Read for MaybeSignal<T, S>
-    where
-        T: Clone,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
-    {
-        type Value = ReadGuard<T, SignalReadGuard<T, S>>;
-
-        fn try_read(&self) -> Option<Self::Value> {
+        fn custom_try_read(&self) -> Option<Option<Self::Value>> {
             match self {
-                Self::Static(t) => {
-                    Some(ReadGuard::new(SignalReadGuard::Owned(t.clone())))
-                }
-                Self::Dynamic(s) => s.try_read(),
+                Self::Static(_) => None,
+                Self::Dynamic(s) => s.custom_try_read(),
             }
-        }
-
-        fn read(&self) -> Self::Value {
-            self.try_read().unwrap_or_else(unwrap_signal!(self))
         }
     }
 
@@ -977,21 +895,6 @@ pub mod read {
         /// reactive signals.
         pub fn derive_local(derived_signal: impl Fn() -> T + 'static) -> Self {
             Self::Dynamic(Signal::derive_local(derived_signal))
-        }
-    }
-
-    impl<T, S> MaybeSignal<T, S>
-    where
-        T: 'static,
-        S: Storage<SignalTypes<T, S>> + Storage<T>,
-    {
-        /// Subscribes to this signal in the current reactive scope without doing anything with its value.
-        #[track_caller]
-        pub fn track(&self) {
-            match self {
-                Self::Static(_) => {}
-                Self::Dynamic(signal) => signal.track(),
-            }
         }
     }
 
@@ -1192,20 +1095,14 @@ pub mod read {
         }
     }
 
-    impl<T, S> With for MaybeProp<T, S>
+    impl<T, S> Track for MaybeProp<T, S>
     where
-        T: Send + Sync + 'static,
-        S: Storage<SignalTypes<Option<T>, S>> + Storage<Option<T>>,
+        S: Storage<Option<T>> + Storage<SignalTypes<Option<T>, S>>,
     {
-        type Value = Option<T>;
-
-        fn try_with<U>(
-            &self,
-            fun: impl FnOnce(&Self::Value) -> U,
-        ) -> Option<U> {
+        fn track(&self) {
             match &self.0 {
-                None => Some(fun(&None)),
-                Some(inner) => inner.try_with(fun),
+                None => {}
+                Some(signal) => signal.track(),
             }
         }
     }
@@ -1223,24 +1120,12 @@ pub mod read {
                 Some(inner) => inner.try_read_untracked(),
             }
         }
-    }
 
-    impl<T, S> Read for MaybeProp<T, S>
-    where
-        T: Clone,
-        S: Storage<SignalTypes<Option<T>, S>> + Storage<Option<T>>,
-    {
-        type Value = ReadGuard<Option<T>, SignalReadGuard<Option<T>, S>>;
-
-        fn try_read(&self) -> Option<Self::Value> {
+        fn custom_try_read(&self) -> Option<Option<Self::Value>> {
             match &self.0 {
-                None => Some(ReadGuard::new(SignalReadGuard::Owned(None))),
-                Some(inner) => inner.try_read(),
+                None => None,
+                Some(inner) => inner.custom_try_read(),
             }
-        }
-
-        fn read(&self) -> Self::Value {
-            self.try_read().unwrap_or_else(unwrap_signal!(self))
         }
     }
 
@@ -1254,21 +1139,6 @@ pub mod read {
             derived_signal: impl Fn() -> Option<T> + Send + Sync + 'static,
         ) -> Self {
             Self(Some(MaybeSignal::derive(derived_signal)))
-        }
-    }
-
-    impl<T, S> MaybeProp<T, S>
-    where
-        T: 'static,
-        S: Storage<SignalTypes<Option<T>, S>> + Storage<Option<T>>,
-    {
-        /// Subscribes to this signal in the current reactive scope without doing anything with its value.
-        #[track_caller]
-        pub fn track(&self) {
-            match &self.0 {
-                None => {}
-                Some(signal) => signal.track(),
-            }
         }
     }
 

--- a/tachys/src/reactive_graph/node_ref.rs
+++ b/tachys/src/reactive_graph/node_ref.rs
@@ -1,7 +1,7 @@
 use crate::html::{element::ElementType, node_ref::NodeRefContainer};
 use reactive_graph::{
     signal::{
-        guards::{Plain, ReadGuard},
+        guards::{Derefable, ReadGuard},
         RwSignal,
     },
     traits::{DefinedAt, ReadUntracked, Set, Track},
@@ -83,13 +83,12 @@ where
     E: ElementType,
     E::Output: JsCast + Clone + 'static,
 {
-    type Value = ReadGuard<
-        Option<SendWrapper<<E as ElementType>::Output>>,
-        Plain<Option<SendWrapper<<E as ElementType>::Output>>>,
-    >;
+    type Value = ReadGuard<Option<E::Output>, Derefable<Option<E::Output>>>;
 
     fn try_read_untracked(&self) -> Option<Self::Value> {
-        self.0.try_read_untracked()
+        Some(ReadGuard::new(Derefable(
+            self.0.try_read_untracked()?.as_deref().cloned(),
+        )))
     }
 }
 


### PR DESCRIPTION
#3031 continuation, allow overriding the auto implemented `Read::try_read` implementation from the `ReadUntracked` trait. 

Doing so in this way means the normal `Track` trait can be used, and the double-clone fix propagates automatically to `MaybeSignal`, `MaybeProp` and any user created trait derivations involving the `Signal` wrapper.