### PR TITLE
Binary size wins

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo binstall wasm-bindgen-cli --no-confirm
       - name: Install cargo-leptos
-        run: cargo binstall cargo-leptos --no-confirm
+        run: cargo binstall cargo-leptos --locked --no-confirm
       - name: Install Trunk
         uses: jetli/trunk-action@v0.5.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,9 +333,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,7 +879,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "either_of"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "paste",
  "pin-project-lite",
@@ -1718,7 +1718,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptos"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "any_spawner",
  "base64",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_actix"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_axum"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "any_spawner",
  "axum",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "config",
  "regex",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "js-sys",
  "leptos",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "camino",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_integration_utils"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "futures",
  "hydration_context",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -1896,7 +1896,7 @@ dependencies = [
  "rstml",
  "serde",
  "server_fn",
- "server_fn_macro 0.7.4",
+ "server_fn_macro 0.7.5",
  "syn 2.0.90",
  "tracing",
  "trybuild",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_meta"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "futures",
  "indexmap",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_router"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "any_spawner",
  "either_of",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_router_macro"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "leptos_macro",
  "leptos_router",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "any_spawner",
  "base64",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_graph"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-lock",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "guardian",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "reactive_stores_macro"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error2",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "actix-web",
  "axum",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "const_format",
  "convert_case 0.6.0",
@@ -3223,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
- "server_fn_macro 0.7.4",
+ "server_fn_macro 0.7.5",
  "syn 2.0.90",
 ]
 
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "any_spawner",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 exclude = ["benchmarks", "examples", "projects"]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 rust-version = "1.76"
 
@@ -50,26 +50,26 @@ any_spawner = { path = "./any_spawner/", version = "0.2.0" }
 const_str_slice_concat = { path = "./const_str_slice_concat", version = "0.1" }
 either_of = { path = "./either_of/", version = "0.1.0" }
 hydration_context = { path = "./hydration_context", version = "0.2.0" }
-leptos = { path = "./leptos", version = "0.7.4" }
-leptos_config = { path = "./leptos_config", version = "0.7.4" }
-leptos_dom = { path = "./leptos_dom", version = "0.7.4" }
-leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.7.4" }
-leptos_integration_utils = { path = "./integrations/utils", version = "0.7.4" }
-leptos_macro = { path = "./leptos_macro", version = "0.7.4" }
-leptos_router = { path = "./router", version = "0.7.4" }
-leptos_router_macro = { path = "./router_macro", version = "0.7.4" }
-leptos_server = { path = "./leptos_server", version = "0.7.4" }
-leptos_meta = { path = "./meta", version = "0.7.4" }
+leptos = { path = "./leptos", version = "0.7.5" }
+leptos_config = { path = "./leptos_config", version = "0.7.5" }
+leptos_dom = { path = "./leptos_dom", version = "0.7.5" }
+leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.7.5" }
+leptos_integration_utils = { path = "./integrations/utils", version = "0.7.5" }
+leptos_macro = { path = "./leptos_macro", version = "0.7.5" }
+leptos_router = { path = "./router", version = "0.7.5" }
+leptos_router_macro = { path = "./router_macro", version = "0.7.5" }
+leptos_server = { path = "./leptos_server", version = "0.7.5" }
+leptos_meta = { path = "./meta", version = "0.7.5" }
 next_tuple = { path = "./next_tuple", version = "0.1.0" }
 oco_ref = { path = "./oco", version = "0.2.0" }
 or_poisoned = { path = "./or_poisoned", version = "0.1.0" }
-reactive_graph = { path = "./reactive_graph", version = "0.1.4" }
+reactive_graph = { path = "./reactive_graph", version = "0.1.5" }
 reactive_stores = { path = "./reactive_stores", version = "0.1.3" }
 reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.1.0" }
-server_fn = { path = "./server_fn", version = "0.7.4" }
-server_fn_macro = { path = "./server_fn_macro", version = "0.7.4" }
-server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.7.4" }
-tachys = { path = "./tachys", version = "0.1.4" }
+server_fn = { path = "./server_fn", version = "0.7.5" }
+server_fn_macro = { path = "./server_fn_macro", version = "0.7.5" }
+server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.7.5" }
+tachys = { path = "./tachys", version = "0.1.5" }
 
 [profile.release]
 codegen-units = 1

--- a/either_of/Cargo.toml
+++ b/either_of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "either_of"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_macro"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -677,17 +677,21 @@ fn component_macro(
             #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
             #unexpanded
         }
-    } else if let Ok(mut dummy) = dummy {
-        dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
-        quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
-            #dummy
-        }
     } else {
-        quote! {}
-    }
-    .into()
+        match dummy {
+            Ok(mut dummy) => {
+                dummy.sig.ident = unmodified_fn_name_from_fn_name(&dummy.sig.ident);
+                quote! {
+                    #[doc(hidden)]
+                    #[allow(non_snake_case, dead_code, clippy::too_many_arguments, clippy::needless_lifetimes)]
+                    #dummy
+                }
+            }
+            Err(e) => {
+                proc_macro_error2::abort!(e.span(), e);
+            }
+        }
+    }.into()
 }
 
 /// Annotates a struct so that it can be used with your Component as a `slot`.

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_meta"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_graph"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores"
-version = "0.1.3"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -82,6 +82,21 @@ where
     }
 }
 
+impl<T, S> From<ArcField<T>> for Field<T, S>
+where
+    T: 'static,
+    S: Storage<ArcField<T>>,
+{
+    #[track_caller]
+    fn from(value: ArcField<T>) -> Self {
+        Field {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: Location::caller(),
+            inner: ArenaItem::new_with_storage(value),
+        }
+    }
+}
+
 impl<T, S> From<ArcStore<T>> for Field<T, S>
 where
     T: Send + Sync + 'static,

--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -77,11 +77,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{self as reactive_stores, Store};
+    use crate::{self as reactive_stores, Patch as _, Store};
     use reactive_graph::{
         effect::Effect,
         traits::{Get, Read, ReadUntracked, Set, Write},
     };
+    use reactive_stores_macro::Patch;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -236,5 +237,116 @@ mod tests {
         tick().await;
         assert_eq!(parent_count.load(Ordering::Relaxed), 3);
         assert_eq!(inner_count.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn patch() {
+        use crate::OptionStoreExt;
+
+        #[derive(Debug, Clone, Store, Patch)]
+        struct Outer {
+            inner: Option<Inner>,
+        }
+
+        #[derive(Debug, Clone, Store, Patch)]
+        struct Inner {
+            first: String,
+            second: String,
+        }
+
+        let store = Store::new(Outer {
+            inner: Some(Inner {
+                first: "A".to_owned(),
+                second: "B".to_owned(),
+            }),
+        });
+
+        _ = any_spawner::Executor::init_tokio();
+
+        let parent_count = Arc::new(AtomicUsize::new(0));
+        let inner_first_count = Arc::new(AtomicUsize::new(0));
+        let inner_second_count = Arc::new(AtomicUsize::new(0));
+
+        Effect::new_sync({
+            let parent_count = Arc::clone(&parent_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("parent: first run");
+                } else {
+                    println!("parent: next run");
+                }
+
+                println!("  value = {:?}", store.inner().get());
+                parent_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Effect::new_sync({
+            let inner_first_count = Arc::clone(&inner_first_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("inner_first: first run");
+                } else {
+                    println!("inner_first: next run");
+                }
+
+                println!(
+                    "  value = {:?}",
+                    store.inner().map(|inner| inner.first().get())
+                );
+                inner_first_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Effect::new_sync({
+            let inner_second_count = Arc::clone(&inner_second_count);
+            move |prev: Option<()>| {
+                if prev.is_none() {
+                    println!("inner_second: first run");
+                } else {
+                    println!("inner_second: next run");
+                }
+
+                println!(
+                    "  value = {:?}",
+                    store.inner().map(|inner| inner.second().get())
+                );
+                inner_second_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 1);
+
+        store.patch(Outer {
+            inner: Some(Inner {
+                first: "A".to_string(),
+                second: "C".to_string(),
+            }),
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 1);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 2);
+
+        store.patch(Outer { inner: None });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 2);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 2);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 3);
+
+        store.patch(Outer {
+            inner: Some(Inner {
+                first: "A".to_string(),
+                second: "B".to_string(),
+            }),
+        });
+
+        tick().await;
+        assert_eq!(parent_count.load(Ordering::Relaxed), 3);
+        assert_eq!(inner_first_count.load(Ordering::Relaxed), 3);
+        assert_eq!(inner_second_count.load(Ordering::Relaxed), 4);
     }
 }

--- a/reactive_stores_macro/Cargo.toml
+++ b/reactive_stores_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reactive_stores_macro"
-version = "0.1.0"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router_macro"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tachys"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 readme = "../README.md"
@@ -204,4 +204,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(leptos_debuginfo)',
   'cfg(erase_components)',
 ] }
-

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -3,7 +3,12 @@ use super::{
     RenderHtml, ToTemplate,
 };
 use crate::{
-    html::attribute::{Attribute, AttributeKey, AttributeValue, NextAttribute},
+    html::attribute::{
+        maybe_next_attr_erasure_macros::{
+            next_attr_combine, next_attr_output_type,
+        },
+        Attribute, AttributeKey, AttributeValue, NextAttribute,
+    },
     hydration::Cursor,
     renderer::{CastFrom, Rndr},
 };
@@ -111,13 +116,13 @@ impl<K, const V: &'static str> NextAttribute for StaticAttr<K, V>
 where
     K: AttributeKey,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (StaticAttr::<K, V> { ty: PhantomData }, new_attr)
+        next_attr_combine!(StaticAttr::<K, V> { ty: PhantomData }, new_attr)
     }
 }
 


### PR DESCRIPTION
Some free binary size optimisations after https://github.com/leptos-rs/leptos/pull/3553

Testing hackernews with `cargo +stable leptos build --release` then looking at `target/pkg/$name.wasm`:
Before https://github.com/leptos-rs/leptos/pull/3553: 577210
After [anyattr change](https://github.com/leptos-rs/leptos/pull/3553): 624529
This PR: 602081