### PR TITLE
fix: correctly support `!Send` Actix APIs in server functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "either_of"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pin-project-lite",
 ]


### PR DESCRIPTION
Actix pins requests and responses to a single thread, allowing it to use a number of `!Send` types in its ecosystem. You need to be able to hold these across `.await` points.

Leptos server functions and resources want server functions to be `Send`.

The `#[server]` macro currently includes a workaround for Actix that automatically wraps a server fn body in `SendWrapper` in the trait implementation. However, it didn't do this in the dummy function body, with the result that this didn't actually work—it would work in the trait implementation but not the dummy function. (The dummy function only needs to exist for better rust-analyzer support.)

Test case:
```rust
#[server]
pub async fn list_post_metadata() -> Result<Vec<PostMetadata>, ServerFnError> {
    // really these would be some Actix ecosystem type that's an Rc internally
    let unsend = std::rc::Rc::new(());
    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
    let _unsend = unsend.clone();
    Ok(POSTS
        .iter()
        .map(|data| PostMetadata {
            id: data.id,
            title: data.title.clone(),
        })
        .collect())
}
```