### PR TITLE
Use full path to Result in Params derive

### DIFF
--- a/leptos_macro/src/params.rs
+++ b/leptos_macro/src/params.rs
@@ -32,7 +32,7 @@ pub fn params_impl(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
 
     let gen = quote! {
         impl Params for #name {
-            fn from_map(map: &::leptos_router::params::ParamsMap) -> Result<Self, ::leptos_router::params::ParamsError> {
+            fn from_map(map: &::leptos_router::params::ParamsMap) -> ::core::result::Result<Self, ::leptos_router::params::ParamsError> {
                 Ok(Self {
                     #(#fields,)*
                 })


### PR DESCRIPTION
Hello!

Just encountered this bug and decided to quickly fix it. Currently it fails if you define your own `Result` alias without second generic.

### Questions

- Should I also create a backport PR for branch with stable release?
- Should I bump version somewhere?