### PR TITLE
AddAnyAttr for AnyView for non-erased

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "either_of"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -1723,11 +1723,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptos"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "base64",
@@ -1778,11 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_actix"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1807,11 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_axum"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "axum",
@@ -1834,11 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "config",
  "regex",
@@ -1852,11 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "js-sys",
  "leptos",
@@ -1873,11 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "anyhow",
  "camino",
@@ -1893,11 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_integration_utils"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "futures",
  "hydration_context",
@@ -1910,11 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -1933,11 +1901,7 @@ dependencies = [
  "rstml",
  "serde",
  "server_fn",
-<<<<<<< HEAD
  "server_fn_macro 0.8.0-alpha",
-=======
- "server_fn_macro 0.7.5",
->>>>>>> 1dcc5838 (`v0.7.5`)
  "syn 2.0.90",
  "tracing",
  "trybuild",
@@ -1947,11 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "futures",
  "indexmap",
@@ -1966,11 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "either_of",
@@ -1994,11 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "leptos_macro",
  "leptos_router",
@@ -2010,11 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "base64",
@@ -2716,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -2738,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores"
-version = "0.1.5"
+version = "0.1.3"
 dependencies = [
  "any_spawner",
  "guardian",
@@ -2755,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.1.5"
+version = "0.1.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error2",
@@ -3212,11 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "actix-web",
  "axum",
@@ -3274,11 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
-=======
-version = "0.7.5"
->>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "const_format",
  "convert_case 0.6.0",
@@ -3290,15 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-<<<<<<< HEAD
 version = "0.8.0-alpha"
 dependencies = [
  "server_fn_macro 0.8.0-alpha",
-=======
-version = "0.7.5"
-dependencies = [
- "server_fn_macro 0.7.5",
->>>>>>> 1dcc5838 (`v0.7.5`)
  "syn 2.0.90",
 ]
 
@@ -3492,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.5"
+version = "0.1.4"
 dependencies = [
  "any_spawner",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "either_of"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "guardian",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error2",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "either_of"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -1723,7 +1723,11 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptos"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "base64",
@@ -1774,7 +1778,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_actix"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1799,7 +1807,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_axum"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "axum",
@@ -1822,7 +1834,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "config",
  "regex",
@@ -1836,7 +1852,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "js-sys",
  "leptos",
@@ -1853,7 +1873,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "anyhow",
  "camino",
@@ -1869,7 +1893,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_integration_utils"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "futures",
  "hydration_context",
@@ -1882,7 +1910,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -1901,7 +1933,11 @@ dependencies = [
  "rstml",
  "serde",
  "server_fn",
+<<<<<<< HEAD
  "server_fn_macro 0.8.0-alpha",
+=======
+ "server_fn_macro 0.7.5",
+>>>>>>> 1dcc5838 (`v0.7.5`)
  "syn 2.0.90",
  "tracing",
  "trybuild",
@@ -1911,7 +1947,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "futures",
  "indexmap",
@@ -1926,7 +1966,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "either_of",
@@ -1950,7 +1994,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "leptos_macro",
  "leptos_router",
@@ -1962,7 +2010,11 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "any_spawner",
  "base64",
@@ -2664,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -2686,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "guardian",
@@ -2703,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error2",
@@ -3160,7 +3212,11 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "actix-web",
  "axum",
@@ -3218,7 +3274,11 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
+=======
+version = "0.7.5"
+>>>>>>> 1dcc5838 (`v0.7.5`)
 dependencies = [
  "const_format",
  "convert_case 0.6.0",
@@ -3230,9 +3290,15 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
+<<<<<<< HEAD
 version = "0.8.0-alpha"
 dependencies = [
  "server_fn_macro 0.8.0-alpha",
+=======
+version = "0.7.5"
+dependencies = [
+ "server_fn_macro 0.7.5",
+>>>>>>> 1dcc5838 (`v0.7.5`)
  "syn 2.0.90",
 ]
 
@@ -3426,7 +3492,7 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ leptos_meta = { path = "./meta", version = "0.8.0-alpha" }
 next_tuple = { path = "./next_tuple", version = "0.1.0" }
 oco_ref = { path = "./oco", version = "0.2.0" }
 or_poisoned = { path = "./or_poisoned", version = "0.1.0" }
-reactive_graph = { path = "./reactive_graph", version = "0.1.4" }
+reactive_graph = { path = "./reactive_graph", version = "0.1.5" }
 reactive_stores = { path = "./reactive_stores", version = "0.1.3" }
 reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.1.0" }
 server_fn = { path = "./server_fn", version = "0.8.0-alpha" }

--- a/either_of/Cargo.toml
+++ b/either_of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either_of"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/examples/counter/tests/web.rs
+++ b/examples/counter/tests/web.rs
@@ -19,7 +19,7 @@ async fn clear() {
     // note that we start at the initial value of 10
     let _dispose = mount_to(
         test_wrapper.clone().unchecked_into(),
-        || view! { <SimpleCounter initial_value=10 step=1/> },
+        || view! { <SimpleCounter initial_value=10 step=1 /> },
     );
 
     // now we extract the buttons by iterating over the DOM
@@ -59,9 +59,9 @@ async fn clear() {
         // .into_view() here is just a convenient way of specifying "use the regular DOM renderer"
         .into_view()
         // views are lazy -- they describe a DOM tree but don't create it yet
-        // calling .build() will actually build the DOM elements
-        .build()
-        // .build() returned an ElementState, which is a smart pointer for
+        // calling .build(None) will actually build the DOM elements
+        .build(None)
+        // .build(None) returned an ElementState, which is a smart pointer for
         // a DOM element. So we can still just call .outer_html(), which access the outerHTML on
         // the actual DOM element
         .outer_html()
@@ -87,7 +87,7 @@ async fn inc() {
 
     let _dispose = mount_to(
         test_wrapper.clone().unchecked_into(),
-        || view! { <SimpleCounter initial_value=0 step=1/> },
+        || view! { <SimpleCounter initial_value=0 step=1 /> },
     );
 
     // You can do testing with vanilla DOM operations
@@ -150,7 +150,7 @@ async fn inc() {
             }
         }
         .into_view()
-        .build()
+        .build(None)
         .outer_html()
     );
 
@@ -173,7 +173,7 @@ async fn inc() {
             }
         }
         .into_view()
-        .build()
+        .build(None)
         .outer_html()
     );
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1985,7 +1985,8 @@ where
 /// This is provided as a convenience, but is a fairly simple function. If you need to adapt it,
 /// simply reuse the source code of this function in your own application.
 #[cfg(feature = "default")]
-pub fn file_and_error_handler<S, IV>(
+pub fn file_and_error_handler_with_context<S, IV>(
+    additional_context: impl Fn() + 'static + Clone + Send,
     shell: fn(LeptosOptions) -> IV,
 ) -> impl Fn(
     Uri,
@@ -2001,38 +2002,66 @@ where
     LeptosOptions: FromRef<S>,
 {
     move |uri: Uri, State(state): State<S>, req: Request<Body>| {
-        Box::pin(async move {
-            let options = LeptosOptions::from_ref(&state);
-            let res = get_static_file(uri, &options.site_root, req.headers());
-            let res = res.await.unwrap();
+        Box::pin({
+            let additional_context = additional_context.clone();
+            async move {
+                let options = LeptosOptions::from_ref(&state);
+                let res =
+                    get_static_file(uri, &options.site_root, req.headers());
+                let res = res.await.unwrap();
 
-            if res.status() == StatusCode::OK {
-                res.into_response()
-            } else {
-                let mut res = handle_response_inner(
-                    move || {
-                        provide_context(state.clone());
-                    },
-                    move || shell(options),
-                    req,
-                    |app, chunks| {
-                        Box::pin(async move {
-                            let app = app
-                                .to_html_stream_in_order()
-                                .collect::<String>()
-                                .await;
-                            let chunks = chunks();
-                            Box::pin(once(async move { app }).chain(chunks))
-                                as PinnedStream<String>
-                        })
-                    },
-                )
-                .await;
-                *res.status_mut() = StatusCode::NOT_FOUND;
-                res
+                if res.status() == StatusCode::OK {
+                    res.into_response()
+                } else {
+                    let mut res = handle_response_inner(
+                        move || {
+                            additional_context();
+                            provide_context(state.clone());
+                        },
+                        move || shell(options),
+                        req,
+                        |app, chunks| {
+                            Box::pin(async move {
+                                let app = app
+                                    .to_html_stream_in_order()
+                                    .collect::<String>()
+                                    .await;
+                                let chunks = chunks();
+                                Box::pin(once(async move { app }).chain(chunks))
+                                    as PinnedStream<String>
+                            })
+                        },
+                    )
+                    .await;
+                    *res.status_mut() = StatusCode::NOT_FOUND;
+                    res
+                }
             }
         })
     }
+}
+
+/// A reasonable handler for serving static files (like JS/WASM/CSS) and 404 errors.
+///
+/// This is provided as a convenience, but is a fairly simple function. If you need to adapt it,
+/// simply reuse the source code of this function in your own application.
+#[cfg(feature = "default")]
+pub fn file_and_error_handler<S, IV>(
+    shell: fn(LeptosOptions) -> IV,
+) -> impl Fn(
+    Uri,
+    State<S>,
+    Request<Body>,
+) -> Pin<Box<dyn Future<Output = Response<Body>> + Send + 'static>>
+       + Clone
+       + Send
+       + 'static
+where
+    IV: IntoView + 'static,
+    S: Send + Sync + Clone + 'static,
+    LeptosOptions: FromRef<S>,
+{
+    file_and_error_handler_with_context(move || (), shell)
 }
 
 #[cfg(feature = "default")]

--- a/leptos/src/attribute_interceptor.rs
+++ b/leptos/src/attribute_interceptor.rs
@@ -3,6 +3,7 @@ use crate::attr::{
     Attribute, NextAttribute,
 };
 use leptos::prelude::*;
+use tachys::view::any_view::ExtraAttrsMut;
 
 /// Function stored to build/rebuild the wrapped children when attributes are added.
 type ChildBuilder<T> = dyn Fn(AnyAttribute) -> T + Send + Sync + 'static;
@@ -43,7 +44,7 @@ pub fn AttributeInterceptor<Chil, T>(
 ) -> impl IntoView
 where
     Chil: Fn(AnyAttribute) -> T + Send + Sync + 'static,
-    T: IntoView,
+    T: IntoView + 'static,
 {
     AttributeInterceptorInner::new(children)
 }
@@ -77,16 +78,20 @@ impl<T: IntoView> AttributeInterceptorInner<T, ()> {
 impl<T: IntoView, A: Attribute> Render for AttributeInterceptorInner<T, A> {
     type State = <T as Render>::State;
 
-    fn build(self) -> Self::State {
-        self.children.build()
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
+        self.children.build(extra_attrs)
     }
 
-    fn rebuild(self, state: &mut Self::State) {
-        self.children.rebuild(state);
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+        self.children.rebuild(state, extra_attrs);
     }
 }
 
-impl<T: IntoView, A> AddAnyAttr for AttributeInterceptorInner<T, A>
+impl<T: IntoView + 'static, A> AddAnyAttr for AttributeInterceptorInner<T, A>
 where
     A: Attribute,
 {
@@ -114,19 +119,23 @@ where
     }
 }
 
-impl<T: IntoView, A: Attribute> RenderHtml for AttributeInterceptorInner<T, A> {
+impl<T: IntoView + 'static, A: Attribute> RenderHtml
+    for AttributeInterceptorInner<T, A>
+{
     type AsyncOutput = T::AsyncOutput;
+    type Owned = AttributeInterceptorInner<T, A::CloneableOwned>;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
-    fn dry_resolve(&mut self) {
-        self.children.dry_resolve()
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
+        self.children.dry_resolve(extra_attrs)
     }
 
     fn resolve(
         self,
+        extra_attrs: ExtraAttrsMut<'_>,
     ) -> impl std::future::Future<Output = Self::AsyncOutput> + Send {
-        self.children.resolve()
+        self.children.resolve(extra_attrs)
     }
 
     fn to_html_with_buf(
@@ -135,16 +144,32 @@ impl<T: IntoView, A: Attribute> RenderHtml for AttributeInterceptorInner<T, A> {
         position: &mut leptos::tachys::view::Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
-        self.children
-            .to_html_with_buf(buf, position, escape, mark_branches)
+        self.children.to_html_with_buf(
+            buf,
+            position,
+            escape,
+            mark_branches,
+            extra_attrs,
+        )
     }
 
     fn hydrate<const FROM_SERVER: bool>(
         self,
         cursor: &leptos::tachys::hydration::Cursor,
         position: &leptos::tachys::view::PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
-        self.children.hydrate::<FROM_SERVER>(cursor, position)
+        self.children
+            .hydrate::<FROM_SERVER>(cursor, position, extra_attrs)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        AttributeInterceptorInner {
+            children_builder: self.children_builder,
+            children: self.children,
+            attributes: self.attributes.into_cloneable_owned(),
+        }
     }
 }

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -11,13 +11,13 @@ use reactive_graph::{
 use rustc_hash::FxHashMap;
 use std::{fmt::Debug, sync::Arc};
 use tachys::{
-    html::attribute::Attribute,
+    html::attribute::{any_attribute::AnyAttribute, Attribute},
     hydration::Cursor,
     reactive_graph::OwnedView,
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-        RenderHtml,
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+        PositionState, Render, RenderHtml,
     },
 };
 use throw_error::{Error, ErrorHook, ErrorId};
@@ -173,10 +173,10 @@ where
 {
     type State = RenderEffect<ErrorBoundaryViewState<Chil::State, Fal::State>>;
 
-    fn build(mut self) -> Self::State {
+    fn build(mut self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let hook = Arc::clone(&self.hook);
         let _hook = throw_error::set_error_hook(Arc::clone(&hook));
-        let mut children = Some(self.children.build());
+        let mut children = Some(self.children.build(extra_attrs.clone()));
         RenderEffect::new(
             move |prev: Option<
                 ErrorBoundaryViewState<Chil::State, Fal::State>,
@@ -193,7 +193,8 @@ where
                         // yes errors, and was showing children
                         (false, None) => {
                             state.fallback = Some(
-                                (self.fallback)(self.errors.clone()).build(),
+                                (self.fallback)(self.errors.clone())
+                                    .build(extra_attrs.clone()),
                             );
                             state
                                 .children
@@ -207,8 +208,10 @@ where
                     }
                     state
                 } else {
-                    let fallback = (!self.errors_empty.get())
-                        .then(|| (self.fallback)(self.errors.clone()).build());
+                    let fallback = (!self.errors_empty.get()).then(|| {
+                        (self.fallback)(self.errors.clone())
+                            .build(extra_attrs.clone())
+                    });
                     ErrorBoundaryViewState {
                         children: children.take().unwrap(),
                         fallback,
@@ -218,8 +221,12 @@ where
         )
     }
 
-    fn rebuild(self, state: &mut Self::State) {
-        let new = self.build();
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+        let new = self.build(extra_attrs);
         let mut old = std::mem::replace(state, new);
         old.insert_before_this(state);
         old.unmount();
@@ -268,14 +275,18 @@ where
     Fal: RenderHtml + Send + 'static,
 {
     type AsyncOutput = ErrorBoundaryView<Chil::AsyncOutput, FalFn>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = Chil::MIN_LENGTH;
 
-    fn dry_resolve(&mut self) {
-        self.children.dry_resolve();
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
+        self.children.dry_resolve(extra_attrs);
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
         let ErrorBoundaryView {
             hook,
             boundary_id,
@@ -289,7 +300,7 @@ where
             hook,
             boundary_id,
             errors_empty,
-            children: children.resolve().await,
+            children: children.resolve(extra_attrs).await,
             fallback,
             errors,
         }
@@ -301,6 +312,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // first, attempt to serialize the children to HTML, then check for errors
         let _hook = throw_error::set_error_hook(self.hook);
@@ -311,6 +323,7 @@ where
             &mut new_pos,
             escape,
             mark_branches,
+            extra_attrs.clone(),
         );
 
         // any thrown errors would've been caught here
@@ -323,6 +336,7 @@ where
                 position,
                 escape,
                 mark_branches,
+                extra_attrs,
             );
         }
     }
@@ -333,6 +347,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -345,6 +360,7 @@ where
             &mut new_pos,
             escape,
             mark_branches,
+            extra_attrs.clone(),
         );
 
         // any thrown errors would've been caught here
@@ -358,6 +374,7 @@ where
                 position,
                 escape,
                 mark_branches,
+                extra_attrs,
             );
             buf.push_sync(&fallback);
         }
@@ -367,6 +384,7 @@ where
         mut self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let mut children = Some(self.children);
         let hook = Arc::clone(&self.hook);
@@ -388,7 +406,8 @@ where
                         // yes errors, and was showing children
                         (false, None) => {
                             state.fallback = Some(
-                                (self.fallback)(self.errors.clone()).build(),
+                                (self.fallback)(self.errors.clone())
+                                    .build(extra_attrs.clone()),
                             );
                             state
                                 .children
@@ -405,15 +424,23 @@ where
                     let children = children.take().unwrap();
                     let (children, fallback) = if self.errors_empty.get() {
                         (
-                            children.hydrate::<FROM_SERVER>(&cursor, &position),
+                            children.hydrate::<FROM_SERVER>(
+                                &cursor,
+                                &position,
+                                extra_attrs.clone(),
+                            ),
                             None,
                         )
                     } else {
                         (
-                            children.build(),
+                            children.build(extra_attrs.clone()),
                             Some(
                                 (self.fallback)(self.errors.clone())
-                                    .hydrate::<FROM_SERVER>(&cursor, &position),
+                                    .hydrate::<FROM_SERVER>(
+                                        &cursor,
+                                        &position,
+                                        extra_attrs.clone(),
+                                    ),
                             ),
                         )
                     };
@@ -422,6 +449,10 @@ where
                 }
             },
         )
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use tachys::{
-    html::attribute::Attribute,
+    html::attribute::{any_attribute::AnyAttribute, Attribute},
     hydration::Cursor,
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, Position, PositionState, Render, RenderHtml,
-        ToTemplate,
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Position, PositionState,
+        Render, RenderHtml, ToTemplate,
     },
 };
 
@@ -76,26 +76,34 @@ where
 impl<T: Render> Render for View<T> {
     type State = T::State;
 
-    fn build(self) -> Self::State {
-        self.inner.build()
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
+        self.inner.build(extra_attrs)
     }
 
-    fn rebuild(self, state: &mut Self::State) {
-        self.inner.rebuild(state)
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+        self.inner.rebuild(state, extra_attrs)
     }
 }
 
 impl<T: RenderHtml> RenderHtml for View<T> {
     type AsyncOutput = T::AsyncOutput;
+    type Owned = View<T::Owned>;
 
     const MIN_LENGTH: usize = <T as RenderHtml>::MIN_LENGTH;
 
-    async fn resolve(self) -> Self::AsyncOutput {
-        self.inner.resolve().await
+    async fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
+        self.inner.resolve(extra_attrs).await
     }
 
-    fn dry_resolve(&mut self) {
-        self.inner.dry_resolve();
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
+        self.inner.dry_resolve(extra_attrs);
     }
 
     fn to_html_with_buf(
@@ -104,6 +112,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         #[cfg(debug_assertions)]
         let vm = self.view_marker.to_owned();
@@ -112,8 +121,13 @@ impl<T: RenderHtml> RenderHtml for View<T> {
             buf.push_str(&format!("<!--hot-reload|{vm}|open-->"));
         }
 
-        self.inner
-            .to_html_with_buf(buf, position, escape, mark_branches);
+        self.inner.to_html_with_buf(
+            buf,
+            position,
+            escape,
+            mark_branches,
+            extra_attrs,
+        );
 
         #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
@@ -127,6 +141,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -142,6 +157,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
             position,
             escape,
             mark_branches,
+            extra_attrs,
         );
 
         #[cfg(debug_assertions)]
@@ -154,8 +170,18 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
-        self.inner.hydrate::<FROM_SERVER>(cursor, position)
+        self.inner
+            .hydrate::<FROM_SERVER>(cursor, position, extra_attrs)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        View {
+            inner: self.inner.into_owned(),
+            #[cfg(debug_assertions)]
+            view_marker: self.view_marker,
+        }
     }
 }
 

--- a/leptos/src/mount.rs
+++ b/leptos/src/mount.rs
@@ -71,6 +71,7 @@ where
         view.hydrate::<true>(
             &Cursor::new(parent.unchecked_into()),
             &PositionState::default(),
+            None,
         )
     });
 
@@ -124,7 +125,7 @@ where
     let owner = Owner::new();
     let mountable = owner.with(move || {
         let view = f().into_view();
-        let mut mountable = view.build();
+        let mut mountable = view.build(None);
         mountable.mount(&parent, None);
         mountable
     });
@@ -152,7 +153,7 @@ where
     let owner = Owner::new();
     let mountable = owner.with(move || {
         let view = f();
-        let mut mountable = view.build();
+        let mut mountable = view.build(None);
         mountable.mount(parent, None);
         mountable
     });

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -677,17 +677,21 @@ fn component_macro(
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
             #unexpanded
         }
-    } else if let Ok(mut dummy) = dummy {
-        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
-        quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
-            #dummy
-        }
     } else {
-        quote! {}
-    }
-    .into()
+        match dummy {
+            Ok(mut dummy) => {
+                dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
+                quote! {
+                    #[doc(hidden)]
+                    #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
+                    #dummy
+                }
+            }
+            Err(e) => {
+                proc_macro_error2::abort!(e.span(), e);
+            }
+        }
+    }.into()
 }
 
 /// Annotates a struct so that it can be used with your Component as a `slot`.

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -1,6 +1,9 @@
 use crate::ServerMetaContext;
 use leptos::{
-    attr::NextAttribute,
+    attr::{
+        any_attribute::{AnyAttribute, AnyAttributeState},
+        NextAttribute,
+    },
     component, html,
     reactive::owner::use_context,
     tachys::{
@@ -8,8 +11,8 @@ use leptos::{
         html::attribute::Attribute,
         hydration::Cursor,
         view::{
-            add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-            RenderHtml,
+            add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+            PositionState, Render, RenderHtml,
         },
     },
     IntoView,
@@ -55,6 +58,7 @@ where
     At: Attribute,
 {
     attributes: At::State,
+    extra_attrs: Option<Vec<AnyAttributeState>>,
 }
 
 impl<At> Render for HtmlView<At>
@@ -63,18 +67,33 @@ where
 {
     type State = HtmlViewState<At>;
 
-    fn build(self) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let el = document()
             .document_element()
             .expect("there to be a <html> element");
 
         let attributes = self.attributes.build(&el);
+        let extra_attrs = extra_attrs.map(|attrs| {
+            attrs.into_iter().map(|attr| attr.build(&el)).collect()
+        });
 
-        HtmlViewState { attributes }
+        HtmlViewState {
+            attributes,
+            extra_attrs,
+        }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         self.attributes.rebuild(&mut state.attributes);
+        if let (Some(extra_attrs), Some(extra_attr_states)) =
+            (extra_attrs, &mut state.extra_attrs)
+        {
+            extra_attrs.rebuild(extra_attr_states);
+        }
     }
 }
 
@@ -103,17 +122,24 @@ where
     At: Attribute,
 {
     type AsyncOutput = HtmlView<At::AsyncOutput>;
+    type Owned = HtmlView<At::CloneableOwned>;
 
     const MIN_LENGTH: usize = At::MIN_LENGTH;
 
-    fn dry_resolve(&mut self) {
+    fn dry_resolve(&mut self, mut extra_attrs: ExtraAttrsMut<'_>) {
         self.attributes.dry_resolve();
+        extra_attrs.iter_mut().for_each(Attribute::dry_resolve);
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
-        HtmlView {
-            attributes: self.attributes.resolve().await,
-        }
+    async fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
+        let (attributes, _) = futures::join!(
+            self.attributes.resolve(),
+            ExtraAttrsMut::resolve(extra_attrs)
+        );
+        HtmlView { attributes }
     }
 
     fn to_html_with_buf(
@@ -122,10 +148,15 @@ where
         _position: &mut Position,
         _escape: bool,
         _mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         if let Some(meta) = use_context::<ServerMetaContext>() {
             let mut buf = String::new();
-            _ = html::attributes_to_html(self.attributes, &mut buf);
+            _ = html::attributes_to_html(
+                self.attributes,
+                extra_attrs,
+                &mut buf,
+            );
             if !buf.is_empty() {
                 _ = meta.html.send(buf);
             }
@@ -136,14 +167,30 @@ where
         self,
         _cursor: &Cursor,
         _position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let el = document()
             .document_element()
             .expect("there to be a <html> element");
 
         let attributes = self.attributes.hydrate::<FROM_SERVER>(&el);
+        let extra_attrs = extra_attrs.map(|attrs| {
+            attrs
+                .into_iter()
+                .map(|attr| attr.hydrate::<FROM_SERVER>(&el))
+                .collect()
+        });
 
-        HtmlViewState { attributes }
+        HtmlViewState {
+            attributes,
+            extra_attrs,
+        }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        HtmlView {
+            attributes: self.attributes.into_cloneable_owned(),
+        }
     }
 }
 

--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -1,6 +1,6 @@
 use crate::{use_head, MetaContext, ServerMetaContext};
 use leptos::{
-    attr::Attribute,
+    attr::{any_attribute::AnyAttribute, Attribute},
     component,
     oco::Oco,
     reactive::{
@@ -11,8 +11,8 @@ use leptos::{
         dom::document,
         hydration::Cursor,
         view::{
-            add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-            RenderHtml,
+            add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+            PositionState, Render, RenderHtml,
         },
     },
     text_prop::TextProp,
@@ -189,7 +189,7 @@ struct TitleViewState {
 impl Render for TitleView {
     type State = TitleViewState;
 
-    fn build(mut self) -> Self::State {
+    fn build(mut self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let el = self.el();
         let meta = self.meta;
         if let Some(formatter) = self.formatter.take() {
@@ -213,8 +213,12 @@ impl Render for TitleView {
         TitleViewState { effect }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
-        *state = self.build();
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+        *state = self.build(extra_attrs);
     }
 }
 
@@ -234,12 +238,16 @@ impl AddAnyAttr for TitleView {
 
 impl RenderHtml for TitleView {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
-    fn dry_resolve(&mut self) {}
+    fn dry_resolve(&mut self, _extra_attrs: ExtraAttrsMut<'_>) {}
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(
+        self,
+        _extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
         self
     }
 
@@ -249,6 +257,7 @@ impl RenderHtml for TitleView {
         _position: &mut Position,
         _escape: bool,
         _mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // meta tags are rendered into the buffer stored into the context
         // the value has already been taken out, when we're on the server
@@ -258,6 +267,7 @@ impl RenderHtml for TitleView {
         mut self,
         _cursor: &Cursor,
         _position: &PositionState,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let el = self.el();
         let meta = self.meta;
@@ -281,6 +291,10 @@ impl RenderHtml for TitleView {
             }
         });
         TitleViewState { effect }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_graph"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -82,6 +82,21 @@ where
     }
 }
 
+impl<T, S> From<ArcField<T>> for Field<T, S>
+where
+    T: 'static,
+    S: Storage<ArcField<T>>,
+{
+    #[track_caller]
+    fn from(value: ArcField<T>) -> Self {
+        Field {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: Location::caller(),
+            inner: ArenaItem::new_with_storage(value),
+        }
+    }
+}
+
 impl<T, S> From<ArcStore<T>> for Field<T, S>
 where
     T: Send + Sync + 'static,

--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -77,11 +77,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{self as reactive_stores, Store};
+    use crate::{self as reactive_stores, Patch as _, Store};
     use reactive_graph::{
         effect::Effect,
         traits::{Get, Read, ReadUntracked, Set, Write},
     };
+    use reactive_stores_macro::Patch;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -236,5 +237,116 @@ mod tests {
         tick().await;
         assert_eq!(parent_count.load(Ordering::Relaxed), 3);
         assert_eq!(inner_count.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn patch() {
+        use crate::OptionStoreExt;
+
+        #[derive(Debug, Clone, Store, Patch)]
+        struct Outer {
+            inner: Option<Inner>,
+        }
+
+        #[derive(Debug, Clone, Store, Patch)]
+        struct Inner {
+            first: String,
+            second: String,
+        }
+
+        let store = Store::new(Outer {
+            inner: Some(Inner {
+                first: "A".to_owned(),
+                second: "B".to_owned(),
+            }),
+        });
+
+        _ = any_spawner::Executor::init_tokio();
+
+        let parent_count = Arc::new(AtomicUsize::new(0));
+        let inner_first_count = Arc::new(AtomicUsize::new(0));
+        let inner_second_count = Arc::new(AtomicUsize::new(0));
+
+        Effect::new_sync({
+            let parent_count = Arc::clone(&parent_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("parent: first run");
+                } else {
+                    println!("parent: next run");
+                }
+
+                println!("  value = {:?}", store.inner().get());
+                parent_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Effect::new_sync({
+            let inner_first_count = Arc::clone(&inner_first_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("inner_first: first run");
+                } else {
+                    println!("inner_first: next run");
+                }
+
+                println!(
+                    "  value = {:?}",
+                    store.inner().map(|inner| inner.first().get())
+                );
+                inner_first_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Effect::new_sync({
+            let inner_second_count = Arc::clone(&inner_second_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("inner_second: first run");
+                } else {
+                    println!("inner_second: next run");
+                }
+
+                println!(
+                    "  value = {:?}",
+                    store.inner().map(|inner| inner.second().get())
+                );
+                inner_second_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 1);
+
+        store.patch(Outer {
+            inner: Some(Inner {
+                first: "A".to_string(),
+                second: "C".to_string(),
+            }),
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 2);
+
+        store.patch(Outer { inner: None });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 2);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 2);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 3);
+
+        store.patch(Outer {
+            inner: Some(Inner {
+                first: "A".to_string(),
+                second: "B".to_string(),
+            }),
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 3);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 3);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 4);
     }
 }

--- a/reactive_stores_macro/Cargo.toml
+++ b/reactive_stores_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores_macro"
-version = "0.1.0"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -354,7 +354,7 @@ impl<Loc, Defs, FalFn, Fal> AddAnyAttr for FlatRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
     Defs: MatchNestedRoutes + Send + 'static,
-    FalFn: FnOnce() -> Fal + Send,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type Output<SomeNewAttr: leptos::attr::Attribute> =
@@ -427,11 +427,11 @@ impl<Loc, Defs, FalFn, Fal> RenderHtml for FlatRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
     Defs: MatchNestedRoutes + Send + 'static,
-    FalFn: FnOnce() -> Fal + Send,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type AsyncOutput = Self;
-    type Owned = FlatRoutesView<Loc, Defs, Box<dyn FnOnce() -> Fal + Send>>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = <Either<Fal, AnyView> as RenderHtml>::MIN_LENGTH;
 
@@ -635,15 +635,6 @@ where
     }
 
     fn into_owned(self) -> Self::Owned {
-        let fallback = (self.fallback)();
-        FlatRoutesView {
-            current_url: self.current_url,
-            location: self.location,
-            routes: self.routes,
-            fallback: Box::new(move || fallback),
-            outer_owner: self.outer_owner,
-            set_is_routing: self.set_is_routing,
-            transition: self.transition,
-        }
+        self
     }
 }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -235,8 +235,8 @@ where
 impl<Loc, Defs, Fal, FalFn> AddAnyAttr for NestedRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
-    Defs: MatchNestedRoutes + Send + 'static, // TODO once the type erased AnyMatchNestedRoutes is merged with this branch, switch to that (adding 'static was a breaking change)
-    FalFn: FnOnce() -> Fal + Send,
+    Defs: MatchNestedRoutes + Send + 'static,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type Output<SomeNewAttr: leptos::attr::Attribute> =
@@ -256,12 +256,12 @@ where
 impl<Loc, Defs, FalFn, Fal> RenderHtml for NestedRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
-    Defs: MatchNestedRoutes + Send + 'static, // TODO once the type erased AnyMatchNestedRoutes is merged with this branch, switch to that (adding 'static was a breaking change)
-    FalFn: FnOnce() -> Fal + Send,
+    Defs: MatchNestedRoutes + Send + 'static,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type AsyncOutput = Self;
-    type Owned = NestedRoutesView<Loc, Defs, Box<dyn FnOnce() -> Fal + Send>>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0; // TODO
 
@@ -479,17 +479,7 @@ where
     }
 
     fn into_owned(self) -> Self::Owned {
-        let fal = (self.fallback)();
-        NestedRoutesView {
-            location: self.location,
-            routes: self.routes,
-            outer_owner: self.outer_owner,
-            current_url: self.current_url,
-            base: self.base,
-            fallback: Box::new(move || fal),
-            set_is_routing: self.set_is_routing,
-            transition: self.transition,
-        }
+        self
     }
 }
 

--- a/router/src/reactive.rs
+++ b/router/src/reactive.rs
@@ -100,7 +100,11 @@ where
         }
     }
 
-    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         let (new_id, view) = self.inner.fallback_or_view();
         if new_id != state.prev_id {
             state.owner = self.owner.with(Owner::new)
@@ -283,7 +287,7 @@ where
 {
     type State = ReactiveRouteState<View::State>;
 
-    fn build(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let MatchedRoute {
             search_params,
             params,
@@ -294,14 +298,19 @@ where
             params: ArcRwSignal::new(params),
             matched: ArcRwSignal::new(matched),
         };
-        let view_state = untrack(|| (self.view_fn)(&matched).build());
+        let view_state =
+            untrack(|| (self.view_fn)(&matched).build(extra_attrs.clone()));
         ReactiveRouteState {
             matched,
             view_state,
         }
     }
 
-    fn rebuild(mut self, state: &mut Self::State) {
+    fn rebuild(
+        mut self,
+        state: &mut Self::State,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         let ReactiveRouteState { matched, .. } = state;
         matched
             .search_params
@@ -327,7 +336,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
-        _extra_attrs: Option<Vec<AnyAttribute>>,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         let MatchedRoute {
             search_params,
@@ -340,7 +349,12 @@ where
             matched: ArcRwSignal::new(matched),
         };
         untrack(|| {
-            (self.view_fn)(&matched).to_html_with_buf(buf, position, escape)
+            (self.view_fn)(&matched).to_html_with_buf(
+                buf,
+                position,
+                escape,
+                extra_attrs.clone(),
+            )
         });
     }
 
@@ -350,7 +364,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
-        _extra_attrs: Option<Vec<AnyAttribute>>,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -365,8 +379,12 @@ where
             matched: ArcRwSignal::new(matched),
         };
         untrack(|| {
-            (self.view_fn)(&matched)
-                .to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape)
+            (self.view_fn)(&matched).to_html_async_with_buf::<OUT_OF_ORDER>(
+                buf,
+                position,
+                escape,
+                extra_attrs.clone(),
+            )
         });
     }
 
@@ -374,7 +392,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
-        _extra_attrs: Option<Vec<AnyAttribute>>,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let MatchedRoute {
             search_params,
@@ -387,7 +405,11 @@ where
             matched: ArcRwSignal::new(matched),
         };
         let view_state = untrack(|| {
-            (self.view_fn)(&matched).hydrate::<FROM_SERVER>(cursor, position)
+            (self.view_fn)(&matched).hydrate::<FROM_SERVER>(
+                cursor,
+                position,
+                extra_attrs.clone(),
+            )
         });
         ReactiveRouteState {
             matched,

--- a/router/src/reactive.rs
+++ b/router/src/reactive.rs
@@ -89,7 +89,7 @@ where
     type State =
         ReactiveRouterInnerState<Rndr, Loc, Defs, FallbackFn, Fallback>;
 
-    fn build(self) -> Self::State {
+    fn build(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let (prev_id, inner) = self.inner.fallback_or_view();
         let owner = self.owner.with(Owner::new);
         ReactiveRouterInnerState {
@@ -100,7 +100,7 @@ where
         }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
         let (new_id, view) = self.inner.fallback_or_view();
         if new_id != state.prev_id {
             state.owner = self.owner.with(Owner::new)
@@ -130,6 +130,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // if this is being run on the server for the first time, generating all possible routes
         if RouteList::is_generating() {
@@ -156,6 +157,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -169,6 +171,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let (prev_id, inner) = self.inner.fallback_or_view();
         let owner = self.owner.with(Owner::new);
@@ -280,7 +283,7 @@ where
 {
     type State = ReactiveRouteState<View::State>;
 
-    fn build(self) -> Self::State {
+    fn build(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let MatchedRoute {
             search_params,
             params,
@@ -324,6 +327,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         let MatchedRoute {
             search_params,
@@ -346,6 +350,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -369,6 +374,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let MatchedRoute {
             search_params,

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tachys"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"
@@ -204,4 +204,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(leptos_debuginfo)',
   'cfg(erase_components)',
 ] }
-

--- a/tachys/src/html/element/element_ext.rs
+++ b/tachys/src/html/element/element_ext.rs
@@ -24,7 +24,7 @@ use web_sys::Element;
 /// let view = element.on(ev::click, move |_| /* ... */);
 ///
 /// // `element` now contains the actual element
-/// let element = element.build();
+/// let element = element.build(None);
 /// let remove = element.on(ev::blur, move |_| /* ... */);
 /// ```
 pub trait ElementExt {

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -281,7 +281,7 @@ where
         } else {
             2 // < ... >
         + E::TAG.len()
-        + self.attributes.html_len() 
+        + self.attributes.html_len()
         + extra_attrs.map(|attrs| {
             attrs.into_iter().map(Attribute::html_len).sum::<usize>()
         }).unwrap_or(0)

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -639,7 +639,7 @@ mod tests {
     fn mock_dom_creates_element() {
         let el: HtmlElement<Main, _, _, MockDom> =
             main().child(p().id("test").lang("en").child("Hello, world!"));
-        let el = el.build();
+        let el = el.build(None);
         assert_eq!(
             el.el.to_debug_html(),
             "<main><p id=\"test\" lang=\"en\">Hello, world!</p></main>"
@@ -653,7 +653,7 @@ mod tests {
             em().child("beautiful"),
             " world!",
         )));
-        let el = el.build();
+        let el = el.build(None);
         assert_eq!(
             el.el.to_debug_html(),
             "<main><p>Hello, <em>beautiful</em> world!</p></main>"

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -6,7 +6,8 @@ use crate::{
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, IntoRender, Mountable, Position, PositionState, Render, RenderHtml, ToTemplate
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, IntoRender, Mountable,
+        Position, PositionState, Render, RenderHtml, ToTemplate,
     },
 };
 use const_str_slice_concat::{
@@ -344,7 +345,8 @@ where
         buf.push('<');
         buf.push_str(self.tag.tag());
 
-        let inner_html = attributes_to_html(self.attributes, extra_attrs, &mut buf);
+        let inner_html =
+            attributes_to_html(self.attributes, extra_attrs, &mut buf);
 
         buf.push('>');
         buffer.push_sync(&buf);
@@ -403,20 +405,15 @@ where
             });
 
         let attrs = self.attributes.hydrate::<FROM_SERVER>(&el);
-        let extra_attrs = extra_attrs.map(|attrs| {
-            Attribute::hydrate::<FROM_SERVER>(attrs, &el)
-        });
+        let extra_attrs = extra_attrs
+            .map(|attrs| Attribute::hydrate::<FROM_SERVER>(attrs, &el));
 
         // hydrate children
         let children = if !Ch::EXISTS || !E::ESCAPE_CHILDREN {
             None
         } else {
             position.set(Position::FirstChild);
-            Some(self.children.hydrate::<FROM_SERVER>(
-                cursor,
-                position,
-                None,
-            ))
+            Some(self.children.hydrate::<FROM_SERVER>(cursor, position, None))
         };
 
         // go to next sibling
@@ -449,9 +446,9 @@ where
 
 /// Renders an [`Attribute`] (which can be one or more HTML attributes) into an HTML buffer.
 pub fn attributes_to_html<At>(
-    attr: At, 
+    attr: At,
     extra_attrs: Option<Vec<AnyAttribute>>,
-    buf: &mut String
+    buf: &mut String,
 ) -> String
 where
     At: Attribute,

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -6,14 +6,13 @@ use crate::{
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, IntoRender, Mountable, Position, PositionState,
-        Render, RenderHtml, ToTemplate,
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, IntoRender, Mountable, Position, PositionState, Render, RenderHtml, ToTemplate
     },
 };
 use const_str_slice_concat::{
     const_concat, const_concat_with_prefix, str_from_buffer,
 };
-use futures::future::join;
+use futures::future::join3;
 use next_tuple::NextTuple;
 use std::ops::Deref;
 
@@ -21,7 +20,10 @@ mod custom;
 mod element_ext;
 mod elements;
 mod inner_html;
-use super::attribute::{escape_attr, NextAttribute};
+use super::attribute::{
+    any_attribute::{AnyAttribute, AnyAttributeState},
+    escape_attr, NextAttribute,
+};
 pub use custom::*;
 pub use element_ext::*;
 pub use elements::*;
@@ -183,31 +185,42 @@ where
 {
     type State = ElementState<At::State, Ch::State>;
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         let ElementState {
             attrs, children, ..
         } = state;
         self.attributes.rebuild(attrs);
+        if let (Some(extra_attrs), Some(extra_attr_states)) =
+            (extra_attrs, &mut state.extra_attrs)
+        {
+            extra_attrs.rebuild(extra_attr_states);
+        }
         if let Some(children) = children {
-            self.children.rebuild(children);
+            self.children.rebuild(children, None);
         }
     }
 
-    fn build(self) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let el = Rndr::create_element(self.tag.tag(), E::NAMESPACE);
 
         let attrs = self.attributes.build(&el);
+        let extra_attrs = extra_attrs.map(|attrs| attrs.build(&el));
         let children = if E::SELF_CLOSING {
             None
         } else {
-            let mut children = self.children.build();
+            let mut children = self.children.build(None);
             children.mount(&el, None);
             Some(children)
         };
         ElementState {
             el,
-            attrs,
             children,
+            attrs,
+            extra_attrs,
         }
     }
 }
@@ -219,6 +232,7 @@ where
     Ch: RenderHtml + Send,
 {
     type AsyncOutput = HtmlElement<E, At::AsyncOutput, Ch::AsyncOutput>;
+    type Owned = HtmlElement<E, At::CloneableOwned, Ch::Owned>;
 
     const MIN_LENGTH: usize = if E::SELF_CLOSING {
         3 // < ... />
@@ -233,14 +247,22 @@ where
         + E::TAG.len()
     };
 
-    fn dry_resolve(&mut self) {
+    fn dry_resolve(&mut self, mut extra_attrs: ExtraAttrsMut<'_>) {
         self.attributes.dry_resolve();
-        self.children.dry_resolve();
+        extra_attrs.iter_mut().for_each(Attribute::dry_resolve);
+        self.children.dry_resolve(ExtraAttrsMut::default());
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
-        let (attributes, children) =
-            join(self.attributes.resolve(), self.children.resolve()).await;
+    async fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
+        let (attributes, _, children) = join3(
+            self.attributes.resolve(),
+            ExtraAttrsMut::resolve(extra_attrs),
+            self.children.resolve(ExtraAttrsMut::default()),
+        )
+        .await;
         HtmlElement {
             #[cfg(any(debug_assertions, leptos_debuginfo))]
             defined_at: self.defined_at,
@@ -250,7 +272,7 @@ where
         }
     }
 
-    fn html_len(&self) -> usize {
+    fn html_len(&self, extra_attrs: Option<Vec<&AnyAttribute>>) -> usize {
         if E::SELF_CLOSING {
             3 // < ... />
         + E::TAG.len()
@@ -258,8 +280,11 @@ where
         } else {
             2 // < ... >
         + E::TAG.len()
-        + self.attributes.html_len()
-        + self.children.html_len()
+        + self.attributes.html_len() 
+        + extra_attrs.map(|attrs| {
+            attrs.into_iter().map(Attribute::html_len).sum::<usize>()
+        }).unwrap_or(0)
+        + self.children.html_len(None)
         + 3 // </ ... >
         + E::TAG.len()
         }
@@ -271,12 +296,13 @@ where
         position: &mut Position,
         _escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // opening tag
         buf.push('<');
         buf.push_str(self.tag.tag());
 
-        let inner_html = attributes_to_html(self.attributes, buf);
+        let inner_html = attributes_to_html(self.attributes, extra_attrs, buf);
 
         buf.push('>');
 
@@ -291,6 +317,7 @@ where
                     position,
                     E::ESCAPE_CHILDREN,
                     mark_branches,
+                    None,
                 );
             }
 
@@ -308,6 +335,7 @@ where
         position: &mut Position,
         _escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -316,7 +344,7 @@ where
         buf.push('<');
         buf.push_str(self.tag.tag());
 
-        let inner_html = attributes_to_html(self.attributes, &mut buf);
+        let inner_html = attributes_to_html(self.attributes, extra_attrs, &mut buf);
 
         buf.push('>');
         buffer.push_sync(&buf);
@@ -332,6 +360,7 @@ where
                     position,
                     E::ESCAPE_CHILDREN,
                     mark_branches,
+                    None,
                 );
             }
 
@@ -349,6 +378,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         #[cfg(any(debug_assertions, leptos_debuginfo))]
         {
@@ -373,13 +403,20 @@ where
             });
 
         let attrs = self.attributes.hydrate::<FROM_SERVER>(&el);
+        let extra_attrs = extra_attrs.map(|attrs| {
+            Attribute::hydrate::<FROM_SERVER>(attrs, &el)
+        });
 
         // hydrate children
         let children = if !Ch::EXISTS || !E::ESCAPE_CHILDREN {
             None
         } else {
             position.set(Position::FirstChild);
-            Some(self.children.hydrate::<FROM_SERVER>(cursor, position))
+            Some(self.children.hydrate::<FROM_SERVER>(
+                cursor,
+                position,
+                None,
+            ))
         };
 
         // go to next sibling
@@ -393,14 +430,29 @@ where
 
         ElementState {
             el,
-            attrs,
             children,
+            attrs,
+            extra_attrs,
+        }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        HtmlElement {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: self.defined_at,
+            tag: self.tag,
+            attributes: self.attributes.into_cloneable_owned(),
+            children: self.children.into_owned(),
         }
     }
 }
 
 /// Renders an [`Attribute`] (which can be one or more HTML attributes) into an HTML buffer.
-pub fn attributes_to_html<At>(attr: At, buf: &mut String) -> String
+pub fn attributes_to_html<At>(
+    attr: At, 
+    extra_attrs: Option<Vec<AnyAttribute>>,
+    buf: &mut String
+) -> String
 where
     At: Attribute,
 {
@@ -419,6 +471,11 @@ where
 
     // inject regular attributes, and fill class and style
     attr.to_html(buf, &mut class, &mut style, &mut inner_html);
+    if let Some(extra_attrs) = extra_attrs {
+        for attr in extra_attrs {
+            attr.to_html(buf, &mut class, &mut style, &mut inner_html);
+        }
+    }
 
     if !class.is_empty() {
         buf.push(' ');
@@ -439,8 +496,10 @@ where
 /// The retained view state for an HTML element.
 pub struct ElementState<At, Ch> {
     pub(crate) el: crate::renderer::types::Element,
-    pub(crate) attrs: At,
     pub(crate) children: Option<Ch>,
+
+    attrs: At,
+    extra_attrs: Option<Vec<AnyAttributeState>>,
 }
 
 impl<At, Ch> Deref for ElementState<At, Ch> {

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -352,7 +352,7 @@ where
         })
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
         let (names, mut f) = self;
         let prev_value = state.take_value();
 
@@ -433,7 +433,7 @@ where
         <String as IntoClass>::build(self.deref().to_owned(), el)
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
         <String as IntoClass>::rebuild(self.deref().to_owned(), state)
     }
 
@@ -447,7 +447,7 @@ where
 
     fn dry_resolve(&mut self) {}
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::AsyncOutput {
         self
     }
 }
@@ -489,7 +489,7 @@ where
         )
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
         <(&'static str, bool) as IntoClass>::rebuild(
             (self.0, *self.1.deref()),
             state,
@@ -506,7 +506,7 @@ where
 
     fn dry_resolve(&mut self) {}
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::AsyncOutput {
         self
     }
 }
@@ -901,7 +901,7 @@ where
         state
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(self, state: &mut Self::State, _extra_attrs: Option<Vec<AnyAttribute>>) {
         reactive_graph::spawn_local_scoped({
             let state = Rc::clone(state);
             async move {
@@ -925,7 +925,7 @@ where
 
     fn dry_resolve(&mut self) {}
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::AsyncOutput {
         self.inner.await
     }
 }

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -985,7 +985,7 @@ mod tests {
         let count = RwSignal::new(0);
         let app: HtmlElement<_, _, _, MockDom> =
             button((), move || count.get().to_string());
-        let el = app.build();
+        let el = app.build(None);
         assert_eq!(el.el.to_debug_html(), "<button>0</button>");
         rt.dispose();
     }
@@ -996,7 +996,7 @@ mod tests {
         let count = RwSignal::new(0);
         let app: HtmlElement<_, _, _, MockDom> =
             button((), move || count.get().to_string());
-        let el = app.build();
+        let el = app.build(None);
         assert_eq!(el.el.to_debug_html(), "<button>0</button>");
         count.set(1);
         assert_eq!(el.el.to_debug_html(), "<button>1</button>");
@@ -1014,7 +1014,7 @@ mod tests {
                 ("Hello, my ", move || count.get().to_string(), " friends."),
             ),
         );
-        let el = app.build();
+        let el = app.build(None);
         assert_eq!(
             el.el.to_debug_html(),
             "<main><button>Hello, my 0 friends.</button></main>"

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
-    html::attribute::{Attribute, AttributeValue},
+    html::attribute::{any_attribute::AnyAttribute, Attribute, AttributeValue},
     hydration::Cursor,
     renderer::Rndr,
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-        RenderHtml, ToTemplate,
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+        PositionState, Render, RenderHtml, ToTemplate,
     },
 };
 use reactive_graph::effect::RenderEffect;
@@ -57,7 +57,7 @@ where
     type State = RenderEffectState<V::State>;
 
     #[track_caller]
-    fn build(mut self) -> Self::State {
+    fn build(mut self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let hook = throw_error::get_error_hook();
         RenderEffect::new(move |prev| {
             let _guard = hook
@@ -65,18 +65,22 @@ where
                 .map(|h| throw_error::set_error_hook(Arc::clone(h)));
             let value = self.invoke();
             if let Some(mut state) = prev {
-                value.rebuild(&mut state);
+                value.rebuild(&mut state, extra_attrs.clone());
                 state
             } else {
-                value.build()
+                value.build(extra_attrs.clone())
             }
         })
         .into()
     }
 
     #[track_caller]
-    fn rebuild(self, state: &mut Self::State) {
-        let new = self.build();
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+        let new = self.build(extra_attrs);
         let mut old = std::mem::replace(state, new);
         old.insert_before_this(state);
         old.unmount();
@@ -128,18 +132,22 @@ where
     V::State: 'static,
 {
     type AsyncOutput = V::AsyncOutput;
+    type Owned = F;
 
     const MIN_LENGTH: usize = 0;
 
-    fn dry_resolve(&mut self) {
-        self.invoke().dry_resolve();
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
+        self.invoke().dry_resolve(extra_attrs);
     }
 
-    async fn resolve(mut self) -> Self::AsyncOutput {
-        self.invoke().resolve().await
+    async fn resolve(
+        mut self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
+        self.invoke().resolve(extra_attrs).await
     }
 
-    fn html_len(&self) -> usize {
+    fn html_len(&self, _extra_attrs: Option<Vec<&AnyAttribute>>) -> usize {
         V::MIN_LENGTH
     }
 
@@ -149,9 +157,16 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         let value = self.invoke();
-        value.to_html_with_buf(buf, position, escape, mark_branches)
+        value.to_html_with_buf(
+            buf,
+            position,
+            escape,
+            mark_branches,
+            extra_attrs,
+        )
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
@@ -160,6 +175,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -169,6 +185,7 @@ where
             position,
             escape,
             mark_branches,
+            extra_attrs,
         );
     }
 
@@ -176,6 +193,7 @@ where
         mut self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let cursor = cursor.clone();
         let position = position.clone();
@@ -186,13 +204,21 @@ where
                 .map(|h| throw_error::set_error_hook(Arc::clone(h)));
             let value = self.invoke();
             if let Some(mut state) = prev {
-                value.rebuild(&mut state);
+                value.rebuild(&mut state, extra_attrs.clone());
                 state
             } else {
-                value.hydrate::<FROM_SERVER>(&cursor, &position)
+                value.hydrate::<FROM_SERVER>(
+                    &cursor,
+                    &position,
+                    extra_attrs.clone(),
+                )
             }
         })
         .into()
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 
@@ -507,12 +533,14 @@ where
 mod stable {
     use super::RenderEffectState;
     use crate::{
-        html::attribute::{Attribute, AttributeValue},
+        html::attribute::{
+            any_attribute::AnyAttribute, Attribute, AttributeValue,
+        },
         hydration::Cursor,
         ssr::StreamBuilder,
         view::{
-            add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-            RenderHtml,
+            add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+            PositionState, Render, RenderHtml,
         },
     };
     #[allow(deprecated)]
@@ -537,13 +565,20 @@ mod stable {
                 type State = RenderEffectState<V::State>;
 
                 #[track_caller]
-                fn build(self) -> Self::State {
-                    (move || self.get()).build()
+                fn build(
+                    self,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
+                ) -> Self::State {
+                    (move || self.get()).build(extra_attrs)
                 }
 
                 #[track_caller]
-                fn rebuild(self, state: &mut Self::State) {
-                    let new = self.build();
+                fn rebuild(
+                    self,
+                    state: &mut Self::State,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
+                ) {
+                    let new = self.build(extra_attrs);
                     let mut old = std::mem::replace(state, new);
                     old.insert_before_this(state);
                     old.unmount();
@@ -576,20 +611,27 @@ mod stable {
                 V::State: 'static,
             {
                 type AsyncOutput = Self;
+                type Owned = Self;
 
                 const MIN_LENGTH: usize = 0;
 
-                fn dry_resolve(&mut self) {
+                fn dry_resolve(&mut self, _extra_attrs: ExtraAttrsMut<'_>) {
                     if $dry_resolve {
                         _ = self.get();
                     }
                 }
 
-                async fn resolve(self) -> Self::AsyncOutput {
+                async fn resolve(
+                    self,
+                    _extra_attrs: ExtraAttrsMut<'_>,
+                ) -> Self::AsyncOutput {
                     self
                 }
 
-                fn html_len(&self) -> usize {
+                fn html_len(
+                    &self,
+                    _extra_attrs: Option<Vec<&AnyAttribute>>,
+                ) -> usize {
                     V::MIN_LENGTH
                 }
 
@@ -599,9 +641,16 @@ mod stable {
                     position: &mut Position,
                     escape: bool,
                     mark_branches: bool,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) {
                     let value = self.get();
-                    value.to_html_with_buf(buf, position, escape, mark_branches)
+                    value.to_html_with_buf(
+                        buf,
+                        position,
+                        escape,
+                        mark_branches,
+                        extra_attrs,
+                    )
                 }
 
                 fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
@@ -610,6 +659,7 @@ mod stable {
                     position: &mut Position,
                     escape: bool,
                     mark_branches: bool,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) where
                     Self: Sized,
                 {
@@ -619,6 +669,7 @@ mod stable {
                         position,
                         escape,
                         mark_branches,
+                        extra_attrs,
                     );
                 }
 
@@ -626,9 +677,17 @@ mod stable {
                     self,
                     cursor: &Cursor,
                     position: &PositionState,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) -> Self::State {
-                    (move || self.get())
-                        .hydrate::<FROM_SERVER>(cursor, position)
+                    (move || self.get()).hydrate::<FROM_SERVER>(
+                        cursor,
+                        position,
+                        extra_attrs,
+                    )
+                }
+
+                fn into_owned(self) -> Self::Owned {
+                    self
                 }
             }
 
@@ -705,13 +764,20 @@ mod stable {
                 type State = RenderEffectState<V::State>;
 
                 #[track_caller]
-                fn build(self) -> Self::State {
-                    (move || self.get()).build()
+                fn build(
+                    self,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
+                ) -> Self::State {
+                    (move || self.get()).build(extra_attrs)
                 }
 
                 #[track_caller]
-                fn rebuild(self, state: &mut Self::State) {
-                    let new = self.build();
+                fn rebuild(
+                    self,
+                    state: &mut Self::State,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
+                ) {
+                    let new = self.build(extra_attrs);
                     let mut old = std::mem::replace(state, new);
                     old.insert_before_this(state);
                     old.unmount();
@@ -750,20 +816,27 @@ mod stable {
                 V::State: 'static,
             {
                 type AsyncOutput = Self;
+                type Owned = Self;
 
                 const MIN_LENGTH: usize = 0;
 
-                fn dry_resolve(&mut self) {
+                fn dry_resolve(&mut self, _extra_attrs: ExtraAttrsMut<'_>) {
                     if $dry_resolve {
                         _ = self.get();
                     }
                 }
 
-                async fn resolve(self) -> Self::AsyncOutput {
+                async fn resolve(
+                    self,
+                    _extra_attrs: ExtraAttrsMut<'_>,
+                ) -> Self::AsyncOutput {
                     self
                 }
 
-                fn html_len(&self) -> usize {
+                fn html_len(
+                    &self,
+                    _extra_attrs: Option<Vec<&AnyAttribute>>,
+                ) -> usize {
                     V::MIN_LENGTH
                 }
 
@@ -773,9 +846,16 @@ mod stable {
                     position: &mut Position,
                     escape: bool,
                     mark_branches: bool,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) {
                     let value = self.get();
-                    value.to_html_with_buf(buf, position, escape, mark_branches)
+                    value.to_html_with_buf(
+                        buf,
+                        position,
+                        escape,
+                        mark_branches,
+                        extra_attrs,
+                    )
                 }
 
                 fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
@@ -784,6 +864,7 @@ mod stable {
                     position: &mut Position,
                     escape: bool,
                     mark_branches: bool,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) where
                     Self: Sized,
                 {
@@ -793,6 +874,7 @@ mod stable {
                         position,
                         escape,
                         mark_branches,
+                        extra_attrs,
                     );
                 }
 
@@ -800,9 +882,17 @@ mod stable {
                     self,
                     cursor: &Cursor,
                     position: &PositionState,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) -> Self::State {
-                    (move || self.get())
-                        .hydrate::<FROM_SERVER>(cursor, position)
+                    (move || self.get()).hydrate::<FROM_SERVER>(
+                        cursor,
+                        position,
+                        extra_attrs,
+                    )
+                }
+
+                fn into_owned(self) -> Self::Owned {
+                    self
                 }
             }
 

--- a/tachys/src/reactive_graph/suspense.rs
+++ b/tachys/src/reactive_graph/suspense.rs
@@ -1,10 +1,10 @@
 use crate::{
-    html::attribute::Attribute,
+    html::attribute::{any_attribute::AnyAttribute, Attribute},
     hydration::Cursor,
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, iterators::OptionState, Mountable, Position,
-        PositionState, Render, RenderHtml,
+        add_attr::AddAnyAttr, any_view::ExtraAttrsMut, iterators::OptionState,
+        Mountable, Position, PositionState, Render, RenderHtml,
     },
 };
 use any_spawner::Executor;
@@ -169,7 +169,7 @@ where
 {
     type State = SuspendState<T>;
 
-    fn build(self) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let Self { subscriber, inner } = self;
 
         // create a Future that will be aborted on on_cleanup
@@ -184,7 +184,7 @@ where
         // otherwise, start with the fallback
         let initial = fut.as_mut().now_or_never().and_then(Result::ok);
         let initially_pending = initial.is_none();
-        let inner = Rc::new(RefCell::new(initial.build()));
+        let inner = Rc::new(RefCell::new(initial.build(extra_attrs.clone())));
 
         // get a unique ID if there's a SuspenseContext
         let id = use_context::<SuspenseContext>().map(|sc| sc.task_id());
@@ -205,7 +205,8 @@ where
                     drop(id);
 
                     if let Ok(value) = value {
-                        Some(value).rebuild(&mut *state.borrow_mut());
+                        Some(value)
+                            .rebuild(&mut *state.borrow_mut(), extra_attrs);
                     }
 
                     subscriber.forward();
@@ -218,7 +219,11 @@ where
         SuspendState { inner }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         let Self { subscriber, inner } = self;
 
         // create a Future that will be aborted on on_cleanup
@@ -248,7 +253,7 @@ where
                 // has no parent
                 Executor::tick().await;
                 if let Ok(value) = value {
-                    Some(value).rebuild(&mut *state.borrow_mut());
+                    Some(value).rebuild(&mut *state.borrow_mut(), extra_attrs);
                 }
 
                 subscriber.forward();
@@ -284,6 +289,7 @@ where
     T: RenderHtml + Sized + 'static,
 {
     type AsyncOutput = Option<T>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -293,12 +299,19 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // TODO wrap this with a Suspense as needed
         // currently this is just used for Routes, which creates a Suspend but never actually needs
         // it (because we don't lazy-load routes on the server)
         if let Some(inner) = self.inner.now_or_never() {
-            inner.to_html_with_buf(buf, position, escape, mark_branches);
+            inner.to_html_with_buf(
+                buf,
+                position,
+                escape,
+                mark_branches,
+                extra_attrs,
+            );
         }
     }
 
@@ -308,6 +321,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -318,6 +332,7 @@ where
                 position,
                 escape,
                 mark_branches,
+                extra_attrs,
             ),
             None => {
                 if use_context::<SuspenseContext>().is_none() {
@@ -342,6 +357,7 @@ where
                             (),
                             &mut fallback_position,
                             mark_branches,
+                            extra_attrs.clone(),
                         );
 
                         // TODO in 0.8: this should include a nonce
@@ -353,6 +369,7 @@ where
                             fut,
                             position,
                             mark_branches,
+                            extra_attrs,
                         );
                     } else {
                         buf.push_async({
@@ -365,6 +382,7 @@ where
                                     &mut position,
                                     escape,
                                     mark_branches,
+                                    extra_attrs,
                                 );
                                 builder.finish().take_chunks()
                             }
@@ -381,6 +399,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let Self { subscriber, inner } = self;
 
@@ -396,9 +415,11 @@ where
         // otherwise, start with the fallback
         let initial = fut.as_mut().now_or_never().and_then(Result::ok);
         let initially_pending = initial.is_none();
-        let inner = Rc::new(RefCell::new(
-            initial.hydrate::<FROM_SERVER>(cursor, position),
-        ));
+        let inner = Rc::new(RefCell::new(initial.hydrate::<FROM_SERVER>(
+            cursor,
+            position,
+            extra_attrs.clone(),
+        )));
 
         // get a unique ID if there's a SuspenseContext
         let id = use_context::<SuspenseContext>().map(|sc| sc.task_id());
@@ -419,7 +440,8 @@ where
                     drop(id);
 
                     if let Ok(value) = value {
-                        Some(value).rebuild(&mut *state.borrow_mut());
+                        Some(value)
+                            .rebuild(&mut *state.borrow_mut(), extra_attrs);
                     }
 
                     subscriber.forward();
@@ -432,11 +454,14 @@ where
         SuspendState { inner }
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(
+        self,
+        _extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
         Some(self.inner.await)
     }
 
-    fn dry_resolve(&mut self) {
+    fn dry_resolve(&mut self, _extra_attrs: ExtraAttrsMut<'_>) {
         // this is a little crazy, but if a Suspend is immediately available, we end up
         // with a situation where polling it multiple times (here in dry_resolve and then in
         // resolve) causes a runtime panic
@@ -455,5 +480,9 @@ where
             self.inner = Box::pin(async move { inner })
                 as Pin<Box<dyn Future<Output = T> + Send>>;
         }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -1,4 +1,7 @@
-use crate::view::{Position, RenderHtml};
+use crate::{
+    html::attribute::any_attribute::AnyAttribute,
+    view::{Position, RenderHtml},
+};
 use futures::Stream;
 use std::{
     collections::VecDeque,
@@ -103,6 +106,7 @@ impl StreamBuilder {
         fallback: View,
         position: &mut Position,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         View: RenderHtml,
     {
@@ -112,6 +116,7 @@ impl StreamBuilder {
             position,
             true,
             mark_branches,
+            extra_attrs,
         );
         self.write_chunk_marker(false);
         *position = Position::NextChild;
@@ -160,6 +165,7 @@ impl StreamBuilder {
         view: impl Future<Output = Option<View>> + Send + 'static,
         position: &mut Position,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         View: RenderHtml,
     {
@@ -168,6 +174,7 @@ impl StreamBuilder {
             position,
             mark_branches,
             None,
+            extra_attrs,
         );
     }
 
@@ -178,6 +185,7 @@ impl StreamBuilder {
         position: &mut Position,
         mark_branches: bool,
         nonce: Option<Arc<str>>,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         View: RenderHtml,
     {
@@ -207,6 +215,7 @@ impl StreamBuilder {
                         &mut position,
                         true,
                         mark_branches,
+                        extra_attrs,
                     );
                 }
                 let chunks = subbuilder.finish().take_chunks();

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -380,6 +380,7 @@ impl<'a> ExtraAttrsMut<'a> {
         }
     }
 
+    #[cfg(feature = "ssr")]
     fn add_layer<'b>(
         mut self,
         extra_attrs: &'b mut Vec<AnyAttribute>,

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -1,9 +1,11 @@
 use super::{
-    add_attr::AddAnyAttr, MarkBranch, Mountable, Position, PositionState,
-    Render, RenderHtml,
+    add_attr::AddAnyAttr, any_view::ExtraAttrsMut, MarkBranch, Mountable,
+    Position, PositionState, Render, RenderHtml,
 };
 use crate::{
-    html::attribute::Attribute, hydration::Cursor, ssr::StreamBuilder,
+    html::attribute::{any_attribute::AnyAttribute, Attribute},
+    hydration::Cursor,
+    ssr::StreamBuilder,
 };
 use either_of::*;
 use futures::future::join;
@@ -15,29 +17,33 @@ where
 {
     type State = Either<A::State, B::State>;
 
-    fn build(self) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         match self {
-            Either::Left(left) => Either::Left(left.build()),
-            Either::Right(right) => Either::Right(right.build()),
+            Either::Left(left) => Either::Left(left.build(extra_attrs)),
+            Either::Right(right) => Either::Right(right.build(extra_attrs)),
         }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         match (self, &mut *state) {
             (Either::Left(new), Either::Left(old)) => {
-                new.rebuild(old);
+                new.rebuild(old, extra_attrs);
             }
             (Either::Right(new), Either::Right(old)) => {
-                new.rebuild(old);
+                new.rebuild(old, extra_attrs);
             }
             (Either::Right(new), Either::Left(old)) => {
-                let mut new_state = new.build();
+                let mut new_state = new.build(extra_attrs);
                 old.insert_before_this(&mut new_state);
                 old.unmount();
                 *state = Either::Right(new_state);
             }
             (Either::Left(new), Either::Right(old)) => {
-                let mut new_state = new.build();
+                let mut new_state = new.build(extra_attrs);
                 old.insert_before_this(&mut new_state);
                 old.unmount();
                 *state = Either::Left(new_state);
@@ -120,28 +126,34 @@ where
     B: RenderHtml,
 {
     type AsyncOutput = Either<A::AsyncOutput, B::AsyncOutput>;
+    type Owned = Either<A::Owned, B::Owned>;
 
-    fn dry_resolve(&mut self) {
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
         match self {
-            Either::Left(left) => left.dry_resolve(),
-            Either::Right(right) => right.dry_resolve(),
+            Either::Left(left) => left.dry_resolve(extra_attrs),
+            Either::Right(right) => right.dry_resolve(extra_attrs),
         }
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
         match self {
-            Either::Left(left) => Either::Left(left.resolve().await),
-            Either::Right(right) => Either::Right(right.resolve().await),
+            Either::Left(left) => Either::Left(left.resolve(extra_attrs).await),
+            Either::Right(right) => {
+                Either::Right(right.resolve(extra_attrs).await)
+            }
         }
     }
 
     const MIN_LENGTH: usize = max_usize(&[A::MIN_LENGTH, B::MIN_LENGTH]);
 
     #[inline(always)]
-    fn html_len(&self) -> usize {
+    fn html_len(&self, extra_attrs: Option<Vec<&AnyAttribute>>) -> usize {
         match self {
-            Either::Left(i) => i.html_len(),
-            Either::Right(i) => i.html_len(),
+            Either::Left(i) => i.html_len(extra_attrs),
+            Either::Right(i) => i.html_len(extra_attrs),
         }
     }
 
@@ -151,13 +163,20 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         match self {
             Either::Left(left) => {
                 if mark_branches {
                     buf.open_branch("0");
                 }
-                left.to_html_with_buf(buf, position, escape, mark_branches);
+                left.to_html_with_buf(
+                    buf,
+                    position,
+                    escape,
+                    mark_branches,
+                    extra_attrs,
+                );
                 if mark_branches {
                     buf.close_branch("0");
                 }
@@ -166,7 +185,13 @@ where
                 if mark_branches {
                     buf.open_branch("1");
                 }
-                right.to_html_with_buf(buf, position, escape, mark_branches);
+                right.to_html_with_buf(
+                    buf,
+                    position,
+                    escape,
+                    mark_branches,
+                    extra_attrs,
+                );
                 if mark_branches {
                     buf.close_branch("1");
                 }
@@ -180,6 +205,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -193,6 +219,7 @@ where
                     position,
                     escape,
                     mark_branches,
+                    extra_attrs,
                 );
                 if mark_branches {
                     buf.close_branch("0");
@@ -207,6 +234,7 @@ where
                     position,
                     escape,
                     mark_branches,
+                    extra_attrs,
                 );
                 if mark_branches {
                     buf.close_branch("1");
@@ -219,14 +247,24 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         match self {
-            Either::Left(left) => {
-                Either::Left(left.hydrate::<FROM_SERVER>(cursor, position))
-            }
-            Either::Right(right) => {
-                Either::Right(right.hydrate::<FROM_SERVER>(cursor, position))
-            }
+            Either::Left(left) => Either::Left(left.hydrate::<FROM_SERVER>(
+                cursor,
+                position,
+                extra_attrs,
+            )),
+            Either::Right(right) => Either::Right(
+                right.hydrate::<FROM_SERVER>(cursor, position, extra_attrs),
+            ),
+        }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        match self {
+            Either::Left(left) => Either::Left(left.into_owned()),
+            Either::Right(right) => Either::Right(right.into_owned()),
         }
     }
 }
@@ -255,25 +293,29 @@ where
 {
     type State = EitherKeepAliveState<A::State, B::State>;
 
-    fn build(self) -> Self::State {
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         let showing_b = self.show_b;
-        let a = self.a.map(Render::build);
-        let b = self.b.map(Render::build);
+        let a = self.a.map(|val| Render::build(val, extra_attrs.clone()));
+        let b = self.b.map(|val| Render::build(val, extra_attrs));
         EitherKeepAliveState { a, b, showing_b }
     }
 
-    fn rebuild(self, state: &mut Self::State) {
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
         // set or update A -- `None` just means "no change"
         match (self.a, &mut state.a) {
-            (Some(new), Some(old)) => new.rebuild(old),
-            (Some(new), None) => state.a = Some(new.build()),
+            (Some(new), Some(old)) => new.rebuild(old, extra_attrs.clone()),
+            (Some(new), None) => state.a = Some(new.build(extra_attrs.clone())),
             _ => {}
         }
 
         // set or update B
         match (self.b, &mut state.b) {
-            (Some(new), Some(old)) => new.rebuild(old),
-            (Some(new), None) => state.b = Some(new.build()),
+            (Some(new), Some(old)) => new.rebuild(old, extra_attrs),
+            (Some(new), None) => state.b = Some(new.build(extra_attrs)),
             _ => {}
         }
 
@@ -333,35 +375,58 @@ where
     B: RenderHtml,
 {
     type AsyncOutput = EitherKeepAlive<A::AsyncOutput, B::AsyncOutput>;
+    type Owned = EitherKeepAlive<A::Owned, B::Owned>;
 
     const MIN_LENGTH: usize = 0;
 
-    fn dry_resolve(&mut self) {
+    fn dry_resolve(&mut self, mut extra_attrs: ExtraAttrsMut<'_>) {
         if let Some(inner) = &mut self.a {
-            inner.dry_resolve();
+            inner.dry_resolve(extra_attrs.as_deref_mut());
         }
         if let Some(inner) = &mut self.b {
-            inner.dry_resolve();
+            inner.dry_resolve(extra_attrs);
         }
     }
 
-    async fn resolve(self) -> Self::AsyncOutput {
+    async fn resolve(
+        self,
+        mut extra_attrs: ExtraAttrsMut<'_>,
+    ) -> Self::AsyncOutput {
         let EitherKeepAlive { a, b, show_b } = self;
-        let (a, b) = join(
-            async move {
-                match a {
-                    Some(a) => Some(a.resolve().await),
-                    None => None,
-                }
-            },
-            async move {
-                match b {
-                    Some(b) => Some(b.resolve().await),
-                    None => None,
-                }
-            },
-        )
-        .await;
+
+        // Has to be sequential if extra attrs are present:
+        let (a, b) = if extra_attrs.is_some() {
+            let a = match a {
+                Some(a) => Some(a.resolve(extra_attrs.as_deref_mut()).await),
+                None => None,
+            };
+            let b = match b {
+                Some(b) => Some(b.resolve(extra_attrs.as_deref_mut()).await),
+                None => None,
+            };
+            (a, b)
+        } else {
+            join(
+                async move {
+                    match a {
+                        Some(a) => {
+                            Some(a.resolve(ExtraAttrsMut::default()).await)
+                        }
+                        None => None,
+                    }
+                },
+                async move {
+                    match b {
+                        Some(b) => {
+                            Some(b.resolve(ExtraAttrsMut::default()).await)
+                        }
+                        None => None,
+                    }
+                },
+            )
+            .await
+        };
+
         EitherKeepAlive { a, b, show_b }
     }
 
@@ -371,15 +436,28 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         if self.show_b {
             self.b
                 .expect("rendering B to HTML without filling it")
-                .to_html_with_buf(buf, position, escape, mark_branches);
+                .to_html_with_buf(
+                    buf,
+                    position,
+                    escape,
+                    mark_branches,
+                    extra_attrs,
+                );
         } else {
             self.a
                 .expect("rendering A to HTML without filling it")
-                .to_html_with_buf(buf, position, escape, mark_branches);
+                .to_html_with_buf(
+                    buf,
+                    position,
+                    escape,
+                    mark_branches,
+                    extra_attrs,
+                );
         }
     }
 
@@ -389,6 +467,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
@@ -400,6 +479,7 @@ where
                     position,
                     escape,
                     mark_branches,
+                    extra_attrs,
                 );
         } else {
             self.a
@@ -409,6 +489,7 @@ where
                     position,
                     escape,
                     mark_branches,
+                    extra_attrs,
                 );
         }
     }
@@ -417,24 +498,33 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         let showing_b = self.show_b;
         let a = self.a.map(|a| {
             if showing_b {
-                a.build()
+                a.build(extra_attrs.clone())
             } else {
-                a.hydrate::<FROM_SERVER>(cursor, position)
+                a.hydrate::<FROM_SERVER>(cursor, position, extra_attrs.clone())
             }
         });
         let b = self.b.map(|b| {
             if showing_b {
-                b.hydrate::<FROM_SERVER>(cursor, position)
+                b.hydrate::<FROM_SERVER>(cursor, position, extra_attrs)
             } else {
-                b.build()
+                b.build(extra_attrs)
             }
         });
 
         EitherKeepAliveState { showing_b, a, b }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        EitherKeepAlive {
+            a: self.a.map(|a| a.into_owned()),
+            b: self.b.map(|b| b.into_owned()),
+            show_b: self.show_b,
+        }
     }
 }
 
@@ -535,20 +625,20 @@ macro_rules! tuples {
                 type State = [<EitherOf $num State>]<$($ty,)*>;
 
 
-                fn build(self) -> Self::State {
+                fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
                     let state = match self {
-                        $([<EitherOf $num>]::$ty(this) => [<EitherOf $num>]::$ty(this.build()),)*
+                        $([<EitherOf $num>]::$ty(this) => [<EitherOf $num>]::$ty(this.build(extra_attrs)),)*
                     };
                     Self::State { state }
                 }
 
-                fn rebuild(self, state: &mut Self::State) {
+                fn rebuild(self, state: &mut Self::State, extra_attrs: Option<Vec<AnyAttribute>>) {
                     let new_state = match (self, &mut state.state) {
                         // rebuild same state and return early
-                        $(([<EitherOf $num>]::$ty(new), [<EitherOf $num>]::$ty(old)) => { return new.rebuild(old); },)*
+                        $(([<EitherOf $num>]::$ty(new), [<EitherOf $num>]::$ty(old)) => { return new.rebuild(old, extra_attrs); },)*
                         // or mount new state
                         $(([<EitherOf $num>]::$ty(new), _) => {
-                            let mut new = new.build();
+                            let mut new = new.build(extra_attrs);
                             state.insert_before_this(&mut new);
                             [<EitherOf $num>]::$ty(new)
                         },)*
@@ -592,38 +682,39 @@ macro_rules! tuples {
 
             {
                 type AsyncOutput = [<EitherOf $num>]<$($ty::AsyncOutput,)*>;
+                type Owned = [<EitherOf $num>]<$($ty::Owned,)*>;
 
                 const MIN_LENGTH: usize = max_usize(&[$($ty ::MIN_LENGTH,)*]);
 
 
-                fn dry_resolve(&mut self) {
+                fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>) {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            this.dry_resolve();
+                            this.dry_resolve(extra_attrs);
                         })*
                     }
                 }
 
-                async fn resolve(self) -> Self::AsyncOutput {
+                async fn resolve(self, extra_attrs: ExtraAttrsMut<'_>) -> Self::AsyncOutput {
                     match self {
-                        $([<EitherOf $num>]::$ty(this) => [<EitherOf $num>]::$ty(this.resolve().await),)*
+                        $([<EitherOf $num>]::$ty(this) => [<EitherOf $num>]::$ty(this.resolve(extra_attrs).await),)*
                     }
                 }
 
                 #[inline(always)]
-                fn html_len(&self) -> usize {
+                fn html_len(&self, extra_attrs: Option<Vec<&AnyAttribute>>) -> usize {
                     match self {
-                        $([<EitherOf $num>]::$ty(i) => i.html_len(),)*
+                        $([<EitherOf $num>]::$ty(i) => i.html_len(extra_attrs),)*
                     }
                 }
 
-                fn to_html_with_buf(self, buf: &mut String, position: &mut Position, escape: bool, mark_branches: bool) {
+                fn to_html_with_buf(self, buf: &mut String, position: &mut Position, escape: bool, mark_branches: bool, extra_attrs: Option<Vec<AnyAttribute>>) {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
                             if mark_branches {
                                 buf.open_branch(stringify!($ty));
                             }
-                            this.to_html_with_buf(buf, position, escape, mark_branches);
+                            this.to_html_with_buf(buf, position, escape, mark_branches, extra_attrs);
                             if mark_branches {
                                 buf.close_branch(stringify!($ty));
                             }
@@ -633,7 +724,7 @@ macro_rules! tuples {
 
                 fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
                     self,
-                    buf: &mut StreamBuilder, position: &mut Position, escape: bool, mark_branches: bool) where
+                    buf: &mut StreamBuilder, position: &mut Position, escape: bool, mark_branches: bool, extra_attrs: Option<Vec<AnyAttribute>>) where
                     Self: Sized,
                 {
                     match self {
@@ -641,7 +732,7 @@ macro_rules! tuples {
                             if mark_branches {
                                 buf.open_branch(stringify!($ty));
                             }
-                            this.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches);
+                            this.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches, extra_attrs);
                             if mark_branches {
                                 buf.close_branch(stringify!($ty));
                             }
@@ -653,14 +744,23 @@ macro_rules! tuples {
                     self,
                     cursor: &Cursor,
                     position: &PositionState,
+                    extra_attrs: Option<Vec<AnyAttribute>>,
                 ) -> Self::State {
                     let state = match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            [<EitherOf $num>]::$ty(this.hydrate::<FROM_SERVER>(cursor, position))
+                            [<EitherOf $num>]::$ty(this.hydrate::<FROM_SERVER>(cursor, position, extra_attrs))
                         })*
                     };
 
                     Self::State { state }
+                }
+
+                fn into_owned(self) -> Self::Owned {
+                    match self {
+                        $([<EitherOf $num>]::$ty(this) => {
+                            [<EitherOf $num>]::$ty(this.into_owned())
+                        })*
+                    }
                 }
             }
         }

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -138,14 +138,14 @@ where
 
 impl<T, I, K, KF, VF, VFS, V> AddAnyAttr for Keyed<T, I, K, KF, VF, VFS, V>
 where
-    I: IntoIterator<Item = T> + Send,
+    I: IntoIterator<Item = T> + Send + 'static,
     K: Eq + Hash + 'static,
     KF: Fn(&T) -> K + Send + 'static,
     V: RenderHtml,
     V: 'static,
     VF: Fn(usize, T) -> (VFS, V) + Send + 'static,
     VFS: Fn(usize) + 'static,
-    T: Send + 'static,
+    T: 'static,
 {
     type Output<SomeNewAttr: Attribute> = Keyed<
         T,
@@ -191,16 +191,16 @@ where
 
 impl<T, I, K, KF, VF, VFS, V> RenderHtml for Keyed<T, I, K, KF, VF, VFS, V>
 where
-    I: IntoIterator<Item = T> + Send,
+    I: IntoIterator<Item = T> + Send + 'static,
     K: Eq + Hash + 'static,
     KF: Fn(&T) -> K + Send + 'static,
     V: RenderHtml + 'static,
     VF: Fn(usize, T) -> (VFS, V) + Send + 'static,
     VFS: Fn(usize) + 'static,
-    T: Send + 'static,
+    T: 'static,
 {
     type AsyncOutput = Vec<V::AsyncOutput>; // TODO
-    type Owned = Keyed<T, Vec<T>, K, KF, VF, VFS, V>;
+    type Owned = Keyed<T, I, K, KF, VF, VFS, V>;
 
     const MIN_LENGTH: usize = 0;
 
@@ -315,16 +315,7 @@ where
     }
 
     fn into_owned(self) -> Self::Owned {
-        let Keyed {
-            items,
-            key_fn,
-            view_fn,
-        } = self;
-        Keyed {
-            items: items.into_iter().collect::<Vec<_>>(),
-            key_fn,
-            view_fn,
-        }
+        self
     }
 }
 

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -729,7 +729,7 @@ mod tests {
     #[test]
     fn keyed_creates_list() {
         let el = ul((), keyed(1..=3, |k| *k, item));
-        let el_state = el.build();
+        let el_state = el.build(None);
         assert_eq!(
             el_state.el.to_debug_html(),
             "<ul><li>1</li><li>2</li><li>3</li></ul>"
@@ -739,7 +739,7 @@ mod tests {
     #[test]
     fn adding_items_updates_list() {
         let el = ul((), keyed(1..=3, |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed(1..=5, |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(
@@ -751,7 +751,7 @@ mod tests {
     #[test]
     fn removing_items_updates_list() {
         let el = ul((), keyed(1..=3, |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed(1..=2, |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(
@@ -763,7 +763,7 @@ mod tests {
     #[test]
     fn swapping_items_updates_list() {
         let el = ul((), keyed([1, 2, 3, 4, 5], |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed([1, 4, 3, 2, 5], |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(
@@ -775,7 +775,7 @@ mod tests {
     #[test]
     fn swapping_and_removing_orders_correctly() {
         let el = ul((), keyed([1, 2, 3, 4, 5], |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed([1, 4, 3, 5], |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(
@@ -787,7 +787,7 @@ mod tests {
     #[test]
     fn arbitrarily_hard_adjustment() {
         let el = ul((), keyed([1, 2, 3, 4, 5], |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed([2, 4, 3], |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(
@@ -799,7 +799,7 @@ mod tests {
     #[test]
     fn a_series_of_moves() {
         let el = ul((), keyed([1, 2, 3, 4, 5], |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed([2, 4, 3], |k| *k, item));
         el.rebuild(&mut el_state);
         let el = ul((), keyed([1, 7, 5, 11, 13, 17], |k| *k, item));
@@ -819,7 +819,7 @@ mod tests {
     #[test]
     fn clearing_works() {
         let el = ul((), keyed([1, 2, 3, 4, 5], |k| *k, item));
-        let mut el_state = el.build();
+        let mut el_state = el.build(None);
         let el = ul((), keyed([], |k| *k, item));
         el.rebuild(&mut el_state);
         assert_eq!(el_state.el.to_debug_html(), "<ul></ul>");

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -1,5 +1,9 @@
 use self::add_attr::AddAnyAttr;
-use crate::{hydration::Cursor, ssr::StreamBuilder};
+use crate::{
+    html::attribute::any_attribute::AnyAttribute, hydration::Cursor,
+    ssr::StreamBuilder,
+};
+use any_view::ExtraAttrsMut;
 use parking_lot::RwLock;
 use std::{cell::RefCell, future::Future, rc::Rc, sync::Arc};
 
@@ -37,10 +41,14 @@ pub trait Render: Sized {
     type State: Mountable;
 
     /// Creates the view for the first time, without hydrating from existing HTML.
-    fn build(self) -> Self::State;
+    fn build(self, extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State;
 
     /// Updates the view with new data.
-    fn rebuild(self, state: &mut Self::State);
+    fn rebuild(
+        self,
+        state: &mut Self::State,
+        extra_attrs: Option<Vec<AnyAttribute>>,
+    );
 }
 
 pub(crate) trait MarkBranch {
@@ -96,6 +104,9 @@ where
     /// The type of the view after waiting for all asynchronous data to load.
     type AsyncOutput: RenderHtml;
 
+    /// A static version of this type.
+    type Owned: RenderHtml + 'static;
+
     /// The minimum length of HTML created when this view is rendered.
     const MIN_LENGTH: usize;
 
@@ -105,17 +116,20 @@ where
     /// “Runs” the view without other side effects. For primitive types, this is a no-op. For
     /// reactive types, this can be used to gather data about reactivity or about asynchronous data
     /// that needs to be loaded.
-    fn dry_resolve(&mut self);
+    fn dry_resolve(&mut self, extra_attrs: ExtraAttrsMut<'_>);
 
     /// Waits for any asynchronous sections of the view to load and returns the output.
-    fn resolve(self) -> impl Future<Output = Self::AsyncOutput> + Send;
+    fn resolve(
+        self,
+        extra_attrs: ExtraAttrsMut<'_>,
+    ) -> impl Future<Output = Self::AsyncOutput> + Send;
 
     /// An estimated length for this view, when rendered to HTML.
     ///
     /// This is used for calculating the string buffer size when rendering HTML. It does not need
     /// to be precise, but should be an appropriate estimate. The more accurate, the fewer
     /// reallocations will be required and the faster server-side rendering will be.
-    fn html_len(&self) -> usize {
+    fn html_len(&self, _extra_attrs: Option<Vec<&AnyAttribute>>) -> usize {
         Self::MIN_LENGTH
     }
 
@@ -124,8 +138,14 @@ where
     where
         Self: Sized,
     {
-        let mut buf = String::with_capacity(self.html_len());
-        self.to_html_with_buf(&mut buf, &mut Position::FirstChild, true, false);
+        let mut buf = String::with_capacity(self.html_len(None));
+        self.to_html_with_buf(
+            &mut buf,
+            &mut Position::FirstChild,
+            true,
+            false,
+            None,
+        );
         buf
     }
 
@@ -136,8 +156,14 @@ where
     where
         Self: Sized,
     {
-        let mut buf = String::with_capacity(self.html_len());
-        self.to_html_with_buf(&mut buf, &mut Position::FirstChild, true, true);
+        let mut buf = String::with_capacity(self.html_len(None));
+        self.to_html_with_buf(
+            &mut buf,
+            &mut Position::FirstChild,
+            true,
+            true,
+            None,
+        );
         buf
     }
 
@@ -146,12 +172,14 @@ where
     where
         Self: Sized,
     {
-        let mut builder = StreamBuilder::with_capacity(self.html_len(), None);
+        let mut builder =
+            StreamBuilder::with_capacity(self.html_len(None), None);
         self.to_html_async_with_buf::<false>(
             &mut builder,
             &mut Position::FirstChild,
             true,
             false,
+            None,
         );
         builder.finish()
     }
@@ -163,12 +191,14 @@ where
     where
         Self: Sized,
     {
-        let mut builder = StreamBuilder::with_capacity(self.html_len(), None);
+        let mut builder =
+            StreamBuilder::with_capacity(self.html_len(None), None);
         self.to_html_async_with_buf::<false>(
             &mut builder,
             &mut Position::FirstChild,
             true,
             true,
+            None,
         );
         builder.finish()
     }
@@ -180,13 +210,14 @@ where
     {
         //let capacity = self.html_len();
         let mut builder =
-            StreamBuilder::with_capacity(self.html_len(), Some(vec![0]));
+            StreamBuilder::with_capacity(self.html_len(None), Some(vec![0]));
 
         self.to_html_async_with_buf::<true>(
             &mut builder,
             &mut Position::FirstChild,
             true,
             false,
+            None,
         );
         builder.finish()
     }
@@ -199,13 +230,14 @@ where
         Self: Sized,
     {
         let mut builder =
-            StreamBuilder::with_capacity(self.html_len(), Some(vec![0]));
+            StreamBuilder::with_capacity(self.html_len(None), Some(vec![0]));
 
         self.to_html_async_with_buf::<true>(
             &mut builder,
             &mut Position::FirstChild,
             true,
             true,
+            None,
         );
         builder.finish()
     }
@@ -217,6 +249,7 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     );
 
     /// Renders a view into a buffer of (synchronous or asynchronous) HTML chunks.
@@ -226,11 +259,18 @@ where
         position: &mut Position,
         escape: bool,
         mark_branches: bool,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) where
         Self: Sized,
     {
         buf.with_buf(|buf| {
-            self.to_html_with_buf(buf, position, escape, mark_branches)
+            self.to_html_with_buf(
+                buf,
+                position,
+                escape,
+                mark_branches,
+                extra_attrs,
+            )
         });
     }
 
@@ -245,6 +285,7 @@ where
         self,
         cursor: &Cursor,
         position: &PositionState,
+        extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State;
 
     /// Hydrates using [`RenderHtml::hydrate`], beginning at the given element.
@@ -269,8 +310,49 @@ where
     {
         let cursor = Cursor::new(el.clone());
         let position = PositionState::new(position);
-        self.hydrate::<FROM_SERVER>(&cursor, &position)
+        self.hydrate::<FROM_SERVER>(&cursor, &position, None)
     }
+
+    /// Converts this view into a owned/static type.
+    fn into_owned(self) -> Self::Owned;
+}
+
+/// Resolving multiple children when extra_attrs exist is tricky, because the extra_attrs are potentially shared.
+///
+/// The current assumption is:
+/// - resolve() should not be run on an AnyAttribute more than once,
+/// - any of the children could resolve() the extra_attr_states
+///
+/// Therefore, if any extra_attrs exist, resolving must happen sequentially, until any of the children resolves the extra_attrs.
+/// After that, the remaining can be done in parallel, like they will be if no extra_attrs exist.
+pub(crate) async fn batch_resolve_items_with_extra_attrs<T: RenderHtml>(
+    items: impl IntoIterator<Item = T>,
+    mut extra_attrs: ExtraAttrsMut<'_>,
+) -> impl IntoIterator<Item = T::AsyncOutput> {
+    let mut item_iter = items.into_iter();
+    let mut preresolved = vec![];
+    if extra_attrs.is_some() {
+        // Reset resolved state to fresh if dirty:
+        extra_attrs
+            .as_deref_mut()
+            .iter_mut()
+            .for_each(|attr| attr.resolved = false);
+        for item in item_iter.by_ref() {
+            preresolved.push(item.resolve(extra_attrs.as_deref_mut()).await);
+            // Once all resolved, can switch to parallel and not pass in extra_attrs anymore,
+            // once they've already all resolved:
+            if extra_attrs.iter_mut().all(|attr| attr.resolved) {
+                break;
+            }
+        }
+    }
+    preresolved.into_iter().chain(
+        futures::future::join_all(
+            item_iter.map(|val| T::resolve(val, ExtraAttrsMut::default())),
+        )
+        .await
+        .into_iter(),
+    )
 }
 
 /// Allows a type to be mounted to the DOM.

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -3,7 +3,12 @@ use super::{
     RenderHtml, ToTemplate,
 };
 use crate::{
-    html::attribute::{Attribute, AttributeKey, AttributeValue, NextAttribute},
+    html::attribute::{
+        maybe_next_attr_erasure_macros::{
+            next_attr_combine, next_attr_output_type,
+        },
+        Attribute, AttributeKey, AttributeValue, NextAttribute,
+    },
     hydration::Cursor,
     renderer::{CastFrom, Rndr},
 };
@@ -111,13 +116,13 @@ impl<K, const V: &'static str> NextAttribute for StaticAttr<K, V>
 where
     K: AttributeKey,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (StaticAttr::<K, V> { ty: PhantomData }, new_attr)
+        next_attr_combine!(StaticAttr::<K, V> { ty: PhantomData }, new_attr)
     }
 }
 

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -1,9 +1,10 @@
 use super::{
-    add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
-    RenderHtml, ToTemplate,
+    add_attr::AddAnyAttr, any_view::ExtraAttrsMut, Mountable, Position,
+    PositionState, Render, RenderHtml, ToTemplate,
 };
 use crate::{
     html::attribute::{
+        any_attribute::AnyAttribute,
         maybe_next_attr_erasure_macros::{
             next_attr_combine, next_attr_output_type,
         },
@@ -150,27 +151,36 @@ where
 {
     type State = Option<crate::renderer::types::Text>;
 
-    fn build(self) -> Self::State {
+    fn build(self, _extra_attrs: Option<Vec<AnyAttribute>>) -> Self::State {
         // a view state has to be returned so it can be mounted
         Some(Rndr::create_text_node(V))
     }
 
     // This type is specified as static, so no rebuilding is done.
-    fn rebuild(self, _state: &mut Self::State) {}
+    fn rebuild(
+        self,
+        _state: &mut Self::State,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
+    ) {
+    }
 }
 
 impl<const V: &'static str> RenderHtml for Static<V> {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = V.len();
 
-    fn dry_resolve(&mut self) {}
+    fn dry_resolve(&mut self, _extra_attrs: ExtraAttrsMut<'_>) {}
 
     // this won't actually compile because if a weird interaction because the const &'static str and
     // the RPITIT, so we just refine it to a concrete future type; this will never change in any
     // case
     #[allow(refining_impl_trait)]
-    fn resolve(self) -> std::future::Ready<Self> {
+    fn resolve(
+        self,
+        _extra_attrs: ExtraAttrsMut<'_>,
+    ) -> std::future::Ready<Self> {
         std::future::ready(self)
     }
 
@@ -180,6 +190,7 @@ impl<const V: &'static str> RenderHtml for Static<V> {
         position: &mut Position,
         escape: bool,
         _mark_branches: bool,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) {
         // add a comment node to separate from previous sibling, if any
         if matches!(position, Position::NextChildAfterText) {
@@ -200,6 +211,7 @@ impl<const V: &'static str> RenderHtml for Static<V> {
         self,
         cursor: &Cursor,
         position: &PositionState,
+        _extra_attrs: Option<Vec<AnyAttribute>>,
     ) -> Self::State {
         if position.get() == Position::FirstChild {
             cursor.child();
@@ -221,6 +233,10 @@ impl<const V: &'static str> RenderHtml for Static<V> {
         position.set(Position::NextChildAfterText);
 
         Some(node)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 


### PR DESCRIPTION
For `AddAnyAttr` in non-erased mode, the issue is simply the number/size of the types generated once something has already become an `AnyView` being too much for the compiler to handle. 

This PR "truly erases" `AnyView` by preventing further types being created once something's been erased, utilising an "attribute bag" that will be passed down through the rendering traits, instead of producing a new type each time an attribute is added.

It's definitely the brute-force fix, but it seems to work!

Edit:
The `into_owned()` method being added to `RenderHtml` is somewhat separate, but is neccessary to make erased mode not cause new compile errors relating to `AnyView` not being static, it allows removing the `static` bound from `IntoAny`.