### PR TITLE
fix failure on try_new() methods which should not fail

### DIFF
--- a/reactive_graph/src/signal/guards.rs
+++ b/reactive_graph/src/signal/guards.rs
@@ -104,7 +104,7 @@ impl<T: 'static> Debug for Plain<T> {
 impl<T: 'static> Plain<T> {
     /// Takes a reference-counted read guard on the given lock.
     pub fn try_new(inner: Arc<RwLock<T>>) -> Option<Self> {
-        ArcRwLockReadGuardian::take(inner)
+        ArcRwLockReadGuardian::try_take(inner)?
             .ok()
             .map(|guard| Plain { guard })
     }
@@ -331,7 +331,7 @@ pub struct UntrackedWriteGuard<T: 'static>(ArcRwLockWriteGuardian<T>);
 impl<T: 'static> UntrackedWriteGuard<T> {
     /// Creates a write guard from the given lock.
     pub fn try_new(inner: Arc<RwLock<T>>) -> Option<Self> {
-        ArcRwLockWriteGuardian::take(inner)
+        ArcRwLockWriteGuardian::try_take(inner)?
             .ok()
             .map(UntrackedWriteGuard)
     }


### PR DESCRIPTION
I stumbled upon a bug while working on https://github.com/Synphonyte/leptos-struct-table.
Specifically these lines: https://github.com/Synphonyte/leptos-struct-table/blob/leptos-0.7/src/components/table_content.rs#L276-L279

```rust
            if let Some(mut rows) = rows.try_write_value() {
                rows.set_sorting(&sorting);
                clear(false);
            };
```

The `rows` is `StoredValue`.

The problem is `try_write_value()` works down to `UntrackedWriteGuard::try_new()`, which calls `ArcRwLockWriteGuardian::take`, which panics if it's impossible to get a write lock. But `try_write_value()` mustn't panic, it must return `None` instead.

Hence the fix.