### PR TITLE
chore: pin wasm-bindgen to 0.2.93 (does this fix example builds?)

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -45,7 +45,7 @@ web-sys = { version = "0.3.70", features = [
   "ShadowRootInit",
   "ShadowRootMode",
 ] }
-wasm-bindgen = "0.2.93"
+wasm-bindgen = "=0.2.93"
 serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.30"


### PR DESCRIPTION
We regularly need to update `cargo-leptos` to match `wasm-bindgen` version updates, as they declare their format incompatible between patch releases.

Unfortunately they also made breaking changes to `wasm-bindgen-cli-support` in 0.2.94 such that `cargo-leptos` no longer compiles, which means it will take us longer to update `cargo-leptos` than usual.

This means all our examples won't compile (because they pull in 0.2.94), and user code won't unless they pin to `=0.2.93`. For now, I'm going to try pinning to `=0.2.93` in `leptos` itself in the hope this will resolve that.

I opened an issue on `wasm-bindgen` but I don't anticipate particularly swift action there. I suspect we'll just need to deopt what cargo-leptos does there a bit and make a new release.
https://github.com/rustwasm/wasm-bindgen/issues/4159