### PR TITLE
Binary size wins

### DIFF
--- a/reactive_graph/src/effect/render_effect.rs
+++ b/reactive_graph/src/effect/render_effect.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     owner::Owner,
 };
-use any_spawner::Executor;
 use futures::StreamExt;
 use or_poisoned::OrPoisoned;
 use std::{

--- a/reactive_graph/src/effect/render_effect.rs
+++ b/reactive_graph/src/effect/render_effect.rs
@@ -54,7 +54,7 @@ where
 {
     /// Creates a new render effect, which immediately runs `fun`.
     pub fn new(fun: impl FnMut(Option<T>) -> T + 'static) -> Self {
-        Self::new_with_value(fun, None)
+        Self::new_with_value_erased(Box::new(fun), None)
     }
 
     /// Creates a new render effect with an initial value.
@@ -62,57 +62,68 @@ where
         fun: impl FnMut(Option<T>) -> T + 'static,
         initial_value: Option<T>,
     ) -> Self {
-        fn erased<T>(
-            mut fun: Box<dyn FnMut(Option<T>) -> T + 'static>,
-            initial_value: Option<T>,
-        ) -> RenderEffect<T> {
-            let (observer, mut rx) = channel();
-            let value = Arc::new(RwLock::new(None::<T>));
+        Self::new_with_value_erased(Box::new(fun), initial_value)
+    }
+
+    fn new_with_value_erased(
+        mut fun: Box<dyn FnMut(Option<T>) -> T + 'static>,
+        initial_value: Option<T>,
+    ) -> Self {
+        // codegen optimisation:
+        fn prep() -> (Owner, Arc<RwLock<EffectInner>>, crate::channel::Receiver)
+        {
+            let (observer, rx) = channel();
             let owner = Owner::new();
             let inner = Arc::new(RwLock::new(EffectInner {
                 dirty: false,
                 observer,
                 sources: SourceSet::new(),
             }));
-
-            let initial_value = cfg!(feature = "effects").then(|| {
-                owner.with(|| {
-                    inner
-                        .to_any_subscriber()
-                        .with_observer(|| fun(initial_value))
-                })
-            });
-            *value.write().or_poisoned() = initial_value;
-
-            if cfg!(feature = "effects") {
-                Executor::spawn_local({
-                    let value = Arc::clone(&value);
-                    let subscriber = inner.to_any_subscriber();
-
-                    async move {
-                        while rx.next().await.is_some() {
-                            if subscriber.with_observer(|| {
-                                subscriber.update_if_necessary()
-                            }) {
-                                subscriber.clear_sources(&subscriber);
-
-                                let old_value = mem::take(
-                                    &mut *value.write().or_poisoned(),
-                                );
-                                let new_value = owner.with_cleanup(|| {
-                                    subscriber.with_observer(|| fun(old_value))
-                                });
-                                *value.write().or_poisoned() = Some(new_value);
-                            }
-                        }
-                    }
-                });
-            }
-
-            RenderEffect { value, inner }
+            (owner, inner, rx)
         }
 
-        erased(Box::new(fun), initial_value)
+        let (owner, inner, mut rx) = prep();
+
+        let value = Arc::new(RwLock::new(None::<T>));
+
+        #[cfg(not(feature = "effects"))]
+        {
+            let _ = initial_value;
+            let _ = owner;
+            let _ = &mut rx;
+            let _ = &mut fun;
+        }
+
+        #[cfg(feature = "effects")]
+        {
+            let subscriber = inner.to_any_subscriber();
+            *value.write().or_poisoned() = Some(
+                owner.with(|| subscriber.with_observer(|| fun(initial_value))),
+            );
+
+            Executor::spawn_local({
+                let value = Arc::clone(&value);
+
+                async move {
+                    while rx.next().await.is_some() {
+                        if subscriber
+                            .with_observer(|| subscriber.update_if_necessary())
+                        {
+                            subscriber.clear_sources(&subscriber);
+
+                            let old_value =
+                                mem::take(&mut *value.write().or_poisoned());
+                            let new_value = owner.with_cleanup(|| {
+                                subscriber.with_observer(|| fun(old_value))
+                            });
+                            *value.write().or_poisoned() = Some(new_value);
+                        }
+                    }
+                }
+            });
+        }
+
+        RenderEffect { value, inner }
     }
 
     /// Mutably accesses the current value.

--- a/reactive_graph/src/effect/render_effect.rs
+++ b/reactive_graph/src/effect/render_effect.rs
@@ -100,7 +100,7 @@ where
                 owner.with(|| subscriber.with_observer(|| fun(initial_value))),
             );
 
-            Executor::spawn_local({
+            any_spawner::Executor::spawn_local({
                 let value = Arc::clone(&value);
 
                 async move {


### PR DESCRIPTION
~Some free binary size optimisations after https://github.com/leptos-rs/leptos/pull/3553 (reduces impact from 8% to 4% on hackernews example)~

~Testing hackernews with `cargo +stable leptos build --release` then looking at `target/pkg/$name.wasm`:~
~Before https://github.com/leptos-rs/leptos/pull/3553: 577210~
~After [#3553 anyattr change](https://github.com/leptos-rs/leptos/pull/3553): 624529~
~This PR: 602081 599795~

Updated, some random optimisations I stumbled on whilst trying to reduce binary impact of https://github.com/leptos-rs/leptos/pull/3553

Testing hackernews with `cargo +stable leptos build --release` then looking at `target/pkg/$name.wasm`:~
Baseline: 597734
This PR: 589089