### PR TITLE
Use type erasure in router 

### DIFF
--- a/examples/hackernews/src/routes/nav.rs
+++ b/examples/hackernews/src/routes/nav.rs
@@ -21,10 +21,16 @@ pub fn Nav() -> impl IntoView {
                 <A href="/job">
                     <strong>"Jobs"</strong>
                 </A>
-                <a class="github" href="http://github.com/leptos-rs/leptos" target="_blank" rel="noreferrer">
+                <a
+                    class="github"
+                    href="http://github.com/leptos-rs/leptos"
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     "Built with Leptos"
                 </a>
             </nav>
         </header>
     }
+    .into_any()
 }

--- a/examples/hackernews/src/routes/stories.rs
+++ b/examples/hackernews/src/routes/stories.rs
@@ -50,30 +50,42 @@ pub fn Stories() -> impl IntoView {
         <div class="news-view">
             <div class="news-list-nav">
                 <span>
-                    {move || if page() > 1 {
-                        Either::Left(view! {
-                            <a class="page-link"
-                                href=move || format!("/{}?page={}", story_type(), page() - 1)
-                                aria-label="Previous Page"
-                            >
-                                "< prev"
-                            </a>
-                        })
-                    } else {
-                        Either::Right(view! {
-                            <span class="page-link disabled" aria-hidden="true">
-                                "< prev"
-                            </span>
-                        })
+                    {move || {
+                        if page() > 1 {
+                            Either::Left(
+                                view! {
+                                    <a
+                                        class="page-link"
+                                        href=move || {
+                                            format!("/{}?page={}", story_type(), page() - 1)
+                                        }
+                                        aria-label="Previous Page"
+                                    >
+                                        "< prev"
+                                    </a>
+                                },
+                            )
+                        } else {
+                            Either::Right(
+                                view! {
+                                    <span class="page-link disabled" aria-hidden="true">
+                                        "< prev"
+                                    </span>
+                                },
+                            )
+                        }
                     }}
+
                 </span>
                 <span>"page " {page}</span>
                 <Suspense>
-                    <span class="page-link"
+                    <span
+                        class="page-link"
                         class:disabled=hide_more_link
                         aria-hidden=hide_more_link
                     >
-                        <a href=move || format!("/{}?page={}", story_type(), page() + 1)
+                        <a
+                            href=move || format!("/{}?page={}", story_type(), page() + 1)
                             aria-label="Next Page"
                         >
                             "more >"
@@ -83,14 +95,10 @@ pub fn Stories() -> impl IntoView {
             </div>
             <main class="news-list">
                 <div>
-                    <Transition
-                        fallback=move || view! { <p>"Loading..."</p> }
-                        set_pending
-                    >
-                        <Show when=move || stories.read().as_ref().map(Option::is_none).unwrap_or(false)>
-                        >
-                            <p>"Error loading stories."</p>
-                        </Show>
+                    <Transition fallback=move || view! { <p>"Loading..."</p> } set_pending>
+                        <Show when=move || {
+                            stories.read().as_ref().map(Option::is_none).unwrap_or(false)
+                        }>> <p>"Error loading stories."</p></Show>
                         <ul>
                             <For
                                 each=move || stories.get().unwrap_or_default().unwrap_or_default()
@@ -105,54 +113,78 @@ pub fn Stories() -> impl IntoView {
             </main>
         </div>
     }
+    .into_any()
 }
 
 #[component]
 fn Story(story: api::Story) -> impl IntoView {
     view! {
-         <li class="news-item">
+        <li class="news-item">
             <span class="score">{story.points}</span>
             <span class="title">
                 {if !story.url.starts_with("item?id=") {
-                    Either::Left(view! {
-                        <span>
-                            <a href=story.url target="_blank" rel="noreferrer">
-                                {story.title.clone()}
-                            </a>
-                            <span class="host">"("{story.domain}")"</span>
-                        </span>
-                    })
+                    Either::Left(
+                        view! {
+                            <span>
+                                <a href=story.url target="_blank" rel="noreferrer">
+                                    {story.title.clone()}
+                                </a>
+                                <span class="host">"(" {story.domain} ")"</span>
+                            </span>
+                        },
+                    )
                 } else {
                     let title = story.title.clone();
                     Either::Right(view! { <A href=format!("/stories/{}", story.id)>{title}</A> })
                 }}
+
             </span>
-            <br />
+            <br/>
             <span class="meta">
                 {if story.story_type != "job" {
-                    Either::Left(view! {
-                        <span>
-                            {"by "}
-                            {story.user.map(|user| view ! {  <A href=format!("/users/{user}")>{user.clone()}</A>})}
-                            {format!(" {} | ", story.time_ago)}
-                            <A href=format!("/stories/{}", story.id)>
-                                {if story.comments_count.unwrap_or_default() > 0 {
-                                    format!("{} comments", story.comments_count.unwrap_or_default())
-                                } else {
-                                    "discuss".into()
-                                }}
-                            </A>
-                        </span>
-                    })
+                    Either::Left(
+                        view! {
+                            <span>
+                                {"by "}
+                                {story
+                                    .user
+                                    .map(|user| {
+                                        view! {
+                                            <A href=format!("/users/{user}")>{user.clone()}</A>
+                                        }
+                                    })} {format!(" {} | ", story.time_ago)}
+                                <A href=format!(
+                                    "/stories/{}",
+                                    story.id,
+                                )>
+                                    {if story.comments_count.unwrap_or_default() > 0 {
+                                        format!(
+                                            "{} comments",
+                                            story.comments_count.unwrap_or_default(),
+                                        )
+                                    } else {
+                                        "discuss".into()
+                                    }}
+
+                                </A>
+                            </span>
+                        },
+                    )
                 } else {
                     let title = story.title.clone();
                     Either::Right(view! { <A href=format!("/item/{}", story.id)>{title}</A> })
                 }}
+
             </span>
-            {(story.story_type != "link").then(|| view! {
-                " "
-                <span class="label">{story.story_type}</span>
-            })}
+            {(story.story_type != "link")
+                .then(|| {
+                    view! {
+                        " "
+                        <span class="label">{story.story_type}</span>
+                    }
+                })}
+
         </li>
     }
+    .into_any()
 }

--- a/examples/hackernews/src/routes/story.rs
+++ b/examples/hackernews/src/routes/story.rs
@@ -28,18 +28,21 @@ pub fn Story() -> impl IntoView {
                     <Meta name="description" content=story.title.clone()/>
                     <div class="item-view">
                         <div class="item-view-header">
-                        <a href=story.url target="_blank">
-                            <h1>{story.title}</h1>
-                        </a>
-                        <span class="host">
-                            "("{story.domain}")"
-                        </span>
-                        {story.user.map(|user| view! {  <p class="meta">
-                            {story.points}
-                            " points | by "
-                            <A href=format!("/users/{user}")>{user.clone()}</A>
-                            {format!(" {}", story.time_ago)}
-                        </p>})}
+                            <a href=story.url target="_blank">
+                                <h1>{story.title}</h1>
+                            </a>
+                            <span class="host">"(" {story.domain} ")"</span>
+                            {story
+                                .user
+                                .map(|user| {
+                                    view! {
+                                        <p class="meta">
+                                            {story.points} " points | by "
+                                            <A href=format!("/users/{user}")>{user.clone()}</A>
+                                            {format!(" {}", story.time_ago)}
+                                        </p>
+                                    }
+                                })}
                         </div>
                         <div class="item-view-comments">
                             <p class="item-view-comments-header">
@@ -48,6 +51,7 @@ pub fn Story() -> impl IntoView {
                                 } else {
                                     "No comments yet.".into()
                                 }}
+
                             </p>
                             <ul class="comment-children">
                                 <For
@@ -55,7 +59,7 @@ pub fn Story() -> impl IntoView {
                                     key=|comment| comment.id
                                     let:comment
                                 >
-                                    <Comment comment />
+                                    <Comment comment/>
                                 </For>
                             </ul>
                         </div>
@@ -64,6 +68,7 @@ pub fn Story() -> impl IntoView {
             }
         }
     }))).build())
+    .into_any()
 }
 
 #[component]
@@ -72,43 +77,65 @@ pub fn Comment(comment: api::Comment) -> impl IntoView {
 
     view! {
         <li class="comment">
-        <div class="by">
-            <A href=format!("/users/{}", comment.user.clone().unwrap_or_default())>{comment.user.clone()}</A>
-            {format!(" {}", comment.time_ago)}
-        </div>
-        <div class="text" inner_html=comment.content></div>
-        {(!comment.comments.is_empty()).then(|| {
-            view! {
-                <div>
-                    <div class="toggle" class:open=open>
-                        <a on:click=move |_| set_open.update(|n| *n = !*n)>
-                            {
-                                let comments_len = comment.comments.len();
-                                move || if open.get() {
-                                    "[-]".into()
-                                } else {
-                                    format!("[+] {}{} collapsed", comments_len, pluralize(comments_len))
-                                }
-                            }
-                        </a>
-                    </div>
-                    {move || open.get().then({
-                        let comments = comment.comments.clone();
-                        move || view! {
-                            <ul class="comment-children">
-                                <For
-                                    each=move || comments.clone()
-                                    key=|comment| comment.id
-                                    let:comment
-                                >
-                                    <Comment comment />
-                                </For>
-                            </ul>
-                        }
-                    })}
-                </div>
-            }
-        })}
+            <div class="by">
+                <A href=format!(
+                    "/users/{}",
+                    comment.user.clone().unwrap_or_default(),
+                )>{comment.user.clone()}</A>
+                {format!(" {}", comment.time_ago)}
+            </div>
+            <div class="text" inner_html=comment.content></div>
+            {(!comment.comments.is_empty())
+                .then(|| {
+                    view! {
+                        <div>
+                            <div class="toggle" class:open=open>
+                                <a on:click=move |_| {
+                                    set_open.update(|n| *n = !*n)
+                                }>
+
+                                    {
+                                        let comments_len = comment.comments.len();
+                                        move || {
+                                            if open.get() {
+                                                "[-]".into()
+                                            } else {
+                                                format!(
+                                                    "[+] {}{} collapsed",
+                                                    comments_len,
+                                                    pluralize(comments_len),
+                                                )
+                                            }
+                                        }
+                                    }
+
+                                </a>
+                            </div>
+                            {move || {
+                                open
+                                    .get()
+                                    .then({
+                                        let comments = comment.comments.clone();
+                                        move || {
+                                            view! {
+                                                <ul class="comment-children">
+                                                    <For
+                                                        each=move || comments.clone()
+                                                        key=|comment| comment.id
+                                                        let:comment
+                                                    >
+                                                        <Comment comment/>
+                                                    </For>
+                                                </ul>
+                                            }
+                                        }
+                                    })
+                            }}
+
+                        </div>
+                    }
+                })}
+
         </li>
     }.into_any()
 }

--- a/examples/hackernews/src/routes/users.rs
+++ b/examples/hackernews/src/routes/users.rs
@@ -18,30 +18,48 @@ pub fn User() -> impl IntoView {
     );
     view! {
         <div class="user-view">
-            <Suspense fallback=|| view! { "Loading..." }>
-                {move || Suspend::new(async move { match user.await.clone() {
-                    None => Either::Left(view! {  <h1>"User not found."</h1> }),
-                    Some(user) => Either::Right(view! {
-                        <div>
-                            <h1>"User: " {user.id.clone()}</h1>
-                            <ul class="meta">
-                                <li>
-                                    <span class="label">"Created: "</span> {user.created}
-                                </li>
-                                <li>
-                                <span class="label">"Karma: "</span> {user.karma}
-                                </li>
-                                <li inner_html={user.about} class="about"></li>
-                            </ul>
-                            <p class="links">
-                                <a href=format!("https://news.ycombinator.com/submitted?id={}", user.id)>"submissions"</a>
-                                " | "
-                                <a href=format!("https://news.ycombinator.com/threads?id={}", user.id)>"comments"</a>
-                            </p>
-                        </div>
-                    })
-                }})}
+            <Suspense fallback=|| {
+                view! { "Loading..." }
+            }>
+                {move || Suspend::new(async move {
+                    match user.await.clone() {
+                        None => Either::Left(view! { <h1>"User not found."</h1> }),
+                        Some(user) => {
+                            Either::Right(
+                                view! {
+                                    <div>
+                                        <h1>"User: " {user.id.clone()}</h1>
+                                        <ul class="meta">
+                                            <li>
+                                                <span class="label">"Created: "</span>
+                                                {user.created}
+                                            </li>
+                                            <li>
+                                                <span class="label">"Karma: "</span>
+                                                {user.karma}
+                                            </li>
+                                            <li inner_html=user.about class="about"></li>
+                                        </ul>
+                                        <p class="links">
+                                            <a href=format!(
+                                                "https://news.ycombinator.com/submitted?id={}",
+                                                user.id,
+                                            )>"submissions"</a>
+                                            " | "
+                                            <a href=format!(
+                                                "https://news.ycombinator.com/threads?id={}",
+                                                user.id,
+                                            )>"comments"</a>
+                                        </p>
+                                    </div>
+                                },
+                            )
+                        }
+                    }
+                })}
+
             </Suspense>
         </div>
     }
+    .into_any()
 }

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -51,7 +51,7 @@ pub struct FlatRoutesViewState {
     matched: ArcRwSignal<String>,
 }
 
-impl<Defs, Fal> Mountable for FlatRoutesViewState<Defs, Fal> {
+impl Mountable for FlatRoutesViewState {
     fn unmount(&mut self) {
         self.view.unmount();
     }
@@ -75,7 +75,6 @@ where
     Defs: MatchNestedRoutes + 'static,
     FalFn: FnOnce() -> Fal + Send,
     Fal: IntoAny,
-    R: Renderer + 'static,
 {
     type State = Rc<RefCell<FlatRoutesViewState>>;
 

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -40,7 +40,7 @@ pub(crate) struct FlatRoutesView<Loc, Defs, FalFn> {
     pub transition: bool,
 }
 
-pub struct FlatRoutesViewState<Defs, Fal> {
+pub struct FlatRoutesViewState {
     #[allow(clippy::type_complexity)]
     view: AnyViewState,
     id: Option<RouteMatchId>,
@@ -364,7 +364,7 @@ where
     FalFn: FnOnce() -> Fal + Send,
     Fal: RenderHtml + 'static,
 {
-    fn choose_ssr(self) -> OwnedView<AnyView, R> {
+    fn choose_ssr(self) -> OwnedView<AnyView> {
         let current_url = self.current_url.read_untracked();
         let new_match = self.routes.match_route(current_url.path());
         let owner = self.outer_owner.child();

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -417,10 +417,7 @@ where
 {
     type AsyncOutput = Self;
 
-    const MIN_LENGTH: usize = <Either<
-        Fal,
-        <Defs::Match as MatchInterface>::View,
-    > as RenderHtml>::MIN_LENGTH;
+    const MIN_LENGTH: usize = <Either<Fal, AnyView> as RenderHtml>::MIN_LENGTH;
 
     fn dry_resolve(&mut self) {}
 

--- a/router/src/matching/choose_view.rs
+++ b/router/src/matching/choose_view.rs
@@ -1,6 +1,6 @@
 use either_of::*;
 use std::{future::Future, marker::PhantomData};
-use tachys::view::{any_view::AnyView, Render};
+use tachys::view::any_view::{AnyView, IntoAny};
 
 pub trait ChooseView
 where
@@ -16,12 +16,12 @@ where
 impl<F, View> ChooseView for F
 where
     F: Fn() -> View + Send + Clone + 'static,
-    View: Render + Send,
+    View: IntoAny,
 {
-    type Output = View;
+    type Output = AnyView<R>;
 
     async fn choose(self) -> Self::Output {
-        self()
+        self().into_any()
     }
 
     async fn preload(&self) {}

--- a/router/src/matching/choose_view.rs
+++ b/router/src/matching/choose_view.rs
@@ -6,7 +6,7 @@ pub trait ChooseView
 where
     Self: Send + Clone + 'static,
 {
-    fn choose(self) -> impl Future<Output = AnyView<R>>;
+    fn choose(self) -> impl Future<Output = AnyView>;
 
     fn preload(&self) -> impl Future<Output = ()>;
 }
@@ -16,7 +16,7 @@ where
     F: Fn() -> View + Send + Clone + 'static,
     View: IntoAny,
 {
-    async fn choose(self) -> AnyView<R> {
+    async fn choose(self) -> AnyView {
         self().into_any()
     }
 
@@ -80,7 +80,7 @@ where
     A: ChooseView,
     B: ChooseView,
 {
-    async fn choose(self) -> AnyView<Rndr> {
+    async fn choose(self) -> AnyView {
         match self {
             Either::Left(f) => f.choose().await.into_any(),
             Either::Right(f) => f.choose().await.into_any(),
@@ -101,7 +101,7 @@ macro_rules! tuples {
         where
             $($ty: ChooseView,)*
         {
-            async fn choose(self ) -> AnyView<Rndr> {
+            async fn choose(self ) -> AnyView {
                 match self {
                     $($either::$ty(f) => f.choose().await.into_any(),)*
                 }

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -101,9 +101,7 @@ pub trait MatchInterface {
 
     fn as_matched(&self) -> &str;
 
-    fn into_view_and_child(
-        self,
-    ) -> (impl ChooseView<Output = Self::View>, Option<Self::Child>);
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>);
 }
 
 pub trait MatchParams {
@@ -114,7 +112,6 @@ pub trait MatchParams {
 
 pub trait MatchNestedRoutes {
     type Data;
-    type View;
     type Match: MatchInterface + MatchParams;
 
     fn match_nested<'a>(

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -10,7 +10,6 @@ use crate::{static_routes::RegenerationFn, Method, SsrMode};
 pub use horizontal::*;
 pub use nested::*;
 use std::{borrow::Cow, collections::HashSet};
-use tachys::view::{Render, RenderHtml};
 pub use vertical::*;
 
 #[derive(Debug)]
@@ -95,7 +94,6 @@ pub struct RouteMatchId(pub(crate) u16);
 
 pub trait MatchInterface {
     type Child: MatchInterface + MatchParams + 'static;
-    type View: Render + RenderHtml + Send + 'static;
 
     fn as_id(&self) -> RouteMatchId;
 

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -10,7 +10,6 @@ use std::{
     collections::HashSet,
     sync::atomic::{AtomicU16, Ordering},
 };
-use tachys::view::any_view::AnyView;
 
 mod tuples;
 
@@ -143,7 +142,6 @@ where
     View: ChooseView,
 {
     type Child = Child;
-    type View = AnyView;
 
     fn as_id(&self) -> RouteMatchId {
         self.id

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -143,7 +143,7 @@ where
     View: ChooseView,
 {
     type Child = Child;
-    type View = AnyView<Rndr>;
+    type View = AnyView;
 
     fn as_id(&self) -> RouteMatchId {
         self.id

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -10,7 +10,7 @@ use std::{
     collections::HashSet,
     sync::atomic::{AtomicU16, Ordering},
 };
-use tachys::view::{Render, RenderHtml};
+use tachys::{renderer::Renderer, view::any_view::AnyView};
 
 mod tuples;
 
@@ -141,10 +141,9 @@ impl<ParamsIter, Child, View> MatchInterface
 where
     Child: MatchInterface + MatchParams + 'static,
     View: ChooseView,
-    View::Output: Render + RenderHtml + Send + 'static,
 {
     type Child = Child;
-    type View = View::Output;
+    type View = AnyView<Rndr>;
 
     fn as_id(&self) -> RouteMatchId {
         self.id
@@ -154,9 +153,7 @@ where
         &self.matched
     }
 
-    fn into_view_and_child(
-        self,
-    ) -> (impl ChooseView<Output = Self::View>, Option<Self::Child>) {
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>) {
         (self.view_fn, self.child)
     }
 }
@@ -173,10 +170,8 @@ where
    Children: 'static,
    <Children::Match as MatchParams>::Params: Clone,
     View: ChooseView + Clone,
-    View::Output: Render + RenderHtml + Send + 'static,
 {
     type Data = Data;
-    type View = View::Output;
     type Match = NestedMatch<iter::Chain<
         <Segments::ParamsIter as IntoIterator>::IntoIter,
         Either<iter::Empty::<

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -10,7 +10,7 @@ use std::{
     collections::HashSet,
     sync::atomic::{AtomicU16, Ordering},
 };
-use tachys::{renderer::Renderer, view::any_view::AnyView};
+use tachys::view::any_view::AnyView;
 
 mod tuples;
 

--- a/router/src/matching/nested/tuples.rs
+++ b/router/src/matching/nested/tuples.rs
@@ -14,7 +14,6 @@ impl MatchParams for () {
 
 impl MatchInterface for () {
     type Child = ();
-    type View = ();
 
     fn as_id(&self) -> RouteMatchId {
         RouteMatchId(0)
@@ -66,7 +65,6 @@ where
     A: MatchInterface + 'static,
 {
     type Child = A::Child;
-    type View = A::View;
 
     fn as_id(&self) -> RouteMatchId {
         self.0.as_id()
@@ -126,7 +124,6 @@ where
     B: MatchInterface,
 {
     type Child = Either<A::Child, B::Child>;
-    type View = Either<A::View, B::View>;
 
     fn as_id(&self) -> RouteMatchId {
         match self {
@@ -227,7 +224,6 @@ macro_rules! tuples {
             $($ty: MatchInterface + 'static),*,
         {
             type Child = $either<$($ty::Child,)*>;
-            type View = $either<$($ty::View,)*>;
 
             fn as_id(&self) -> RouteMatchId {
                 match self {

--- a/router/src/matching/nested/tuples.rs
+++ b/router/src/matching/nested/tuples.rs
@@ -24,16 +24,13 @@ impl MatchInterface for () {
         ""
     }
 
-    fn into_view_and_child(
-        self,
-    ) -> (impl ChooseView<Output = Self::View>, Option<Self::Child>) {
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>) {
         ((), None)
     }
 }
 
 impl MatchNestedRoutes for () {
     type Data = ();
-    type View = ();
     type Match = ();
 
     fn match_nested<'a>(
@@ -79,9 +76,7 @@ where
         self.0.as_matched()
     }
 
-    fn into_view_and_child(
-        self,
-    ) -> (impl ChooseView<Output = Self::View>, Option<Self::Child>) {
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>) {
         self.0.into_view_and_child()
     }
 }
@@ -91,7 +86,6 @@ where
     A: MatchNestedRoutes + 'static,
 {
     type Data = A::Data;
-    type View = A::View;
     type Match = A::Match;
 
     fn match_nested<'a>(
@@ -148,9 +142,7 @@ where
         }
     }
 
-    fn into_view_and_child(
-        self,
-    ) -> (impl ChooseView<Output = Self::View>, Option<Self::Child>) {
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>) {
         match self {
             Either::Left(i) => {
                 let (view, child) = i.into_view_and_child();
@@ -170,7 +162,6 @@ where
     B: MatchNestedRoutes,
 {
     type Data = (A::Data, B::Data);
-    type View = Either<A::View, B::View>;
     type Match = Either<A::Match, B::Match>;
 
     fn match_nested<'a>(
@@ -253,7 +244,7 @@ macro_rules! tuples {
             fn into_view_and_child(
                 self,
             ) -> (
-                impl ChooseView<Output = Self::View>,
+                impl ChooseView,
                 Option<Self::Child>,
             ) {
                 match self {
@@ -270,7 +261,6 @@ macro_rules! tuples {
 			$($ty: MatchNestedRoutes + 'static),*,
         {
             type Data = ($($ty::Data,)*);
-            type View = $either<$($ty::View,)*>;
             type Match = $either<$($ty::Match,)*>;
 
             fn match_nested<'a>(&'a self, path: &'a str) -> (Option<(RouteMatchId, Self::Match)>, &'a str) {

--- a/router/src/static_routes.rs
+++ b/router/src/static_routes.rs
@@ -353,7 +353,7 @@ impl ResolvedStaticPath {
                             eprintln!("{e}");
                         }
                     }
-                    drop(owner);
+                    owner.unset();
                 }
             }
         });


### PR DESCRIPTION
This erases view types throughout the router by using `AnyView`.

It was initially an experiment with compile times, but also happens to fix #3093 so that's good. As with other issues with statically typed view trees, that is (generally speaking) caused by reducing the "depth" and/or "breadth" of the type for any given type. The example in #3093 has a few dozen pages, each of which was (previously) represented as returning some type `A` (`B`, `C`, etc). Snipping each of these concrete types out so that they become `AnyView` instead reduces the "depth" of the type tree significantly.

There is some cost in terms of binary size (and a minor runtime cost) to doing this. However, automatically doing it for routes makes a reasonable amount of sense.

The binary size cost for `AnyView` in general comes because it means the compiler cannot eliminate dead code: it needs to include the `build()` method (CSR), `rebuild()` method (update this page), and (in hydrate mode) `hydrate()` method, even if these are not all always used. However, for a page in the router you pretty much always need these methods (you can either land on this page from the server and need to hydrate it, or navigate to it in the browser and need to build it, etc.) so the overhead here should be minimal. And you're only doing it per page, which is not likely to be a large number per app (relative to e.g., doing it per component as in the `erase_components` dev-mode feature).