### PR TITLE
Improvements around custom error handling in ServerFnError

### DIFF
--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -64,10 +64,7 @@ where
                 } else {
                     (base.as_ref(), path)
                 };
-                match path.strip_prefix(base) {
-                    Some(path) => path,
-                    None => return None,
-                }
+                path.strip_prefix(base)?
             }
         };
 


### PR DESCRIPTION
This implements a fix for #3154 by making `NoDefaultError` unhinabited, and proposes workarounds for #3153 and #3155 to make converting easier:
1. from `Result<T, ServerFnError<NoCustomError>>` to `Result<T, ServerFnError<AnyOtherCustomError>>`
2. from some `Result<T, ServerFnError<SourceCustomError>>` to `Result<T, ServerFnError<TargetCustomError>>` when `TargetCustomError: From<SourceCustomError>`
3. from `Result<T, E>` to `Result<T, ServerFnError<AnyCustomError>>` when `E: std::error::Error`, reflecting the existing `From<E: std::error::Error> for ServerFnError<NoCustomError>`

Usage examples are provided in the docstring for each of these new traits. My typical uses cases are:
- for 1. and 2. shared helper functions returning ServerFnError already, for instance a function that calls `use_context`.
- for 3. external functions that may raise an error, a database call for instance.

As mentioned in #3153 and #3155 I would have preferred implementing `From<ServerFnError<SourceCustomError>> for ServerFnError<TargetCustomError>` and `From<E: std::error::Error> for ServerFnError`, but as @benwis correctly pointed out those conflict with `From<T> for T`, at least until specialization becomes available.