### PR TITLE
feat: generalize response data injection

### DIFF
--- a/examples/axum_js_ssr/src/main.rs
+++ b/examples/axum_js_ssr/src/main.rs
@@ -29,6 +29,7 @@ async fn main() {
     use leptos::logging::log;
     use leptos::prelude::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
+    use leptos_meta::ServerMetaContext;
 
     latency::LATENCY.get_or_init(|| [0, 4, 40, 400].iter().cycle().into());
     latency::ES_LATENCY.get_or_init(|| [0].iter().cycle().into());
@@ -43,7 +44,7 @@ async fn main() {
     let addr = conf.leptos_options.site_addr;
     let leptos_options = conf.leptos_options;
     // Generate the list of routes in your Leptos App
-    let routes = generate_route_list(App);
+    let routes = generate_route_list::<ServerMetaContext, _>(App);
 
     async fn highlight_js() -> impl IntoResponse {
         (
@@ -128,11 +129,11 @@ async fn main() {
 
     let app = Router::new()
         .route("/highlight.min.js", get(highlight_js))
-        .leptos_routes(&leptos_options, routes, {
+        .leptos_routes::<ServerMetaContext, _>(&leptos_options, routes, {
             let leptos_options = leptos_options.clone();
             move || shell(leptos_options.clone())
         })
-        .fallback(leptos_axum::file_and_error_handler(shell))
+        .fallback(leptos_axum::file_and_error_handler::<_, ServerMetaContext, _>(shell))
         .layer(middleware::from_fn(latency_for_highlight_js))
         .with_state(leptos_options);
 

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -19,7 +19,6 @@ futures = "0.3.30"
 leptos = { workspace = true, features = ["nonce", "ssr"] }
 server_fn = { workspace = true, features = ["axum-no-default"] }
 leptos_macro = { workspace = true, features = ["axum"] }
-leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_integration_utils = { workspace = true }
 once_cell = "1"


### PR DESCRIPTION
I have a leptos styled components library, which is using leptos_meta for SSR for a long time.

However, I had some problems with this flow, that are probably solvable by extension of leptos_meta public API, but I decided to generalize leptos_meta server integration instead, now any other library may hook into response data generation.

This PR only implements axum integration, because I'm not sure if there is a better way to implement this feature.