### PR TITLE
AddAnyAttr working with erase_components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,8 +3550,10 @@ name = "tachys"
 version = "0.1.4"
 dependencies = [
  "any_spawner",
+ "async-trait",
  "const_str_slice_concat",
  "drain_filter_polyfill",
+ "dyn-clone",
  "either_of",
  "futures",
  "html-escape",

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -171,7 +171,7 @@ pub(crate) fn component_to_tokens(
 
     let spreads = (!(spreads.is_empty())).then(|| {
         quote! {
-            .add_any_attr((#(#spreads,)*))
+            .add_any_attr((#(#spreads,)*).into_attr())
         }
     });
 

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -20,6 +20,8 @@ reactive_graph = { workspace = true, optional = true }
 reactive_stores = { workspace = true, optional = true }
 slotmap = { version = "1.0", optional = true }
 oco_ref = { workspace = true, optional = true }
+async-trait = "0.1.81"
+dyn-clone = "1.0.17"
 once_cell = "1.20"
 paste = "1.0"
 wasm-bindgen = "0.2.97"
@@ -198,4 +200,8 @@ skip_feature_sets = [
 ]
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(leptos_debuginfo)',
+  'cfg(erase_components)',
+] }
+

--- a/tachys/src/html/attribute/any_attribute.rs
+++ b/tachys/src/html/attribute/any_attribute.rs
@@ -9,6 +9,7 @@ use std::{future::Future, pin::Pin};
 
 trait DynAttr: DynClone + Any + Send + 'static {
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    #[cfg(feature = "ssr")]
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
@@ -22,6 +23,7 @@ where
         self
     }
 
+    #[cfg(feature = "ssr")]
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
@@ -366,11 +368,11 @@ impl Attribute for Vec<AnyAttribute> {
         #[cfg(feature = "hydrate")]
         if FROM_SERVER {
             self.into_iter()
-                .map(|mut attr| attr.hydrate::<true>(el))
+                .map(|attr| attr.hydrate::<true>(el))
                 .collect()
         } else {
             self.into_iter()
-                .map(|mut attr| attr.hydrate::<false>(el))
+                .map(|attr| attr.hydrate::<false>(el))
                 .collect()
         }
         #[cfg(not(feature = "hydrate"))]

--- a/tachys/src/html/attribute/any_attribute.rs
+++ b/tachys/src/html/attribute/any_attribute.rs
@@ -1,4 +1,5 @@
 use super::{Attribute, NextAttribute};
+use dyn_clone::DynClone;
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
@@ -6,31 +7,62 @@ use std::{
 #[cfg(feature = "ssr")]
 use std::{future::Future, pin::Pin};
 
+trait DynAttr: DynClone + Any + Send + 'static {
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+dyn_clone::clone_trait_object!(DynAttr);
+
+impl<T: Clone> DynAttr for T
+where
+    T: Attribute + 'static,
+{
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
 /// A type-erased container for any [`Attribute`].
+#[derive(Clone)]
 pub struct AnyAttribute {
     type_id: TypeId,
     html_len: usize,
-    value: Box<dyn Any + Send>,
+    value: Box<dyn DynAttr>,
     #[cfg(feature = "ssr")]
-    to_html:
-        fn(Box<dyn Any>, &mut String, &mut String, &mut String, &mut String),
+    to_html: fn(
+        Box<dyn DynAttr>,
+        &mut String,
+        &mut String,
+        &mut String,
+        &mut String,
+    ),
     build: fn(
-        Box<dyn Any>,
+        Box<dyn DynAttr>,
         el: &crate::renderer::types::Element,
     ) -> AnyAttributeState,
-    rebuild: fn(TypeId, Box<dyn Any>, &mut AnyAttributeState),
+    rebuild: fn(TypeId, Box<dyn DynAttr>, &mut AnyAttributeState),
     #[cfg(feature = "hydrate")]
-    hydrate_from_server:
-        fn(Box<dyn Any>, &crate::renderer::types::Element) -> AnyAttributeState,
+    hydrate_from_server: fn(
+        Box<dyn DynAttr>,
+        &crate::renderer::types::Element,
+    ) -> AnyAttributeState,
     #[cfg(feature = "hydrate")]
-    hydrate_from_template:
-        fn(Box<dyn Any>, &crate::renderer::types::Element) -> AnyAttributeState,
+    hydrate_from_template: fn(
+        Box<dyn DynAttr>,
+        &crate::renderer::types::Element,
+    ) -> AnyAttributeState,
     #[cfg(feature = "ssr")]
     #[allow(clippy::type_complexity)]
-    resolve:
-        fn(Box<dyn Any>) -> Pin<Box<dyn Future<Output = AnyAttribute> + Send>>,
+    resolve: fn(
+        Box<dyn DynAttr>,
+    ) -> Pin<Box<dyn Future<Output = AnyAttribute> + Send>>,
     #[cfg(feature = "ssr")]
-    dry_resolve: fn(&mut Box<dyn Any + Send>),
+    dry_resolve: fn(&mut Box<dyn DynAttr>),
 }
 
 impl Debug for AnyAttribute {
@@ -55,145 +87,138 @@ pub trait IntoAnyAttribute {
 impl<T> IntoAnyAttribute for T
 where
     Self: Send,
-    T: Attribute + 'static,
-    T::State: 'static,
+    T: Attribute,
     crate::renderer::types::Element: Clone,
 {
-    // inlining allows the compiler to remove the unused functions
-    // i.e., doesn't ship HTML-generating code that isn't used
-    #[inline(always)]
     fn into_any_attr(self) -> AnyAttribute {
-        let html_len = self.html_len();
-
-        let value = Box::new(self) as Box<dyn Any + Send>;
-
-        match value.downcast::<AnyAttribute>() {
+        let value =
+            Box::new(self.into_cloneable_owned()) as Box<dyn Any + Send>;
+        let value = match (value as Box<dyn Any>).downcast::<AnyAttribute>() {
             // if it's already an AnyAttribute, we don't need to double-wrap it
-            Ok(any_attribute) => *any_attribute,
-            Err(value) => {
-                #[cfg(feature = "ssr")]
-                let to_html =
-                    |value: Box<dyn Any>,
-                     buf: &mut String,
-                     class: &mut String,
-                     style: &mut String,
-                     inner_html: &mut String| {
-                        let value = value.downcast::<T>().expect(
-                            "AnyAttribute::to_html could not be downcast",
-                        );
-                        value.to_html(buf, class, style, inner_html);
-                    };
-                let build =
-                    |value: Box<dyn Any>,
+            Ok(any_attribute) => return *any_attribute,
+            Err(value) => value.downcast::<T::CloneableOwned>().unwrap(),
+        };
+
+        #[cfg(feature = "ssr")]
+        let to_html = |value: Box<dyn DynAttr>,
+                       buf: &mut String,
+                       class: &mut String,
+                       style: &mut String,
+                       inner_html: &mut String| {
+            let value = value
+                .into_any()
+                .downcast::<T::CloneableOwned>()
+                .expect("AnyAttribute::to_html could not be downcast");
+            value.to_html(buf, class, style, inner_html);
+        };
+        let build = |value: Box<dyn DynAttr>,
                      el: &crate::renderer::types::Element| {
-                        let value = value
-                            .downcast::<T>()
-                            .expect("AnyAttribute::build couldn't downcast");
-                        let state = Box::new(value.build(el));
+            let value = value
+                .into_any()
+                .downcast::<T::CloneableOwned>()
+                .expect("AnyAttribute::build couldn't downcast");
+            let state = Box::new(value.build(el));
 
-                        AnyAttributeState {
-                            type_id: TypeId::of::<T>(),
-                            state,
-                            el: el.clone(),
-                        }
-                    };
-                #[cfg(feature = "hydrate")]
-                let hydrate_from_server =
-                    |value: Box<dyn Any>,
-                     el: &crate::renderer::types::Element| {
-                        let value = value.downcast::<T>().expect(
-                            "AnyAttribute::hydrate_from_server couldn't \
-                             downcast",
-                        );
-                        let state = Box::new(value.hydrate::<true>(el));
-
-                        AnyAttributeState {
-                            type_id: TypeId::of::<T>(),
-                            state,
-                            el: el.clone(),
-                        }
-                    };
-                #[cfg(feature = "hydrate")]
-                let hydrate_from_template =
-                    |value: Box<dyn Any>,
-                     el: &crate::renderer::types::Element| {
-                        let value = value.downcast::<T>().expect(
-                            "AnyAttribute::hydrate_from_server couldn't \
-                             downcast",
-                        );
-                        let state = Box::new(value.hydrate::<true>(el));
-
-                        AnyAttributeState {
-                            type_id: TypeId::of::<T>(),
-                            state,
-                            el: el.clone(),
-                        }
-                    };
-                let rebuild =
-                    |new_type_id: TypeId,
-                     value: Box<dyn Any>,
-                     state: &mut AnyAttributeState| {
-                        let value = value.downcast::<T>().expect(
-                            "AnyAttribute::rebuild couldn't downcast value",
-                        );
-                        if new_type_id == state.type_id {
-                            let state = state.state.downcast_mut().expect(
-                                "AnyAttribute::rebuild couldn't downcast state",
-                            );
-                            value.rebuild(state);
-                        } else {
-                            let new = value.into_any_attr().build(&state.el);
-                            *state = new;
-                        }
-                    };
-                #[cfg(feature = "ssr")]
-                let dry_resolve = |value: &mut Box<dyn Any + Send>| {
-                    let value = value
-                        .downcast_mut::<T>()
-                        .expect("AnyView::resolve could not be downcast");
-                    value.dry_resolve();
-                };
-
-                #[cfg(feature = "ssr")]
-                let resolve = |value: Box<dyn Any>| {
-                    let value = value
-                        .downcast::<T>()
-                        .expect("AnyView::resolve could not be downcast");
-                    Box::pin(
-                        async move { value.resolve().await.into_any_attr() },
-                    )
-                        as Pin<Box<dyn Future<Output = AnyAttribute> + Send>>
-                };
-                AnyAttribute {
-                    type_id: TypeId::of::<T>(),
-                    html_len,
-                    value,
-                    #[cfg(feature = "ssr")]
-                    to_html,
-                    build,
-                    rebuild,
-                    #[cfg(feature = "hydrate")]
-                    hydrate_from_server,
-                    #[cfg(feature = "hydrate")]
-                    hydrate_from_template,
-                    #[cfg(feature = "ssr")]
-                    resolve,
-                    #[cfg(feature = "ssr")]
-                    dry_resolve,
-                }
+            AnyAttributeState {
+                type_id: TypeId::of::<T::CloneableOwned>(),
+                state,
+                el: el.clone(),
             }
+        };
+        #[cfg(feature = "hydrate")]
+        let hydrate_from_server =
+            |value: Box<dyn DynAttr>, el: &crate::renderer::types::Element| {
+                let value =
+                    value.into_any().downcast::<T::CloneableOwned>().expect(
+                        "AnyAttribute::hydrate_from_server couldn't downcast",
+                    );
+                let state = Box::new(value.hydrate::<true>(el));
+
+                AnyAttributeState {
+                    type_id: TypeId::of::<T::CloneableOwned>(),
+                    state,
+                    el: el.clone(),
+                }
+            };
+        #[cfg(feature = "hydrate")]
+        let hydrate_from_template =
+            |value: Box<dyn DynAttr>, el: &crate::renderer::types::Element| {
+                let value =
+                    value.into_any().downcast::<T::CloneableOwned>().expect(
+                        "AnyAttribute::hydrate_from_server couldn't downcast",
+                    );
+                let state = Box::new(value.hydrate::<true>(el));
+
+                AnyAttributeState {
+                    type_id: TypeId::of::<T::CloneableOwned>(),
+                    state,
+                    el: el.clone(),
+                }
+            };
+        let rebuild = |new_type_id: TypeId,
+                       value: Box<dyn DynAttr>,
+                       state: &mut AnyAttributeState| {
+            let value = value
+                .into_any()
+                .downcast::<T::CloneableOwned>()
+                .expect("AnyAttribute::rebuild couldn't downcast value");
+            if new_type_id == state.type_id {
+                let state = state
+                    .state
+                    .downcast_mut()
+                    .expect("AnyAttribute::rebuild couldn't downcast state");
+                value.rebuild(state);
+            } else {
+                let new = value.into_any_attr().build(&state.el);
+                *state = new;
+            }
+        };
+        #[cfg(feature = "ssr")]
+        let dry_resolve = |value: &mut Box<dyn DynAttr>| {
+            let value = value
+                .as_any_mut()
+                .downcast_mut::<T::CloneableOwned>()
+                .expect("AnyView::resolve could not be downcast");
+            value.dry_resolve();
+        };
+
+        #[cfg(feature = "ssr")]
+        let resolve = |value: Box<dyn DynAttr>| {
+            let value = value
+                .into_any()
+                .downcast::<T::CloneableOwned>()
+                .expect("AnyView::resolve could not be downcast");
+            Box::pin(async move { value.resolve().await.into_any_attr() })
+                as Pin<Box<dyn Future<Output = AnyAttribute> + Send>>
+        };
+        AnyAttribute {
+            type_id: TypeId::of::<T::CloneableOwned>(),
+            html_len: value.html_len(),
+            value,
+            #[cfg(feature = "ssr")]
+            to_html,
+            build,
+            rebuild,
+            #[cfg(feature = "hydrate")]
+            hydrate_from_server,
+            #[cfg(feature = "hydrate")]
+            hydrate_from_template,
+            #[cfg(feature = "ssr")]
+            resolve,
+            #[cfg(feature = "ssr")]
+            dry_resolve,
         }
     }
 }
 
 impl NextAttribute for AnyAttribute {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    type Output<NewAttr: Attribute> = Vec<AnyAttribute>;
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        vec![self, new_attr.into_any_attr()]
     }
 }
 
@@ -202,8 +227,8 @@ impl Attribute for AnyAttribute {
 
     type AsyncOutput = AnyAttribute;
     type State = AnyAttributeState;
-    type Cloneable = ();
-    type CloneableOwned = ();
+    type Cloneable = AnyAttribute;
+    type CloneableOwned = AnyAttribute;
 
     fn html_len(&self) -> usize {
         self.html_len
@@ -257,11 +282,11 @@ impl Attribute for AnyAttribute {
     }
 
     fn into_cloneable(self) -> Self::Cloneable {
-        todo!()
+        self
     }
 
     fn into_cloneable_owned(self) -> Self::CloneableOwned {
-        todo!()
+        self
     }
 
     fn dry_resolve(&mut self) {
@@ -280,6 +305,123 @@ impl Attribute for AnyAttribute {
         #[cfg(feature = "ssr")]
         {
             (self.resolve)(self.value).await
+        }
+        #[cfg(not(feature = "ssr"))]
+        panic!(
+            "You are rendering AnyAttribute to HTML without the `ssr` feature \
+             enabled."
+        );
+    }
+}
+
+impl NextAttribute for Vec<AnyAttribute> {
+    type Output<NewAttr: Attribute> = Self;
+
+    fn add_any_attr<NewAttr: Attribute>(
+        mut self,
+        new_attr: NewAttr,
+    ) -> Self::Output<NewAttr> {
+        self.push(new_attr.into_any_attr());
+        self
+    }
+}
+
+impl Attribute for Vec<AnyAttribute> {
+    const MIN_LENGTH: usize = 0;
+
+    type AsyncOutput = Vec<AnyAttribute>;
+    type State = Vec<AnyAttributeState>;
+    type Cloneable = Vec<AnyAttribute>;
+    type CloneableOwned = Vec<AnyAttribute>;
+
+    fn html_len(&self) -> usize {
+        self.iter().map(|attr| attr.html_len()).sum()
+    }
+
+    #[allow(unused)] // they are used in SSR
+    fn to_html(
+        self,
+        buf: &mut String,
+        class: &mut String,
+        style: &mut String,
+        inner_html: &mut String,
+    ) {
+        #[cfg(feature = "ssr")]
+        {
+            for mut attr in self {
+                attr.to_html(buf, class, style, inner_html)
+            }
+        }
+        #[cfg(not(feature = "ssr"))]
+        panic!(
+            "You are rendering AnyAttribute to HTML without the `ssr` feature \
+             enabled."
+        );
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        el: &crate::renderer::types::Element,
+    ) -> Self::State {
+        #[cfg(feature = "hydrate")]
+        if FROM_SERVER {
+            self.into_iter()
+                .map(|mut attr| attr.hydrate::<true>(el))
+                .collect()
+        } else {
+            self.into_iter()
+                .map(|mut attr| attr.hydrate::<false>(el))
+                .collect()
+        }
+        #[cfg(not(feature = "hydrate"))]
+        {
+            _ = el;
+            panic!(
+                "You are trying to hydrate AnyAttribute without the `hydrate` \
+                 feature enabled."
+            );
+        }
+    }
+
+    fn build(self, el: &crate::renderer::types::Element) -> Self::State {
+        self.into_iter().map(|attr| attr.build(el)).collect()
+    }
+
+    fn rebuild(self, state: &mut Self::State) {
+        for (attr, state) in self.into_iter().zip(state.iter_mut()) {
+            attr.rebuild(state)
+        }
+    }
+
+    fn into_cloneable(self) -> Self::Cloneable {
+        self
+    }
+
+    fn into_cloneable_owned(self) -> Self::CloneableOwned {
+        self
+    }
+
+    fn dry_resolve(&mut self) {
+        #[cfg(feature = "ssr")]
+        {
+            for attr in self.iter_mut() {
+                attr.dry_resolve()
+            }
+        }
+        #[cfg(not(feature = "ssr"))]
+        panic!(
+            "You are rendering AnyAttribute to HTML without the `ssr` feature \
+             enabled."
+        );
+    }
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        #[cfg(feature = "ssr")]
+        {
+            futures::future::join_all(
+                self.into_iter().map(|attr| attr.resolve()),
+            )
+            .await
         }
         #[cfg(not(feature = "ssr"))]
         panic!(

--- a/tachys/src/html/attribute/custom.rs
+++ b/tachys/src/html/attribute/custom.rs
@@ -1,6 +1,11 @@
-use super::NextAttribute;
+use super::{
+    maybe_next_attr_erasure_macros::next_attr_output_type, NextAttribute,
+};
 use crate::{
-    html::attribute::{Attribute, AttributeValue},
+    html::attribute::{
+        maybe_next_attr_erasure_macros::next_attr_combine, Attribute,
+        AttributeValue,
+    },
     view::{add_attr::AddAnyAttr, Position, ToTemplate},
 };
 use std::{borrow::Cow, sync::Arc};
@@ -114,13 +119,13 @@ where
     K: CustomAttributeKey,
     V: AttributeValue,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/html/attribute/maybe_next_attr_erasure_macros.rs
+++ b/tachys/src/html/attribute/maybe_next_attr_erasure_macros.rs
@@ -1,0 +1,27 @@
+macro_rules! next_attr_output_type {
+    ($current:ty, $next:ty) => {
+        #[cfg(not(erase_components))]
+        type Output<NewAttr: Attribute> = ($current, $next);
+
+        #[cfg(erase_components)]
+        type Output<NewAttr: Attribute> =
+            Vec<$crate::html::attribute::any_attribute::AnyAttribute>;
+    };
+}
+
+macro_rules! next_attr_combine {
+    ($self:expr, $next_attr:expr) => {{
+        #[cfg(not(erase_components))]
+        {
+            ($self, $next_attr)
+        }
+        #[cfg(erase_components)]
+        {
+            use $crate::html::attribute::any_attribute::IntoAnyAttribute;
+            vec![$self.into_any_attr(), $next_attr.into_any_attr()]
+        }
+    }};
+}
+
+pub(crate) use next_attr_combine;
+pub(crate) use next_attr_output_type;

--- a/tachys/src/html/attribute/panic_on_clone_attribute.rs
+++ b/tachys/src/html/attribute/panic_on_clone_attribute.rs
@@ -1,0 +1,88 @@
+use super::{Attribute, NextAttribute};
+
+/// When type erasing with `AnyAttribute`, the underling attribute must be cloneable.
+///
+/// For most this is possible, but for some like `NodeRef` it is not.
+///
+/// This allows for a panic to be thrown if a non-cloneable attribute is cloned, whilst still seeming like it can be cloned.
+pub struct PanicOnCloneAttr<T: Attribute + 'static> {
+    msg: &'static str,
+    attr: T,
+}
+
+impl<T: Attribute + 'static> PanicOnCloneAttr<T> {
+    pub(crate) fn new(attr: T, msg: &'static str) -> Self {
+        Self { msg, attr }
+    }
+}
+
+impl<T: Attribute + 'static> Clone for PanicOnCloneAttr<T> {
+    fn clone(&self) -> Self {
+        panic!("{}", self.msg)
+    }
+}
+
+impl<T: Attribute + 'static> NextAttribute for PanicOnCloneAttr<T> {
+    type Output<NewAttr: Attribute> = <T as NextAttribute>::Output<NewAttr>;
+
+    fn add_any_attr<NewAttr: Attribute>(
+        self,
+        new_attr: NewAttr,
+    ) -> Self::Output<NewAttr> {
+        self.attr.add_any_attr(new_attr)
+    }
+}
+
+impl<T: Attribute + 'static> Attribute for PanicOnCloneAttr<T> {
+    const MIN_LENGTH: usize = T::MIN_LENGTH;
+
+    type State = T::State;
+    type AsyncOutput = T::AsyncOutput;
+    type Cloneable = Self;
+    type CloneableOwned = Self;
+
+    fn html_len(&self) -> usize {
+        self.attr.html_len()
+    }
+
+    fn to_html(
+        self,
+        buf: &mut String,
+        class: &mut String,
+        style: &mut String,
+        inner_html: &mut String,
+    ) {
+        self.attr.to_html(buf, class, style, inner_html)
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        el: &crate::renderer::types::Element,
+    ) -> Self::State {
+        self.attr.hydrate::<FROM_SERVER>(el)
+    }
+
+    fn build(self, el: &crate::renderer::types::Element) -> Self::State {
+        self.attr.build(el)
+    }
+
+    fn rebuild(self, state: &mut Self::State) {
+        self.attr.rebuild(state)
+    }
+
+    fn into_cloneable(self) -> Self::Cloneable {
+        self
+    }
+
+    fn into_cloneable_owned(self) -> Self::CloneableOwned {
+        self
+    }
+
+    fn dry_resolve(&mut self) {
+        self.attr.dry_resolve()
+    }
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        self.attr.resolve().await
+    }
+}

--- a/tachys/src/html/class.rs
+++ b/tachys/src/html/class.rs
@@ -1,5 +1,9 @@
-use super::attribute::{Attribute, NextAttribute};
+use super::attribute::{
+    maybe_next_attr_erasure_macros::next_attr_output_type, Attribute,
+    NextAttribute,
+};
 use crate::{
+    html::attribute::maybe_next_attr_erasure_macros::next_attr_combine,
     renderer::Rndr,
     view::{Position, ToTemplate},
 };
@@ -99,13 +103,13 @@ impl<C> NextAttribute for Class<C>
 where
     C: IntoClass,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/html/directive.rs
+++ b/tachys/src/html/directive.rs
@@ -1,5 +1,9 @@
-use super::attribute::{Attribute, NextAttribute};
+use super::attribute::{
+    maybe_next_attr_erasure_macros::next_attr_output_type, Attribute,
+    NextAttribute,
+};
 use crate::{
+    html::attribute::maybe_next_attr_erasure_macros::next_attr_combine,
     prelude::AddAnyAttr,
     view::{Position, ToTemplate},
 };
@@ -164,13 +168,13 @@ where
     P: Clone + 'static,
     T: 'static,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/html/element/custom.rs
+++ b/tachys/src/html/element/custom.rs
@@ -21,7 +21,7 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Custom<E>(E);
 
-impl<E> ElementType for Custom<E>
+impl<E: 'static> ElementType for Custom<E>
 where
     E: AsRef<str> + Send,
 {

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -1,11 +1,10 @@
 use crate::{
     html::{
-        attribute::{Attr, Attribute, AttributeValue},
+        attribute::{Attr, Attribute, AttributeValue, NextAttribute},
         element::{ElementType, ElementWithChildren, HtmlElement},
     },
     view::Render,
 };
-use next_tuple::NextTuple;
 use std::fmt::Debug;
 
 macro_rules! html_element_inner {
@@ -48,13 +47,13 @@ macro_rules! html_element_inner {
                     #[doc = concat!("The [`", stringify!($attr), "`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/", stringify!($tag), "#", stringify!($attr) ,") attribute on `<", stringify!($tag), ">`.")]
                     pub fn $attr<V>(self, value: V) -> HtmlElement <
                         $struct_name,
-                        <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
+                        <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
                         Ch
                     >
                     where
                         V: AttributeValue,
-                        At: NextTuple,
-                        <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
+                        At: NextAttribute,
+                        <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
                     {
                         let HtmlElement {
                             #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -68,7 +67,7 @@ macro_rules! html_element_inner {
                             defined_at,
                             tag,
                             children,
-                            attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
+                            attributes: attributes.add_any_attr($crate::html::attribute::$attr(value)),
                         }
                     }
                 )*
@@ -153,13 +152,13 @@ macro_rules! html_self_closing_elements {
                         #[doc = concat!("The [`", stringify!($attr), "`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/", stringify!($tag), "#", stringify!($attr) ,") attribute on `<", stringify!($tag), ">`.")]
                         pub fn $attr<V>(self, value: V) -> HtmlElement<
                             [<$tag:camel>],
-                            <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
+                            <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
                             (),
                         >
                         where
                             V: AttributeValue,
-                            At: NextTuple,
-                            <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
+                            At: NextAttribute,
+                            <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
                         {
                             let HtmlElement {
                                  #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -173,7 +172,7 @@ macro_rules! html_self_closing_elements {
                                 defined_at,
                                 tag,
                                 children,
-                                attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
+                                attributes: attributes.add_any_attr($crate::html::attribute::$attr(value)),
                             }
                         }
                     )*

--- a/tachys/src/html/element/inner_html.rs
+++ b/tachys/src/html/element/inner_html.rs
@@ -1,6 +1,11 @@
 use super::{ElementWithChildren, HtmlElement};
 use crate::{
-    html::attribute::{Attribute, NextAttribute},
+    html::attribute::{
+        maybe_next_attr_erasure_macros::{
+            next_attr_combine, next_attr_output_type,
+        },
+        Attribute, NextAttribute,
+    },
     renderer::Rndr,
     view::add_attr::AddAnyAttr,
 };
@@ -106,13 +111,13 @@ impl<T> NextAttribute for InnerHtml<T>
 where
     T: InnerHtmlValue,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -141,7 +141,7 @@ where
 }
 
 /// An HTML element.
-pub trait ElementType: Send {
+pub trait ElementType: Send + 'static {
     /// The underlying native widget type that this represents.
     type Output;
 

--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -1,5 +1,7 @@
 use crate::{
-    html::attribute::Attribute,
+    html::attribute::{
+        maybe_next_attr_erasure_macros::next_attr_combine, Attribute,
+    },
     renderer::{CastFrom, RemoveEventHandler, Rndr},
     view::{Position, ToTemplate},
 };
@@ -302,13 +304,13 @@ where
 
     E::EventType: From<crate::renderer::types::Event>,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 
@@ -671,7 +673,12 @@ generate_event_types! {
 }
 
 // Export `web_sys` event types
-use super::{attribute::NextAttribute, element::HasElementType};
+use super::{
+    attribute::{
+        maybe_next_attr_erasure_macros::next_attr_output_type, NextAttribute,
+    },
+    element::HasElementType,
+};
 #[doc(no_inline)]
 pub use web_sys::{
     AnimationEvent, BeforeUnloadEvent, CompositionEvent, CustomEvent,

--- a/tachys/src/html/property.rs
+++ b/tachys/src/html/property.rs
@@ -1,5 +1,9 @@
-use super::attribute::{Attribute, NextAttribute};
+use super::attribute::{
+    maybe_next_attr_erasure_macros::next_attr_output_type, Attribute,
+    NextAttribute,
+};
 use crate::{
+    html::attribute::maybe_next_attr_erasure_macros::next_attr_combine,
     renderer::Rndr,
     view::{Position, ToTemplate},
 };
@@ -127,13 +131,13 @@ where
     K: AsRef<str> + Send,
     P: IntoProperty,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -1,7 +1,11 @@
-use super::attribute::{Attribute, NextAttribute};
+use super::attribute::{
+    maybe_next_attr_erasure_macros::next_attr_output_type, Attribute,
+    NextAttribute,
+};
 #[cfg(feature = "nightly")]
 use crate::view::static_types::Static;
 use crate::{
+    html::attribute::maybe_next_attr_erasure_macros::next_attr_combine,
     renderer::Rndr,
     view::{Position, ToTemplate},
 };
@@ -102,13 +106,13 @@ impl<S> NextAttribute for Style<S>
 where
     S: IntoStyle,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -21,7 +21,7 @@ pub mod prelude {
                     OnAttribute, OnTargetAttribute, PropAttribute,
                     StyleAttribute,
                 },
-                IntoAttributeValue,
+                IntoAttribute, IntoAttributeValue,
             },
             directive::DirectiveAttribute,
             element::{ElementChild, ElementExt, InnerHtmlAttribute},

--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -1,11 +1,10 @@
 use crate::{
     html::{
-        attribute::{Attr, Attribute, AttributeValue},
+        attribute::{Attr, Attribute, AttributeValue, NextAttribute},
         element::{ElementType, ElementWithChildren, HtmlElement},
     },
     view::Render,
 };
-use next_tuple::NextTuple;
 use std::fmt::Debug;
 
 macro_rules! mathml_global {
@@ -14,13 +13,13 @@ macro_rules! mathml_global {
             /// A MathML attribute.
 			pub fn $attr<V>(self, value: V) -> HtmlElement <
 				[<$tag:camel>],
-				<At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
+				<At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
 				Ch
 			>
 			where
 				V: AttributeValue,
-				At: NextTuple,
-				<At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
+				At: NextAttribute,
+				<At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
 			{
 				let HtmlElement {
                     #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -34,7 +33,7 @@ macro_rules! mathml_global {
                     defined_at,
 					tag,
 					children,
-					attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
+					attributes: attributes.add_any_attr($crate::html::attribute::$attr(value)),
 				}
 			}
 		}
@@ -84,13 +83,13 @@ macro_rules! mathml_elements {
                         /// A MathML attribute.
                         pub fn $attr<V>(self, value: V) -> HtmlElement <
                             [<$tag:camel>],
-                            <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
+                            <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
                             Ch
                         >
                         where
                             V: AttributeValue,
-                            At: NextTuple,
-                            <At as NextTuple>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
+                            At: NextAttribute,
+                            <At as NextAttribute>::Output<Attr<$crate::html::attribute::[<$attr:camel>], V>>: Attribute,
                         {
                             let HtmlElement {
                                 #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -104,7 +103,7 @@ macro_rules! mathml_elements {
                                 defined_at,
                                 tag,
                                 children,
-                                attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
+                                attributes: attributes.add_any_attr($crate::html::attribute::$attr(value)),
                             }
                         }
 					)*

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -1,7 +1,12 @@
 use crate::{
     dom::{event_target_checked, event_target_value},
     html::{
-        attribute::{Attribute, AttributeKey, AttributeValue, NextAttribute},
+        attribute::{
+            maybe_next_attr_erasure_macros::{
+                next_attr_combine, next_attr_output_type,
+            },
+            Attribute, AttributeKey, AttributeValue, NextAttribute,
+        },
         event::{change, input, on},
         property::{prop, IntoProperty},
     },
@@ -276,13 +281,13 @@ where
     W: Update<Value = T> + Clone + Send + 'static,
     Element: ChangeEvent + GetValue<T>,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (self, new_attr)
+        next_attr_combine!(self, new_attr)
     }
 }
 

--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -40,13 +40,13 @@ macro_rules! svg_elements {
 					$(
                         pub fn $attr<V>(self, value: V) -> HtmlElement <
                             [<$tag:camel>],
-                            <At as NextTuple<Attr<$crate::html::attribute::[<$attr:camel>], V>>>::Output,
+                            <At as $crate::html::attribute::NextAttribute<Attr<$crate::html::attribute::[<$attr:camel>], V>>>::Output,
                             Ch
                         >
                         where
                             V: AttributeValue,
-                            At: NextTuple<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
-                            <At as NextTuple<Attr<$crate::html::attribute::[<$attr:camel>], V>>>::Output: Attribute,
+                            At: $crate::html::attribute::NextAttribute<Attr<$crate::html::attribute::[<$attr:camel>], V>>,
+                            <At as $crate::html::attribute::NextAttribute<Attr<$crate::html::attribute::[<$attr:camel>], V>>>::Output: Attribute,
                         {
                             let HtmlElement { tag, children, attributes,
                                 #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -56,7 +56,7 @@ macro_rules! svg_elements {
                                 tag,
 
                                 children,
-                                attributes: attributes.next_tuple($crate::html::attribute::$attr(value)),
+                                attributes: attributes.add_any_attr($crate::html::attribute::$attr(value)),
                                 #[cfg(any(debug_assertions, leptos_debuginfo))]
                                 defined_at
                             }


### PR DESCRIPTION
cc #3156 #3458 #3460 #3461 #3476

TLDR: this PR enables `AddAnyAttr` on `AnyView` when the`--cfg erase_components` feature flag is enabled. Made possible by further type erasing tuples of attrs types to `Vec<AnyAttribute>` before they even became tuples preventing generation of an exponential number of types. `--cfg erase_components` is now feature complete and provides up to 1.5-3x faster compilation speed. Yay!

Unfortunately this means the issues surrounding `AddAnyAttr` and `AnyView` without type erasure are most likely not an issue with rust or the compiler, but too many unique attribute tuple types, monorphisation and codegen, but importantly this missing feature is actually what is making stable leptos compile, by trimming the potential for futher attr types at each `AnyView` boundary and preventing further tuple types of that type being created, and why the feature cannot be enabled without reducing the number of unique types.

Arguably the above **is** an issue with rust/the compiler, but on further analysis it looks like the solution isn't "fix a bug in rust/compiler" it's "how do we reduce the number of unique types without hurting binary size or runtime too much because the current number seems to be insane".

As I've mentioned, the compile bottleneck is only surrounding the static typing of attributes, not the entire view tree, which makes sense considering these are the "leaves" whereas html elements are the "branches". Maybe erasing attributes is a worthwhile cost, whilst leaving the tree itself static (i.e splitting `--cfg erase_components` into 2 parts, the attr part being erased.

The main takeaway is that compiler issues, compile time, the `AnyAttr` feature not working on `AnyView`, are all down to the tuple impls that create an exponential number of types.

Using [thaw](https://github.com/thaw-ui/thaw)'s demo project, pointing leptos to this PR, you can see the effect of erasing the components with [cargo-llvm-lines](https://github.com/dtolnay/cargo-llvm-lines): llvm lines drop by 35% from 11million to 7million, still huge but it get's it down to something that seems manageable.

Without erasure:
```
cd demo
CARGO_PROFILE_RELEASE_LTO=fat cargo +stable llvm-lines --bin demo --release --features ssr | head -50
```

```
  11037943                245438                (TOTAL)
    753224 (6.8%,  6.8%)   14798 (6.0%,  6.0%)  core::ops::function::FnOnce::call_once
    344453 (3.1%,  9.9%)    3661 (1.5%,  7.5%)  <T as tachys::view::any_view::IntoAny>::into_any::{{closure}}
    344398 (3.1%, 13.1%)    1671 (0.7%,  8.2%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::to_html_async_with_buf
    273222 (2.5%, 15.5%)    2868 (1.2%,  9.4%)  <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
    261056 (2.4%, 17.9%)    2191 (0.9%, 10.3%)  <T as tachys::view::any_view::IntoAny>::into_any::{{closure}}::{{closure}}
    210774 (1.9%, 19.8%)   13073 (5.3%, 15.6%)  core::ops::function::FnOnce::call_once{{vtable.shim}}
    167520 (1.5%, 21.3%)    1139 (0.5%, 16.1%)  reactive_graph::owner::Owner::with
    161694 (1.5%, 22.8%)    7963 (3.2%, 19.3%)  alloc::boxed::Box<T>::new
    146147 (1.3%, 24.1%)    1587 (0.6%, 19.9%)  <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
    130325 (1.2%, 25.3%)     878 (0.4%, 20.3%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::to_html_with_buf
     96664 (0.9%, 26.2%)     470 (0.2%, 20.5%)  tachys::html::element::attributes_to_html
     95371 (0.9%, 27.0%)     139 (0.1%, 20.6%)  reactive_graph::computed::inner::<impl reactive_graph::graph::node::ReactiveNode for std::sync::rwlock::RwLock<reactive_graph::computed::inner::MemoInner<T,S>>>::update_if_necessary
     95137 (0.9%, 27.9%)     520 (0.2%, 20.8%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::resolve::{{closure}}
     90507 (0.8%, 28.7%)    1026 (0.4%, 21.2%)  <futures_util::future::join::Join<Fut1,Fut2> as core::future::future::Future>::poll
     89915 (0.8%, 29.5%)    1106 (0.5%, 21.6%)  <T as tachys::view::any_view::IntoAny>::into_any
     82920 (0.8%, 30.3%)     794 (0.3%, 22.0%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::build
     79087 (0.7%, 31.0%)    1623 (0.7%, 22.6%)  alloc::sync::Arc<T,A>::drop_slow
     78547 (0.7%, 31.7%)     788 (0.3%, 22.9%)  reactive_graph::owner::arena::Arena::with
     74110 (0.7%, 32.4%)    1193 (0.5%, 23.4%)  std::thread::local::LocalKey<T>::try_with
     67549 (0.6%, 33.0%)    1271 (0.5%, 23.9%)  futures_util::future::maybe_done::MaybeDone<Fut>::take_output
     64881 (0.6%, 33.6%)     290 (0.1%, 24.1%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::resolve::{{closure}}
     61440 (0.6%, 34.1%)    1024 (0.4%, 24.5%)  reactive_graph::owner::Owner::with::{{closure}}
     58562 (0.5%, 34.7%)    1272 (0.5%, 25.0%)  core::pin::Pin<Ptr>::set
     56212 (0.5%, 35.2%)     771 (0.3%, 25.3%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::to_html_async_with_buf
     55705 (0.5%, 35.7%)     550 (0.2%, 25.5%)  <T as reactive_graph::traits::Update>::try_maybe_update
     52200 (0.5%, 36.2%)     332 (0.1%, 25.7%)  reactive_graph::owner::Owner::with_cleanup
     44080 (0.4%, 36.6%)    1102 (0.4%, 26.1%)  <dyn core::any::Any>::is
     43997 (0.4%, 37.0%)     279 (0.1%, 26.2%)  reactive_graph::owner::Owner::on_cleanup
     43929 (0.4%, 37.4%)     114 (0.0%, 26.3%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value::erased::{{closure}}
     42502 (0.4%, 37.7%)     323 (0.1%, 26.4%)  <leptos::into_view::View<T> as tachys::view::RenderHtml>::resolve::{{closure}}
     42152 (0.4%, 38.1%)     767 (0.3%, 26.7%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::rebuild
     39406 (0.4%, 38.5%)    1026 (0.4%, 27.1%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,)>::to_html_async_with_buf
     36577 (0.3%, 38.8%)     286 (0.1%, 27.3%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::resolve::{{closure}}::{{closure}}
     36469 (0.3%, 39.1%)     275 (0.1%, 27.4%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,)>::resolve::{{closure}}
     36018 (0.3%, 39.5%)     413 (0.2%, 27.5%)  reactive_graph::owner::arena::Arena::with_mut
     34979 (0.3%, 39.8%)     499 (0.2%, 27.7%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::insert_before_this
     32461 (0.3%, 40.1%)     516 (0.2%, 27.9%)  <reactive_graph::graph::subscriber::AnySubscriber as reactive_graph::graph::subscriber::WithObserver>::with_observer
     31836 (0.3%, 40.4%)     614 (0.3%, 28.2%)  <alloc::sync::Weak<T,A> as core::ops::drop::Drop>::drop
     31787 (0.3%, 40.7%)     664 (0.3%, 28.5%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value
     31451 (0.3%, 40.9%)     102 (0.0%, 28.5%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B,C)>::resolve::{{closure}}
     30857 (0.3%, 41.2%)     523 (0.2%, 28.7%)  alloc::boxed::convert::<impl alloc::boxed::Box<dyn core::any::Any,A>>::downcast
     30824 (0.3%, 41.5%)     808 (0.3%, 29.1%)  reactive_graph::graph::subscriber::untrack_with_diagnostics
     29347 (0.3%, 41.8%)     515 (0.2%, 29.3%)  tachys::view::tuples::<impl tachys::view::Render for (A,)>::build
     28308 (0.3%, 42.0%)     664 (0.3%, 29.5%)  core::result::Result<T,E>::expect
     28292 (0.3%, 42.3%)    5141 (2.1%, 31.6%)  <alloc::boxed::Box<dyn core::ops::function::FnOnce<()>+Output = tachys::view::any_view::AnyView+core::marker::Send> as leptos::children::ToChildren<F>>::to_children::{{closure}}
     26919 (0.2%, 42.5%)     411 (0.2%, 31.8%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::to_html_with_buf
     25205 (0.2%, 42.8%)     198 (0.1%, 31.9%)  reactive_graph::traits::Get::get
```

With erasure:
```
RUSTFLAGS="--cfg erase_components" CARGO_PROFILE_RELEASE_LTO=fat cargo +stable llvm-lines --bin demo --release --features ssr | head -50`
```

```
  7164754                168452                (TOTAL)
   847252 (11.8%, 11.8%)  14887 (8.8%,  8.8%)  core::ops::function::FnOnce::call_once
   189182 (2.6%, 14.5%)   12341 (7.3%, 16.2%)  core::ops::function::FnOnce::call_once{{vtable.shim}}
   152782 (2.1%, 16.6%)    1081 (0.6%, 16.8%)  <T as tachys::view::any_view::IntoAny>::into_any::{{closure}}::{{closure}}
   150806 (2.1%, 18.7%)    1608 (1.0%, 17.8%)  <T as tachys::view::any_view::IntoAny>::into_any::{{closure}}
   129567 (1.8%, 20.5%)    6642 (3.9%, 21.7%)  alloc::boxed::Box<T>::new
   107322 (1.5%, 22.0%)     507 (0.3%, 22.0%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::to_html_async_with_buf
    87836 (1.2%, 23.2%)     556 (0.3%, 22.3%)  <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll
    74279 (1.0%, 24.3%)     431 (0.3%, 22.6%)  reactive_graph::owner::Owner::with
    73787 (1.0%, 25.3%)     102 (0.1%, 22.7%)  reactive_graph::computed::inner::<impl reactive_graph::graph::node::ReactiveNode for std::sync::rwlock::RwLock<reactive_graph::computed::inner::MemoInner<T,S>>>::update_if_necessary
    71172 (1.0%, 26.3%)    1444 (0.9%, 23.5%)  alloc::sync::Arc<T,A>::drop_slow
    67005 (0.9%, 27.2%)     658 (0.4%, 23.9%)  <T as tachys::html::attribute::any_attribute::IntoAnyAttribute>::into_any_attr::{{closure}}::{{closure}}
    55648 (0.8%, 28.0%)     592 (0.4%, 24.2%)  reactive_graph::owner::arena::Arena::with
    48538 (0.7%, 28.7%)     486 (0.3%, 24.5%)  <T as reactive_graph::traits::Update>::try_maybe_update
    43887 (0.6%, 29.3%)     619 (0.4%, 24.9%)  <T as tachys::view::any_view::IntoAny>::into_any
    42946 (0.6%, 29.9%)     243 (0.1%, 25.0%)  reactive_graph::owner::Owner::with_cleanup
    40953 (0.6%, 30.5%)     277 (0.2%, 25.2%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::to_html_with_buf
    40163 (0.6%, 31.0%)     517 (0.3%, 25.5%)  <T as tachys::html::attribute::any_attribute::IntoAnyAttribute>::into_any_attr
    39664 (0.6%, 31.6%)     355 (0.2%, 25.7%)  <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
    32298 (0.5%, 32.0%)     480 (0.3%, 26.0%)  <T as tachys::html::attribute::any_attribute::IntoAnyAttribute>::into_any_attr::{{closure}}
    30591 (0.4%, 32.5%)      87 (0.1%, 26.1%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value::erased::{{closure}}
    30048 (0.4%, 32.9%)     793 (0.5%, 26.5%)  reactive_graph::graph::subscriber::untrack_with_diagnostics
    29254 (0.4%, 33.3%)     328 (0.2%, 26.7%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::to_html_async_with_buf
    28263 (0.4%, 33.7%)    5137 (3.0%, 29.8%)  <alloc::boxed::Box<dyn core::ops::function::FnOnce<()>+Output = tachys::view::any_view::AnyView+core::marker::Send> as leptos::children::ToChildren<F>>::to_children::{{closure}}
    26464 (0.4%, 34.1%)     446 (0.3%, 30.0%)  <reactive_graph::graph::subscriber::AnySubscriber as reactive_graph::graph::subscriber::WithObserver>::with_observer
    26297 (0.4%, 34.4%)     316 (0.2%, 30.2%)  reactive_graph::owner::arena::Arena::with_mut
    25983 (0.4%, 34.8%)     290 (0.2%, 30.4%)  <futures_util::future::join::Join<Fut1,Fut2> as core::future::future::Future>::poll
    25591 (0.4%, 35.1%)     422 (0.3%, 30.7%)  std::thread::local::LocalKey<T>::try_with
    24230 (0.3%, 35.5%)     450 (0.3%, 30.9%)  <alloc::sync::Weak<T,A> as core::ops::drop::Drop>::drop
    24209 (0.3%, 35.8%)     161 (0.1%, 31.0%)  reactive_graph::traits::Get::get
    22697 (0.3%, 36.1%)      75 (0.0%, 31.1%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value::erased
    22681 (0.3%, 36.4%)     103 (0.1%, 31.1%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,B)>::resolve::{{closure}}
    22128 (0.3%, 36.8%)     234 (0.1%, 31.3%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::build
    22091 (0.3%, 37.1%)     401 (0.2%, 31.5%)  reactive_graph::owner::arena_item::ArenaItem<T,S>::new_with_storage
    21840 (0.3%, 37.4%)     263 (0.2%, 31.7%)  reactive_graph::signal::guards::Plain<T>::try_new
    20626 (0.3%, 37.7%)      87 (0.1%, 31.7%)  thaw_utils::class_list::ClassList::add
    19949 (0.3%, 37.9%)     114 (0.1%, 31.8%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::resolve::{{closure}}
    19810 (0.3%, 38.2%)     402 (0.2%, 32.0%)  tachys::view::tuples::<impl tachys::view::RenderHtml for (A,)>::to_html_async_with_buf
    19356 (0.3%, 38.5%)     128 (0.1%, 32.1%)  tachys::view::tuples::<impl tachys::view::add_attr::AddAnyAttr for (A,B)>::add_any_attr
    18783 (0.3%, 38.7%)      65 (0.0%, 32.1%)  <leptos_router::matching::nested::NestedRoute<Segments,Children,Data,View> as leptos_router::matching::MatchNestedRoutes>::generate_routes
    18746 (0.3%, 39.0%)     405 (0.2%, 32.4%)  alloc::raw_vec::RawVec<T,A>::grow_one
    18392 (0.3%, 39.3%)     161 (0.1%, 32.5%)  <T as reactive_graph::traits::Track>::track
    18360 (0.3%, 39.5%)     459 (0.3%, 32.7%)  <dyn core::any::Any>::is
    18182 (0.3%, 39.8%)      65 (0.0%, 32.8%)  <leptos_router::matching::nested::NestedRoute<Segments,Children,Data,View> as leptos_router::matching::MatchNestedRoutes>::match_nested::{{closure}}
    17668 (0.2%, 40.0%)     781 (0.5%, 33.2%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::add_attr::AddAnyAttr>::add_any_attr
    17453 (0.2%, 40.3%)     104 (0.1%, 33.3%)  reactive_graph::owner::Owner::on_cleanup
    16532 (0.2%, 40.5%)     202 (0.1%, 33.4%)  tachys::view::tuples::<impl tachys::view::Render for (A,)>::build
    16417 (0.2%, 40.7%)     127 (0.1%, 33.5%)  tachys::reactive_graph::<impl tachys::view::Render for F>::build::{{closure}}
```