### PR TITLE
feat: allow to destructure props

### DIFF
--- a/leptos_macro/tests/component.rs
+++ b/leptos_macro/tests/component.rs
@@ -1,6 +1,15 @@
 use core::num::NonZeroUsize;
 use leptos::prelude::*;
 
+#[derive(PartialEq, Debug)]
+struct UserInfo {
+    user_id: String,
+    email: String,
+}
+
+#[derive(PartialEq, Debug)]
+struct Admin(bool);
+
 #[component]
 fn Component(
     #[prop(optional)] optional: bool,
@@ -10,6 +19,10 @@ fn Component(
     #[prop(default = NonZeroUsize::new(10).unwrap())] default: NonZeroUsize,
     #[prop(into)] into: String,
     impl_trait: impl Fn() -> i32 + 'static,
+    #[prop(name = "data")] UserInfo { email, user_id }: UserInfo,
+    #[prop(name = "tuple")] (name, id): (String, i32),
+    #[prop(name = "tuple_struct")] Admin(is_admin): Admin,
+    #[prop(name = "outside_name")] inside_name: i32,
 ) -> impl IntoView {
     _ = optional;
     _ = optional_into;
@@ -18,6 +31,12 @@ fn Component(
     _ = default;
     _ = into;
     _ = impl_trait;
+    _ = email;
+    _ = user_id;
+    _ = id;
+    _ = name;
+    _ = is_admin;
+    _ = inside_name;
 }
 
 #[test]
@@ -26,6 +45,13 @@ fn component() {
         .into("")
         .strip_option(9)
         .impl_trait(|| 42)
+        .data(UserInfo {
+            email: "em@il".into(),
+            user_id: "1".into(),
+        })
+        .tuple(("Joe".into(), 12))
+        .tuple_struct(Admin(true))
+        .outside_name(1)
         .build();
     assert!(!cp.optional);
     assert_eq!(cp.optional_into, None);
@@ -34,6 +60,16 @@ fn component() {
     assert_eq!(cp.default, NonZeroUsize::new(10).unwrap());
     assert_eq!(cp.into, "");
     assert_eq!((cp.impl_trait)(), 42);
+    assert_eq!(
+        cp.data,
+        UserInfo {
+            email: "em@il".into(),
+            user_id: "1".into(),
+        }
+    );
+    assert_eq!(cp.tuple, ("Joe".into(), 12));
+    assert_eq!(cp.tuple_struct, Admin(true));
+    assert_eq!(cp.outside_name, 1);
 }
 
 #[test]
@@ -45,12 +81,26 @@ fn component_nostrip() {
             strip_option=9
             into=""
             impl_trait=|| 42
+            data=UserInfo {
+                email: "em@il".into(),
+                user_id: "1".into(),
+            }
+            tuple=("Joe".into(), 12)
+            tuple_struct=Admin(true)
+            outside_name=1
         />
         <Component
             nostrip:optional_into=Some("foo")
             strip_option=9
             into=""
             impl_trait=|| 42
+            data=UserInfo {
+                email: "em@il".into(),
+                user_id: "1".into(),
+            }
+            tuple=("Joe".into(), 12)
+            tuple_struct=Admin(true)
+            outside_name=1
         />
     };
 }

--- a/leptos_macro/tests/ui/component.rs
+++ b/leptos_macro/tests/ui/component.rs
@@ -44,4 +44,10 @@ fn default_with_invalid_value(
     _ = default;
 }
 
+#[component]
+fn destructure_without_name((default, value): (bool, i32)) -> impl IntoView {
+    _ = default;
+    _ = value;
+}
+
 fn main() {}

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -8,19 +8,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component.rs:16:12
    |
 16 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:23:12
    |
 23 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:30:12
    |
 30 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 

--- a/leptos_macro/tests/ui/component.stderr
+++ b/leptos_macro/tests/ui/component.stderr
@@ -1,4 +1,4 @@
-error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into` and `attrs`
+error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into`, `attrs` and `name`
   --> tests/ui/component.rs:10:31
    |
 10 | fn unknown_prop_option(#[prop(hello)] test: bool) -> impl IntoView {
@@ -8,19 +8,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component.rs:16:12
    |
 16 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:23:12
    |
 23 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component.rs:30:12
    |
 30 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 
@@ -41,3 +41,9 @@ error: unexpected end of input, expected one of: identifier, `::`, `<`, `_`, lit
    | ^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: destructured props must be given a name e.g. #[prop(name = "data")]
+  --> tests/ui/component.rs:48:29
+   |
+48 | fn destructure_without_name((default, value): (bool, i32)) -> impl IntoView {
+   |                             ^^^^^^^^^^^^^^^^

--- a/leptos_macro/tests/ui/component_absolute.stderr
+++ b/leptos_macro/tests/ui/component_absolute.stderr
@@ -1,4 +1,4 @@
-error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into` and `attrs`
+error: supported fields are `optional`, `optional_no_strip`, `strip_option`, `default`, `into`, `attrs` and `name`
  --> tests/ui/component_absolute.rs:5:31
   |
 5 | fn unknown_prop_option(#[prop(hello)] test: bool) -> impl ::leptos::IntoView {
@@ -8,19 +8,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component_absolute.rs:11:12
    |
 11 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:18:12
    |
 18 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:25:12
    |
 25 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 

--- a/leptos_macro/tests/ui/component_absolute.stderr
+++ b/leptos_macro/tests/ui/component_absolute.stderr
@@ -8,19 +8,19 @@ error: `optional` conflicts with mutually exclusive `optional_no_strip`
   --> tests/ui/component_absolute.rs:11:12
    |
 11 |     #[prop(optional, optional_no_strip)] conflicting: bool,
-   |            ^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `optional` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:18:12
    |
 18 |     #[prop(optional, strip_option)] conflicting: bool,
-   |            ^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^
 
 error: `optional_no_strip` conflicts with mutually exclusive `strip_option`
   --> tests/ui/component_absolute.rs:25:12
    |
 25 |     #[prop(optional_no_strip, strip_option)] conflicting: bool,
-   |            ^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected `=` or `(`
 

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -117,7 +117,7 @@ impl<T> JsonStream<T> {
     pub fn new(
         value: impl Stream<Item = Result<T, ServerFnError>> + Send + 'static,
     ) -> Self {
-        Self(Box::pin(value.map(|value| value.map(Into::into))))
+        Self(Box::pin(value.map(|value| value)))
     }
 }
 

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -175,7 +175,7 @@ impl TextStream {
     pub fn new(
         value: impl Stream<Item = Result<String, ServerFnError>> + Send + 'static,
     ) -> Self {
-        Self(Box::pin(value.map(|value| value.map(Into::into))))
+        Self(Box::pin(value.map(|value| value)))
     }
 }
 


### PR DESCRIPTION
Allows props to be destructured in the component definition e.g.
```rust
    #[prop(name = "data")] UserInfo { email, user_id }: UserInfo,
 ```
 
for that to work a `name` attribute was introduced which is used to define the name of the prop in the generated builder.