### PR TITLE
impl IntoAttributeValue for TextProp

### DIFF
--- a/leptos/src/text_prop.rs
+++ b/leptos/src/text_prop.rs
@@ -1,5 +1,6 @@
 use oco_ref::Oco;
 use std::sync::Arc;
+use tachys::prelude::IntoAttributeValue;
 
 /// Describes a value that is either a static or a reactive string, i.e.,
 /// a [`String`], a [`&str`], or a reactive `Fn() -> String`.
@@ -71,5 +72,13 @@ where
 impl Default for TextProp {
     fn default() -> Self {
         Self(Arc::new(|| Oco::Borrowed("")))
+    }
+}
+
+impl IntoAttributeValue for TextProp {
+    type Output = Oco<'static, str>;
+
+    fn into_attribute_value(self) -> Self::Output {
+        self.get()
     }
 }

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -98,7 +98,7 @@
 //! # fn main() {
 //! # }
 //! ```
-//!
+//! 
 //! ### Additional field types
 //!
 //! Most of the time, your structs will have fields as in the example above: the struct is comprised


### PR DESCRIPTION
I noticed that I can't pass `TextProp`s directly to HTML elements as attributes. This seems like something it should be able to do, so I made `TextProp` impl `IntoAttributeValue`.