### PR TITLE
fix: remove unused `Params` attribute `params`

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -926,7 +926,7 @@ pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 
 /// Derives a trait that parses a map of string keys and values into a typed
 /// data structure, e.g., for route params.
-#[proc_macro_derive(Params, attributes(params))]
+#[proc_macro_derive(Params)]
 pub fn params_derive(
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {


### PR DESCRIPTION
See #1966 for original PR on older version.

This was held off as a breaking change. The breaking change is now acceptable prior to 0.7 release