### PR TITLE
feat(breaking): allow make `PossibleRouteMatch` dyn-safe

### DIFF
--- a/router/src/matching/horizontal/mod.rs
+++ b/router/src/matching/horizontal/mod.rs
@@ -17,3 +17,17 @@ pub trait PossibleRouteMatch {
 
     fn generate_path(&self, path: &mut Vec<PathSegment>);
 }
+
+impl PossibleRouteMatch for Box<dyn PossibleRouteMatch> {
+    fn optional(&self) -> bool {
+        (**self).optional()
+    }
+
+    fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
+        (**self).test(path)
+    }
+
+    fn generate_path(&self, path: &mut Vec<PathSegment>) {
+        (**self).generate_path(path);
+    }
+}

--- a/router/src/matching/horizontal/mod.rs
+++ b/router/src/matching/horizontal/mod.rs
@@ -1,4 +1,5 @@
 use super::{PartialPathMatch, PathSegment};
+use std::sync::Arc;
 mod param_segments;
 mod static_segment;
 mod tuples;
@@ -18,7 +19,21 @@ pub trait PossibleRouteMatch {
     fn generate_path(&self, path: &mut Vec<PathSegment>);
 }
 
-impl PossibleRouteMatch for Box<dyn PossibleRouteMatch> {
+impl PossibleRouteMatch for Box<dyn PossibleRouteMatch + Send + Sync> {
+    fn optional(&self) -> bool {
+        (**self).optional()
+    }
+
+    fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
+        (**self).test(path)
+    }
+
+    fn generate_path(&self, path: &mut Vec<PathSegment>) {
+        (**self).generate_path(path);
+    }
+}
+
+impl PossibleRouteMatch for Arc<dyn PossibleRouteMatch + Send + Sync> {
     fn optional(&self) -> bool {
         (**self).optional()
     }

--- a/router/src/matching/horizontal/mod.rs
+++ b/router/src/matching/horizontal/mod.rs
@@ -11,7 +11,7 @@ pub use static_segment::*;
 /// This is a "horizontal" matching: i.e., it treats a tuple of route segments
 /// as subsequent segments of the URL and tries to match them all.
 pub trait PossibleRouteMatch {
-    const OPTIONAL: bool = false;
+    fn optional(&self) -> bool;
 
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>>;
 

--- a/router/src/matching/horizontal/param_segments.rs
+++ b/router/src/matching/horizontal/param_segments.rs
@@ -35,6 +35,10 @@ use std::borrow::Cow;
 pub struct ParamSegment(pub &'static str);
 
 impl PossibleRouteMatch for ParamSegment {
+    fn optional(&self) -> bool {
+        false
+    }
+
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let mut matched_len = 0;
         let mut param_offset = 0;
@@ -121,6 +125,10 @@ impl PossibleRouteMatch for ParamSegment {
 pub struct WildcardSegment(pub &'static str);
 
 impl PossibleRouteMatch for WildcardSegment {
+    fn optional(&self) -> bool {
+        false
+    }
+
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let mut matched_len = 0;
         let mut param_offset = 0;
@@ -158,7 +166,9 @@ impl PossibleRouteMatch for WildcardSegment {
 pub struct OptionalParamSegment(pub &'static str);
 
 impl PossibleRouteMatch for OptionalParamSegment {
-    const OPTIONAL: bool = true;
+    fn optional(&self) -> bool {
+        true
+    }
 
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let mut matched_len = 0;

--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -2,6 +2,10 @@ use super::{PartialPathMatch, PathSegment, PossibleRouteMatch};
 use std::fmt::Debug;
 
 impl PossibleRouteMatch for () {
+    fn optional(&self) -> bool {
+        false
+    }
+
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         Some(PartialPathMatch::new(path, vec![], ""))
     }
@@ -54,6 +58,10 @@ impl AsPath for &'static str {
 pub struct StaticSegment<T: AsPath>(pub T);
 
 impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
+    fn optional(&self) -> bool {
+        false
+    }
+
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let mut matched_len = 0;
         let mut test = path.chars().peekable();

--- a/router/src/matching/horizontal/tuples.rs
+++ b/router/src/matching/horizontal/tuples.rs
@@ -8,14 +8,20 @@ macro_rules! tuples {
             $first: PossibleRouteMatch,
 			$($ty: PossibleRouteMatch),*,
         {
-            fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
-                // on the first run, include all optionals
-                let mut include_optionals = {
-                    [$first::OPTIONAL, $($ty::OPTIONAL),*].into_iter().filter(|n| *n).count()
-                };
-
+            fn optional(&self) -> bool {
                 #[allow(non_snake_case)]
                 let ($first, $($ty,)*) = &self;
+                [$first.optional(), $($ty.optional()),*].into_iter().any(|n| n)
+            }
+
+            fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
+                #[allow(non_snake_case)]
+                let ($first, $($ty,)*) = &self;
+
+                // on the first run, include all optionals
+                let mut include_optionals = {
+                    [$first.optional(), $($ty.optional()),*].into_iter().filter(|n| *n).count()
+                };
 
                 loop {
                     let mut nth_field = 0;
@@ -25,7 +31,7 @@ macro_rules! tuples {
                     let mut p = Vec::new();
                     let mut m = String::new();
 
-                    if !$first::OPTIONAL || nth_field < include_optionals {
+                    if !$first.optional() || nth_field < include_optionals {
                         match $first.test(r) {
                             None => {
                                 return None;
@@ -40,16 +46,16 @@ macro_rules! tuples {
 
                     matched_len += m.len();
                     $(
-                        if $ty::OPTIONAL {
+                        if $ty.optional() {
                             nth_field += 1;
                         }
-                        if !$ty::OPTIONAL || nth_field < include_optionals {
+                        if !$ty.optional() || nth_field < include_optionals {
                             let PartialPathMatch {
                                 remaining,
                                 matched,
                                 params
                             } = match $ty.test(r) {
-                                None => if $ty::OPTIONAL {
+                                None => if $ty.optional() {
                                     return None;
                                 } else {
                                     if include_optionals == 0 {
@@ -90,6 +96,10 @@ where
     Self: core::fmt::Debug,
     A: PossibleRouteMatch,
 {
+    fn optional(&self) -> bool {
+        self.0.optional()
+    }
+
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let remaining = path;
         let PartialPathMatch {

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -151,7 +151,7 @@ impl<Segments, Children, Data, View> MatchNestedRoutes
     for NestedRoute<Segments, Children, Data, View>
 where
     Self: 'static,
-    Segments: PossibleRouteMatch + std::fmt::Debug,
+    Segments: PossibleRouteMatch,
     Children: MatchNestedRoutes,
     Children::Match: MatchParams,
     Children: 'static,


### PR DESCRIPTION
This allows a pattern like this:
```rust
enum Page {
    Home { f1: u8 },
    Account(u8),
}

impl Page {
    fn to_route(&self) -> Arc<dyn PossibleRouteMatch + Send + Sync> {
        match self {
            Self::Home { f1 } => {
                Arc::new((StaticSegment("home"), ParamSegment("f1")))
            }
            Self::Account(acc) => {
                Arc::new((StaticSegment("accounts"), ParamSegment("f1")))
            }
        }
    }
}
```