### PR TITLE
TypedChildrenFn impl Clone trait

### DIFF
--- a/leptos/src/children.rs
+++ b/leptos/src/children.rs
@@ -285,6 +285,13 @@ impl<T> Debug for TypedChildrenFn<T> {
     }
 }
 
+impl<T> Clone for TypedChildrenFn<T> {
+    // Manual implementation to avoid the `T: Clone` bound.
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T> TypedChildrenFn<T> {
     /// Extracts the inner `children` function.
     pub fn into_inner(self) -> Arc<dyn Fn() -> View<T> + Send + Sync> {


### PR DESCRIPTION
TypedChildrenFn wraps `Arc<dyn Fn() -> View<T> + Send + Sync>`, but not derived with `Clone`, I think it is logical for a type based on `Arc`, and type `ViewFn` derived with Clone as well.