### PR TITLE
docs: adds more helpful text for hydration errors (closes #3267)

### DIFF
--- a/tachys/src/html/element/custom.rs
+++ b/tachys/src/html/element/custom.rs
@@ -9,8 +9,9 @@ where
     E: AsRef<str>,
 {
     HtmlElement {
+        #[cfg(debug_assertions)]
+        defined_at: std::panic::Location::caller(),
         tag: Custom(tag),
-
         attributes: (),
         children: (),
     }

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -25,10 +25,11 @@ macro_rules! html_element_inner {
 
             {
                 HtmlElement {
+                    #[cfg(debug_assertions)]
+                    defined_at: std::panic::Location::caller(),
                     tag: $struct_name,
                     attributes: (),
                     children: (),
-
                 }
             }
 
@@ -55,10 +56,17 @@ macro_rules! html_element_inner {
                         At: NextTuple,
                         <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
                     {
-                        let HtmlElement { tag, children, attributes } = self;
-                        HtmlElement {
+                        let HtmlElement {
+                            #[cfg(debug_assertions)]
+                            defined_at,
                             tag,
-
+                            children,
+                            attributes
+                        } = self;
+                        HtmlElement {
+                            #[cfg(debug_assertions)]
+                            defined_at,
+                            tag,
                             children,
                             attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
                         }
@@ -118,14 +126,16 @@ macro_rules! html_self_closing_elements {
         paste::paste! {
             $(
                 #[$meta]
+                #[track_caller]
                 pub fn $tag() -> HtmlElement<[<$tag:camel>], (), ()>
                 where
 
                 {
                     HtmlElement {
+                        #[cfg(debug_assertions)]
+                        defined_at: std::panic::Location::caller(),
                         attributes: (),
                         children: (),
-
                         tag: [<$tag:camel>],
                     }
                 }
@@ -138,7 +148,6 @@ macro_rules! html_self_closing_elements {
                 impl<At> HtmlElement<[<$tag:camel>], At, ()>
                 where
                     At: Attribute,
-
                 {
                     $(
                         #[doc = concat!("The [`", stringify!($attr), "`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/", stringify!($tag), "#", stringify!($attr) ,") attribute on `<", stringify!($tag), ">`.")]
@@ -151,13 +160,18 @@ macro_rules! html_self_closing_elements {
                             V: AttributeValue,
                             At: NextTuple,
                             <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
-
                         {
-                            let HtmlElement { tag, children, attributes,
+                            let HtmlElement {
+                                 #[cfg(debug_assertions)]
+                                 defined_at,
+                                tag,
+                                children,
+                                attributes,
                             } = self;
                             HtmlElement {
+                                #[cfg(debug_assertions)]
+                                defined_at,
                                 tag,
-
                                 children,
                                 attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
                             }

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -1,6 +1,8 @@
+#[cfg(debug_assertions)]
+use crate::hydration::set_currently_hydrating;
 use crate::{
     html::attribute::Attribute,
-    hydration::{failed_to_cast_element, set_currently_hydrating, Cursor},
+    hydration::{failed_to_cast_element, Cursor},
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{

--- a/tachys/src/hydration.rs
+++ b/tachys/src/hydration.rs
@@ -2,11 +2,9 @@ use crate::{
     renderer::{CastFrom, Rndr},
     view::{Position, PositionState},
 };
-use std::{
-    cell::{Cell, RefCell},
-    panic::Location,
-    rc::Rc,
-};
+#[cfg(debug_assertions)]
+use std::cell::Cell;
+use std::{cell::RefCell, panic::Location, rc::Rc};
 use web_sys::{Comment, Element, Node, Text};
 
 /// Hydration works by walking over the DOM, adding interactivity as needed.

--- a/tachys/src/hydration.rs
+++ b/tachys/src/hydration.rs
@@ -113,7 +113,14 @@ thread_local! {
 pub(crate) fn set_currently_hydrating(
     location: Option<&'static Location<'static>>,
 ) {
-    CURRENTLY_HYDRATING.set(location);
+    #[cfg(debug_assertions)]
+    {
+        CURRENTLY_HYDRATING.set(location);
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        _ = location;
+    }
 }
 
 pub(crate) fn failed_to_cast_element(tag_name: &str, node: Node) -> Element {

--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -22,10 +22,17 @@ macro_rules! mathml_global {
 				At: NextTuple,
 				<At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
 			{
-				let HtmlElement { tag, children, attributes } = self;
+				let HtmlElement {
+                    #[cfg(debug_assertions)]
+                    defined_at,
+                    tag,
+                    children,
+                    attributes
+                } = self;
 				HtmlElement {
+                    #[cfg(debug_assertions)]
+                    defined_at,
 					tag,
-
 					children,
 					attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
 				}
@@ -46,10 +53,11 @@ macro_rules! mathml_elements {
 
                 {
                     HtmlElement {
+                        #[cfg(debug_assertions)]
+                        defined_at: std::panic::Location::caller(),
                         tag: [<$tag:camel>],
                         attributes: (),
                         children: (),
-
                     }
                 }
 
@@ -84,10 +92,17 @@ macro_rules! mathml_elements {
                             At: NextTuple,
                             <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
                         {
-                            let HtmlElement { tag, children, attributes } = self;
-                            HtmlElement {
+                            let HtmlElement {
+                                #[cfg(debug_assertions)]
+                                defined_at,
                                 tag,
-
+                                children,
+                                attributes
+                            } = self;
+                            HtmlElement {
+                                #[cfg(debug_assertions)]
+                                defined_at,
+                                tag,
                                 children,
                                 attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
                             }

--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -14,15 +14,16 @@ macro_rules! svg_elements {
                 /// An SVG element.
                 // `tag()` function
                 #[allow(non_snake_case)]
+                #[track_caller]
                 pub fn $tag() -> HtmlElement<[<$tag:camel>], (), ()>
                 where
-
                 {
                     HtmlElement {
+                        #[cfg(debug_assertions)]
+                        defined_at: std::panic::Location::caller(),
                         tag: [<$tag:camel>],
                         attributes: (),
                         children: (),
-
                     }
                 }
 
@@ -153,9 +154,12 @@ svg_elements![
 
 /// An SVG element.
 #[allow(non_snake_case)]
+#[track_caller]
 pub fn r#use() -> HtmlElement<Use, (), ()>
 where {
     HtmlElement {
+        #[cfg(debug_assertions)]
+        defined_at: std::panic::Location::caller(),
         tag: Use,
         attributes: (),
         children: (),

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -100,8 +100,8 @@ macro_rules! render_primitive {
 					}
 
 					let node = cursor.current();
-					let node = crate::renderer::types::Text::cast_from(node)
-						.expect("couldn't cast text node from node");
+					let node = crate::renderer::types::Text::cast_from(node.clone())
+						.unwrap_or_else(|| crate::hydration::failed_to_cast_text_node(node));
 
 					if !FROM_SERVER {
 						Rndr::set_text(&node, &self.to_string());

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -90,8 +90,10 @@ impl RenderHtml for &str {
         }
 
         let node = cursor.current();
-        let node = crate::renderer::types::Text::cast_from(node)
-            .expect("couldn't cast text node from node");
+        let node = crate::renderer::types::Text::cast_from(node.clone())
+            .unwrap_or_else(|| {
+                crate::hydration::failed_to_cast_text_node(node)
+            });
 
         if !FROM_SERVER {
             Rndr::set_text(&node, self);


### PR DESCRIPTION
Error messages in the case of hydration problems are currently very unhelpful in 0.7, as I had not yet done anything to make them more useful. For example, if the renderer was expected to find an element and found something else instead, you just got an `.unwrap()` inside `HtmlElement::hydrate()`.

This adds some debugging machinery that attempts to do the following:
1. Provide a useful error message.
2. List the location of the `view!` or element that is currently being hydrated, to help narrow down problems.
3. Logs out the unexpected node as part of the error message in the JS console. Most browser devtools allow you to right-click and go to where that node is used in the page, which means you can navigate directly to wherever in your application the unexpected node was found.