### PR TITLE
Add FromServerFnError trait to server_fn crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,6 +3266,7 @@ version = "0.7.0-rc1"
 dependencies = [
  "actix-web",
  "axum",
+ "base64",
  "bytes",
  "ciborium",
  "const_format",

--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -3,7 +3,10 @@ use reactive_graph::{
     owner::use_context,
     traits::DefinedAt,
 };
-use server_fn::{error::ServerFnErrorSerde, ServerFn, ServerFnError};
+use server_fn::{
+    error::{FromServerFnError, ServerFnErrorSerde},
+    ServerFn,
+};
 use std::{ops::Deref, panic::Location, sync::Arc};
 
 /// An error that can be caused by a server action.
@@ -42,7 +45,7 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    inner: ArcAction<S, Result<S::Output, ServerFnError<S::Error>>>,
+    inner: ArcAction<S, Result<S::Output, S::Error>>,
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
 }
@@ -52,13 +55,14 @@ where
     S: ServerFn + Clone + Send + Sync + 'static,
     S::Output: Send + Sync + 'static,
     S::Error: Send + Sync + 'static,
+    S::Error: FromServerFnError,
 {
     /// Creates a new [`ArcAction`] that will call the server function `S` when dispatched.
     #[track_caller]
     pub fn new() -> Self {
         let err = use_context::<ServerActionError>().and_then(|error| {
             (error.path() == S::PATH)
-                .then(|| ServerFnError::<S::Error>::de(error.err()))
+                .then(|| S::Error::de(error.err()))
                 .map(Err)
         });
         Self {
@@ -76,7 +80,7 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    type Target = ArcAction<S, Result<S::Output, ServerFnError<S::Error>>>;
+    type Target = ArcAction<S, Result<S::Output, S::Error>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -131,7 +135,7 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    inner: Action<S, Result<S::Output, ServerFnError<S::Error>>>,
+    inner: Action<S, Result<S::Output, S::Error>>,
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
 }
@@ -146,7 +150,7 @@ where
     pub fn new() -> Self {
         let err = use_context::<ServerActionError>().and_then(|error| {
             (error.path() == S::PATH)
-                .then(|| ServerFnError::<S::Error>::de(error.err()))
+                .then(|| S::Error::de(error.err()))
                 .map(Err)
         });
         Self {
@@ -182,15 +186,14 @@ where
     S::Output: Send + Sync + 'static,
     S::Error: Send + Sync + 'static,
 {
-    type Target = Action<S, Result<S::Output, ServerFnError<S::Error>>>;
+    type Target = Action<S, Result<S::Output, S::Error>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<S> From<ServerAction<S>>
-    for Action<S, Result<S::Output, ServerFnError<S::Error>>>
+impl<S> From<ServerAction<S>> for Action<S, Result<S::Output, S::Error>>
 where
     S: ServerFn + 'static,
     S::Output: 'static,

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -2,7 +2,7 @@ use reactive_graph::{
     actions::{ArcMultiAction, MultiAction},
     traits::DefinedAt,
 };
-use server_fn::{ServerFn, ServerFnError};
+use server_fn::ServerFn;
 use std::{ops::Deref, panic::Location};
 
 /// An [`ArcMultiAction`] that can be used to call a server function.
@@ -11,7 +11,7 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    inner: ArcMultiAction<S, Result<S::Output, ServerFnError<S::Error>>>,
+    inner: ArcMultiAction<S, Result<S::Output, S::Error>>,
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
 }
@@ -40,7 +40,7 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    type Target = ArcMultiAction<S, Result<S::Output, ServerFnError<S::Error>>>;
+    type Target = ArcMultiAction<S, Result<S::Output, S::Error>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -95,13 +95,13 @@ where
     S: ServerFn + 'static,
     S::Output: 'static,
 {
-    inner: MultiAction<S, Result<S::Output, ServerFnError<S::Error>>>,
+    inner: MultiAction<S, Result<S::Output, S::Error>>,
     #[cfg(debug_assertions)]
     defined_at: &'static Location<'static>,
 }
 
 impl<S> From<ServerMultiAction<S>>
-    for MultiAction<S, Result<S::Output, ServerFnError<S::Error>>>
+    for MultiAction<S, Result<S::Output, S::Error>>
 where
     S: ServerFn + 'static,
     S::Output: 'static,
@@ -152,7 +152,7 @@ where
     S::Output: 'static,
     S::Error: 'static,
 {
-    type Target = MultiAction<S, Result<S::Output, ServerFnError<S::Error>>>;
+    type Target = MultiAction<S, Result<S::Output, S::Error>>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -53,6 +53,7 @@ bytes = "1.8"
 http-body-util = { version = "0.1.2", optional = true }
 rkyv = { version = "0.8.8", optional = true }
 rmp-serde = { version = "1.3.0", optional = true }
+base64 = { version = "0.22.1" }
 
 # client
 gloo-net = { version = "0.6.0", optional = true }

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{error::ServerFnError, request::ClientReq, response::ClientRes};
+use crate::{request::ClientReq, response::ClientRes};
 use std::{future::Future, sync::OnceLock};
 
 static ROOT_URL: OnceLock<&'static str> = OnceLock::new();
@@ -21,16 +21,16 @@ pub fn get_server_url() -> &'static str {
 /// This trait is implemented for things like a browser `fetch` request or for
 /// the `reqwest` trait. It should almost never be necessary to implement it
 /// yourself, unless you’re trying to use an alternative HTTP crate on the client side.
-pub trait Client<CustErr> {
+pub trait Client<E> {
     /// The type of a request sent by this client.
-    type Request: ClientReq<CustErr> + Send;
+    type Request: ClientReq<E> + Send;
     /// The type of a response received by this client.
-    type Response: ClientRes<CustErr> + Send;
+    type Response: ClientRes<E> + Send;
 
     /// Sends the request and receives a response.
     fn send(
         req: Self::Request,
-    ) -> impl Future<Output = Result<Self::Response, ServerFnError<CustErr>>> + Send;
+    ) -> impl Future<Output = Result<Self::Response, E>> + Send;
 }
 
 #[cfg(feature = "browser")]
@@ -38,24 +38,23 @@ pub trait Client<CustErr> {
 pub mod browser {
     use super::Client;
     use crate::{
-        error::ServerFnError,
+        error::{FromServerFnError, ServerFnErrorErr},
         request::browser::{BrowserRequest, RequestInner},
         response::browser::BrowserResponse,
     };
     use send_wrapper::SendWrapper;
     use std::future::Future;
 
-    /// Implements [`Client`] for a `fetch` request in the browser.    
+    /// Implements [`Client`] for a `fetch` request in the browser.
     pub struct BrowserClient;
 
-    impl<CustErr> Client<CustErr> for BrowserClient {
+    impl<E: FromServerFnError> Client<E> for BrowserClient {
         type Request = BrowserRequest;
         type Response = BrowserResponse;
 
         fn send(
             req: Self::Request,
-        ) -> impl Future<Output = Result<Self::Response, ServerFnError<CustErr>>>
-               + Send {
+        ) -> impl Future<Output = Result<Self::Response, E>> + Send {
             SendWrapper::new(async move {
                 let req = req.0.take();
                 let RequestInner {
@@ -66,7 +65,9 @@ pub mod browser {
                     .send()
                     .await
                     .map(|res| BrowserResponse(SendWrapper::new(res)))
-                    .map_err(|e| ServerFnError::Request(e.to_string()));
+                    .map_err(|e| {
+                        ServerFnErrorErr::Request(e.to_string()).into()
+                    });
 
                 // at this point, the future has successfully resolved without being dropped, so we
                 // can prevent the `AbortController` from firing
@@ -83,7 +84,10 @@ pub mod browser {
 /// Implements [`Client`] for a request made by [`reqwest`].
 pub mod reqwest {
     use super::Client;
-    use crate::{error::ServerFnError, request::reqwest::CLIENT};
+    use crate::{
+        error::{FromServerFnError, ServerFnErrorErr},
+        request::reqwest::CLIENT,
+    };
     use futures::TryFutureExt;
     use reqwest::{Request, Response};
     use std::future::Future;
@@ -91,17 +95,16 @@ pub mod reqwest {
     /// Implements [`Client`] for a request made by [`reqwest`].
     pub struct ReqwestClient;
 
-    impl<CustErr> Client<CustErr> for ReqwestClient {
+    impl<E: FromServerFnError> Client<E> for ReqwestClient {
         type Request = Request;
         type Response = Response;
 
         fn send(
             req: Self::Request,
-        ) -> impl Future<Output = Result<Self::Response, ServerFnError<CustErr>>>
-               + Send {
+        ) -> impl Future<Output = Result<Self::Response, E>> + Send {
             CLIENT
                 .execute(req)
-                .map_err(|e| ServerFnError::Request(e.to_string()))
+                .map_err(|e| ServerFnErrorErr::Request(e.to_string()).into())
         }
     }
 }

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes, Streaming};
 use crate::{
-    error::{NoCustomError, ServerFnError},
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, Res},
     IntoReq, IntoRes,
@@ -18,55 +18,58 @@ impl Encoding for Json {
     const METHOD: Method = Method::POST;
 }
 
-impl<CustErr, T, Request> IntoReq<Json, Request, CustErr> for T
+impl<E, T, Request> IntoReq<Json, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let data = serde_json::to_string(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_json::to_string(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Request::try_new_post(path, accepts, Json::CONTENT_TYPE, data)
     }
 }
 
-impl<CustErr, T, Request> FromReq<Json, Request, CustErr> for T
+impl<E, T, Request> FromReq<Json, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let string_data = req.try_into_string().await?;
         serde_json::from_str::<Self>(&string_data)
-            .map_err(|e| ServerFnError::Args(e.to_string()))
+            .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))
     }
 }
 
-impl<CustErr, T, Response> IntoRes<Json, Response, CustErr> for T
+impl<E, T, Response> IntoRes<Json, Response, E> for T
 where
-    Response: Res<CustErr>,
+    Response: Res<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
-        let data = serde_json::to_string(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    async fn into_res(self) -> Result<Response, E> {
+        let data = serde_json::to_string(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Response::try_from_string(Json::CONTENT_TYPE, data)
     }
 }
 
-impl<CustErr, T, Response> FromRes<Json, Response, CustErr> for T
+impl<E, T, Response> FromRes<Json, Response, E> for T
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
     T: DeserializeOwned + Send,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let data = res.try_into_string().await?;
-        serde_json::from_str(&data)
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        serde_json::from_str(&data).map_err(|e| {
+            E::from(ServerFnErrorErr::Deserialization(e.to_string()))
+        })
     }
 }
 
@@ -102,35 +105,31 @@ impl Encoding for StreamingJson {
 /// end before the output will begin.
 ///
 /// Streaming requests are only allowed over HTTP2 or HTTP3.
-pub struct JsonStream<T, CustErr = NoCustomError>(
-    Pin<Box<dyn Stream<Item = Result<T, ServerFnError<CustErr>>> + Send>>,
-);
+pub struct JsonStream<T, E>(Pin<Box<dyn Stream<Item = Result<T, E>> + Send>>);
 
-impl<T, CustErr> std::fmt::Debug for JsonStream<T, CustErr> {
+impl<T, E> std::fmt::Debug for JsonStream<T, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("JsonStream").finish()
     }
 }
 
-impl<T> JsonStream<T> {
+impl<T, E> JsonStream<T, E> {
     /// Creates a new `ByteStream` from the given stream.
     pub fn new(
-        value: impl Stream<Item = Result<T, ServerFnError>> + Send + 'static,
+        value: impl Stream<Item = Result<T, E>> + Send + 'static,
     ) -> Self {
         Self(Box::pin(value.map(|value| value.map(Into::into))))
     }
 }
 
-impl<T, CustErr> JsonStream<T, CustErr> {
+impl<T, E> JsonStream<T, E> {
     /// Consumes the wrapper, returning a stream of text.
-    pub fn into_inner(
-        self,
-    ) -> impl Stream<Item = Result<T, ServerFnError<CustErr>>> + Send {
+    pub fn into_inner(self) -> impl Stream<Item = Result<T, E>> + Send {
         self.0
     }
 }
 
-impl<S, T: 'static, CustErr: 'static> From<S> for JsonStream<T, CustErr>
+impl<S, T: 'static, E: 'static> From<S> for JsonStream<T, E>
 where
     S: Stream<Item = T> + Send + 'static,
 {
@@ -139,18 +138,15 @@ where
     }
 }
 
-impl<CustErr, S, T, Request> IntoReq<StreamingJson, Request, CustErr> for S
+impl<E, S, T, Request> IntoReq<StreamingJson, Request, E> for S
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     S: Stream<Item = T> + Send + 'static,
     T: Serialize + 'static,
+    E: FromServerFnError + Serialize,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let data: JsonStream<T> = self.into();
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data: JsonStream<T, E> = self.into();
         Request::try_new_streaming(
             path,
             accepts,
@@ -164,56 +160,58 @@ where
     }
 }
 
-impl<CustErr, T, S, Request> FromReq<StreamingJson, Request, CustErr> for S
+impl<E, T, S, Request> FromReq<StreamingJson, Request, E> for S
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     // The additional `Stream<Item = T>` bound is never used, but it is required to avoid an error where `T` is unconstrained
-    S: Stream<Item = T> + From<JsonStream<T>> + Send + 'static,
+    S: Stream<Item = T> + From<JsonStream<T, E>> + Send + 'static,
     T: DeserializeOwned + 'static,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
         let s = JsonStream::new(data.map(|chunk| {
             chunk.and_then(|bytes| {
-                serde_json::from_slice(bytes.as_ref())
-                    .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+                serde_json::from_slice(bytes.as_ref()).map_err(|e| {
+                    E::from(ServerFnErrorErr::Deserialization(e.to_string()))
+                })
             })
         }));
         Ok(s.into())
     }
 }
 
-impl<CustErr, T, Response> IntoRes<StreamingJson, Response, CustErr>
-    for JsonStream<T, CustErr>
+impl<E, T, Response> IntoRes<StreamingJson, Response, E> for JsonStream<T, E>
 where
-    Response: Res<CustErr>,
-    CustErr: 'static,
+    Response: Res<E>,
     T: Serialize + 'static,
+    E: FromServerFnError,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
+    async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(
             Streaming::CONTENT_TYPE,
             self.into_inner().map(|value| {
-                serde_json::to_vec(&value?)
-                    .map(Bytes::from)
-                    .map_err(|e| ServerFnError::Serialization(e.to_string()))
+                serde_json::to_vec(&value?).map(Bytes::from).map_err(|e| {
+                    ServerFnErrorErr::Serialization(e.to_string()).into()
+                })
             }),
         )
     }
 }
 
-impl<CustErr, T, Response> FromRes<StreamingJson, Response, CustErr>
-    for JsonStream<T>
+impl<E, T, Response> FromRes<StreamingJson, Response, E> for JsonStream<T, E>
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let stream = res.try_into_stream()?;
         Ok(JsonStream::new(stream.map(|chunk| {
             chunk.and_then(|bytes| {
-                serde_json::from_slice(bytes.as_ref())
-                    .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+                serde_json::from_slice(bytes.as_ref()).map_err(|e| {
+                    ServerFnErrorErr::Deserialization(e.to_string()).into()
+                })
             })
         })))
     }

--- a/server_fn/src/codec/mod.rs
+++ b/server_fn/src/codec/mod.rs
@@ -55,7 +55,6 @@ mod postcard;
 pub use postcard::*;
 
 mod stream;
-use crate::error::ServerFnError;
 use futures::Future;
 use http::Method;
 pub use stream::*;
@@ -71,31 +70,27 @@ pub use stream::*;
 /// For example, here’s the implementation for [`Json`].
 ///
 /// ```rust,ignore
-/// impl<CustErr, T, Request> IntoReq<Json, Request, CustErr> for T
+/// impl<E, T, Request> IntoReq<Json, Request, E> for T
 /// where
-///     Request: ClientReq<CustErr>,
+///     Request: ClientReq<E>,
 ///     T: Serialize + Send,
 /// {
 ///     fn into_req(
 ///         self,
 ///         path: &str,
 ///         accepts: &str,
-///     ) -> Result<Request, ServerFnError<CustErr>> {
+///     ) -> Result<Request, E> {
 ///         // try to serialize the data
 ///         let data = serde_json::to_string(&self)
-///             .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+///             .map_err(|e| ServerFnErrorErr::Serialization(e.to_string()).into())?;
 ///         // and use it as the body of a POST request
 ///         Request::try_new_post(path, accepts, Json::CONTENT_TYPE, data)
 ///     }
 /// }
 /// ```
-pub trait IntoReq<Encoding, Request, CustErr> {
+pub trait IntoReq<Encoding, Request, E> {
     /// Attempts to serialize the arguments into an HTTP request.
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>>;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E>;
 }
 
 /// Deserializes an HTTP request into the data type, on the server.
@@ -109,32 +104,31 @@ pub trait IntoReq<Encoding, Request, CustErr> {
 /// For example, here’s the implementation for [`Json`].
 ///
 /// ```rust,ignore
-/// impl<CustErr, T, Request> FromReq<Json, Request, CustErr> for T
+/// impl<E, T, Request> FromReq<Json, Request, E> for T
 /// where
 ///     // require the Request implement `Req`
-///     Request: Req<CustErr> + Send + 'static,
+///     Request: Req<E> + Send + 'static,
 ///     // require that the type can be deserialized with `serde`
 ///     T: DeserializeOwned,
+///     E: FromServerFnError,
 /// {
 ///     async fn from_req(
 ///         req: Request,
-///     ) -> Result<Self, ServerFnError<CustErr>> {
+///     ) -> Result<Self, E> {
 ///         // try to convert the body of the request into a `String`
 ///         let string_data = req.try_into_string().await?;
 ///         // deserialize the data
-///         serde_json::from_str::<Self>(&string_data)
-///             .map_err(|e| ServerFnError::Args(e.to_string()))
+///         serde_json::from_str(&string_data)
+///             .map_err(|e| ServerFnErrorErr::Args(e.to_string()).into())
 ///     }
 /// }
 /// ```
-pub trait FromReq<Encoding, Request, CustErr>
+pub trait FromReq<Encoding, Request, E>
 where
     Self: Sized,
 {
     /// Attempts to deserialize the arguments from a request.
-    fn from_req(
-        req: Request,
-    ) -> impl Future<Output = Result<Self, ServerFnError<CustErr>>> + Send;
+    fn from_req(req: Request) -> impl Future<Output = Result<Self, E>> + Send;
 }
 
 /// Serializes the data type into an HTTP response.
@@ -148,25 +142,24 @@ where
 /// For example, here’s the implementation for [`Json`].
 ///
 /// ```rust,ignore
-/// impl<CustErr, T, Response> IntoRes<Json, Response, CustErr> for T
+/// impl<E, T, Response> IntoRes<Json, Response, E> for T
 /// where
-///     Response: Res<CustErr>,
+///     Response: Res<E>,
 ///     T: Serialize + Send,
+///     E: FromServerFnError,
 /// {
-///     async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
+///     async fn into_res(self) -> Result<Response, E> {
 ///         // try to serialize the data
 ///         let data = serde_json::to_string(&self)
-///             .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+///             .map_err(|e| ServerFnErrorErr::Serialization(e.to_string()).into())?;
 ///         // and use it as the body of a response
 ///         Response::try_from_string(Json::CONTENT_TYPE, data)
 ///     }
 /// }
 /// ```
-pub trait IntoRes<Encoding, Response, CustErr> {
+pub trait IntoRes<Encoding, Response, E> {
     /// Attempts to serialize the output into an HTTP response.
-    fn into_res(
-        self,
-    ) -> impl Future<Output = Result<Response, ServerFnError<CustErr>>> + Send;
+    fn into_res(self) -> impl Future<Output = Result<Response, E>> + Send;
 }
 
 /// Deserializes the data type from an HTTP response.
@@ -181,30 +174,29 @@ pub trait IntoRes<Encoding, Response, CustErr> {
 /// For example, here’s the implementation for [`Json`].
 ///
 /// ```rust,ignore
-/// impl<CustErr, T, Response> FromRes<Json, Response, CustErr> for T
+/// impl<E, T, Response> FromRes<Json, Response, E> for T
 /// where
-///     Response: ClientRes<CustErr> + Send,
+///     Response: ClientRes<E> + Send,
 ///     T: DeserializeOwned + Send,
+///     E: FromServerFnError,
 /// {
 ///     async fn from_res(
 ///         res: Response,
-///     ) -> Result<Self, ServerFnError<CustErr>> {
+///     ) -> Result<Self, E> {
 ///         // extracts the request body
 ///         let data = res.try_into_string().await?;
 ///         // and tries to deserialize it as JSON
 ///         serde_json::from_str(&data)
-///             .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+///             .map_err(|e| ServerFnErrorErr::Deserialization(e.to_string()).into())
 ///     }
 /// }
 /// ```
-pub trait FromRes<Encoding, Response, CustErr>
+pub trait FromRes<Encoding, Response, E>
 where
     Self: Sized,
 {
     /// Attempts to deserialize the outputs from a response.
-    fn from_res(
-        res: Response,
-    ) -> impl Future<Output = Result<Self, ServerFnError<CustErr>>> + Send;
+    fn from_res(res: Response) -> impl Future<Output = Result<Self, E>> + Send;
 }
 
 /// Defines a particular encoding format, which can be used for serializing or deserializing data.

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
 use crate::{
-    error::ServerFnError,
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, Res},
 };
@@ -16,18 +16,16 @@ impl Encoding for MsgPack {
     const METHOD: Method = Method::POST;
 }
 
-impl<T, Request, Err> IntoReq<MsgPack, Request, Err> for T
+impl<T, Request, E> IntoReq<MsgPack, Request, E> for T
 where
-    Request: ClientReq<Err>,
+    Request: ClientReq<E>,
     T: Serialize,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<Err>> {
-        let data = rmp_serde::to_vec(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = rmp_serde::to_vec(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Request::try_new_post_bytes(
             path,
             MsgPack::CONTENT_TYPE,
@@ -37,38 +35,43 @@ where
     }
 }
 
-impl<T, Request, Err> FromReq<MsgPack, Request, Err> for T
+impl<T, Request, E> FromReq<MsgPack, Request, E> for T
 where
-    Request: Req<Err> + Send,
+    Request: Req<E> + Send,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<Err>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_bytes().await?;
         rmp_serde::from_slice::<T>(&data)
-            .map_err(|e| ServerFnError::Args(e.to_string()))
+            .map_err(|e| ServerFnErrorErr::Args(e.to_string()).into())
     }
 }
 
-impl<T, Response, Err> IntoRes<MsgPack, Response, Err> for T
+impl<T, Response, E> IntoRes<MsgPack, Response, E> for T
 where
-    Response: Res<Err>,
+    Response: Res<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<Err>> {
-        let data = rmp_serde::to_vec(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    async fn into_res(self) -> Result<Response, E> {
+        let data = rmp_serde::to_vec(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Response::try_from_bytes(MsgPack::CONTENT_TYPE, Bytes::from(data))
     }
 }
 
-impl<T, Response, Err> FromRes<MsgPack, Response, Err> for T
+impl<T, Response, E> FromRes<MsgPack, Response, E> for T
 where
-    Response: ClientRes<Err> + Send,
+    Response: ClientRes<E> + Send,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<Err>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let data = res.try_into_bytes().await?;
-        rmp_serde::from_slice(&data)
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        rmp_serde::from_slice(&data).map_err(|e| {
+            E::from(ServerFnErrorErr::Deserialization(e.to_string()))
+        })
     }
 }

--- a/server_fn/src/codec/rkyv.rs
+++ b/server_fn/src/codec/rkyv.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
 use crate::{
-    error::ServerFnError,
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, Res},
 };
@@ -29,39 +29,41 @@ impl Encoding for Rkyv {
     const METHOD: Method = Method::POST;
 }
 
-impl<CustErr, T, Request> IntoReq<Rkyv, Request, CustErr> for T
+impl<E, T, Request> IntoReq<Rkyv, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Archive + for<'a> Serialize<RkyvSerializer<'a>>,
     T::Archived: Deserialize<T, RkyvDeserializer>
         + for<'a> CheckBytes<RkyvValidator<'a>>,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let encoded = rkyv::to_bytes::<rancor::Error>(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let encoded = rkyv::to_bytes::<rancor::Error>(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         let bytes = Bytes::copy_from_slice(encoded.as_ref());
         Request::try_new_post_bytes(path, accepts, Rkyv::CONTENT_TYPE, bytes)
     }
 }
 
-impl<CustErr, T, Request> FromReq<Rkyv, Request, CustErr> for T
+impl<E, T, Request> FromReq<Rkyv, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     T: Archive + for<'a> Serialize<RkyvSerializer<'a>>,
     T::Archived: Deserialize<T, RkyvDeserializer>
         + for<'a> CheckBytes<RkyvValidator<'a>>,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let mut aligned = AlignedVec::<1024>::new();
         let mut body_stream = Box::pin(req.try_into_stream()?);
         while let Some(chunk) = body_stream.next().await {
             match chunk {
                 Err(e) => {
-                    return Err(ServerFnError::Deserialization(e.to_string()))
+                    return Err(ServerFnErrorErr::Deserialization(
+                        e.to_string(),
+                    )
+                    .into())
                 }
                 Ok(bytes) => {
                     for byte in bytes {
@@ -71,36 +73,40 @@ where
             }
         }
         rkyv::from_bytes::<T, rancor::Error>(aligned.as_ref())
-            .map_err(|e| ServerFnError::Args(e.to_string()))
+            .map_err(|e| ServerFnErrorErr::Args(e.to_string()).into())
     }
 }
 
-impl<CustErr, T, Response> IntoRes<Rkyv, Response, CustErr> for T
+impl<E, T, Response> IntoRes<Rkyv, Response, E> for T
 where
-    Response: Res<CustErr>,
+    Response: Res<E>,
     T: Send,
     T: Archive + for<'a> Serialize<RkyvSerializer<'a>>,
     T::Archived: Deserialize<T, RkyvDeserializer>
         + for<'a> CheckBytes<RkyvValidator<'a>>,
+    E: FromServerFnError,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
-        let encoded = rkyv::to_bytes::<rancor::Error>(&self)
-            .map_err(|e| ServerFnError::Serialization(format!("{e:?}")))?;
+    async fn into_res(self) -> Result<Response, E> {
+        let encoded = rkyv::to_bytes::<rancor::Error>(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(format!("{e:?}")))
+        })?;
         let bytes = Bytes::copy_from_slice(encoded.as_ref());
         Response::try_from_bytes(Rkyv::CONTENT_TYPE, bytes)
     }
 }
 
-impl<CustErr, T, Response> FromRes<Rkyv, Response, CustErr> for T
+impl<E, T, Response> FromRes<Rkyv, Response, E> for T
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
     T: Archive + for<'a> Serialize<RkyvSerializer<'a>>,
     T::Archived: Deserialize<T, RkyvDeserializer>
         + for<'a> CheckBytes<RkyvValidator<'a>>,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let data = res.try_into_bytes().await?;
-        rkyv::from_bytes::<T, rancor::Error>(&data)
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        rkyv::from_bytes::<T, rancor::Error>(&data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 }

--- a/server_fn/src/codec/serde_lite.rs
+++ b/server_fn/src/codec/serde_lite.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes};
 use crate::{
-    error::ServerFnError,
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, Res},
     IntoReq, IntoRes,
@@ -15,68 +15,64 @@ impl Encoding for SerdeLite {
     const METHOD: Method = Method::POST;
 }
 
-impl<CustErr, T, Request> IntoReq<SerdeLite, Request, CustErr> for T
+impl<E, T, Request> IntoReq<SerdeLite, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let data = serde_json::to_string(
-            &self
-                .serialize()
-                .map_err(|e| ServerFnError::Serialization(e.to_string()))?,
-        )
-        .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_json::to_string(&self.serialize().map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?)
+        .map_err(|e| E::from(ServerFnErrorErr::Serialization(e.to_string())))?;
         Request::try_new_post(path, accepts, SerdeLite::CONTENT_TYPE, data)
     }
 }
 
-impl<CustErr, T, Request> FromReq<SerdeLite, Request, CustErr> for T
+impl<E, T, Request> FromReq<SerdeLite, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     T: Deserialize,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let string_data = req.try_into_string().await?;
         Self::deserialize(
             &serde_json::from_str(&string_data)
-                .map_err(|e| ServerFnError::Args(e.to_string()))?,
+                .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))?,
         )
-        .map_err(|e| ServerFnError::Args(e.to_string()))
+        .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))
     }
 }
 
-impl<CustErr, T, Response> IntoRes<SerdeLite, Response, CustErr> for T
+impl<E, T, Response> IntoRes<SerdeLite, Response, E> for T
 where
-    Response: Res<CustErr>,
+    Response: Res<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
-        let data = serde_json::to_string(
-            &self
-                .serialize()
-                .map_err(|e| ServerFnError::Serialization(e.to_string()))?,
-        )
-        .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    async fn into_res(self) -> Result<Response, E> {
+        let data = serde_json::to_string(&self.serialize().map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?)
+        .map_err(|e| E::from(ServerFnErrorErr::Serialization(e.to_string())))?;
         Response::try_from_string(SerdeLite::CONTENT_TYPE, data)
     }
 }
 
-impl<CustErr, T, Response> FromRes<SerdeLite, Response, CustErr> for T
+impl<E, T, Response> FromRes<SerdeLite, Response, E> for T
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
     T: Deserialize + Send,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let data = res.try_into_string().await?;
         Self::deserialize(
             &serde_json::from_str(&data)
-                .map_err(|e| ServerFnError::Args(e.to_string()))?,
+                .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))?,
         )
-        .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        .map_err(|e| E::from(ServerFnErrorErr::Deserialization(e.to_string())))
     }
 }

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes, IntoReq};
 use crate::{
-    error::{NoCustomError, ServerFnError},
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, Res},
     IntoRes,
@@ -29,26 +29,22 @@ impl Encoding for Streaming {
     const METHOD: Method = Method::POST;
 }
 
-impl<CustErr, T, Request> IntoReq<Streaming, Request, CustErr> for T
+impl<E, T, Request> IntoReq<Streaming, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Stream<Item = Bytes> + Send + Sync + 'static,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
         Request::try_new_streaming(path, accepts, Streaming::CONTENT_TYPE, self)
     }
 }
 
-impl<CustErr, T, Request> FromReq<Streaming, Request, CustErr> for T
+impl<E, T, Request> FromReq<Streaming, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
-    T: From<ByteStream> + 'static,
+    Request: Req<E> + Send + 'static,
+    T: From<ByteStream<E>> + 'static,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
         let s = ByteStream::new(data);
         Ok(s.into())
@@ -67,29 +63,25 @@ where
 /// end before the output will begin.
 ///
 /// Streaming requests are only allowed over HTTP2 or HTTP3.
-pub struct ByteStream<CustErr = NoCustomError>(
-    Pin<Box<dyn Stream<Item = Result<Bytes, ServerFnError<CustErr>>> + Send>>,
-);
+pub struct ByteStream<E>(Pin<Box<dyn Stream<Item = Result<Bytes, E>> + Send>>);
 
-impl<CustErr> ByteStream<CustErr> {
+impl<E> ByteStream<E> {
     /// Consumes the wrapper, returning a stream of bytes.
-    pub fn into_inner(
-        self,
-    ) -> impl Stream<Item = Result<Bytes, ServerFnError<CustErr>>> + Send {
+    pub fn into_inner(self) -> impl Stream<Item = Result<Bytes, E>> + Send {
         self.0
     }
 }
 
-impl<CustErr> Debug for ByteStream<CustErr> {
+impl<E> Debug for ByteStream<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ByteStream").finish()
     }
 }
 
-impl ByteStream {
+impl<E> ByteStream<E> {
     /// Creates a new `ByteStream` from the given stream.
     pub fn new<T>(
-        value: impl Stream<Item = Result<T, ServerFnError>> + Send + 'static,
+        value: impl Stream<Item = Result<T, E>> + Send + 'static,
     ) -> Self
     where
         T: Into<Bytes>,
@@ -98,7 +90,7 @@ impl ByteStream {
     }
 }
 
-impl<S, T> From<S> for ByteStream
+impl<E, S, T> From<S> for ByteStream<E>
 where
     S: Stream<Item = T> + Send + 'static,
     T: Into<Bytes>,
@@ -108,22 +100,21 @@ where
     }
 }
 
-impl<CustErr, Response> IntoRes<Streaming, Response, CustErr>
-    for ByteStream<CustErr>
+impl<E, Response> IntoRes<Streaming, Response, E> for ByteStream<E>
 where
-    Response: Res<CustErr>,
-    CustErr: 'static,
+    Response: Res<E>,
+    E: 'static,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
+    async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(Streaming::CONTENT_TYPE, self.into_inner())
     }
 }
 
-impl<CustErr, Response> FromRes<Streaming, Response, CustErr> for ByteStream
+impl<E, Response> FromRes<Streaming, Response, E> for ByteStream<E>
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let stream = res.try_into_stream()?;
         Ok(ByteStream(Box::pin(stream)))
     }
@@ -160,35 +151,31 @@ impl Encoding for StreamingText {
 /// end before the output will begin.
 ///
 /// Streaming requests are only allowed over HTTP2 or HTTP3.
-pub struct TextStream<CustErr = NoCustomError>(
-    Pin<Box<dyn Stream<Item = Result<String, ServerFnError<CustErr>>> + Send>>,
-);
+pub struct TextStream<E>(Pin<Box<dyn Stream<Item = Result<String, E>> + Send>>);
 
-impl<CustErr> Debug for TextStream<CustErr> {
+impl<E> Debug for TextStream<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("TextStream").finish()
     }
 }
 
-impl TextStream {
+impl<E> TextStream<E> {
     /// Creates a new `ByteStream` from the given stream.
     pub fn new(
-        value: impl Stream<Item = Result<String, ServerFnError>> + Send + 'static,
+        value: impl Stream<Item = Result<String, E>> + Send + 'static,
     ) -> Self {
         Self(Box::pin(value.map(|value| value.map(Into::into))))
     }
 }
 
-impl<CustErr> TextStream<CustErr> {
+impl<E> TextStream<E> {
     /// Consumes the wrapper, returning a stream of text.
-    pub fn into_inner(
-        self,
-    ) -> impl Stream<Item = Result<String, ServerFnError<CustErr>>> + Send {
+    pub fn into_inner(self) -> impl Stream<Item = Result<String, E>> + Send {
         self.0
     }
 }
 
-impl<S, T> From<S> for TextStream
+impl<E, S, T> From<S> for TextStream<E>
 where
     S: Stream<Item = T> + Send + 'static,
     T: Into<String>,
@@ -198,16 +185,13 @@ where
     }
 }
 
-impl<CustErr, T, Request> IntoReq<StreamingText, Request, CustErr> for T
+impl<E, T, Request> IntoReq<StreamingText, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
-    T: Into<TextStream>,
+    Request: ClientReq<E>,
+    T: Into<TextStream<E>>,
+    E: 'static,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
         let data = self.into();
         Request::try_new_streaming(
             path,
@@ -218,30 +202,31 @@ where
     }
 }
 
-impl<CustErr, T, Request> FromReq<StreamingText, Request, CustErr> for T
+impl<E, T, Request> FromReq<StreamingText, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
-    T: From<TextStream> + 'static,
+    Request: Req<E> + Send + 'static,
+    T: From<TextStream<E>> + 'static,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
         let s = TextStream::new(data.map(|chunk| {
             chunk.and_then(|bytes| {
-                String::from_utf8(bytes.to_vec())
-                    .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+                String::from_utf8(bytes.to_vec()).map_err(|e| {
+                    ServerFnErrorErr::Deserialization(e.to_string()).into()
+                })
             })
         }));
         Ok(s.into())
     }
 }
 
-impl<CustErr, Response> IntoRes<StreamingText, Response, CustErr>
-    for TextStream<CustErr>
+impl<E, Response> IntoRes<StreamingText, Response, E> for TextStream<E>
 where
-    Response: Res<CustErr>,
-    CustErr: 'static,
+    Response: Res<E>,
+    E: 'static,
 {
-    async fn into_res(self) -> Result<Response, ServerFnError<CustErr>> {
+    async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(
             Streaming::CONTENT_TYPE,
             self.into_inner().map(|stream| stream.map(Into::into)),
@@ -249,16 +234,18 @@ where
     }
 }
 
-impl<CustErr, Response> FromRes<StreamingText, Response, CustErr> for TextStream
+impl<E, Response> FromRes<StreamingText, Response, E> for TextStream<E>
 where
-    Response: ClientRes<CustErr> + Send,
+    Response: ClientRes<E> + Send,
+    E: FromServerFnError,
 {
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, E> {
         let stream = res.try_into_stream()?;
         Ok(TextStream(Box::pin(stream.map(|chunk| {
             chunk.and_then(|bytes| {
-                String::from_utf8(bytes.into())
-                    .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+                String::from_utf8(bytes.into()).map_err(|e| {
+                    ServerFnErrorErr::Deserialization(e.to_string()).into()
+                })
             })
         }))))
     }

--- a/server_fn/src/codec/url.rs
+++ b/server_fn/src/codec/url.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, IntoReq};
 use crate::{
-    error::ServerFnError,
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
 };
 use http::Method;
@@ -17,32 +17,31 @@ impl Encoding for GetUrl {
     const METHOD: Method = Method::GET;
 }
 
-impl<CustErr, T, Request> IntoReq<GetUrl, Request, CustErr> for T
+impl<E, T, Request> IntoReq<GetUrl, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let data = serde_qs::to_string(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_qs::to_string(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Request::try_new_get(path, accepts, GetUrl::CONTENT_TYPE, &data)
     }
 }
 
-impl<CustErr, T, Request> FromReq<GetUrl, Request, CustErr> for T
+impl<E, T, Request> FromReq<GetUrl, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let string_data = req.as_query().unwrap_or_default();
         let args = serde_qs::Config::new(5, false)
             .deserialize_str::<Self>(string_data)
-            .map_err(|e| ServerFnError::Args(e.to_string()))?;
+            .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))?;
         Ok(args)
     }
 }
@@ -52,32 +51,31 @@ impl Encoding for PostUrl {
     const METHOD: Method = Method::POST;
 }
 
-impl<CustErr, T, Request> IntoReq<PostUrl, Request, CustErr> for T
+impl<E, T, Request> IntoReq<PostUrl, Request, E> for T
 where
-    Request: ClientReq<CustErr>,
+    Request: ClientReq<E>,
     T: Serialize + Send,
+    E: FromServerFnError,
 {
-    fn into_req(
-        self,
-        path: &str,
-        accepts: &str,
-    ) -> Result<Request, ServerFnError<CustErr>> {
-        let qs = serde_qs::to_string(&self)
-            .map_err(|e| ServerFnError::Serialization(e.to_string()))?;
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let qs = serde_qs::to_string(&self).map_err(|e| {
+            E::from(ServerFnErrorErr::Serialization(e.to_string()))
+        })?;
         Request::try_new_post(path, accepts, PostUrl::CONTENT_TYPE, qs)
     }
 }
 
-impl<CustErr, T, Request> FromReq<PostUrl, Request, CustErr> for T
+impl<E, T, Request> FromReq<PostUrl, Request, E> for T
 where
-    Request: Req<CustErr> + Send + 'static,
+    Request: Req<E> + Send + 'static,
     T: DeserializeOwned,
+    E: FromServerFnError,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, E> {
         let string_data = req.try_into_string().await?;
         let args = serde_qs::Config::new(5, false)
             .deserialize_str::<Self>(&string_data)
-            .map_err(|e| ServerFnError::Args(e.to_string()))?;
+            .map_err(|e| E::from(ServerFnErrorErr::Args(e.to_string())))?;
         Ok(args)
     }
 }
@@ -86,18 +84,18 @@ where
 impl<T, Request, Response> Codec<Request, Response, GetUrlJson> for T
 where
     T: DeserializeOwned + Serialize + Send,
-    Request: Req<CustErr> + Send,
-    Response: Res<CustErr> + Send,
+    Request: Req<E> + Send,
+    Response: Res<E> + Send,
 {
-    async fn from_req(req: Request) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_req(req: Request) -> Result<Self, ServerFnError<E>> {
         let string_data = req.try_into_string()?;
 
         let args = serde_json::from_str::<Self>(&string_data)
-            .map_err(|e| ServerFnError::Args(e.to_string()))?;
+            .map_err(|e| ServerFnErrorErr::Args(e.to_string()).into())?;
         Ok(args)
     }
 
-    async fn into_req(self) -> Result<Request, ServerFnError<CustErr>> {
+    async fn into_req(self) -> Result<Request, ServerFnError<E>> {
         /* let qs = serde_qs::to_string(&self)?;
         let req = http::Request::builder()
             .method("GET")
@@ -110,7 +108,7 @@ where
         todo!()
     }
 
-    async fn from_res(res: Response) -> Result<Self, ServerFnError<CustErr>> {
+    async fn from_res(res: Response) -> Result<Self, ServerFnError<E>> {
         todo!()
         /* let (_parts, body) = res.into_parts();
 
@@ -118,7 +116,7 @@ where
             .collect()
             .await
             .map(|c| c.to_bytes())
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))?;
+            .map_err(|e| ServerFnErrorErr::Deserialization(e.to_string()).into())?;
         let string_data = String::from_utf8(body_bytes.to_vec())?;
         serde_json::from_str(&string_data)
             .map_err(|e| ServerFnError::Deserialization(e.to_string())) */

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -1,4 +1,7 @@
-use crate::{error::ServerFnError, request::Req};
+use crate::{
+    error::{FromServerFnError, ServerFnErrorErr},
+    request::Req,
+};
 use axum::body::{Body, Bytes};
 use futures::{Stream, StreamExt};
 use http::{
@@ -8,9 +11,9 @@ use http::{
 use http_body_util::BodyExt;
 use std::borrow::Cow;
 
-impl<CustErr> Req<CustErr> for Request<Body>
+impl<E> Req<E> for Request<Body>
 where
-    CustErr: 'static,
+    E: FromServerFnError,
 {
     fn as_query(&self) -> Option<&str> {
         self.uri().query()
@@ -34,29 +37,28 @@ where
             .map(|h| String::from_utf8_lossy(h.as_bytes()))
     }
 
-    async fn try_into_bytes(self) -> Result<Bytes, ServerFnError<CustErr>> {
+    async fn try_into_bytes(self) -> Result<Bytes, E> {
         let (_parts, body) = self.into_parts();
 
-        body.collect()
-            .await
-            .map(|c| c.to_bytes())
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        body.collect().await.map(|c| c.to_bytes()).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
-    async fn try_into_string(self) -> Result<String, ServerFnError<CustErr>> {
+    async fn try_into_string(self) -> Result<String, E> {
         let bytes = self.try_into_bytes().await?;
-        String::from_utf8(bytes.to_vec())
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        String::from_utf8(bytes.to_vec()).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, ServerFnError>> + Send + 'static,
-        ServerFnError<CustErr>,
-    > {
+    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + 'static, E> {
         Ok(self.into_body().into_data_stream().map(|chunk| {
-            chunk.map_err(|e| ServerFnError::Deserialization(e.to_string()))
+            chunk.map_err(|e| {
+                ServerFnErrorErr::Deserialization(e.to_string()).into()
+            })
         }))
     }
 }

--- a/server_fn/src/request/generic.rs
+++ b/server_fn/src/request/generic.rs
@@ -12,7 +12,10 @@
 //! * `wasm32-wasip*` integration crate `leptos_wasi` is using this
 //!   crate under the hood.
 
-use crate::request::Req;
+use crate::{
+    error::{FromServerFnError, ServerFnErrorErr},
+    request::Req,
+};
 use bytes::Bytes;
 use futures::{
     stream::{self, Stream},
@@ -21,30 +24,23 @@ use futures::{
 use http::Request;
 use std::borrow::Cow;
 
-impl<CustErr> Req<CustErr> for Request<Bytes>
+impl<E> Req<E> for Request<Bytes>
 where
-    CustErr: 'static,
+    E: FromServerFnError,
 {
-    async fn try_into_bytes(
-        self,
-    ) -> Result<Bytes, crate::ServerFnError<CustErr>> {
+    async fn try_into_bytes(self) -> Result<Bytes, E> {
         Ok(self.into_body())
     }
 
-    async fn try_into_string(
-        self,
-    ) -> Result<String, crate::ServerFnError<CustErr>> {
+    async fn try_into_string(self) -> Result<String, E> {
         String::from_utf8(self.into_body().into()).map_err(|err| {
-            crate::ServerFnError::Deserialization(err.to_string())
+            ServerFnErrorErr::Deserialization(err.to_string()).into()
         })
     }
 
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, crate::ServerFnError>> + Send + 'static,
-        crate::ServerFnError<CustErr>,
-    > {
+    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + 'static, E> {
         Ok(stream::iter(self.into_body())
             .ready_chunks(16)
             .map(|chunk| Ok(Bytes::from(chunk))))

--- a/server_fn/src/request/spin.rs
+++ b/server_fn/src/request/spin.rs
@@ -8,7 +8,7 @@ use http::{
 use http_body_util::BodyExt;
 use std::borrow::Cow;
 
-impl<CustErr> Req<CustErr> for IncomingRequest
+impl<E> Req<E> for IncomingRequest
 where
     CustErr: 'static,
 {
@@ -34,29 +34,31 @@ where
             .map(|h| String::from_utf8_lossy(h.as_bytes()))
     }
 
-    async fn try_into_bytes(self) -> Result<Bytes, ServerFnError<CustErr>> {
+    async fn try_into_bytes(self) -> Result<Bytes, E> {
         let (_parts, body) = self.into_parts();
 
-        body.collect()
-            .await
-            .map(|c| c.to_bytes())
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        body.collect().await.map(|c| c.to_bytes()).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
-    async fn try_into_string(self) -> Result<String, ServerFnError<CustErr>> {
+    async fn try_into_string(self) -> Result<String, E> {
         let bytes = self.try_into_bytes().await?;
-        String::from_utf8(bytes.to_vec())
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+        String::from_utf8(bytes.to_vec()).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
     fn try_into_stream(
         self,
     ) -> Result<
         impl Stream<Item = Result<Bytes, ServerFnError>> + Send + 'static,
-        ServerFnError<CustErr>,
+        E,
     > {
         Ok(self.into_body().into_data_stream().map(|chunk| {
-            chunk.map_err(|e| ServerFnError::Deserialization(e.to_string()))
+            chunk.map_err(|e| {
+                ServerFnErrorErr::Deserialization(e.to_string()).into()
+            })
         }))
     }
 }

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -1,6 +1,6 @@
 use super::Res;
 use crate::error::{
-    ServerFnError, ServerFnErrorErr, ServerFnErrorSerde, SERVER_FN_ERROR_HEADER,
+    FromServerFnError, ServerFnErrorWrapper, SERVER_FN_ERROR_HEADER,
 };
 use actix_web::{
     http::{
@@ -13,10 +13,6 @@ use actix_web::{
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use send_wrapper::SendWrapper;
-use std::{
-    fmt::{Debug, Display},
-    str::FromStr,
-};
 
 /// A wrapped Actix response.
 ///
@@ -38,14 +34,11 @@ impl From<HttpResponse> for ActixResponse {
     }
 }
 
-impl<CustErr> Res<CustErr> for ActixResponse
+impl<E> Res<E> for ActixResponse
 where
-    CustErr: FromStr + Display + Debug + 'static,
+    E: FromServerFnError,
 {
-    fn try_from_string(
-        content_type: &str,
-        data: String,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+    fn try_from_string(content_type: &str, data: String) -> Result<Self, E> {
         let mut builder = HttpResponse::build(StatusCode::OK);
         Ok(ActixResponse(SendWrapper::new(
             builder
@@ -54,10 +47,7 @@ where
         )))
     }
 
-    fn try_from_bytes(
-        content_type: &str,
-        data: Bytes,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+    fn try_from_bytes(content_type: &str, data: Bytes) -> Result<Self, E> {
         let mut builder = HttpResponse::build(StatusCode::OK);
         Ok(ActixResponse(SendWrapper::new(
             builder
@@ -68,19 +58,17 @@ where
 
     fn try_from_stream(
         content_type: &str,
-        data: impl Stream<Item = Result<Bytes, ServerFnError<CustErr>>> + 'static,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+        data: impl Stream<Item = Result<Bytes, E>> + 'static,
+    ) -> Result<Self, E> {
         let mut builder = HttpResponse::build(StatusCode::OK);
         Ok(ActixResponse(SendWrapper::new(
             builder
                 .insert_header((header::CONTENT_TYPE, content_type))
-                .streaming(
-                    data.map(|data| data.map_err(ServerFnErrorErr::from)),
-                ),
+                .streaming(data.map(|data| data.map_err(ServerFnErrorWrapper))),
         )))
     }
 
-    fn error_response(path: &str, err: &ServerFnError<CustErr>) -> Self {
+    fn error_response(path: &str, err: &E) -> Self {
         ActixResponse(SendWrapper::new(
             HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
                 .append_header((SERVER_FN_ERROR_HEADER, path))

--- a/server_fn/src/response/browser.rs
+++ b/server_fn/src/response/browser.rs
@@ -1,5 +1,8 @@
 use super::ClientRes;
-use crate::{error::ServerFnError, redirect::REDIRECT_HEADER};
+use crate::{
+    error::{FromServerFnError, ServerFnErrorErr},
+    redirect::REDIRECT_HEADER,
+};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 pub use gloo_net::http::Response;
@@ -12,48 +15,36 @@ use wasm_streams::ReadableStream;
 /// The response to a `fetch` request made in the browser.
 pub struct BrowserResponse(pub(crate) SendWrapper<Response>);
 
-impl<CustErr> ClientRes<CustErr> for BrowserResponse {
-    fn try_into_string(
-        self,
-    ) -> impl Future<Output = Result<String, ServerFnError<CustErr>>> + Send
-    {
+impl<E: FromServerFnError> ClientRes<E> for BrowserResponse {
+    fn try_into_string(self) -> impl Future<Output = Result<String, E>> + Send {
         // the browser won't send this async work between threads (because it's single-threaded)
         // so we can safely wrap this
         SendWrapper::new(async move {
-            self.0
-                .text()
-                .await
-                .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+            self.0.text().await.map_err(|e| {
+                ServerFnErrorErr::Deserialization(e.to_string()).into()
+            })
         })
     }
 
-    fn try_into_bytes(
-        self,
-    ) -> impl Future<Output = Result<Bytes, ServerFnError<CustErr>>> + Send
-    {
+    fn try_into_bytes(self) -> impl Future<Output = Result<Bytes, E>> + Send {
         // the browser won't send this async work between threads (because it's single-threaded)
         // so we can safely wrap this
         SendWrapper::new(async move {
-            self.0
-                .binary()
-                .await
-                .map(Bytes::from)
-                .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+            self.0.binary().await.map(Bytes::from).map_err(|e| {
+                ServerFnErrorErr::Deserialization(e.to_string()).into()
+            })
         })
     }
 
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, ServerFnError>> + Send + 'static,
-        ServerFnError<CustErr>,
-    > {
+    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + 'static, E> {
         let stream = ReadableStream::from_raw(self.0.body().unwrap())
             .into_stream()
             .map(|data| match data {
                 Err(e) => {
                     web_sys::console::error_1(&e);
-                    Err(ServerFnError::Request(format!("{e:?}")))
+                    Err(ServerFnErrorErr::Request(format!("{e:?}")).into())
                 }
                 Ok(data) => {
                     let data = data.unchecked_into::<Uint8Array>();

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -13,62 +13,46 @@ pub mod http;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 
-use crate::error::ServerFnError;
 use bytes::Bytes;
 use futures::Stream;
 use std::future::Future;
 
 /// Represents the response as created by the server;
-pub trait Res<CustErr>
+pub trait Res<E>
 where
     Self: Sized,
 {
     /// Attempts to convert a UTF-8 string into an HTTP response.
-    fn try_from_string(
-        content_type: &str,
-        data: String,
-    ) -> Result<Self, ServerFnError<CustErr>>;
+    fn try_from_string(content_type: &str, data: String) -> Result<Self, E>;
 
     /// Attempts to convert a binary blob represented as bytes into an HTTP response.
-    fn try_from_bytes(
-        content_type: &str,
-        data: Bytes,
-    ) -> Result<Self, ServerFnError<CustErr>>;
+    fn try_from_bytes(content_type: &str, data: Bytes) -> Result<Self, E>;
 
     /// Attempts to convert a stream of bytes into an HTTP response.
     fn try_from_stream(
         content_type: &str,
-        data: impl Stream<Item = Result<Bytes, ServerFnError<CustErr>>>
-            + Send
-            + 'static,
-    ) -> Result<Self, ServerFnError<CustErr>>;
+        data: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+    ) -> Result<Self, E>;
 
     /// Converts an error into a response, with a `500` status code and the error text as its body.
-    fn error_response(path: &str, err: &ServerFnError<CustErr>) -> Self;
+    fn error_response(path: &str, err: &E) -> Self;
 
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
 }
 
 /// Represents the response as received by the client.
-pub trait ClientRes<CustErr> {
+pub trait ClientRes<E> {
     /// Attempts to extract a UTF-8 string from an HTTP response.
-    fn try_into_string(
-        self,
-    ) -> impl Future<Output = Result<String, ServerFnError<CustErr>>> + Send;
+    fn try_into_string(self) -> impl Future<Output = Result<String, E>> + Send;
 
     /// Attempts to extract a binary blob from an HTTP response.
-    fn try_into_bytes(
-        self,
-    ) -> impl Future<Output = Result<Bytes, ServerFnError<CustErr>>> + Send;
+    fn try_into_bytes(self) -> impl Future<Output = Result<Bytes, E>> + Send;
 
     /// Attempts to extract a binary stream from an HTTP response.
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, ServerFnError>> + Send + Sync + 'static,
-        ServerFnError<CustErr>,
-    >;
+    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + Sync + 'static, E>;
 
     /// HTTP status code of the response.
     fn status(&self) -> u16;
@@ -91,29 +75,23 @@ pub trait ClientRes<CustErr> {
 /// server response type when compiling for the client.
 pub struct BrowserMockRes;
 
-impl<CustErr> Res<CustErr> for BrowserMockRes {
-    fn try_from_string(
-        _content_type: &str,
-        _data: String,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+impl<E> Res<E> for BrowserMockRes {
+    fn try_from_string(_content_type: &str, _data: String) -> Result<Self, E> {
         unreachable!()
     }
 
-    fn try_from_bytes(
-        _content_type: &str,
-        _data: Bytes,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+    fn try_from_bytes(_content_type: &str, _data: Bytes) -> Result<Self, E> {
         unreachable!()
     }
 
-    fn error_response(_path: &str, _err: &ServerFnError<CustErr>) -> Self {
+    fn error_response(_path: &str, _err: &E) -> Self {
         unreachable!()
     }
 
     fn try_from_stream(
         _content_type: &str,
-        _data: impl Stream<Item = Result<Bytes, ServerFnError<CustErr>>>,
-    ) -> Result<Self, ServerFnError<CustErr>> {
+        _data: impl Stream<Item = Result<Bytes, E>>,
+    ) -> Result<Self, E> {
         unreachable!()
     }
 

--- a/server_fn/src/response/reqwest.rs
+++ b/server_fn/src/response/reqwest.rs
@@ -1,31 +1,28 @@
 use super::ClientRes;
-use crate::error::ServerFnError;
+use crate::error::{FromServerFnError, ServerFnErrorErr};
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use reqwest::Response;
 
-impl<CustErr> ClientRes<CustErr> for Response {
-    async fn try_into_string(self) -> Result<String, ServerFnError<CustErr>> {
-        self.text()
-            .await
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+impl<E: FromServerFnError> ClientRes<E> for Response {
+    async fn try_into_string(self) -> Result<String, E> {
+        self.text().await.map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
-    async fn try_into_bytes(self) -> Result<Bytes, ServerFnError<CustErr>> {
-        self.bytes()
-            .await
-            .map_err(|e| ServerFnError::Deserialization(e.to_string()))
+    async fn try_into_bytes(self) -> Result<Bytes, E> {
+        self.bytes().await.map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into()
+        })
     }
 
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, ServerFnError>> + Send + 'static,
-        ServerFnError<CustErr>,
-    > {
+    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + 'static, E> {
         Ok(self
             .bytes_stream()
-            .map_err(|e| ServerFnError::Response(e.to_string())))
+            .map_err(|e| ServerFnErrorErr::Response(e.to_string()).into()))
     }
 
     fn status(&self) -> u16 {


### PR DESCRIPTION
Closes #3270 

- [x] Added `FromServerFnError`
- [x] `cargo clippy -p server_fn --all-features`
- [x] `cargo clippy -p leptos_server --all-features`
- [ ] Update `server_fn_macros` to use `FromServerFnError` trait
- [ ] End to end smoke tests???