### PR TITLE
Fix a doc typo and one broken intra-doc link

### DIFF
--- a/reactive_graph/src/owner/arena.rs
+++ b/reactive_graph/src/owner/arena.rs
@@ -121,8 +121,11 @@ pub mod sandboxed {
     }
 
     impl<T> Sandboxed<T> {
-        /// Wraps the given [`Future`], ensuring that any [`ArenaItem`] created while it is being
-        /// polled will be associated with the same arena that was active when this was called.
+        /// Wraps the given [`Future`], ensuring that any [`ArenaItem`][item] created while it is
+        /// being polled will be associated with the same arena that was active when this was
+        /// called.
+        ///
+        /// [item]:[crate::owner::ArenaItem]
         pub fn new(inner: T) -> Self {
             let arena = MAP.with_borrow(|n| n.as_ref().and_then(Weak::upgrade));
             Self { arena, inner }

--- a/reactive_graph/src/wrappers.rs
+++ b/reactive_graph/src/wrappers.rs
@@ -97,7 +97,7 @@ pub mod read {
     /// or derived signal closure.
     ///
     /// This allows you to create APIs that take any kind of `ArcSignal<T>` as an argument,
-    /// rather than adding a generic `F: Fn() -> T`. Values can be access with the same
+    /// rather than adding a generic `F: Fn() -> T`. Values can be accessed with the same
     /// function call, `with()`, and `get()` APIs as other signals.
     pub struct ArcSignal<T: 'static, S = SyncStorage>
     where
@@ -333,7 +333,7 @@ pub mod read {
     /// an [`ReadSignal`], [`Memo`], [`RwSignal`], or derived signal closure.
     ///
     /// This allows you to create APIs that take any kind of `Signal<T>` as an argument,
-    /// rather than adding a generic `F: Fn() -> T`. Values can be access with the same
+    /// rather than adding a generic `F: Fn() -> T`. Values can be accessed with the same
     /// function call, `with()`, and `get()` APIs as other signals.
     pub struct Signal<T, S = SyncStorage>
     where


### PR DESCRIPTION
Noticed the typo while following along with the book, and then got a rustdoc warning for the `ArenaItem` link. Figured that I might as well fix that too.