### PR TITLE
fix: prevent multiple location headers on redirect (#3298)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -375,8 +375,8 @@ pub fn handle_server_fns_with_context(
                                     .take(),
                             );
 
-                            // it it accepts text/html (i.e., is a plain form post) and doesn't already have a
-                            // Location set, then redirect to to Referer
+                            // if it accepts text/html (i.e., is a plain form post) and doesn't already have a
+                            // Location set, then redirect to the Referer
                             if accepts_html {
                                 if let Some(referrer) = referrer {
                                     let has_location =
@@ -390,7 +390,20 @@ pub fn handle_server_fns_with_context(
                                 }
                             }
 
-                            // apply status code and headers if used changed them
+                            // the Location header may have been set to Referer, so any redirection by the
+                            // user must overwrite it
+                            {
+                                let mut res_options = res_options.0.write();
+                                let headers = res.0.headers_mut();
+
+                                for location in
+                                    res_options.headers.remove(header::LOCATION)
+                                {
+                                    headers.insert(header::LOCATION, location);
+                                }
+                            }
+
+                            // apply status code and headers if user changed them
                             res.extend_response(&res_options);
                             res.0
                         })

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -399,8 +399,8 @@ async fn handle_server_fns_inner(
                     // actually run the server fn
                     let mut res = AxumResponse(service.run(req).await);
 
-                    // it it accepts text/html (i.e., is a plain form post) and doesn't already have a
-                    // Location set, then redirect to to Referer
+                    // if it accepts text/html (i.e., is a plain form post) and doesn't already have a
+                    // Location set, then redirect to the Referer
                     if accepts_html {
                         if let Some(referrer) = referrer {
                             let has_location =
@@ -412,7 +412,7 @@ async fn handle_server_fns_inner(
                         }
                     }
 
-                    // apply status code and headers if used changed them
+                    // apply status code and headers if user changed them
                     res.extend_response(&res_options);
                     Ok(res.0)
                 })


### PR DESCRIPTION
The problem turned out to be specific to 0.7 Actix, which I did not expect.

This solution is what was proposed by @gbj in #3298, although I did not make the new code part of `extend_response` because `extend_response` is also [called in `handle_static_route`](https://github.com/leptos-rs/leptos/blob/d665dd4b89151e5d797df3db5cd2260cbe1e8fae/integrations/actix/src/lib.rs#L1285), and I don't think it needs this (maybe I'm wrong?).

I believe a better solution would actually be to match the Axum behavior, that uses [`http::HeaderMap::extend`](https://github.com/hyperium/http/blob/5a1a5e8ee54fc2e2f274faf318d9a8b1129c386a/src/header/map.rs#L2081): For merging map A with map B, if map B contains a key that is present in A, all values with such key in A are removed and all values with that key in B are added. That would at least be more consistent.

I also still don't understand why both `server_fn::ServerFn::run_on_server` and `leptos_actix::handle_server_fns_with_context` need to handle redirection to Referer, but I assume there is a reason.

Took the oportunity to fix the surrounding comments too, to the best of my ability.