### PR TITLE
feat: `#[lazy]` macros to support lazy loading and code splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,10 +1999,12 @@ dependencies = [
 name = "leptos_router_macro"
 version = "0.7.4"
 dependencies = [
+ "leptos_macro",
  "leptos_router",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -1,0 +1,96 @@
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use proc_macro_error2::abort;
+use quote::quote;
+use syn::{
+    spanned::Spanned, Block, ImplItem, ImplItemFn, ItemFn, ItemImpl, Path,
+    Type, TypePath,
+};
+
+pub fn lazy_impl(
+    _args: proc_macro::TokenStream,
+    s: TokenStream,
+) -> TokenStream {
+    let fun = syn::parse::<ItemFn>(s).unwrap_or_else(|e| {
+        abort!(e.span(), "`lazy` can only be used on a function")
+    });
+    if fun.sig.asyncness.is_none() {
+        abort!(
+            fun.sig.asyncness.span(),
+            "`lazy` can only be used on an async function"
+        )
+    }
+
+    let converted_name = Ident::new(
+        &fun.sig.ident.to_string().to_case(Case::Snake),
+        fun.sig.ident.span(),
+    );
+
+    quote! {
+        #[cfg_attr(feature = "split", wasm_split::wasm_split(#converted_name))]
+        #fun
+    }
+    .into()
+}
+
+pub fn lazy_route_impl(
+    _args: proc_macro::TokenStream,
+    s: TokenStream,
+) -> TokenStream {
+    let mut im = syn::parse::<ItemImpl>(s).unwrap_or_else(|e| {
+        abort!(e.span(), "`lazy_route` can only be used on an `impl` block")
+    });
+    if im.trait_.is_none() {
+        abort!(
+            im.span(),
+            "`lazy_route` can only be used on an `impl LazyRoute for ...` \
+             block"
+        )
+    }
+
+    let self_ty = im.self_ty.clone();
+    let ty_name_to_snake = match &*self_ty {
+        Type::Path(TypePath {
+            path: Path { segments, .. },
+            ..
+        }) => segments.last().unwrap().ident.to_string(),
+        _ => abort!(self_ty.span(), "only path types are supported"),
+    };
+    let lazy_view_ident = Ident::new(&ty_name_to_snake, im.self_ty.span());
+
+    let item = im.items.iter_mut().find_map(|item| match item {
+        ImplItem::Fn(inner) => {
+            if inner.sig.ident.to_string().as_str() == "view" {
+                Some(inner)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    });
+    match item {
+        None => abort!(im.span(), "must contain a fn called `view`"),
+        Some(fun) => {
+            let body = fun.block.clone();
+            let new_block = quote! {{
+                    #[cfg_attr(feature = "split", wasm_split::wasm_split(view_c))]
+                    async fn view(this: #self_ty) -> ::leptos::prelude::AnyView {
+                        #body
+                    }
+
+                    view(self).await
+            }};
+            let block =
+                syn::parse::<Block>(new_block.into()).unwrap_or_else(|e| {
+                    abort!(
+                        e.span(),
+                        "`lazy_route` can only be used on an `impl` block"
+                    )
+                });
+            fun.block = block;
+        }
+    }
+
+    quote! { #im }.into()
+}

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -4,8 +4,7 @@ use proc_macro2::Ident;
 use proc_macro_error2::abort;
 use quote::quote;
 use syn::{
-    spanned::Spanned, Block, ImplItem, ImplItemFn, ItemFn, ItemImpl, Path,
-    Type, TypePath,
+    spanned::Spanned, Block, ImplItem, ItemFn, ItemImpl, Path, Type, TypePath,
 };
 
 pub fn lazy_impl(
@@ -74,7 +73,7 @@ pub fn lazy_route_impl(
         Some(fun) => {
             let body = fun.block.clone();
             let new_block = quote! {{
-                    #[cfg_attr(feature = "split", wasm_split::wasm_split(view_c))]
+                    #[cfg_attr(feature = "split", wasm_split::wasm_split(#lazy_view_ident))]
                     async fn view(this: #self_ty) -> ::leptos::prelude::AnyView {
                         #body
                     }

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -3,9 +3,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Ident;
 use proc_macro_error2::abort;
 use quote::quote;
-use syn::{
-    spanned::Spanned, Block, ImplItem, ItemFn, ItemImpl, Path, Type, TypePath,
-};
+use syn::{spanned::Spanned, ItemFn};
 
 pub fn lazy_impl(
     _args: proc_macro::TokenStream,
@@ -31,65 +29,4 @@ pub fn lazy_impl(
         #fun
     }
     .into()
-}
-
-pub fn lazy_route_impl(
-    _args: proc_macro::TokenStream,
-    s: TokenStream,
-) -> TokenStream {
-    let mut im = syn::parse::<ItemImpl>(s).unwrap_or_else(|e| {
-        abort!(e.span(), "`lazy_route` can only be used on an `impl` block")
-    });
-    if im.trait_.is_none() {
-        abort!(
-            im.span(),
-            "`lazy_route` can only be used on an `impl LazyRoute for ...` \
-             block"
-        )
-    }
-
-    let self_ty = im.self_ty.clone();
-    let ty_name_to_snake = match &*self_ty {
-        Type::Path(TypePath {
-            path: Path { segments, .. },
-            ..
-        }) => segments.last().unwrap().ident.to_string(),
-        _ => abort!(self_ty.span(), "only path types are supported"),
-    };
-    let lazy_view_ident = Ident::new(&ty_name_to_snake, im.self_ty.span());
-
-    let item = im.items.iter_mut().find_map(|item| match item {
-        ImplItem::Fn(inner) => {
-            if inner.sig.ident.to_string().as_str() == "view" {
-                Some(inner)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    });
-    match item {
-        None => abort!(im.span(), "must contain a fn called `view`"),
-        Some(fun) => {
-            let body = fun.block.clone();
-            let new_block = quote! {{
-                    #[cfg_attr(feature = "split", wasm_split::wasm_split(#lazy_view_ident))]
-                    async fn view(this: #self_ty) -> ::leptos::prelude::AnyView {
-                        #body
-                    }
-
-                    view(self).await
-            }};
-            let block =
-                syn::parse::<Block>(new_block.into()).unwrap_or_else(|e| {
-                    abort!(
-                        e.span(),
-                        "`lazy_route` can only be used on an `impl` block"
-                    )
-                });
-            fun.block = block;
-        }
-    }
-
-    quote! { #im }.into()
 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -1004,19 +1004,16 @@ pub fn memo(input: TokenStream) -> TokenStream {
     memo::memo_impl(input)
 }
 
-/// TODO docs for lazy macros.
+/// The `#[lazy]` macro marks an `async` function as a function that can be lazy-loaded from a
+/// separate (WebAssembly) binary.
+///
+/// The first time the function is called, calling the function will first load that other binary,
+/// then call the function. On subsequent call it will be called immediately, but still return 
+/// asynchronously to maintain the same API.
+///
+/// All parameters and output types should be concrete types, with no generics.
 #[proc_macro_attribute]
 #[proc_macro_error]
 pub fn lazy(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     lazy::lazy_impl(args, s)
-}
-
-/// TODO docs for lazy macros.
-#[proc_macro_attribute]
-#[proc_macro_error]
-pub fn lazy_route(
-    args: proc_macro::TokenStream,
-    s: TokenStream,
-) -> TokenStream {
-    lazy::lazy_route_impl(args, s)
 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -1008,7 +1008,7 @@ pub fn memo(input: TokenStream) -> TokenStream {
 /// separate (WebAssembly) binary.
 ///
 /// The first time the function is called, calling the function will first load that other binary,
-/// then call the function. On subsequent call it will be called immediately, but still return 
+/// then call the function. On subsequent call it will be called immediately, but still return
 /// asynchronously to maintain the same API.
 ///
 /// All parameters and output types should be concrete types, with no generics.

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -23,6 +23,7 @@ mod params;
 mod view;
 use crate::component::unmodified_fn_name_from_fn_name;
 mod component;
+mod lazy;
 mod memo;
 mod slice;
 mod slot;
@@ -1001,4 +1002,21 @@ pub fn slice(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn memo(input: TokenStream) -> TokenStream {
     memo::memo_impl(input)
+}
+
+/// TODO docs for lazy macros.
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn lazy(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
+    lazy::lazy_impl(args, s)
+}
+
+/// TODO docs for lazy macros.
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn lazy_route(
+    args: proc_macro::TokenStream,
+    s: TokenStream,
+) -> TokenStream {
+    lazy::lazy_route_impl(args, s)
 }

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -16,9 +16,11 @@ proc-macro = true
 proc-macro-error2 = { version = "2.0", default-features = false }
 proc-macro2 = "1.0"
 quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 leptos_router = { path = "../router" }
+leptos_macro = { path = "../leptos_macro" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }


### PR DESCRIPTION
For context and an example, see [my fork of `wasm-split-prototype`](https://github.com/gbj/wasm-split-prototype/blob/main/crates/example/src/lib.rs).