### PR TITLE
Add futures-executor feature for any_spawner

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 
 [dependencies]
 throw_error = { workspace = true }
-any_spawner = { workspace = true, features = ["wasm-bindgen"] }
+any_spawner = { workspace = true, features = ["wasm-bindgen", "futures-executor"] }
 base64 = { version = "0.22.1", optional = true }
 cfg-if = "1.0"
 hydration_context = { workspace = true }


### PR DESCRIPTION
Hi folks! Creating this PR to add the `futures-executor` feature to any_spawner, which is needed for leptos-wasi integrations [(example)](https://github.com/ogghead/leptos-wasi-test/blob/main/src/server.rs#L17) to call `Executor::init_local_custom_executor` without pulling that crate in directly. This allows using `leptos::task::Executor` for the same