### PR TITLE
Fix: values being moved with the debug_warn! macro when compiling with not(debug_assertions)

### DIFF
--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -29,13 +29,8 @@ macro_rules! error {
 macro_rules! debug_warn {
     ($($x:tt)*) => {
         {
-            #[cfg(debug_assertions)]
-            {
+            if cfg!(debug_assertions) {
                 $crate::warn!($($x)*)
-            }
-            #[cfg(not(debug_assertions))]
-            {
-                ($($x)*)
             }
         }
     }


### PR DESCRIPTION
This unifies the code path by using the `cfg!` macro instead of `#[cfg]` attribute. The alternative will *move* arguments passed to the debug_warn! macro only when compiling without debug_assertions. This version will instead always use additional format arguments by reference.

A minimal test code the shows the avoided bug:

```rust
let foo = "foo".to_string(); // A value that is not copy
leptos::logging::debug_warn!("Message: {}", foo); // foo is passed as an additional argument
let _ = foo.len(); // A usage after logging
```

The above will complain about `foo` being moved in the unpatched code only when compiling with `not(debug_assertions)`, since in that case the macro expands to a tuple of the arguments which counts as a usage and moves `foo` (into the void, but still).

Further advantage of the patched code is that the usual `format_args!` checks run with *and* without `debug_assertions` enable.