### PR TITLE
fix: Implement PatchField for `usize`

### DIFF
--- a/reactive_stores/src/patch.rs
+++ b/reactive_stores/src/patch.rs
@@ -78,6 +78,7 @@ patch_primitives! {
     Arc<str>,
     Rc<str>,
     Cow<'_, str>,
+    usize,
     u8,
     u16,
     u32,


### PR DESCRIPTION
As part of [a larger discussion ](https://github.com/leptos-rs/leptos/discussions/3345) r.e. implementing `PatchField` for non-primative types, I noticed that the primative type `usize` is missing from the primative types that _do_ implement `PatchField`.

This PR is a one line change (made via GitHub, i.e. untested) that adds it to the list.