### PR TITLE
Derive clone for RouteChildren

### DIFF
--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -32,7 +32,7 @@ use tachys::view::any_view::AnyView;
 
 /// A wrapper that allows passing route definitions as children to a component like [`Routes`],
 /// [`FlatRoutes`], [`ParentRoute`], or [`ProtectedParentRoute`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RouteChildren<Children>(Children);
 
 impl<Children> RouteChildren<Children> {


### PR DESCRIPTION
This change allows users to clone RouteChildren and call .into_inner() on it to get an owned version of \<Children\>, and then pass on the original RouteChildren to an underlying Routes, or ParentRoute component. This helps users snapshot all possible routes in an application.