### PR TITLE
fix: make free space for ci workflows before running them

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -19,6 +19,19 @@ jobs:
     name: Run ${{ inputs.cargo_make_task }} (${{ inputs.toolchain }})
     runs-on: ubuntu-latest
     steps:
+      - name: Free Disk Space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
       # Setup environment
       - uses: actions/checkout@v4
       - name: Setup Rust


### PR DESCRIPTION
Related: https://github.com/leptos-rs/leptos/pull/3204

Credit: https://github.com/actions/runner-images/issues/10386#issuecomment-2271613335