### PR TITLE
feat: add two-way data binding support for stores

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -28,7 +28,7 @@ paste = "1.0"
 rand = { version = "0.8.5", optional = true }
 reactive_graph = { workspace = true, features = ["serde"] }
 rustc-hash = "2.0"
-tachys = { workspace = true, features = ["reactive_graph", "oco"] }
+tachys = { workspace = true, features = ["reactive_graph", "reactive_stores", "oco"] }
 thiserror = "1.0"
 tracing = { version = "0.1.40", optional = true }
 typed-builder = "0.19.1"

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -17,6 +17,7 @@ either_of = { workspace = true }
 next_tuple = { workspace = true }
 or_poisoned = { workspace = true }
 reactive_graph = { workspace = true, optional = true }
+reactive_stores = { workspace = true, optional = true }
 slotmap = { version = "1.0", optional = true }
 oco_ref = { workspace = true, optional = true }
 once_cell = "1.19"
@@ -175,6 +176,7 @@ oco = ["dep:oco_ref"]
 nightly = ["reactive_graph/nightly"]
 testing = ["dep:slotmap"]
 reactive_graph = ["dep:reactive_graph", "dep:any_spawner"]
+reactive_stores = ["reactive_graph", "dep:reactive_stores"]
 sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils"]
 tracing = ["dep:tracing"]
 

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -14,6 +14,8 @@ use reactive_graph::{
     traits::{Get, Update},
     wrappers::read::Signal,
 };
+#[cfg(feature = "reactive_stores")]
+use reactive_stores::{KeyedSubfield, Subfield};
 use send_wrapper::SendWrapper;
 use wasm_bindgen::JsValue;
 
@@ -339,6 +341,35 @@ where
 
     fn into_split_signal(self) -> (Self::Read, Self::Write) {
         self
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<Inner, Prev, T> IntoSplitSignal for Subfield<Inner, Prev, T>
+where
+    Self: Get<Value = T> + Update<Value = T> + Clone,
+{
+    type Value = T;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<Inner, Prev, K, T> IntoSplitSignal for KeyedSubfield<Inner, Prev, K, T>
+where
+    Self: Get<Value = T> + Update<Value = T> + Clone,
+    for<'a> &'a T: IntoIterator,
+{
+    type Value = T;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
     }
 }
 


### PR DESCRIPTION
This add support for directly using `Store` fields with the new two-way `bind:` for elements.
Needed only to `impl IntoSplitSignal` for `Subfield`, also added a impl for `KeyedSubfield` but don't know the utility yet.
Tested with `Subfield`

```rust
use reactive_stores::{Field, Patch, Store};
use serde::{Deserialize, Serialize};

#[derive(Debug, Store, Patch, Serialize, Deserialize, Clone)]
struct User {
    name: String,
    email: String,
}

let user = Store::new(User {
  name: "John Doe".to_string(),
  email: "john.doe@example.com".to_string(),
});

view! {
  <input type="text" bind:value=user.name() />
  <span>{move || user.name().get()}</span>
}
```

I had to add `reactive_stores` as a feature of `tachys` in the leptos Cargo.toml, not sure if that's a good approach, as leptos crate doesn't depend on the stores right now.