### PR TITLE
Implement signal.into_inner()

### DIFF
--- a/reactive_graph/src/owner/arc_stored_value.rs
+++ b/reactive_graph/src/owner/arc_stored_value.rs
@@ -1,6 +1,6 @@
 use crate::{
     signal::guards::{Plain, ReadGuard, UntrackedWriteGuard},
-    traits::{DefinedAt, IsDisposed, ReadValue, WriteValue},
+    traits::{DefinedAt, IntoInner, IsDisposed, ReadValue, WriteValue},
 };
 use std::{
     fmt::{Debug, Formatter},
@@ -122,5 +122,14 @@ where
 impl<T> IsDisposed for ArcStoredValue<T> {
     fn is_disposed(&self) -> bool {
         false
+    }
+}
+
+impl<T> IntoInner for ArcStoredValue<T> {
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        Some(Arc::into_inner(self.value)?.into_inner().unwrap())
     }
 }

--- a/reactive_graph/src/owner/arena_item.rs
+++ b/reactive_graph/src/owner/arena_item.rs
@@ -2,7 +2,7 @@ use super::{
     arena::{Arena, NodeId},
     LocalStorage, Storage, SyncStorage, OWNER,
 };
-use crate::traits::{Dispose, IsDisposed};
+use crate::traits::{Dispose, IntoInner, IsDisposed};
 use send_wrapper::SendWrapper;
 use std::{any::Any, hash::Hash, marker::PhantomData};
 
@@ -132,5 +132,14 @@ impl<T, S> IsDisposed for ArenaItem<T, S> {
 impl<T, S> Dispose for ArenaItem<T, S> {
     fn dispose(self) {
         Arena::with_mut(|arena| arena.remove(self.node));
+    }
+}
+
+impl<T, S: Storage<T>> IntoInner for ArenaItem<T, S> {
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        S::take(self.node)
     }
 }

--- a/reactive_graph/src/owner/stored_value.rs
+++ b/reactive_graph/src/owner/stored_value.rs
@@ -4,7 +4,9 @@ use super::{
 };
 use crate::{
     signal::guards::{Plain, ReadGuard, UntrackedWriteGuard},
-    traits::{DefinedAt, Dispose, IsDisposed, ReadValue, WriteValue},
+    traits::{
+        DefinedAt, Dispose, IntoInner, IsDisposed, ReadValue, WriteValue,
+    },
     unwrap_signal,
 };
 use std::{
@@ -159,6 +161,19 @@ impl<T, S> IsDisposed for StoredValue<T, S> {
 impl<T, S> Dispose for StoredValue<T, S> {
     fn dispose(self) {
         self.value.dispose();
+    }
+}
+
+impl<T, S> IntoInner for StoredValue<T, S>
+where
+    T: 'static,
+    S: Storage<ArcStoredValue<T>>,
+{
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        self.value.into_inner()?.into_inner()
     }
 }
 

--- a/reactive_graph/src/signal.rs
+++ b/reactive_graph/src/signal.rs
@@ -113,7 +113,8 @@ pub fn arc_signal<T>(value: T) -> (ArcReadSignal<T>, ArcWriteSignal<T>) {
 pub fn signal<T: Send + Sync + 'static>(
     value: T,
 ) -> (ReadSignal<T>, WriteSignal<T>) {
-    RwSignal::new(value).split()
+    let (r, w) = arc_signal(value);
+    (r.into(), w.into())
 }
 
 /// Creates an arena-allocated signal.

--- a/reactive_graph/src/signal/arc_read.rs
+++ b/reactive_graph/src/signal/arc_read.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     graph::SubscriberSet,
-    traits::{DefinedAt, IsDisposed, ReadUntracked},
+    traits::{DefinedAt, IntoInner, IsDisposed, ReadUntracked},
 };
 use core::fmt::{Debug, Formatter, Result};
 use std::{
@@ -125,6 +125,15 @@ impl<T> IsDisposed for ArcReadSignal<T> {
     #[inline(always)]
     fn is_disposed(&self) -> bool {
         false
+    }
+}
+
+impl<T> IntoInner for ArcReadSignal<T> {
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        Some(Arc::into_inner(self.value)?.into_inner().unwrap())
     }
 }
 

--- a/reactive_graph/src/signal/arc_rw.rs
+++ b/reactive_graph/src/signal/arc_rw.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     graph::{ReactiveNode, SubscriberSet},
     prelude::{IsDisposed, Notify},
-    traits::{DefinedAt, ReadUntracked, UntrackableGuard, Write},
+    traits::{DefinedAt, IntoInner, ReadUntracked, UntrackableGuard, Write},
 };
 use core::fmt::{Debug, Formatter, Result};
 use std::{
@@ -227,6 +227,15 @@ impl<T> IsDisposed for ArcRwSignal<T> {
     #[inline(always)]
     fn is_disposed(&self) -> bool {
         false
+    }
+}
+
+impl<T> IntoInner for ArcRwSignal<T> {
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        Some(Arc::into_inner(self.value)?.into_inner().unwrap())
     }
 }
 

--- a/reactive_graph/src/signal/arc_write.rs
+++ b/reactive_graph/src/signal/arc_write.rs
@@ -2,7 +2,7 @@ use super::guards::{UntrackedWriteGuard, WriteGuard};
 use crate::{
     graph::{ReactiveNode, SubscriberSet},
     prelude::{IsDisposed, Notify},
-    traits::{DefinedAt, UntrackableGuard, Write},
+    traits::{DefinedAt, IntoInner, UntrackableGuard, Write},
 };
 use core::fmt::{Debug, Formatter, Result};
 use std::{
@@ -113,6 +113,15 @@ impl<T> IsDisposed for ArcWriteSignal<T> {
     #[inline(always)]
     fn is_disposed(&self) -> bool {
         false
+    }
+}
+
+impl<T> IntoInner for ArcWriteSignal<T> {
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        Some(Arc::into_inner(self.value)?.into_inner().unwrap())
     }
 }
 

--- a/reactive_graph/src/signal/read.rs
+++ b/reactive_graph/src/signal/read.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     graph::SubscriberSet,
     owner::{ArenaItem, FromLocal, LocalStorage, Storage, SyncStorage},
-    traits::{DefinedAt, Dispose, IsDisposed, ReadUntracked},
+    traits::{DefinedAt, Dispose, IntoInner, IsDisposed, ReadUntracked},
     unwrap_signal,
 };
 use core::fmt::Debug;
@@ -119,6 +119,18 @@ impl<T, S> DefinedAt for ReadSignal<T, S> {
 impl<T, S> IsDisposed for ReadSignal<T, S> {
     fn is_disposed(&self) -> bool {
         self.inner.is_disposed()
+    }
+}
+
+impl<T, S> IntoInner for ReadSignal<T, S>
+where
+    S: Storage<ArcReadSignal<T>>,
+{
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        self.inner.into_inner()?.into_inner()
     }
 }
 

--- a/reactive_graph/src/signal/rw.rs
+++ b/reactive_graph/src/signal/rw.rs
@@ -8,7 +8,7 @@ use crate::{
     owner::{ArenaItem, FromLocal, LocalStorage, Storage, SyncStorage},
     signal::guards::{UntrackedWriteGuard, WriteGuard},
     traits::{
-        DefinedAt, Dispose, IsDisposed, Notify, ReadUntracked,
+        DefinedAt, Dispose, IntoInner, IsDisposed, Notify, ReadUntracked,
         UntrackableGuard, Write,
     },
     unwrap_signal,
@@ -310,6 +310,18 @@ impl<T, S> DefinedAt for RwSignal<T, S> {
 impl<T: 'static, S> IsDisposed for RwSignal<T, S> {
     fn is_disposed(&self) -> bool {
         self.inner.is_disposed()
+    }
+}
+
+impl<T, S> IntoInner for RwSignal<T, S>
+where
+    S: Storage<ArcRwSignal<T>>,
+{
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        self.inner.into_inner()?.into_inner()
     }
 }
 

--- a/reactive_graph/src/signal/write.rs
+++ b/reactive_graph/src/signal/write.rs
@@ -1,7 +1,10 @@
 use super::{guards::WriteGuard, ArcWriteSignal};
 use crate::{
     owner::{ArenaItem, Storage, SyncStorage},
-    traits::{DefinedAt, Dispose, IsDisposed, Notify, UntrackableGuard, Write},
+    traits::{
+        DefinedAt, Dispose, IntoInner, IsDisposed, Notify, UntrackableGuard,
+        Write,
+    },
 };
 use core::fmt::Debug;
 use guardian::ArcRwLockWriteGuardian;
@@ -111,6 +114,18 @@ impl<T, S> DefinedAt for WriteSignal<T, S> {
 impl<T, S> IsDisposed for WriteSignal<T, S> {
     fn is_disposed(&self) -> bool {
         self.inner.is_disposed()
+    }
+}
+
+impl<T, S> IntoInner for WriteSignal<T, S>
+where
+    S: Storage<ArcWriteSignal<T>>,
+{
+    type Value = T;
+
+    #[inline(always)]
+    fn into_inner(self) -> Option<Self::Value> {
+        self.inner.into_inner()?.into_inner()
     }
 }
 

--- a/reactive_graph/src/traits.rs
+++ b/reactive_graph/src/traits.rs
@@ -630,6 +630,18 @@ pub trait IsDisposed {
     fn is_disposed(&self) -> bool;
 }
 
+/// Turns a signal back into a raw value.
+pub trait IntoInner {
+    /// The type of the value contained in the signal.
+    type Value;
+
+    /// Returns the inner value if this is the only reference to to the signal.
+    /// Otherwise, returns `None` and drops this reference.
+    /// # Panics
+    /// Panics if the inner lock is poisoned.
+    fn into_inner(self) -> Option<Self::Value>;
+}
+
 /// Describes where the signal was defined. This is used for diagnostic warnings and is purely a
 /// debug-mode tool.
 pub trait DefinedAt {

--- a/reactive_graph/tests/signal.rs
+++ b/reactive_graph/tests/signal.rs
@@ -2,8 +2,8 @@ use reactive_graph::{
     owner::Owner,
     signal::{arc_signal, signal, ArcRwSignal, RwSignal},
     traits::{
-        Get, GetUntracked, IntoInner, Read, Set, Update, UpdateUntracked, With,
-        WithUntracked, Write,
+        Dispose, Get, GetUntracked, IntoInner, Read, Set, Update,
+        UpdateUntracked, With, WithUntracked, Write,
     },
 };
 
@@ -127,5 +127,16 @@ fn into_inner_arc_signal() {
     let (a, b) = arc_signal(2);
     assert_eq!(a.get(), 2);
     std::mem::drop(b);
+    assert_eq!(a.into_inner(), Some(2));
+}
+
+#[test]
+fn into_inner_non_arc_signal() {
+    let owner = Owner::new();
+    owner.set();
+
+    let (a, b) = signal(2);
+    assert_eq!(a.get(), 2);
+    b.dispose();
     assert_eq!(a.into_inner(), Some(2));
 }

--- a/reactive_graph/tests/signal.rs
+++ b/reactive_graph/tests/signal.rs
@@ -2,7 +2,7 @@ use reactive_graph::{
     owner::Owner,
     signal::{arc_signal, signal, ArcRwSignal, RwSignal},
     traits::{
-        Get, GetUntracked, Read, Set, Update, UpdateUntracked, With,
+        Get, GetUntracked, IntoInner, Read, Set, Update, UpdateUntracked, With,
         WithUntracked, Write,
     },
 };
@@ -107,4 +107,25 @@ fn update_signal() {
     assert_eq!(a.get(), 3);
     set_a.set(4);
     assert_eq!(a.get(), 4);
+}
+
+#[test]
+fn into_inner_signal() {
+    let owner = Owner::new();
+    owner.set();
+
+    let rw_signal = RwSignal::new(1);
+    assert_eq!(rw_signal.get(), 1);
+    assert_eq!(rw_signal.into_inner(), Some(1));
+}
+
+#[test]
+fn into_inner_arc_signal() {
+    let owner = Owner::new();
+    owner.set();
+
+    let (a, b) = arc_signal(2);
+    assert_eq!(a.get(), 2);
+    std::mem::drop(b);
+    assert_eq!(a.into_inner(), Some(2));
 }


### PR DESCRIPTION
This implements `into_inner` the way it is implemented for `Arc`s. This fixes #3068 .

However, with the non-arc signals, the behaviour can be rather unintuitive. For example, the following does not succeed.
Why?
Because there's still the original `RwSignal` that was created inside the `signal` function. (`RwSignal::new(value).split()` creates 3 signals)

```rust
#[test]
fn into_inner_non_arc_signal() {
    let owner = Owner::new();
    owner.set();

    let (a, b) = signal(2);
    assert_eq!(a.get(), 2);
    b.dispose(); // strong count is now 2
    assert_eq!(a.into_inner(), Some(2)); // fails
}
```

I'm happy to document this, or to attempt a fix, or to remove the trait for normal signals.