### PR TITLE
Fix deprecated parameters js warning

### DIFF
--- a/leptos/src/hydration/hydration_script.js
+++ b/leptos/src/hydration/hydration_script.js
@@ -1,7 +1,7 @@
 (function (root, pkg_path, output_name, wasm_output_name) {
 	import(`${root}/${pkg_path}/${output_name}.js`)
 		.then(mod => {
-			mod.default(`${root}/${pkg_path}/${wasm_output_name}.wasm`).then(() => {
+			mod.default({module_or_path: `${root}/${pkg_path}/${wasm_output_name}.wasm`}).then(() => {
 				mod.hydrate();
 			});
 		})


### PR DESCRIPTION
Fixes the browser js console warning when running Leptos apps: 
> using deprecated parameters for the initialization function; pass a single object instead

I figured it out by following the link in the wasm-bindgen changelog entry:
> Deprecated parameters to default (init) and initSync in favor of an object. https://github.com/rustwasm/wasm-bindgen/pull/3995

Which told me it was our calling of the default function that was changed/deprecated, and I looked at the changed examples to see how it should be now be called with an object like `{module_or_path: path}` here: 
https://github.com/daxpedda/wasm-bindgen/blob/152dcf22f241d0245cccd97e5d1bd3286ebc5514/examples/websockets/index.js#L4

I tested it with the hackernews_axum example and the warning no longer showed up with this change.