### PR TITLE
Fix deprecated parameters js warning (0.6)

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -136,7 +136,7 @@ pub fn html_parts_separated(
                         idle(() => {{
                             import('{pkg_path}/{output_name}{js_hash}.js')
                                 .then(mod => {{
-                                    mod.default('{pkg_path}/{wasm_output_name}{wasm_hash}.wasm').then({import_callback});
+                                    mod.default({{module_or_path: '{pkg_path}/{wasm_output_name}{wasm_hash}.wasm'}}).then({import_callback});
                                 }})
                         }});
                     </script>


### PR DESCRIPTION
Same as #3219 but for Leptos 0.6

Feel free to close if you don't want to bother backporting this. I just was using it so thought I'd share. I do plan on upgrading to 0.7 when I can.