### PR TITLE
impl Dispose for Callback types and add try_run to the Callable trait

### DIFF
--- a/leptos/src/callback.rs
+++ b/leptos/src/callback.rs
@@ -241,11 +241,9 @@ impl<In: 'static, Out: 'static> Callback<In, Out> {
 
 #[cfg(test)]
 mod tests {
-    use reactive_graph::traits::Dispose;
-
-    use crate::callback::{Callback, UnsyncCallback};
-
     use super::Callable;
+    use crate::callback::{Callback, UnsyncCallback};
+    use reactive_graph::traits::Dispose;
 
     struct NoClone {}
 

--- a/leptos/src/callback.rs
+++ b/leptos/src/callback.rs
@@ -43,13 +43,20 @@
 
 use reactive_graph::{
     owner::{LocalStorage, StoredValue},
-    traits::WithValue,
+    traits::{Dispose, WithValue},
 };
 use std::{fmt, rc::Rc, sync::Arc};
 
 /// A wrapper trait for calling callbacks.
 pub trait Callable<In: 'static, Out: 'static = ()> {
     /// calls the callback with the specified argument.
+    ///
+    /// Returns None if the callback has been disposed
+    fn try_run(&self, input: In) -> Option<Out>;
+    /// calls the callback with the specified argument.
+    ///
+    /// # Panics
+    /// Panics if you try to run a callback that has been disposed
     fn run(&self, input: In) -> Out;
 }
 
@@ -72,6 +79,12 @@ impl<In, Out> Clone for UnsyncCallback<In, Out> {
     }
 }
 
+impl<In, Out> Dispose for UnsyncCallback<In, Out> {
+    fn dispose(self) {
+        self.0.dispose();
+    }
+}
+
 impl<In, Out> UnsyncCallback<In, Out> {
     /// Creates a new callback from the given function.
     pub fn new<F>(f: F) -> UnsyncCallback<In, Out>
@@ -83,6 +96,10 @@ impl<In, Out> UnsyncCallback<In, Out> {
 }
 
 impl<In: 'static, Out: 'static> Callable<In, Out> for UnsyncCallback<In, Out> {
+    fn try_run(&self, input: In) -> Option<Out> {
+        self.0.try_with_value(|fun| fun(input))
+    }
+
     fn run(&self, input: In) -> Out {
         self.0.with_value(|fun| fun(input))
     }
@@ -158,16 +175,24 @@ impl<In, Out> fmt::Debug for Callback<In, Out> {
 }
 
 impl<In, Out> Callable<In, Out> for Callback<In, Out> {
+    fn try_run(&self, input: In) -> Option<Out> {
+        self.0.try_with_value(|fun| fun(input))
+    }
+
     fn run(&self, input: In) -> Out {
-        self.0
-            .try_with_value(|f| f(input))
-            .expect("called a callback that has been disposed")
+        self.0.with_value(|f| f(input))
     }
 }
 
 impl<In, Out> Clone for Callback<In, Out> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+impl<In, Out> Dispose for Callback<In, Out> {
+    fn dispose(self) {
+        self.0.dispose();
     }
 }
 
@@ -216,7 +241,11 @@ impl<In: 'static, Out: 'static> Callback<In, Out> {
 
 #[cfg(test)]
 mod tests {
+    use reactive_graph::traits::Dispose;
+
     use crate::callback::{Callback, UnsyncCallback};
+
+    use super::Callable;
 
     struct NoClone {}
 
@@ -245,5 +274,21 @@ mod tests {
         let _callback: UnsyncCallback<(), String> = (|| "test").into();
         let _callback: UnsyncCallback<(i32, String), String> =
             (|num, s| format!("{num} {s}")).into();
+    }
+
+    #[test]
+    fn sync_callback_try_run() {
+        let callback = Callback::new(move |arg| arg);
+        assert_eq!(callback.try_run((0,)), Some((0,)));
+        callback.dispose();
+        assert_eq!(callback.try_run((0,)), None);
+    }
+
+    #[test]
+    fn unsync_callback_try_run() {
+        let callback = UnsyncCallback::new(move |arg| arg);
+        assert_eq!(callback.try_run((0,)), Some((0,)));
+        callback.dispose();
+        assert_eq!(callback.try_run((0,)), None);
     }
 }


### PR DESCRIPTION
PR aims to make the Callback types more consistent with the other stored types in leptos.

* Adds `try_run` to callable which (in line with other stored types) will return `None` if the callback had been disposed.
* Adds `impl Dispose` for both `Callback` and `UnsyncCallback`


Small detail regarding implementation:
The impl of `Callable::run` for `UnsyncCallback` and `Callback` was inconsistent. One used `try_with_value` with expect while the other was using `with_value`.
I chose to make them consistent and use `with_value` in both impls. I'm unsure if I chose the right option, perhaps try_with_value was preferable.