### PR TITLE
docs: showcase let syntax in for_loop

### DIFF
--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -49,13 +49,30 @@ use tachys::{reactive_graph::OwnedView, view::keyed::keyed};
 /// component, using the `let` syntax:
 ///
 /// ```
-///  <For
-///    each=move || counters.get()
-///    key=|counter| counter.id
-///    let(counter)
-///  >
-///      <button>"Value: " {move || counter.count.get()}</button>
-///  </For>
+/// # use leptos::prelude::*;
+///
+/// # #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// # struct Counter {
+/// #   id: usize,
+/// #   count: RwSignal<i32>
+/// # }
+/// #
+/// # #[component]
+/// # fn Counters() -> impl IntoView {
+/// #   let (counters, set_counters) = create_signal::<Vec<Counter>>(vec![]);
+/// #
+///   view! {
+///     <div>
+///         <For
+///           each=move || counters.get()
+///           key=|counter| counter.id
+///           let(counter)
+///         >
+///             <button>"Value: " {move || counter.count.get()}</button>
+///         </For>
+///     </div>
+///   }
+/// # }
 /// ```
 ///
 /// The `let` syntax also supports destructuring the pattern of your data.
@@ -63,13 +80,30 @@ use tachys::{reactive_graph::OwnedView, view::keyed::keyed};
 /// in the case of structs.
 ///
 /// ```
-///  <For
-///    each=move || counters.get()
-///    key=|counter| counter.id
-///    let(Counter { id, count })
-///  >
-///      <button>"Value: " {move || count.get()}</button>
-///  </For>
+/// # use leptos::prelude::*;
+///
+/// # #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// # struct Counter {
+/// #   id: usize,
+/// #   count: RwSignal<i32>
+/// # }
+/// #
+/// # #[component]
+/// # fn Counters() -> impl IntoView {
+/// #   let (counters, set_counters) = create_signal::<Vec<Counter>>(vec![]);
+/// #
+///   view! {
+///     <div>
+///         <For
+///           each=move || counters.get()
+///           key=|counter| counter.id
+///           let(Counter { id, count })
+///         >
+///             <button>"Value: " {move || count.get()}</button>
+///         </For>
+///     </div>
+///   }
+/// # }
 /// ```
 #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
 #[component]

--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -44,6 +44,33 @@ use tachys::{reactive_graph::OwnedView, view::keyed::keyed};
 ///   }
 /// }
 /// ```
+///
+/// For convenience, you can also choose to write template code directly in the `<For>`
+/// component, using the `let` syntax:
+///
+/// ```
+///  <For
+///    each=move || counters.get()
+///    key=|counter| counter.id
+///    let(counter)
+///  >
+///      <button>"Value: " {move || counter.count.get()}</button>
+///  </For>
+/// ```
+///
+/// The `let` syntax also supports destructuring the pattern of your data.
+/// `let((one, two))` in the case of tuples, and `let(Struct { field_one, field_two })`
+/// in the case of structs.
+///
+/// ```
+///  <For
+///    each=move || counters.get()
+///    key=|counter| counter.id
+///    let(Counter { id, count })
+///  >
+///      <button>"Value: " {move || count.get()}</button>
+///  </For>
+/// ```
 #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
 #[component]
 pub fn For<IF, I, T, EF, N, KF, K>(


### PR DESCRIPTION
I thought it would be a boon for DX to showcase the `let` syntax for the `<For>` component. 

I knew there were some improvements, but I erroneously tried the legacy `let:item` style to destructure my struct and had to go looking for docs. It was kind of hard to find so I thought I'd try to contribute :sweat_smile: Please, edit and adjust to your liking. 

I think this should close #3059 

See cousin PR for the book. 