### PR TITLE
fix: emit syntax errors in components rather than swallowing them (closes #3535)

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -677,17 +677,21 @@ fn component_macro(
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
             #unexpanded
         }
-    } else if let Ok(mut dummy) = dummy {
-        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
-        quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
-            #dummy
-        }
     } else {
-        quote! {}
-    }
-    .into()
+        match dummy {
+            Ok(mut dummy) => {
+                dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
+                quote! {
+                    #[doc(hidden)]
+                    #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
+                    #dummy
+                }
+            }
+            Err(e) => {
+                proc_macro_error2::abort!(e);
+            }
+        }
+    }.into()
 }
 
 /// Annotates a struct so that it can be used with your Component as a `slot`.

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -688,7 +688,7 @@ fn component_macro(
                 }
             }
             Err(e) => {
-                proc_macro_error2::abort!(e);
+                proc_macro_error2::abort!(e.span(), e);
             }
         }
     }.into()


### PR DESCRIPTION
In theory this is a breaking change, because it emits an error where previously it emitted no error. However, it emits an error if there is a syntax error in a component, rather than simply emitting an empty token stream with no error. i.e., if this causes a new compile error your code was already broken.