### PR TITLE
Rkyv feature should propagate properly

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -84,7 +84,10 @@ ssr = [
   "tachys/ssr",
 ]
 nightly = ["leptos_macro/nightly", "reactive_graph/nightly", "tachys/nightly"]
-rkyv = ["server_fn/rkyv"]
+rkyv = [
+  "server_fn/rkyv",
+  "leptos_server/rkyv"
+]
 tracing = [
   "dep:tracing",
   "reactive_graph/tracing",


### PR DESCRIPTION
I suppose enabling `rkyv` feature on `leptos` crate should enable it on all dependencies. 

Otherwise `Resource::new_rkyv()` is not accessible without extra dependency juggling i.e. explicitly bringign in `leptos_server` with `rkyv` feature enabled. 