### PR TITLE
Update Leptos to use latest wasm-bindgen version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4125,9 +4125,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4136,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
  "log",
@@ -4151,21 +4151,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
+checksum = "951fe82312ed48443ac78b66fa43eded9999f738f6022e67aead7b708659e49a"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4173,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4186,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wasm-streams"
@@ -4205,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/any_spawner/Cargo.toml
+++ b/any_spawner/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { version = "1.41", optional = true, default-features = false, features 
   "rt",
 ] }
 tracing = { version = "0.1.40", optional = true }
-wasm-bindgen-futures = { version = "0.4.45", optional = true }
+wasm-bindgen-futures = { version = "0.4.46", optional = true }
 
 [features]
 async-executor = ["dep:async-executor"]

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -40,12 +40,12 @@ server_fn = { workspace = true, features = [
   "browser",
   "url",
 ] }
-web-sys = { version = "0.3.72", features = [
+web-sys = { version = "0.3.73", features = [
   "ShadowRoot",
   "ShadowRootInit",
   "ShadowRootMode",
 ] }
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.31"

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -12,10 +12,10 @@ edition.workspace = true
 tachys = { workspace = true }
 reactive_graph = { workspace = true }
 or_poisoned = { workspace = true }
-js-sys = "0.3.72"
+js-sys = "0.3.73"
 send_wrapper = "0.6.0"
 tracing = { version = "0.1.40", optional = true }
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
 
@@ -23,7 +23,7 @@ serde = { version = "1.0", optional = true }
 leptos = { path = "../leptos" }
 
 [dependencies.web-sys]
-version = "0.3.72"
+version = "0.3.73"
 features = ["Location"]
 
 [features]

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -15,11 +15,11 @@ or_poisoned = { workspace = true }
 indexmap = "2.6"
 send_wrapper = "0.6.0"
 tracing = { version = "0.1.40", optional = true }
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 futures = "0.3.31"
 
 [dependencies.web-sys]
-version = "0.3.72"
+version = "0.3.73"
 features = ["HtmlLinkElement", "HtmlMetaElement", "HtmlTitleElement"]
 
 [features]

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -25,7 +25,7 @@ async-lock = "3.4.0"
 send_wrapper = { version = "0.6.0", features = ["futures"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-web-sys = "0.3.72"
+web-sys = "0.3.73"
 
 [dev-dependencies]
 tokio = { version = "1.41", features = ["rt-multi-thread", "macros"] }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -19,8 +19,8 @@ reactive_graph = { workspace = true }
 tachys = { workspace = true, features = ["reactive_graph"] }
 futures = "0.3.31"
 url = "2.5"
-js-sys = { version = "0.3.72" }
-wasm-bindgen = { version = "0.2.95" }
+js-sys = "0.3.73"
+wasm-bindgen = "0.2.96"
 tracing = { version = "0.1.40", optional = true }
 once_cell = "1.20"
 send_wrapper = "0.6.0"
@@ -29,7 +29,7 @@ percent-encoding = { version = "2.3", optional = true }
 gloo-net = "0.6.0"
 
 [dependencies.web-sys]
-version = "0.3.72"
+version = "0.3.73"
 features = [
   "Document",
   "Window",

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -56,11 +56,11 @@ rmp-serde = { version = "1.3.0", optional = true }
 
 # client
 gloo-net = { version = "0.6.0", optional = true }
-js-sys = { version = "0.3.72", optional = true }
-wasm-bindgen = { version = "0.2.95", optional = true }
-wasm-bindgen-futures = { version = "0.4.45", optional = true }
+js-sys = { version = "0.3.73", optional = true }
+wasm-bindgen = { version = "0.2.96", optional = true }
+wasm-bindgen-futures = { version = "0.4.46", optional = true }
 wasm-streams = { version = "0.4.2", optional = true }
-web-sys = { version = "0.3.72", optional = true, features = [
+web-sys = { version = "0.3.73", optional = true, features = [
   "console",
   "ReadableStream",
   "ReadableStreamDefaultReader",

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -22,10 +22,10 @@ slotmap = { version = "1.0", optional = true }
 oco_ref = { workspace = true, optional = true }
 once_cell = "1.20"
 paste = "1.0"
-wasm-bindgen = "0.2.95"
+wasm-bindgen = "0.2.96"
 html-escape = "0.2.13"
-js-sys = "0.3.72"
-web-sys = { version = "0.3.72", features = [
+js-sys = "0.3.73"
+web-sys = { version = "0.3.73", features = [
   "Window",
   "Document",
   "HtmlElement",


### PR DESCRIPTION
`wasm-bindgen` got another update, so I took the liberty of bumping the version used by Leptos.