### PR TITLE
Fix help message for island macro

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -639,7 +639,7 @@ pub fn island(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             abort!(
                 transparent,
                 "only `transparent` is supported";
-                help = "try `#[component(transparent)]` or `#[component]`"
+                help = "try `#[island(transparent)]` or `#[island]`"
             );
         }
 


### PR DESCRIPTION
I stumbled over the help message of the `island` macro using `component` instead of `island`.