### PR TITLE
batch navigation updates

### DIFF
--- a/router/src/components/router.rs
+++ b/router/src/components/router.rs
@@ -322,11 +322,15 @@ impl RouterContextInner {
 
                         let resolved = resolved_to.to_string();
                         let state = options.state.clone();
-                        set_reference.update(move |r| *r = resolved);
 
-                        set_state.update({
-                            let next_state = state.clone();
-                            move |state| *state = next_state
+                        // batch these so the history update is atomic
+                        batch(|| {
+                            set_reference.update(move |r| *r = resolved);
+                            
+                            set_state.update({
+                                let next_state = state.clone();
+                                move |state| *state = next_state
+                            });
                         });
 
                         let global_suspense =


### PR DESCRIPTION
simple change here to make history updates atomic. 

this is especially useful when doing navigation based on state. e.g.:
```
let hash_memo = use_location().hash;
let state_signal = use_location().state;

let location_signal = create_memo(move |_| {
    let hash = hash_memo.get();
    let state = state_signal.get()

    let path = todo!(); // some processing
    (path)
});
```

making the nav updates atomic ensures that this memo doesn't get updated twice for a single navigation event