### PR TITLE
Fix static routing example

### DIFF
--- a/router/src/static_routes.rs
+++ b/router/src/static_routes.rs
@@ -208,7 +208,7 @@ impl StaticPath {
                     paths = paths
                         .into_iter()
                         .map(|p| {
-                            if s.starts_with("/") {
+                            if s.starts_with("/") || s.is_empty() {
                                 ResolvedStaticPath {
                                     path: format!("{}{s}", p.path),
                                 }


### PR DESCRIPTION
As far as I can tell, both #3224 and #3226 are really the same problem, caused by the fact that the static path expansion algorithm was accidentally expanding `(StaticSegment(""), StaticSegment("post"), ParamSegment("slug"), StaticSegment("/"))` into routes like `//post/1/` instead of `/post/1/`.