### PR TITLE
Add fixed size array rendering

### DIFF
--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -336,3 +336,149 @@ where
         VecState { states, marker }
     }
 }
+
+impl<T, const N: usize> Render for [T; N]
+where
+    T: Render,
+{
+    type State = ArrayState<T::State, N>;
+
+    fn build(self) -> Self::State {
+        Self::State {
+            states: self.map(T::build),
+        }
+    }
+
+    fn rebuild(self, state: &mut Self::State) {
+        let Self::State { states } = state;
+        let old = states;
+        // this is an unkeyed diff
+        self.into_iter()
+            .zip(old.iter_mut())
+            .for_each(|(new, old)| T::rebuild(new, old));
+    }
+}
+
+/// Retained view state for a `Vec<_>`.
+pub struct ArrayState<T, const N: usize>
+where
+    T: Mountable,
+{
+    states: [T; N],
+}
+
+impl<T, const N: usize> Mountable for ArrayState<T, N>
+where
+    T: Mountable,
+{
+    fn unmount(&mut self) {
+        self.states.iter_mut().for_each(Mountable::unmount);
+    }
+
+    fn mount(
+        &mut self,
+        parent: &crate::renderer::types::Element,
+        marker: Option<&crate::renderer::types::Node>,
+    ) {
+        for state in self.states.iter_mut() {
+            state.mount(parent, marker);
+        }
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        if let Some(first) = self.states.first() {
+            first.insert_before_this(child)
+        } else {
+            false
+        }
+    }
+}
+impl<T, const N: usize> AddAnyAttr for [T; N]
+where
+    T: AddAnyAttr,
+{
+    type Output<SomeNewAttr: Attribute> =
+        [<T as AddAnyAttr>::Output<SomeNewAttr::Cloneable>; N];
+
+    fn add_any_attr<NewAttr: Attribute>(
+        self,
+        attr: NewAttr,
+    ) -> Self::Output<NewAttr>
+    where
+        Self::Output<NewAttr>: RenderHtml,
+    {
+        let attr = attr.into_cloneable();
+        self.map(|n| n.add_any_attr(attr.clone()))
+    }
+}
+
+impl<T, const N: usize> RenderHtml for [T; N]
+where
+    T: RenderHtml,
+{
+    type AsyncOutput = [T::AsyncOutput; N];
+
+    const MIN_LENGTH: usize = 0;
+
+    fn dry_resolve(&mut self) {
+        for inner in self.iter_mut() {
+            inner.dry_resolve();
+        }
+    }
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        futures::future::join_all(self.into_iter().map(T::resolve))
+            .await
+            .into_iter()
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap_or_else(|_| unreachable!())
+    }
+
+    fn html_len(&self) -> usize {
+        self.iter().map(RenderHtml::html_len).sum::<usize>() + 2
+    }
+
+    fn to_html_with_buf(
+        self,
+        buf: &mut String,
+        position: &mut Position,
+        escape: bool,
+        mark_branches: bool,
+    ) {
+        for child in self.into_iter() {
+            child.to_html_with_buf(buf, position, escape, mark_branches);
+        }
+        buf.push_str("<!>");
+    }
+
+    fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
+        self,
+        buf: &mut StreamBuilder,
+        position: &mut Position,
+        escape: bool,
+        mark_branches: bool,
+    ) where
+        Self: Sized,
+    {
+        for child in self.into_iter() {
+            child.to_html_async_with_buf::<OUT_OF_ORDER>(
+                buf,
+                position,
+                escape,
+                mark_branches,
+            );
+        }
+        buf.push_sync("<!>");
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        cursor: &Cursor,
+        position: &PositionState,
+    ) -> Self::State {
+        let states =
+            self.map(|child| child.hydrate::<FROM_SERVER>(cursor, position));
+        ArrayState { states }
+    }
+}


### PR DESCRIPTION
Hello, I was using fixed size array and the render method is not implemented on them.
I find it weird that it's implemented on Vec but not arrays. So I wrote a quick implementation.
Is there a reason it's not implemented ?

This allow to pass the array directly to the view method without converting it into a vec.

```rust
// before
view! { <div> {array.to_vec()} </div> }

// after
view! { <div> {array} </div> }

```

It's mostly a copy of the Vec implementation with minor adjustments :

- I removed the marker since it's used to insert new items on size change

```rust
pub struct VecState<T>
where
    T: Mountable,
{
    states: Vec<T>,
    // Vecs keep a placeholder because they have the potential to add additional items,
    // after their own items but before the next neighbor. It is much easier to add an
    // item before a known placeholder than to add it after the last known item, so we
    // just leave a placeholder here unlike zero-or-one iterators (Option, Result, etc.)
    marker: crate::renderer::types::Placeholder,
}
```

- I used the `<[]>::map` function most of the time.
The only exception is for the `future::join_all` that takes and return an iterator.

- For the `Render::rebuild` method I don't know if there is a smart way of handling it. So I just wrote a naive implementation.