### PR TITLE
Enable `console` feature of `web-sys` for `reactive_graph`

### DIFF
--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -25,7 +25,7 @@ async-lock = "3.4.0"
 send_wrapper = { version = "0.6.0", features = ["futures"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-web-sys = "0.3.72"
+web-sys = { version = "0.3.72", features = ["console"] }
 
 [dev-dependencies]
 tokio = { version = "1.41", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
Without the feature enabled, having a direct dependency to `reactive_graph` fails to `cargo check` under `wasm32-unknown-unknown`.
Just to give you some context, I'm building my own store in a separate library which only needs the reactive primitives.