### PR TITLE
fix: missing `mathvariant` attribute for `<mi>` mathml tag

### DIFF
--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -132,7 +132,7 @@ macro_rules! mathml_elements {
 
 mathml_elements![
     math [display, xmlns],
-    mi [],
+    mi [mathvariant],
     mn [],
     mo [
         accent, fence, lspace, maxsize, minsize, movablelimits,


### PR DESCRIPTION
Small edit to address issue #3412