### PR TITLE
Implement IntoSplitSignal for Field.

### DIFF
--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -371,7 +371,7 @@ where
     type Write = Self;
 
     fn into_split_signal(self) -> (Self::Read, Self::Write) {
-        (self.clone(), self.clone())
+        (self, self)
     }
 }
 

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -10,12 +10,13 @@ use crate::{
     view::{Position, ToTemplate},
 };
 use reactive_graph::{
+    owner::Storage,
     signal::{ReadSignal, RwSignal, WriteSignal},
     traits::{Get, Update},
     wrappers::read::Signal,
 };
 #[cfg(feature = "reactive_stores")]
-use reactive_stores::{KeyedSubfield, Subfield};
+use reactive_stores::{ArcField, Field, KeyedSubfield, Subfield};
 use send_wrapper::SendWrapper;
 use wasm_bindgen::JsValue;
 
@@ -348,6 +349,21 @@ where
 impl<Inner, Prev, T> IntoSplitSignal for Subfield<Inner, Prev, T>
 where
     Self: Get<Value = T> + Update<Value = T> + Clone,
+{
+    type Value = T;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<T, S> IntoSplitSignal for Field<T, S>
+where
+    Self: Get<Value = T> + Update<Value = T> + Clone,
+    S: Storage<ArcField<T>>,
 {
     type Value = T;
     type Read = Self;

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -9,8 +9,9 @@ use crate::{
     renderer::{types::Element, RemoveEventHandler},
     view::{Position, ToTemplate},
 };
+#[cfg(feature = "reactive_stores")]
+use reactive_graph::owner::Storage;
 use reactive_graph::{
-    owner::Storage,
     signal::{ReadSignal, RwSignal, WriteSignal},
     traits::{Get, Update},
     wrappers::read::Signal,


### PR DESCRIPTION
Adds `IntoSplitSignal` for `Field`. This allows us to use `bind:value=field` instead of `bind:value=(field, field)`.

Copying some similar trait bounds, so please take a look and see if they make sense.

Fixes https://github.com/leptos-rs/leptos/issues/3362