### PR TITLE
docs: add note to ElementExt::on about dropping the handle

### DIFF
--- a/tachys/src/html/element/element_ext.rs
+++ b/tachys/src/html/element/element_ext.rs
@@ -44,6 +44,14 @@ pub trait ElementExt {
         S: IntoStyle;
 
     /// Adds an event listener to the element, at runtime.
+    ///
+    /// Dropping the returned handle also drops the closure and invalidates the event listener.
+    /// Consider using [on_cleanup](reactive_graph::owner::Owner::on_cleanup) to delay dropping:
+    ///
+    /// ```rust,ignore
+    /// let remove = element.on(ev::blur, move |_| /* ... */);
+    /// on_cleanup(move || std::mem::drop(remove));
+    /// ```
     fn on<E>(
         &self,
         ev: E,


### PR DESCRIPTION
Dropping the `RemoveEventHandler` returned by [`ElementExt::on`](https://docs.rs/leptos/latest/leptos/prelude/trait.ElementExt.html#tymethod.on) also drops the closure, which invalidates the event listener.

Example code:
```rust
let button_ref: NodeRef<Button> = NodeRef::new();

button_ref.on_load(move |btn| {
    let cb = btn.on(leptos::ev::click, move |ev| {
        /* ... */
    });
    // Delay the drop to keep the event listener alive
    on_cleanup(move || std::mem::drop(cb));
});
```