### PR TITLE
fix: exclude excluded server fn paths instead of unregistering them (closes #3150, #3175)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -41,10 +41,10 @@ use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use send_wrapper::SendWrapper;
 use server_fn::{
-    actix::unregister_server_fns, redirect::REDIRECT_HEADER,
-    request::actix::ActixRequest, ServerFnError,
+    redirect::REDIRECT_HEADER, request::actix::ActixRequest, ServerFnError,
 };
 use std::{
+    collections::HashSet,
     fmt::{Debug, Display},
     future::Future,
     ops::{Deref, DerefMut},
@@ -944,6 +944,7 @@ pub struct ActixRouteListing {
     mode: SsrMode,
     methods: Vec<leptos_router::Method>,
     regenerate: Vec<RegenerationFn>,
+    exclude: bool,
 }
 
 trait IntoRouteListing: Sized {
@@ -971,6 +972,7 @@ impl IntoRouteListing for RouteListing {
                     mode: mode.clone(),
                     methods,
                     regenerate,
+                    exclude: false,
                 }
             })
             .collect()
@@ -990,6 +992,7 @@ impl ActixRouteListing {
             mode,
             methods: methods.into_iter().collect(),
             regenerate: regenerate.into(),
+            exclude: false,
         }
     }
 
@@ -1024,11 +1027,6 @@ where
 {
     let _ = any_spawner::Executor::init_tokio();
 
-    // remove any server fns that match excluded paths
-    if let Some(excluded) = &excluded_routes {
-        unregister_server_fns(excluded);
-    }
-
     let owner = Owner::new_root(Some(Arc::new(SsrSharedContext::new())));
     let (mock_meta, _) = ServerMetaContext::new();
     let routes = owner
@@ -1055,24 +1053,34 @@ where
         .flat_map(IntoRouteListing::into_route_listing)
         .collect::<Vec<_>>();
 
-    (
-        if routes.is_empty() {
-            vec![ActixRouteListing::new(
-                "/".to_string(),
-                Default::default(),
-                [leptos_router::Method::Get],
-                vec![],
-            )]
-        } else {
-            // Routes to exclude from auto generation
-            if let Some(excluded_routes) = excluded_routes {
-                routes
-                    .retain(|p| !excluded_routes.iter().any(|e| e == p.path()))
-            }
-            routes
-        },
-        generator,
-    )
+    let routes = if routes.is_empty() {
+        vec![ActixRouteListing::new(
+            "/".to_string(),
+            Default::default(),
+            [leptos_router::Method::Get],
+            vec![],
+        )]
+    } else {
+        // Routes to exclude from auto generation
+        if let Some(excluded_routes) = &excluded_routes {
+            routes.retain(|p| !excluded_routes.iter().any(|e| e == p.path()))
+        }
+        routes
+    };
+
+    let excluded =
+        excluded_routes
+            .into_iter()
+            .flatten()
+            .map(|path| ActixRouteListing {
+                path,
+                mode: Default::default(),
+                methods: Vec::new(),
+                regenerate: Vec::new(),
+                exclude: true,
+            });
+
+    (routes.into_iter().chain(excluded).collect(), generator)
 }
 
 /// Allows generating any prerendered routes.
@@ -1378,11 +1386,20 @@ where
     {
         let mut router = self;
 
+        let excluded = paths
+            .iter()
+            .filter(|&p| p.exclude)
+            .map(|p| p.path.as_str())
+            .collect::<HashSet<_>>();
+
         // register server functions first to allow for wildcard route in Leptos's Router
         for (path, _) in server_fn::actix::server_fn_paths() {
-            let additional_context = additional_context.clone();
-            let handler = handle_server_fns_with_context(additional_context);
-            router = router.route(path, handler);
+            if !excluded.contains(path) {
+                let additional_context = additional_context.clone();
+                let handler =
+                    handle_server_fns_with_context(additional_context);
+                router = router.route(path, handler);
+            }
         }
 
         // register routes defined in Leptos's Router

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1403,7 +1403,7 @@ where
         }
 
         // register routes defined in Leptos's Router
-        for listing in paths.iter() {
+        for listing in paths.iter().filter(|p| !p.exclude) {
             let path = listing.path();
             let mode = listing.mode();
 
@@ -1499,15 +1499,24 @@ impl LeptosRoutes for &mut ServiceConfig {
     {
         let mut router = self;
 
+        let excluded = paths
+            .iter()
+            .filter(|&p| p.exclude)
+            .map(|p| p.path.as_str())
+            .collect::<HashSet<_>>();
+
         // register server functions first to allow for wildcard route in Leptos's Router
         for (path, _) in server_fn::actix::server_fn_paths() {
-            let additional_context = additional_context.clone();
-            let handler = handle_server_fns_with_context(additional_context);
-            router = router.route(path, handler);
+            if !excluded.contains(path) {
+                let additional_context = additional_context.clone();
+                let handler =
+                    handle_server_fns_with_context(additional_context);
+                router = router.route(path, handler);
+            }
         }
 
         // register routes defined in Leptos's Router
-        for listing in paths.iter() {
+        for listing in paths.iter().filter(|p| !p.exclude) {
             let path = listing.path();
             let mode = listing.mode();
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1833,7 +1833,7 @@ where
         }
 
         // register router paths
-        for listing in paths.iter() {
+        for listing in paths.iter().filter(|p| !p.exclude) {
             let path = listing.path();
 
             for method in listing.methods() {
@@ -1942,7 +1942,7 @@ where
         T: 'static,
     {
         let mut router = self;
-        for listing in paths.iter() {
+        for listing in paths.iter().filter(|p| !p.exclude) {
             for method in listing.methods() {
                 router = router.route(
                     listing.path(),

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -71,12 +71,10 @@ use leptos_router::{
 #[cfg(feature = "default")]
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use server_fn::{
-    axum::unregister_server_fns, redirect::REDIRECT_HEADER, ServerFnError,
-};
+use server_fn::{redirect::REDIRECT_HEADER, ServerFnError};
 #[cfg(feature = "default")]
 use std::path::Path;
-use std::{fmt::Debug, io, pin::Pin, sync::Arc};
+use std::{collections::HashSet, fmt::Debug, io, pin::Pin, sync::Arc};
 #[cfg(feature = "default")]
 use tower::util::ServiceExt;
 #[cfg(feature = "default")]
@@ -1265,6 +1263,7 @@ pub struct AxumRouteListing {
     methods: Vec<leptos_router::Method>,
     #[allow(unused)]
     regenerate: Vec<RegenerationFn>,
+    exclude: bool,
 }
 
 trait IntoRouteListing: Sized {
@@ -1292,6 +1291,7 @@ impl IntoRouteListing for RouteListing {
                     mode: mode.clone(),
                     methods,
                     regenerate,
+                    exclude: false,
                 }
             })
             .collect()
@@ -1311,6 +1311,7 @@ impl AxumRouteListing {
             mode,
             methods: methods.into_iter().collect(),
             regenerate: regenerate.into(),
+            exclude: false,
         }
     }
 
@@ -1351,11 +1352,6 @@ where
     init_executor();
     let owner = Owner::new_root(Some(Arc::new(SsrSharedContext::new())));
 
-    // remove any server fns that match excluded paths
-    if let Some(excluded) = &excluded_routes {
-        unregister_server_fns(excluded);
-    }
-
     let routes = owner
         .with(|| {
             // stub out a path for now
@@ -1381,24 +1377,33 @@ where
         .flat_map(IntoRouteListing::into_route_listing)
         .collect::<Vec<_>>();
 
-    (
-        if routes.is_empty() {
-            vec![AxumRouteListing::new(
-                "/".to_string(),
-                Default::default(),
-                [leptos_router::Method::Get],
-                vec![],
-            )]
-        } else {
-            // Routes to exclude from auto generation
-            if let Some(excluded_routes) = excluded_routes {
-                routes
-                    .retain(|p| !excluded_routes.iter().any(|e| e == p.path()))
-            }
-            routes
-        },
-        generator,
-    )
+    let routes = if routes.is_empty() {
+        vec![AxumRouteListing::new(
+            "/".to_string(),
+            Default::default(),
+            [leptos_router::Method::Get],
+            vec![],
+        )]
+    } else {
+        // Routes to exclude from auto generation
+        if let Some(excluded_routes) = &excluded_routes {
+            routes.retain(|p| !excluded_routes.iter().any(|e| e == p.path()))
+        }
+        routes
+    };
+    let excluded =
+        excluded_routes
+            .into_iter()
+            .flatten()
+            .map(|path| AxumRouteListing {
+                path,
+                mode: Default::default(),
+                methods: Vec::new(),
+                regenerate: Vec::new(),
+                exclude: true,
+            });
+
+    (routes.into_iter().chain(excluded).collect(), generator)
 }
 
 /// Allows generating any prerendered routes.
@@ -1794,28 +1799,37 @@ where
 
         let mut router = self;
 
+        let excluded = paths
+            .iter()
+            .filter(|&p| p.exclude)
+            .map(|p| p.path.as_str())
+            .collect::<HashSet<_>>();
+
         // register server functions
         for (path, method) in server_fn::axum::server_fn_paths() {
             let cx_with_state = cx_with_state.clone();
             let handler = move |req: Request<Body>| async move {
                 handle_server_fns_with_context(cx_with_state, req).await
             };
-            router = router.route(
-                path,
-                match method {
-                    Method::GET => get(handler),
-                    Method::POST => post(handler),
-                    Method::PUT => put(handler),
-                    Method::DELETE => delete(handler),
-                    Method::PATCH => patch(handler),
-                    _ => {
-                        panic!(
-                            "Unsupported server function HTTP method: \
-                             {method:?}"
-                        );
-                    }
-                },
-            );
+
+            if !excluded.contains(path) {
+                router = router.route(
+                    path,
+                    match method {
+                        Method::GET => get(handler),
+                        Method::POST => post(handler),
+                        Method::PUT => put(handler),
+                        Method::DELETE => delete(handler),
+                        Method::PATCH => patch(handler),
+                        _ => {
+                            panic!(
+                                "Unsupported server function HTTP method: \
+                                 {method:?}"
+                            );
+                        }
+                    },
+                );
+            }
         }
 
         // register router paths

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -500,17 +500,6 @@ pub mod axum {
             .map(|item| (item.path(), item.method()))
     }
 
-    /// Removes any server functions with an included path from the map of
-    /// registered server functions.
-    ///
-    /// Calling this will mean that these server functions are not found unless you provide
-    /// alternate handlers for them in your application.
-    pub fn unregister_server_fns(paths: &[String]) {
-        if !paths.is_empty() {
-            REGISTERED_SERVER_FUNCTIONS.retain(|(p, _), _| !paths.contains(p));
-        }
-    }
-
     /// An Axum handler that responds to a server function request.
     pub async fn handle_server_fn(req: Request<Body>) -> Response<Body> {
         let path = req.uri().path();
@@ -597,17 +586,6 @@ pub mod actix {
         REGISTERED_SERVER_FUNCTIONS
             .iter()
             .map(|item| (item.path(), item.method()))
-    }
-
-    /// Removes any server functions with an included path from the map of
-    /// registered server functions.
-    ///
-    /// Calling this will mean that these server functions are not found unless you provide
-    /// alternate handlers for them in your application.
-    pub fn unregister_server_fns(paths: &[String]) {
-        if !paths.is_empty() {
-            REGISTERED_SERVER_FUNCTIONS.retain(|(p, _), _| !paths.contains(p));
-        }
     }
 
     /// An Actix handler that responds to a server function request.


### PR DESCRIPTION
@benwis I had a slightly different idea on how to implement this, without any type signature changes, by simply creating a separate "excluded route" category in the generated route list, and then checking against that. Could you test it out for me? 