### PR TITLE
Add missing tracing span when using `render_route_with_context` for `SsrMode::Async` on Leptos 0.6.15

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1031,9 +1031,7 @@ where
 
                 let (tx, rx) = futures::channel::oneshot::channel();
 
-                // capture current span to enable trace context propagation
                 let current_span = tracing::Span::current();
-
                 spawn_task!(async move {
                     let app = {
                         let full_path = full_path.clone();
@@ -1864,3 +1862,4 @@ where
         .await
         .map_err(|e| ServerFnError::ServerError(format!("{e:?}")))
 }
+

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1030,6 +1030,10 @@ where
                 let full_path = format!("http://leptos.dev{path}");
 
                 let (tx, rx) = futures::channel::oneshot::channel();
+
+                // capture current span to enable trace context propagation
+                let current_span = tracing::Span::current();
+
                 spawn_task!(async move {
                     let app = {
                         let full_path = full_path.clone();
@@ -1063,7 +1067,7 @@ where
                     *writable = new_res_parts;
 
                     _ = tx.send(html);
-                });
+                }.instrument(current_span));
 
                 let html = rx.await.expect("to complete HTML rendering");
 


### PR DESCRIPTION
I'm not sure if this is the right branch to merge, but this applies to Leptos `v0.6.15` and not the latest `main` branch for `v0.7-...`.

When using a custom leptos route handler (`render_route_with_context`), I noticed that traces where not being propagated if using `SsrMode::Async`. The other `SsrMode`s work correctly.

My handler:
```rust
#[tracing::instrument(skip_all)]
async fn leptos_routes_handler_protected(
    auth_session: AuthSession,
    read_session: ReadSession,
    State(app_state): State<AppState>,
    request: Request<Body>,
) -> axum::response::Response {
    let handler = leptos_axum::render_route_with_context(
        app_state.leptos_options.clone(),
        app_state.routes.clone(),
        move || {
            provide_context(auth_session.clone());
            provide_context(read_session.clone());
            provide_context(app_state.clone());
        },
        App,
    );

    handler(request).await.into_response()
}
```

Relevant logic:
```rust
#[tracing::instrument(level = "trace", fields(error), skip_all)]
pub fn render_route_with_context<IV>(
    options: LeptosOptions,
    paths: Vec<RouteListing>,
    additional_context: impl Fn() + 'static + Clone + Send,
    app_fn: impl Fn() -> IV + Clone + Send + 'static,
) -> impl Fn(
    Request<Body>,
) -> Pin<Box<dyn Future<Output = Response<Body>> + Send + 'static>>
       + Clone
       + Send
       + 'static
where
    IV: IntoView,
{
    let ooo = render_app_to_stream_with_context(
        LeptosOptions::from_ref(&options),
        additional_context.clone(),
        app_fn.clone(),
    );
    let pb = render_app_to_stream_with_context_and_replace_blocks(
        LeptosOptions::from_ref(&options),
        additional_context.clone(),
        app_fn.clone(),
        true,
    );
    let io = render_app_to_stream_in_order_with_context(
        LeptosOptions::from_ref(&options),
        additional_context.clone(),
        app_fn.clone(),
    );
    // <-- MISSING SPAN -->
    let asyn = render_app_async_stream_with_context(
        LeptosOptions::from_ref(&options),
        additional_context.clone(),
        app_fn.clone(),
    );
...
```

Before:
<img width="724" alt="image" src="https://github.com/user-attachments/assets/a33cb292-c3c0-4eeb-8520-0e7b8c90da93">


The other 3 function obtain the correct current span. I've added the same logic as the other 3 in the `render_app_async_stream_with_context` function.

After:
<img width="695" alt="image" src="https://github.com/user-attachments/assets/c67b9223-a7e4-470c-95d6-795de7693597">

Please ignore the fact that s3 is super slow from my region :P