### PR TITLE
Enhanced docs for reactive_stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,6 +2764,7 @@ dependencies = [
  "any_spawner",
  "guardian",
  "itertools",
+ "leptos",
  "or_poisoned",
  "paste",
  "reactive_graph",

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.41", features = ["rt-multi-thread", "macros"] }
 tokio-test = { version = "0.4.4" }
 any_spawner = { workspace = true, features = ["futures-executor", "tokio"] }
 reactive_graph = { workspace = true, features = ["effects"] }
+leptos = { path = "../leptos", features = ["csr"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }


### PR DESCRIPTION
After building with Stores I found there we places the docs could be enhanced.  I took a stab at documenting the things that tripped me up. I also included some docs for the new support for Box.  Added docs on shadow traits, Option, Enum, Vec, and Box usage with Store.

I'm not sure if you have a particular way you want docs done, or even want this sort of detail.  I also realize you might want the docs in the Leptos Book - but I figured I'd start here and then get guidance from the maintainers.