### PR TITLE
test: fixtures for testing aria-current

### DIFF
--- a/examples/suspense_tests/e2e/features/check_aria_current.feature
+++ b/examples/suspense_tests/e2e/features/check_aria_current.feature
@@ -1,0 +1,12 @@
+@check_aria_current
+Feature: Check aria-current being applied to make links bolded
+
+    Background:
+
+        Given I see the app
+
+    Scenario: Should see the base case working
+        Then I see the link Out-of-Order being bolded
+        Then I see the following links being bolded
+            | Out-of-Order |
+            | Nested       |

--- a/examples/suspense_tests/e2e/tests/fixtures/check.rs
+++ b/examples/suspense_tests/e2e/tests/fixtures/check.rs
@@ -81,3 +81,12 @@ pub async fn instrumented_counts(
 
     Ok(())
 }
+
+pub async fn link_text_is_aria_current(client: &Client, text: &str) -> Result<()> {
+    let link = find::link_with_text(client, text).await?;
+
+    link.attr("aria-current").await?
+        .expect(format!("aria-current missing for {text}").as_str());
+
+    Ok(())
+}

--- a/examples/suspense_tests/e2e/tests/fixtures/find.rs
+++ b/examples/suspense_tests/e2e/tests/fixtures/find.rs
@@ -124,3 +124,12 @@ async fn component_message(client: &Client, id: &str) -> Result<String> {
 
     Ok(text)
 }
+
+pub async fn link_with_text(client: &Client, text: &str) -> Result<Element> {
+    let link = client
+        .wait()
+        .for_element(Locator::LinkText(text))
+        .await
+        .expect(format!("Link not found by `{}`", text).as_str());
+    Ok(link)
+}

--- a/examples/suspense_tests/e2e/tests/fixtures/world/check_steps.rs
+++ b/examples/suspense_tests/e2e/tests/fixtures/world/check_steps.rs
@@ -80,6 +80,32 @@ async fn i_see_the_second_count_is(
     Ok(())
 }
 
+#[then(regex = r"^I see the link (.*) being bolded$")]
+async fn i_see_the_link_being_bolded(
+    world: &mut AppWorld,
+    text: String,
+) -> Result<()> {
+    let client = &world.client;
+    check::link_text_is_aria_current(client, &text).await?;
+
+    Ok(())
+}
+
+#[then(expr = "I see the following links being bolded")]
+async fn i_see_the_following_links_being_bolded(
+    world: &mut AppWorld,
+    step: &Step,
+) -> Result<()> {
+    let client = &world.client;
+    if let Some(table) = step.table.as_ref() {
+        for row in table.rows.iter() {
+            check::link_text_is_aria_current(client, &row[0]).await?;
+        }
+    }
+
+    Ok(())
+}
+
 #[then(expr = "I see the following counters under section")]
 #[then(expr = "the following counters under section")]
 async fn i_see_the_following_counters_under_section(


### PR DESCRIPTION
This provide the basic fixtures to check for `aria-current` for links, plus a basic test case to show that it works - can easily be modified to use non-highlighted link to trigger text failure.

This may be merged separately via this pull request or be part of the bigger pull request that includes the fix plus tests.  Navigating around `suspense_test` will demonstrate the particular issue as reported in #3196 so this was as good place as any to set this up.