### PR TITLE
Replace `get()` with `try_get()` in several trait implementations for signals

### DIFF
--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -494,72 +494,9 @@ pub enum BoolOrT<T> {
     T(T),
 }
 
-impl<T> IntoProperty for BoolOrT<T>
-where
-    T: IntoProperty<State = (Element, JsValue)>
-        + Into<JsValue>
-        + Clone
-        + 'static,
-{
-    type State = (Element, JsValue);
-    type Cloneable = Self;
-    type CloneableOwned = Self;
-
-    fn hydrate<const FROM_SERVER: bool>(
-        self,
-        el: &Element,
-        key: &str,
-    ) -> Self::State {
-        match self.clone() {
-            Self::T(s) => {
-                s.hydrate::<FROM_SERVER>(el, key);
-            }
-            Self::Bool(b) => {
-                <bool as IntoProperty>::hydrate::<FROM_SERVER>(b, el, key);
-            }
-        };
-
-        (el.clone(), self.into())
-    }
-
-    fn build(self, el: &Element, key: &str) -> Self::State {
-        match self.clone() {
-            Self::T(s) => {
-                s.build(el, key);
-            }
-            Self::Bool(b) => {
-                <bool as IntoProperty>::build(b, el, key);
-            }
-        }
-
-        (el.clone(), self.into())
-    }
-
-    fn rebuild(self, state: &mut Self::State, key: &str) {
-        let (el, prev) = state;
-
-        match self {
-            Self::T(s) => s.rebuild(&mut (el.clone(), prev.clone()), key),
-            Self::Bool(b) => <bool as IntoProperty>::rebuild(
-                b,
-                &mut (el.clone(), prev.clone()),
-                key,
-            ),
-        }
-    }
-
-    fn into_cloneable(self) -> Self::Cloneable {
-        self
-    }
-
-    fn into_cloneable_owned(self) -> Self::CloneableOwned {
-        self
-    }
-}
-
 impl<T> IntoProperty for Option<BoolOrT<T>>
 where
-    T: IntoProperty<State = Option<(Element, JsValue)>>
+    T: IntoProperty<State = (Element, JsValue)>
         + Into<JsValue>
         + Clone
         + 'static,
@@ -607,7 +544,7 @@ where
             let (el, prev) = state;
             match f {
                 BoolOrT::T(s) => {
-                    s.rebuild(&mut Some((el.clone(), prev.clone())), key)
+                    s.rebuild(&mut (el.clone(), prev.clone()), key)
                 }
                 BoolOrT::Bool(b) => <bool as IntoProperty>::rebuild(
                     b,

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -177,9 +177,18 @@ where
                 read_signal
                     .try_get()
                     .map(|r| BoolOrT::Bool(el.get_value() == r))
+                    .or_else(|| {
+                        crate::dispose_warn!();
+                        None
+                    })
             })
         } else {
-            Signal::derive(move || read_signal.try_get().map(BoolOrT::T))
+            Signal::derive(move || {
+                read_signal.try_get().map(BoolOrT::T).or_else(|| {
+                    crate::dispose_warn!();
+                    None
+                })
+            })
         }
     }
 

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -170,22 +170,35 @@ where
     pub fn read_signal(&self, el: &Element) -> Signal<Option<BoolOrT<T>>> {
         let read_signal = self.read_signal.clone();
 
+        let el = SendWrapper::new(el.clone());
         if Key::KEY == "group" {
-            let el = SendWrapper::new(el.clone());
-
             Signal::derive(move || {
                 read_signal
                     .try_get()
                     .map(|r| BoolOrT::Bool(el.get_value() == r))
                     .or_else(|| {
-                        crate::dispose_warn!();
+                        crate::dispose_warn!(
+                            read_signal,
+                            format!(
+                                "Reactive value passed to: bind:{}\nElement: {}",
+                                Key::KEY,
+                                el.node_name().to_lowercase(),
+                            )
+                        );
                         None
                     })
             })
         } else {
             Signal::derive(move || {
                 read_signal.try_get().map(BoolOrT::T).or_else(|| {
-                    crate::dispose_warn!();
+                    crate::dispose_warn!(
+                        read_signal,
+                        format!(
+                            "Reactive value passed to: bind:{}\nElement: {}",
+                            Key::KEY,
+                            el.node_name().to_lowercase(),
+                        ),
+                    );
                     None
                 })
             })

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -180,7 +180,8 @@ where
                         crate::dispose_warn!(
                             read_signal,
                             format!(
-                                "Reactive value passed to: bind:{}\nElement: {}",
+                                "Reactive value passed to: bind:{}\nElement: \
+                                 {}",
                                 Key::KEY,
                                 el.node_name().to_lowercase(),
                             )

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -493,6 +493,70 @@ pub enum BoolOrT<T> {
     /// Standard case with some type `T`
     T(T),
 }
+
+impl<T> IntoProperty for BoolOrT<T>
+where
+    T: IntoProperty<State = (Element, JsValue)>
+        + Into<JsValue>
+        + Clone
+        + 'static,
+{
+    type State = (Element, JsValue);
+    type Cloneable = Self;
+    type CloneableOwned = Self;
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        el: &Element,
+        key: &str,
+    ) -> Self::State {
+        match self.clone() {
+            Self::T(s) => {
+                s.hydrate::<FROM_SERVER>(el, key);
+            }
+            Self::Bool(b) => {
+                <bool as IntoProperty>::hydrate::<FROM_SERVER>(b, el, key);
+            }
+        };
+
+        (el.clone(), self.into())
+    }
+
+    fn build(self, el: &Element, key: &str) -> Self::State {
+        match self.clone() {
+            Self::T(s) => {
+                s.build(el, key);
+            }
+            Self::Bool(b) => {
+                <bool as IntoProperty>::build(b, el, key);
+            }
+        }
+
+        (el.clone(), self.into())
+    }
+
+    fn rebuild(self, state: &mut Self::State, key: &str) {
+        let (el, prev) = state;
+
+        match self {
+            Self::T(s) => s.rebuild(&mut (el.clone(), prev.clone()), key),
+            Self::Bool(b) => <bool as IntoProperty>::rebuild(
+                b,
+                &mut (el.clone(), prev.clone()),
+                key,
+            ),
+        }
+    }
+
+    fn into_cloneable(self) -> Self::Cloneable {
+        self
+    }
+
+    fn into_cloneable_owned(self) -> Self::CloneableOwned {
+        self
+    }
+}
+
 impl<T> IntoProperty for Option<BoolOrT<T>>
 where
     T: IntoProperty<State = Option<(Element, JsValue)>>

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -539,7 +539,11 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let value = self.try_get();
-                    value.to_html(class);
+                    if let Some(value) = value {
+                        value.to_html(class);
+                    } else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn hydrate<const FROM_SERVER: bool>(
@@ -561,12 +565,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -584,10 +586,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -602,11 +604,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,
@@ -663,7 +665,10 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.try_get().unwrap_or(false);
+                    let include = f.try_get().unwrap_or_else(|| {
+                        crate::dispose_warn!();
+                        false
+                    });
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -685,7 +690,11 @@ mod stable {
                                 crate::renderer::types::ClassList,
                                 bool,
                             )>| {
-                                let include = f.try_get().unwrap_or(false);
+                                let include =
+                                    f.try_get().unwrap_or_else(|| {
+                                        crate::dispose_warn!();
+                                        false
+                                    });
                                 if let Some((class_list, prev)) = prev {
                                     if include {
                                         if !prev {
@@ -716,7 +725,11 @@ mod stable {
                                 crate::renderer::types::ClassList,
                                 bool,
                             )>| {
-                                let include = f.try_get().unwrap_or(false);
+                                let include =
+                                    f.try_get().unwrap_or_else(|| {
+                                        crate::dispose_warn!();
+                                        false
+                                    });
                                 match prev {
                                     Some((class_list, prev)) => {
                                         if include {
@@ -751,7 +764,10 @@ mod stable {
                     state.name = name;
                     state.effect = RenderEffect::new_with_value(
                         move |prev| {
-                            let include = f.try_get().unwrap_or(false);
+                            let include = f.try_get().unwrap_or_else(|| {
+                                crate::dispose_warn!();
+                                false
+                            });
                             match prev {
                                 Some((class_list, prev)) => {
                                     if include {
@@ -828,7 +844,11 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let value = self.try_get();
-                    value.to_html(class);
+                    if let Some(value) = value {
+                        value.to_html(class);
+                    } else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn hydrate<const FROM_SERVER: bool>(
@@ -850,12 +870,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -873,10 +891,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -891,11 +909,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,
@@ -949,7 +967,10 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.try_get().unwrap_or(false);
+                    let include = f.try_get().unwrap_or_else(|| {
+                        crate::dispose_warn!();
+                        false
+                    });
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -971,7 +992,11 @@ mod stable {
                                 crate::renderer::types::ClassList,
                                 bool,
                             )>| {
-                                let include = f.try_get().unwrap_or(false);
+                                let include =
+                                    f.try_get().unwrap_or_else(|| {
+                                        crate::dispose_warn!();
+                                        false
+                                    });
                                 if let Some((class_list, prev)) = prev {
                                     if include {
                                         if !prev {
@@ -1002,7 +1027,11 @@ mod stable {
                                 crate::renderer::types::ClassList,
                                 bool,
                             )>| {
-                                let include = f.try_get().unwrap_or(false);
+                                let include =
+                                    f.try_get().unwrap_or_else(|| {
+                                        crate::dispose_warn!();
+                                        false
+                                    });
                                 match prev {
                                     Some((class_list, prev)) => {
                                         if include {
@@ -1037,7 +1066,10 @@ mod stable {
                     state.name = name;
                     state.effect = RenderEffect::new_with_value(
                         move |prev| {
-                            let include = f.try_get().unwrap_or(false);
+                            let include = f.try_get().unwrap_or_else(|| {
+                                crate::dispose_warn!();
+                                false
+                            });
                             match prev {
                                 Some((class_list, prev)) => {
                                     if include {

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -605,8 +605,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -635,7 +635,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -894,8 +894,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -924,7 +924,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -529,7 +529,7 @@ mod stable {
                 C::State: 'static,
             {
                 type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
+                type State = RenderEffect<Option<C::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -538,7 +538,7 @@ mod stable {
                 }
 
                 fn to_html(self, class: &mut String) {
-                    let value = self.get();
+                    let value = self.try_get();
                     value.to_html(class);
                 }
 
@@ -546,18 +546,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el)
+                    // TODO FROM_SERVER vs template
+                    let el = el.clone();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).build(el)
+                    let el = el.to_owned();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.build(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    (move || self.get()).rebuild(state)
+                    let prev_value = state.take_value();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -576,13 +629,13 @@ mod stable {
 
                 fn reset(state: &mut Self::State) {
                     *state = RenderEffect::new_with_value(
-                        move |prev| {
-                            if let Some(mut state) = prev {
+                        move |prev| match (prev) {
+                            Some(Some(mut state)) => {
                                 C::reset(&mut state);
-                                state
-                            } else {
-                                unreachable!()
+                                Some(state)
                             }
+                            Some(None) => None,
+                            None => None,
                         },
                         state.take_value(),
                     );
@@ -610,7 +663,7 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.get();
+                    let include = f.try_get().unwrap_or(false);
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -620,9 +673,31 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::hydrate::<FROM_SERVER>(
-                        (self.0, move || self.1.get()),
-                        el,
+                    // TODO FROM_SERVER vs template
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                if let Some((class_list, prev)) = prev {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
                     )
                 }
 
@@ -630,11 +705,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::build((self.0, move || self.1.get()), el)
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                match prev {
+                                    Some((class_list, prev)) => {
+                                        if include {
+                                            if !prev {
+                                                Rndr::add_class(
+                                                    &class_list,
+                                                    name,
+                                                );
+                                            }
+                                        } else if prev {
+                                            Rndr::remove_class(
+                                                &class_list,
+                                                name,
+                                            );
+                                        }
+                                    }
+                                    None => {
+                                        if include {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
+                    )
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    IntoClass::rebuild((self.0, move || self.1.get()), state)
+                    let (name, f) = self;
+                    // Name might've updated:
+                    state.name = name;
+                    state.effect = RenderEffect::new_with_value(
+                        move |prev| {
+                            let include = f.try_get().unwrap_or(false);
+                            match prev {
+                                Some((class_list, prev)) => {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                    (class_list.clone(), include)
+                                }
+                                None => {
+                                    unreachable!()
+                                }
+                            }
+                        },
+                        state.effect.take_value(),
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -683,7 +818,7 @@ mod stable {
                 C::State: 'static,
             {
                 type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
+                type State = RenderEffect<Option<C::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -692,7 +827,7 @@ mod stable {
                 }
 
                 fn to_html(self, class: &mut String) {
-                    let value = self.get();
+                    let value = self.try_get();
                     value.to_html(class);
                 }
 
@@ -700,18 +835,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el)
+                    // TODO FROM_SERVER vs template
+                    let el = el.clone();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).build(el)
+                    let el = el.to_owned();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.build(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    (move || self.get()).rebuild(state)
+                    let prev_value = state.take_value();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -730,13 +918,13 @@ mod stable {
 
                 fn reset(state: &mut Self::State) {
                     *state = RenderEffect::new_with_value(
-                        move |prev| {
-                            if let Some(mut state) = prev {
+                        move |prev| match (prev) {
+                            Some(Some(mut state)) => {
                                 C::reset(&mut state);
-                                state
-                            } else {
-                                unreachable!()
+                                Some(state)
                             }
+                            Some(None) => None,
+                            None => None,
                         },
                         state.take_value(),
                     );
@@ -761,7 +949,7 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.get();
+                    let include = f.try_get().unwrap_or(false);
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -771,9 +959,31 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::hydrate::<FROM_SERVER>(
-                        (self.0, move || self.1.get()),
-                        el,
+                    // TODO FROM_SERVER vs template
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                if let Some((class_list, prev)) = prev {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
                     )
                 }
 
@@ -781,11 +991,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::build((self.0, move || self.1.get()), el)
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                match prev {
+                                    Some((class_list, prev)) => {
+                                        if include {
+                                            if !prev {
+                                                Rndr::add_class(
+                                                    &class_list,
+                                                    name,
+                                                );
+                                            }
+                                        } else if prev {
+                                            Rndr::remove_class(
+                                                &class_list,
+                                                name,
+                                            );
+                                        }
+                                    }
+                                    None => {
+                                        if include {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
+                    )
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    IntoClass::rebuild((self.0, move || self.1.get()), state)
+                    let (name, f) = self;
+                    // Name might've updated:
+                    state.name = name;
+                    state.effect = RenderEffect::new_with_value(
+                        move |prev| {
+                            let include = f.try_get().unwrap_or(false);
+                            match prev {
+                                Some((class_list, prev)) => {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                    (class_list.clone(), include)
+                                }
+                                None => {
+                                    unreachable!()
+                                }
+                            }
+                        },
+                        state.effect.take_value(),
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {

--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -119,7 +119,11 @@ mod stable {
 
                 fn to_html(self, buf: &mut String) {
                     let value = self.try_get();
-                    value.to_html(buf);
+                    if let Some(value) = value {
+                        value.to_html(buf);
+                    } else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn to_template(_buf: &mut String) {}
@@ -142,12 +146,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -168,10 +170,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -186,11 +188,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,
@@ -236,7 +238,11 @@ mod stable {
 
                 fn to_html(self, buf: &mut String) {
                     let value = self.try_get();
-                    value.to_html(buf);
+                    if let Some(value) = value {
+                        value.to_html(buf);
+                    } else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn to_template(_buf: &mut String) {}
@@ -259,12 +265,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -285,10 +289,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -303,11 +307,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -33,11 +33,24 @@ pub use suspense::*;
 #[macro_export]
 macro_rules! dispose_warn {
     () => {
-        // panic!();
         let called_at = std::panic::Location::caller();
         reactive_graph::log_warning(format_args!(
             "At {called_at}, you access a signal which is already disposed"
         ));
+    };
+    ($signal:ident,$($context:tt)*) => {
+        if let Some(defined_at) = $signal.defined_at() {
+            let called_at = std::panic::Location::caller();
+            reactive_graph::log_warning(format_args!(
+                "At {called_at}, you tried to access a reactive value which was \
+                defined at {defined_at}, but it has already been disposed.\n{}",$($context)*
+            ));
+        } else {
+            let called_at = std::panic::Location::caller();
+            reactive_graph::log_warning(format_args!(
+                "At {called_at}, you access a signal which is already disposed.\n{}", $($context)*
+            ));
+        }
     };
 }
 

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -506,10 +506,10 @@ where
 #[cfg(not(feature = "nightly"))]
 mod stable {
     use super::RenderEffectState;
-    use crate::renderer::Rndr;
     use crate::{
         html::attribute::{Attribute, AttributeValue},
         hydration::Cursor,
+        renderer::Rndr,
         ssr::StreamBuilder,
         view::{
             add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -786,8 +786,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -1081,8 +1081,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -178,8 +178,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -284,8 +284,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -101,7 +101,7 @@ mod stable {
                 V: IntoProperty + Send + Sync + Clone + 'static,
                 V::State: 'static,
             {
-                type State = RenderEffect<V::State>;
+                type State = RenderEffect<Option<V::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -110,7 +110,31 @@ mod stable {
                     el: &crate::renderer::types::Element,
                     key: &str,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el, key)
+                    let key = Rndr::intern(key);
+                    let key = key.to_owned();
+                    let el = el.to_owned();
+
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state, &key);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
@@ -118,11 +142,48 @@ mod stable {
                     el: &crate::renderer::types::Element,
                     key: &str,
                 ) -> Self::State {
-                    (move || self.get()).build(el, key)
+                    let key = Rndr::intern(key);
+                    let key = key.to_owned();
+                    let el = el.to_owned();
+
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state, &key);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el, &key)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.build(&el, &key))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State, key: &str) {
-                    (move || self.get()).rebuild(state, key)
+                    let prev_value = state.take_value();
+                    let key = key.to_owned();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state, &key);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -116,6 +116,7 @@ mod stable {
 
                     RenderEffect::new(move |prev| {
                         let value = self.try_get();
+
                         // Outer Some means there was a previous state
                         // Inner Some means the previous state was valid
                         // (i.e., the signal was successfully accessed)
@@ -127,12 +128,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el, &key))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -154,12 +153,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el, &key)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.build(&el, &key))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -175,11 +172,11 @@ mod stable {
                                     value.rebuild(&mut state, &key);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,
@@ -234,12 +231,10 @@ mod stable {
                             (None, Some(value)) => {
                                 Some(value.hydrate::<FROM_SERVER>(&el, &key))
                             }
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -260,12 +255,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el, &key)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => {
-                                Some(value.build(&el, &key))
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
                             }
-                            (Some(None), None) => None,
-                            (None, None) => None,
                         }
                     })
                 }
@@ -282,10 +275,11 @@ mod stable {
                                     Some(state)
                                 }
                                 (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None, // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -329,8 +329,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -358,7 +358,8 @@ mod stable {
                                 C::reset(&mut state);
                                 Some(state)
                             }
-                            _ => None,
+                            Some(None) => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -581,8 +582,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -611,7 +612,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -760,7 +761,6 @@ mod stable {
             }
         };
     }
-
 
     use super::RenderEffect;
     use crate::html::style::IntoStyle;

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -254,9 +254,10 @@ where
 
 #[cfg(not(feature = "nightly"))]
 mod stable {
-    use crate::reactive_graph::style::RenderEffectWithCssStyleName;
-    use crate::renderer::types::CssStyleDeclaration;
-    use crate::renderer::Rndr;
+    use crate::{
+        reactive_graph::style::RenderEffectWithCssStyleName,
+        renderer::{types::CssStyleDeclaration, Rndr},
+    };
 
     macro_rules! style_signal {
         ($sig:ident) => {

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -462,8 +462,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, _)), None) => (style.clone(), None),
-                                _ => unreachable!(),
+                                (Some((style, Some(prev))), None) => (style, Some(prev)),
+                                (Some((style, None)), Some(_)) => (style, None),
+                                (Some((style, None)), None) => (style, None),
+                                (None, _) => unreachable!(),
                             }
                         },
                         state.effect.take_value(),
@@ -495,7 +497,8 @@ mod stable {
                                     prev = Cow::Borrowed("");
                                     (style, Some(prev))
                                 }
-                                _ => unreachable!(),
+                                Some((style, None)) => (style, None),
+                                None => unreachable!(),
                             },
                             state.effect.take_value(),
                         ),
@@ -719,8 +722,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, _)), None) => (style.clone(), None),
-                                _ => unreachable!(),
+                                (Some((style, Some(prev))), None) => (style, Some(prev)),
+                                (Some((style, None)), Some(_)) => (style, None),
+                                (Some((style, None)), None) => (style, None),
+                                (None, _) => unreachable!(),
                             }
                         },
                         state.effect.take_value(),
@@ -752,7 +757,8 @@ mod stable {
                                     prev = Cow::Borrowed("");
                                     (style, Some(prev))
                                 }
-                                _ => unreachable!(),
+                                Some((style, None)) => (style, None),
+                                None => unreachable!(),
                             },
                             state.effect.take_value(),
                         ),

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -274,7 +274,12 @@ mod stable {
 
                 fn to_html(self, style: &mut String) {
                     let value = self.try_get();
-                    value.to_html(style);
+                    if let Some(value) = value {
+                        value.to_html(style);
+                    }
+                    else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn hydrate<const FROM_SERVER: bool>(self, el: &crate::renderer::types::Element) -> Self::State {
@@ -291,10 +296,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -309,10 +314,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -327,11 +332,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None,  // unreachable!()
                             }
                         },
                         prev_value,
@@ -388,6 +393,8 @@ mod stable {
                         style.push(':');
                         style.push_str(&value.into());
                         style.push(';');
+                    } else {
+                        crate::dispose_warn!();
                     }
                 }
 
@@ -414,7 +421,10 @@ mod stable {
                                     }
                                     (style.clone(), Some(value))
                                 }
-                                _ => (style.clone(), None),
+                                _ => {
+                                    crate::dispose_warn!();
+                                    (style.clone(), None)
+                                },
                             }
                         }),
                     )
@@ -442,7 +452,10 @@ mod stable {
                                     Rndr::set_css_property(&style, name, &value);
                                     (style.clone(), Some(value))
                                 }
-                                _ => (style.clone(), None),
+                                _ => {
+                                    crate::dispose_warn!();
+                                    (style.clone(), None)
+                                },
                             }
                         }),
                     )
@@ -463,9 +476,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, Some(prev))), None) => (style, Some(prev)),
-                                (Some((style, None)), Some(_)) => (style, None),
-                                (Some((style, None)), None) => (style, None),
+                                (Some((style, _)), None) | (Some((style, None)), Some(_)) => {
+                                    crate::dispose_warn!();
+                                    (style, None)
+                                }
                                 (None, _) => unreachable!(),
                             }
                         },
@@ -527,7 +541,12 @@ mod stable {
 
                 fn to_html(self, style: &mut String) {
                     let value = self.try_get();
-                    value.to_html(style);
+                    if let Some(value) = value {
+                        value.to_html(style);
+                    }
+                    else {
+                        crate::dispose_warn!();
+                    }
                 }
 
                 fn hydrate<const FROM_SERVER: bool>(
@@ -547,10 +566,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -565,10 +584,10 @@ mod stable {
                                 Some(state)
                             }
                             (None, Some(value)) => Some(value.build(&el)),
-                            (Some(Some(state)), None) => Some(state),
-                            (Some(None), Some(value)) => Some(value.build(&el)),
-                            (Some(None), None) => None,
-                            (None, None) => None,
+                            (_, None) | (Some(None), _) => {
+                                crate::dispose_warn!();
+                                None
+                            }
                         }
                     })
                 }
@@ -583,11 +602,11 @@ mod stable {
                                     value.rebuild(&mut state);
                                     Some(state)
                                 }
-                                (Some(Some(state)), None) => Some(state),
-                                (Some(None), Some(_)) => None,
-                                (Some(None), None) => None,
-                                (None, Some(_)) => None, // unreachable!()
-                                (None, None) => None,    // unreachable!()
+                                (_, None) | (Some(None), _) => {
+                                    crate::dispose_warn!();
+                                    None
+                                }
+                                (None, _) => None,  // unreachable!()
                             }
                         },
                         prev_value,
@@ -645,6 +664,8 @@ mod stable {
                         style.push(':');
                         style.push_str(&value.into());
                         style.push(';');
+                    } else {
+                        crate::dispose_warn!();
                     }
                 }
 
@@ -674,7 +695,10 @@ mod stable {
                                     }
                                     (style.clone(), Some(value))
                                 }
-                                _ => (style.clone(), None),
+                                _ => {
+                                    crate::dispose_warn!();
+                                    (style.clone(), None)
+                                },
                             }
                         }),
                     )
@@ -702,7 +726,10 @@ mod stable {
                                     Rndr::set_css_property(&style, name, &value);
                                     (style.clone(), Some(value))
                                 }
-                                _ => (style.clone(), None),
+                                _ => {
+                                    crate::dispose_warn!();
+                                    (style.clone(), None)
+                                },
                             }
                         }),
                     )
@@ -723,9 +750,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, Some(prev))), None) => (style, Some(prev)),
-                                (Some((style, None)), Some(_)) => (style, None),
-                                (Some((style, None)), None) => (style, None),
+                                (Some((style, _)), None) | (Some((style, None)), Some(_)) => {
+                                    crate::dispose_warn!();
+                                    (style, None)
+                                }
                                 (None, _) => unreachable!(),
                             }
                         },


### PR DESCRIPTION
This PR replaces the use of `get()` with `try_get()` for retrieving signal values in these trait implementations:
- `IntoProperty`
- `IntoClass`
- `IntoStyle`
- `Render`
- `RenderHtml`
- `AttributeValue`
- `InnerHtmlValue`
This change prevents potential panics when the signal is disposed.
As a result, I've replaced most `if let` blocks in `RenderEffect`s with `match` statements to handle different variations of the previous state and the signal value better. 
There are some match arms that don't make much sense to me, which usually happens when a signal is disposed, so I just returned `None` or the previous state if it was possible.