### PR TITLE
Add transpose to the OptionStoreExt

### DIFF
--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -14,7 +14,9 @@ where
     fn unwrap(self) -> Subfield<Self, Option<Self::Output>, Self::Output>;
 
     /// Transposes a subfield of an `Option` to an `Option` of a subfield.
-    fn transpose(self) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>>;
+    fn transpose(
+        self,
+    ) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>>;
 
     /// Reactively maps over the field.
     ///
@@ -55,7 +57,9 @@ where
         )
     }
 
-    fn transpose(self)->Option<Subfield<Self, Option<Self::Output>, Self::Output>>{
+    fn transpose(
+        self,
+    ) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>> {
         if self.read().is_some() {
             Some(self.unwrap())
         } else {

--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -13,8 +13,8 @@ where
     /// Provides access to the inner value, as a subfield, unwrapping the outer value.
     fn unwrap(self) -> Subfield<Self, Option<Self::Output>, Self::Output>;
 
-    /// Transposes a subfield of an `Option` to an `Option` of a subfield.
-    fn transpose(
+    /// Inverts a subfield of an `Option` to an `Option` of a subfield.
+    fn invert(
         self,
     ) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>> {
         self.map(|f| f)

--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -13,6 +13,9 @@ where
     /// Provides access to the inner value, as a subfield, unwrapping the outer value.
     fn unwrap(self) -> Subfield<Self, Option<Self::Output>, Self::Output>;
 
+    /// Transposes a subfield of an `Option` to an `Option` of a subfield.
+    fn transpose(self) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>>;
+
     /// Reactively maps over the field.
     ///
     /// This returns `None` if the subfield is currently `None`,
@@ -50,6 +53,14 @@ where
             |t| t.as_ref().unwrap(),
             |t| t.as_mut().unwrap(),
         )
+    }
+
+    fn transpose(self)->Option<Subfield<Self, Option<Self::Output>, Self::Output>>{
+        if self.read().is_some() {
+            Some(self.unwrap())
+        } else {
+            None
+        }
     }
 
     fn map<U>(


### PR DESCRIPTION
This PR adds a method called "transpose" to the OptionStoreExt which converts a subfield with an option into an option of a subfield. 
I found it useful in pattern matching while we want to keep the reactivity of the subfield.
