### PR TITLE
(wip) feat: use View Transition API for router animations

### DIFF
--- a/examples/router/index.html
+++ b/examples/router/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<link data-trunk rel="rust" data-wasm-opt="z"/>
 		<link data-trunk rel="icon" type="image/ico" href="/public/favicon.ico"/>
-        <link data-trunk rel="css" href="style.css"/>
+		<link data-trunk rel="css" href="style.css"/>
 	</head>
 	<body></body>
 </html>

--- a/examples/router/src/lib.rs
+++ b/examples/router/src/lib.rs
@@ -50,7 +50,7 @@ pub fn RouterExample() -> impl IntoView {
                 }>{move || if logged_in.get() { "Log Out" } else { "Log In" }}</button>
             </nav>
             <main>
-                <Routes fallback=|| "This page could not be found.">
+                <Routes transition=true fallback=|| "This page could not be found.">
                     // paths can be created using the path!() macro, or provided as types like
                     // StaticSegment("about")
                     <Route path=path!("about") view=About/>

--- a/examples/router/style.css
+++ b/examples/router/style.css
@@ -41,12 +41,16 @@ a[aria-current] {
   }
 }
 
-main {
+.router-outlet-0 main {
   view-transition-name: main;
 }
 
 .router-back main {
   view-transition-name: main-back;
+}
+
+.router-outlet-1 .contact-list {
+  view-transition-name: contact;
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/examples/router/style.css
+++ b/examples/router/style.css
@@ -1,3 +1,8 @@
+.routing-progress {
+	width: 100%;
+	height: 20px;
+}
+
 a[aria-current] {
     font-weight: bold;
 }
@@ -12,12 +17,8 @@ a[aria-current] {
     padding: 1rem;
 }
 
-.fadeIn {
-  animation: 0.5s fadeIn forwards;
-}
-
-.fadeOut {
-  animation: 0.5s fadeOut forwards;
+.contact {
+	view-transition-name: contact;
 }
 
 @keyframes fadeIn {
@@ -40,12 +41,40 @@ a[aria-current] {
   }
 }
 
-.slideIn {
-  animation: 0.25s slideIn forwards;
+main {
+  view-transition-name: main;
 }
 
-.slideOut {
-  animation: 0.25s slideOut forwards;
+.router-back main {
+  view-transition-name: main-back;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	::view-transition-old(contact) {
+	  animation: 0.5s fadeOut;
+	}
+
+	::view-transition-new(contact) {
+	  animation: 0.5s fadeIn;
+	}
+
+	::view-transition-old(main) {
+	  animation: 0.5s slideOut;
+	}
+
+	::view-transition-new(main) {
+	  animation: 0.5s slideIn;
+	}
+
+	::view-transition-old(main-back) {
+		color: red;
+		animation: 0.5s slideOutBack;
+	}
+
+	::view-transition-new(main-back) {
+		color: blue;
+		animation: 0.5s slideInBack;
+	}
 }
 
 @keyframes slideIn {
@@ -64,14 +93,6 @@ a[aria-current] {
   to {
     transform: translate(-100vw, 0);
   }
-}
-
-.slideInBack {
-  animation: 0.25s slideInBack forwards;
-}
-
-.slideOutBack {
-  animation: 0.25s slideOutBack forwards;
 }
 
 @keyframes slideInBack {

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -322,7 +322,7 @@ where
                                         .rebuild(&mut state.borrow_mut().view);
                                 };
                                 if transition {
-                                    start_view_transition(is_back, rebuild);
+                                    start_view_transition(0, is_back, rebuild);
                                 } else {
                                     rebuild();
                                 }

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -3,6 +3,7 @@ use crate::{
     location::{LocationProvider, Url},
     matching::Routes,
     params::ParamsMap,
+    view_transition::start_view_transition,
     ChooseView, MatchInterface, MatchNestedRoutes, MatchParams, PathSegment,
     RouteList, RouteListing, RouteMatchId,
 };
@@ -13,7 +14,7 @@ use reactive_graph::{
     computed::{ArcMemo, ScopedFuture},
     owner::{provide_context, Owner},
     signal::ArcRwSignal,
-    traits::{ReadUntracked, Set},
+    traits::{GetUntracked, ReadUntracked, Set},
     transition::AsyncTransition,
     wrappers::write::SignalSetter,
 };
@@ -35,6 +36,7 @@ pub(crate) struct FlatRoutesView<Loc, Defs, FalFn> {
     pub fallback: FalFn,
     pub outer_owner: Owner,
     pub set_is_routing: Option<SignalSetter<bool>>,
+    pub transition: bool,
 }
 
 pub struct FlatRoutesViewState<Defs, Fal>
@@ -198,6 +200,7 @@ where
             fallback,
             outer_owner,
             set_is_routing,
+            transition,
         } = self;
         let url_snapshot = current_url.read_untracked();
 
@@ -283,6 +286,10 @@ where
 
                 let spawned_path = url_snapshot.path().to_string();
 
+                let is_back = location
+                    .as_ref()
+                    .map(|nav| nav.is_back().get_untracked())
+                    .unwrap_or(false);
                 Executor::spawn_local(owner.with(|| {
                     ScopedFuture::new({
                         let state = Rc::clone(state);
@@ -310,8 +317,15 @@ where
                             if current_url.read_untracked().path()
                                 == spawned_path
                             {
-                                EitherOf3::C(view)
-                                    .rebuild(&mut state.borrow_mut().view);
+                                let rebuild = move || {
+                                    EitherOf3::C(view)
+                                        .rebuild(&mut state.borrow_mut().view);
+                                };
+                                if transition {
+                                    start_view_transition(is_back, rebuild);
+                                } else {
+                                    rebuild();
+                                }
                             }
 
                             if let Some(location) = location {

--- a/router/src/hooks.rs
+++ b/router/src/hooks.rs
@@ -281,38 +281,3 @@ pub fn use_matched() -> Memo<String> {
         .0
         .into()
 }
-
-/*
-/// Returns a signal that tells you whether you are currently navigating backwards.
-pub(crate) fn use_is_back_navigation() -> ReadSignal<bool> {
-    let router = use_router();
-    router.inner.is_back.read_only()
-}
-*/
-
-/* TODO check how this is used in 0.6 and use it
-/// Resolves a redirect location to an (absolute) URL.
-pub(crate) fn resolve_redirect_url(loc: &str) -> Option<web_sys::Url> {
-    let origin = match window().location().origin() {
-        Ok(origin) => origin,
-        Err(e) => {
-            leptos::logging::error!("Failed to get origin: {:#?}", e);
-            return None;
-        }
-    };
-
-    // TODO: Use server function's URL as base instead.
-    let base = origin;
-
-    match web_sys::Url::new_with_base(loc, &base) {
-        Ok(url) => Some(url),
-        Err(e) => {
-            leptos::logging::error!(
-                "Invalid redirect location: {}",
-                e.as_string().unwrap_or_default(),
-            );
-            None
-        }
-    }
-}
-*/

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -31,18 +31,21 @@ pub(crate) mod view_transition {
     use wasm_bindgen::{closure::Closure, intern, JsCast, JsValue};
 
     pub fn start_view_transition(
+        level: u8,
         is_back_navigation: bool,
         fun: impl FnOnce() + 'static,
     ) {
         let document = document();
         let document_element = document.document_element().unwrap();
+        let class_list = document_element.class_list();
         let svt = Reflect::get(
             &document,
             &JsValue::from_str(intern("startViewTransition")),
         )
         .and_then(|svt| svt.dyn_into::<Function>());
+        _ = class_list.add_1(&format!("router-outlet-{level}"));
         if is_back_navigation {
-            _ = document_element.class_list().add_1("router-back");
+            _ = class_list.add_1("router-back");
         }
         match svt {
             Ok(svt) => {
@@ -51,25 +54,27 @@ pub(crate) mod view_transition {
                 }));
                 match svt.call1(
                     document.unchecked_ref(),
-                    &cb.as_ref().unchecked_ref(),
+                    cb.as_ref().unchecked_ref(),
                 ) {
                     Ok(view_transition) => {
-                        if is_back_navigation {
-                            let finished = Reflect::get(
-                                &view_transition,
-                                &JsValue::from_str("finished"),
-                            )
-                            .expect("no `finished` property on ViewTransition")
-                            .unchecked_into::<Promise>();
-                            let cb = Closure::new(Box::new(move |_| {
-                                _ = document_element
-                                    .class_list()
-                                    .remove_1("router-back");
-                            })
-                                as Box<dyn FnMut(JsValue)>);
-                            _ = finished.then(&cb);
-                            cb.into_js_value();
-                        }
+                        let class_list = document_element.class_list();
+                        let finished = Reflect::get(
+                            &view_transition,
+                            &JsValue::from_str("finished"),
+                        )
+                        .expect("no `finished` property on ViewTransition")
+                        .unchecked_into::<Promise>();
+                        let cb = Closure::new(Box::new(move |_| {
+                            if is_back_navigation {
+                                class_list.remove_1("router-back").unwrap();
+                            }
+                            class_list
+                                .remove_1(&format!("router-outlet-{level}"))
+                                .unwrap();
+                        })
+                            as Box<dyn FnMut(JsValue)>);
+                        _ = finished.then(&cb);
+                        cb.into_js_value();
                     }
                     Err(e) => {
                         web_sys::console::log_1(&e);

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -24,3 +24,66 @@ pub use matching::*;
 pub use method::*;
 pub use navigate::*;
 pub use ssr_mode::*;
+
+pub(crate) mod view_transition {
+    use js_sys::{Function, Promise, Reflect};
+    use leptos::leptos_dom::helpers::document;
+    use wasm_bindgen::{closure::Closure, intern, JsCast, JsValue};
+
+    pub fn start_view_transition(
+        is_back_navigation: bool,
+        fun: impl FnOnce() + 'static,
+    ) {
+        let document = document();
+        let document_element = document.document_element().unwrap();
+        let svt = Reflect::get(
+            &document,
+            &JsValue::from_str(intern("startViewTransition")),
+        )
+        .and_then(|svt| svt.dyn_into::<Function>());
+        if is_back_navigation {
+            _ = document_element.class_list().add_1("router-back");
+        }
+        match svt {
+            Ok(svt) => {
+                let cb = Closure::once_into_js(Box::new(move || {
+                    fun();
+                }));
+                match svt.call1(
+                    document.unchecked_ref(),
+                    &cb.as_ref().unchecked_ref(),
+                ) {
+                    Ok(view_transition) => {
+                        if is_back_navigation {
+                            let finished = Reflect::get(
+                                &view_transition,
+                                &JsValue::from_str("finished"),
+                            )
+                            .expect("no `finished` property on ViewTransition")
+                            .unchecked_into::<Promise>();
+                            let cb = Closure::new(Box::new(move |_| {
+                                _ = document_element
+                                    .class_list()
+                                    .remove_1("router-back");
+                            })
+                                as Box<dyn FnMut(JsValue)>);
+                            _ = finished.then(&cb);
+                            cb.into_js_value();
+                        }
+                    }
+                    Err(e) => {
+                        web_sys::console::log_1(&e);
+                    }
+                }
+            }
+            Err(_) => {
+                leptos::logging::warn!(
+                    "NOTE: View transitions are not supported in this \
+                     browser; unless you provide a polyfill, view transitions \
+                     will not be applied."
+                );
+                fun();
+            }
+        }
+    }
+}

--- a/router/src/location/history.rs
+++ b/router/src/location/history.rs
@@ -12,6 +12,7 @@ use reactive_graph::{
 use std::{
     borrow::Cow,
     boxed::Box,
+    mem,
     string::String,
     sync::{Arc, Mutex},
 };
@@ -22,7 +23,9 @@ use web_sys::{Event, UrlSearchParams};
 #[derive(Clone)]
 pub struct BrowserUrl {
     url: ArcRwSignal<Url>,
-    pending_navigation: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    pub(crate) pending_navigation: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    pub(crate) path_stack: ArcStoredValue<Vec<Url>>,
+    pub(crate) is_back: ArcRwSignal<bool>,
 }
 
 impl fmt::Debug for BrowserUrl {
@@ -59,10 +62,14 @@ impl LocationProvider for BrowserUrl {
 
     fn new() -> Result<Self, JsValue> {
         let url = ArcRwSignal::new(Self::current()?);
-        let pending_navigation = Default::default();
+        let path_stack = ArcStoredValue::new(
+            Self::current().map(|n| vec![n]).unwrap_or_default(),
+        );
         Ok(Self {
             url,
-            pending_navigation,
+            pending_navigation: Default::default(),
+            path_stack,
+            is_back: Default::default(),
         })
     }
 
@@ -114,6 +121,7 @@ impl LocationProvider for BrowserUrl {
         let navigate = {
             let url = self.url.clone();
             let pending = Arc::clone(&self.pending_navigation);
+            let this = self.clone();
             move |new_url: Url, loc| {
                 let same_path = {
                     let curr = url.read_untracked();
@@ -123,7 +131,7 @@ impl LocationProvider for BrowserUrl {
 
                 url.set(new_url.clone());
                 if same_path {
-                    Self::complete_navigation(&loc);
+                    this.complete_navigation(&loc);
                 }
                 let pending = Arc::clone(&pending);
                 let (tx, rx) = oneshot::channel::<()>();
@@ -131,6 +139,7 @@ impl LocationProvider for BrowserUrl {
                     *pending.lock().or_poisoned() = Some(tx);
                 }
                 let url = url.clone();
+                let this = this.clone();
                 async move {
                     if !same_path {
                         // if it has been canceled, ignore
@@ -141,7 +150,7 @@ impl LocationProvider for BrowserUrl {
                             // browser URL
                             let curr = url.read_untracked();
                             if curr == new_url {
-                                Self::complete_navigation(&loc);
+                                this.complete_navigation(&loc);
                             }
                         }
                     }
@@ -173,8 +182,19 @@ impl LocationProvider for BrowserUrl {
         // handle popstate event (forward/back navigation)
         let cb = {
             let url = self.url.clone();
+            let path_stack = self.path_stack.clone();
+            let is_back = self.is_back.clone();
             move || match Self::current() {
-                Ok(new_url) => url.set(new_url),
+                Ok(new_url) => {
+                    let stack = path_stack.read_value();
+                    let is_navigating_back = stack.len() == 1
+                        || (stack.len() >= 2
+                            && stack.get(stack.len() - 2) == Some(&new_url));
+
+                    is_back.set(is_navigating_back);
+
+                    url.set(new_url);
+                }
                 Err(e) => {
                     #[cfg(feature = "tracing")]
                     tracing::error!("{e:?}");
@@ -199,7 +219,7 @@ impl LocationProvider for BrowserUrl {
         }
     }
 
-    fn complete_navigation(loc: &LocationChange) {
+    fn complete_navigation(&self, loc: &LocationChange) {
         let history = window().history().unwrap();
 
         if loc.replace {
@@ -217,6 +237,14 @@ impl LocationProvider for BrowserUrl {
                 .push_state_with_url(state, "", Some(&loc.value))
                 .unwrap();
         }
+
+        // add this URL to the "path stack" for detecting back navigations, and
+        // unset "navigating back" state
+        if let Ok(url) = Self::current() {
+            self.path_stack.write_value().push(url);
+            self.is_back.set(false);
+        }
+
         // scroll to el
         Self::scroll_to_el(loc.scroll);
     }
@@ -237,6 +265,10 @@ impl LocationProvider for BrowserUrl {
         } else if let Err(e) = helpers::location().set_href(&url.href()) {
             leptos::logging::error!("Failed to redirect: {e:#?}");
         }
+    }
+
+    fn is_back(&self) -> ReadSignal<bool> {
+        self.is_back.read_only().into()
     }
 }
 

--- a/router/src/location/history.rs
+++ b/router/src/location/history.rs
@@ -12,7 +12,6 @@ use reactive_graph::{
 use std::{
     borrow::Cow,
     boxed::Box,
-    mem,
     string::String,
     sync::{Arc, Mutex},
 };

--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -191,7 +191,7 @@ pub trait LocationProvider: Clone + 'static {
     fn ready_to_complete(&self);
 
     /// Update the browser's history to reflect a new location.
-    fn complete_navigation(loc: &LocationChange);
+    fn complete_navigation(&self, loc: &LocationChange);
 
     fn parse(url: &str) -> Result<Url, Self::Error> {
         Self::parse_with_base(url, BASE)
@@ -200,6 +200,9 @@ pub trait LocationProvider: Clone + 'static {
     fn parse_with_base(url: &str, base: &str) -> Result<Url, Self::Error>;
 
     fn redirect(loc: &str);
+
+    /// Whether we are currently in a "back" navigation.
+    fn is_back(&self) -> ReadSignal<bool>;
 }
 
 #[derive(Debug, Clone, Default)]

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -120,7 +120,7 @@ pub trait MatchNestedRoutes {
     fn match_nested<'a>(
         &'a self,
         path: &'a str,
-    ) -> (Option<(RouteMatchId, Self::Match)>, &str);
+    ) -> (Option<(RouteMatchId, Self::Match)>, &'a str);
 
     fn generate_routes(
         &self,

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -163,7 +163,7 @@ where
 
                 let mut preloaders = Vec::new();
                 let mut full_loaders = Vec::new();
-                route.rebuild_nested_route(
+                let different_level = route.rebuild_nested_route(
                     &self.current_url.read_untracked(),
                     self.base,
                     &mut 0,
@@ -172,6 +172,7 @@ where
                     &mut state.outlets,
                     &self.outer_owner,
                     self.set_is_routing.is_some(),
+                    0,
                 );
 
                 let location = self.location.clone();
@@ -188,7 +189,7 @@ where
                         }
                     };
                     if self.transition {
-                        start_view_transition(is_back, notify);
+                        start_view_transition(different_level, is_back, notify);
                     } else {
                         notify();
                     }
@@ -522,7 +523,8 @@ trait AddNestedRoute {
         outlets: &mut Vec<RouteContext>,
         parent: &Owner,
         set_is_routing: bool,
-    );
+        level: u8,
+    ) -> u8;
 }
 
 impl<Match> AddNestedRoute for Match
@@ -668,7 +670,8 @@ where
         outlets: &mut Vec<RouteContext>,
         parent: &Owner,
         set_is_routing: bool,
-    ) {
+        level: u8,
+    ) -> u8 {
         let (parent_params, parent_matches): (Vec<_>, Vec<_>) = outlets
             .iter()
             .take(*items)
@@ -679,6 +682,7 @@ where
             // if there's nothing currently in the routes at this point, build from here
             None => {
                 self.build_nested_route(url, base, preloaders, outlets, parent);
+                level
             }
             Some(current) => {
                 // a unique ID for each route, which allows us to compare when we get new matches
@@ -815,7 +819,7 @@ where
                         );
                     }
 
-                    return;
+                    return level;
                 }
 
                 // otherwise, set the params and URL signals,
@@ -835,7 +839,10 @@ where
                         outlets,
                         &owner,
                         set_is_routing,
-                    );
+                        level + 1,
+                    )
+                } else {
+                    level
                 }
             }
         }


### PR DESCRIPTION
The current router includes `AnimatedRoutes` and `AnimatedOutlet` components, which allow for animating route transitions. These were quite tricky to implement on my part, buggy in hard-to-resolve ways (#1754, #2058), and don't work as well with the new model in 0.7 because they relied on cloning the view and keeping two copies of it around in memory during the transition.

This is very similar to how the native View Transition API works. This API has stabilized fairly view and is being adopted by a number of frameworks. It [can be polyfilled](https://github.com/demarketed/view-transitions-polyfill) to support browsers that do not support it themselves. Using a feature that has browser support allows us to have faster compile times, smaller WASM binary sizes, and reduces the overall complexity of the framework. View Transitions come with some default gentle fade animations, but can be heavily customized.

To-dos
- [x] Prevent animation when only updating params on an outlet
- [ ] Test polyfill or include it in example 