### PR TITLE
Unpin `wasm-bindgen` to improve compatibility with other crates

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -45,7 +45,7 @@ web-sys = { version = "0.3.70", features = [
   "ShadowRootInit",
   "ShadowRootMode",
 ] }
-wasm-bindgen = "0.2.93"
+wasm-bindgen = "0.2.95"
 serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.30"

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -45,7 +45,7 @@ web-sys = { version = "0.3.70", features = [
   "ShadowRootInit",
   "ShadowRootMode",
 ] }
-wasm-bindgen = "=0.2.93"
+wasm-bindgen = "0.2.93"
 serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.30"


### PR DESCRIPTION
Leptos can't be installed alongside another crate that uses a newer `wasm-bindgen` version. For example:

```
error: failed to select a version for `wasm-bindgen`.
    ... required by package `web-sys v0.3.72`
    ... which satisfies dependency `web-sys = "^0.3.72"` of package `crate-c v0.0.1`
    ... which satisfies dependency `crate-c` of package `crate-b v0.0.1`
versions that meet the requirements `^0.2.95` are: 0.2.95

all possible versions conflict with previously selected packages.

  previously selected package `wasm-bindgen v0.2.93`
    ... which satisfies dependency `wasm-bindgen = "=0.2.93"` of package `leptos v0.7.0-rc0`
    ... which satisfies dependency `leptos = "^0.7.0-rc0"` (locked to 0.7.0-rc0) of package `crate-a v0.0.1`

failed to select a version for `wasm-bindgen` which could resolve this conflict
```

Unpinning `wasm-bindgen` in Leptos should improve compatibility with other crates.