### PR TITLE
docs: remove `islands` mention from `leptos_axum`

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -16,7 +16,6 @@
 //! - `default`: supports running in a typical native Tokio/Axum environment
 //! - `wasm`: with `default-features = false`, supports running in a JS Fetch-based
 //!   environment
-//! - `islands`: activates Leptos [islands mode](https://leptos-rs.github.io/leptos/islands.html)
 //!
 //! ### Important Note
 //! Prior to 0.5, using `default-features = false` on `leptos_axum` simply did nothing. Now, it actively


### PR DESCRIPTION
[This feature no longer exists](https://github.com/leptos-rs/leptos/blob/7a5b27ad2081dbc751c21291ce2702a0e3915da6/integrations/axum/Cargo.toml#L36).
