### PR TITLE
Handle `erase_components` on `Either<A, B>`

### DIFF
--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -116,6 +116,7 @@ const fn max_usize(vals: &[usize]) -> usize {
     max
 }
 
+#[cfg(not(erase_components))]
 impl<A, B> NextAttribute for Either<A, B>
 where
     B: NextAttribute,
@@ -134,6 +135,31 @@ where
             Either::Left(left) => Either::Left(left.add_any_attr(new_attr)),
             Either::Right(right) => Either::Right(right.add_any_attr(new_attr)),
         }
+    }
+}
+
+#[cfg(erase_components)]
+use crate::html::attribute::any_attribute::{AnyAttribute, IntoAnyAttribute};
+
+#[cfg(erase_components)]
+impl<A, B> NextAttribute for Either<A, B>
+where
+    B: IntoAnyAttribute,
+    A: IntoAnyAttribute,
+{
+    type Output<NewAttr: Attribute> = Vec<AnyAttribute>;
+
+    fn add_any_attr<NewAttr: Attribute>(
+        self,
+        new_attr: NewAttr,
+    ) -> Self::Output<NewAttr> {
+        vec![
+            match self {
+                Either::Left(left) => left.into_any_attr(),
+                Either::Right(right) => right.into_any_attr(),
+            },
+            new_attr.into_any_attr(),
+        ]
     }
 }
 

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -170,10 +170,10 @@ where
 {
     const MIN_LENGTH: usize = max_usize(&[A::MIN_LENGTH, B::MIN_LENGTH]);
 
-    type AsyncOutput = (Either<A::AsyncOutput, B::AsyncOutput>,);
+    type AsyncOutput = Either<A::AsyncOutput, B::AsyncOutput>;
     type State = Either<A::State, B::State>;
-    type Cloneable = (Either<A::Cloneable, B::Cloneable>,);
-    type CloneableOwned = (Either<A::CloneableOwned, B::CloneableOwned>,);
+    type Cloneable = Either<A::Cloneable, B::Cloneable>;
+    type CloneableOwned = Either<A::CloneableOwned, B::CloneableOwned>;
 
     fn html_len(&self) -> usize {
         match self {
@@ -232,17 +232,17 @@ where
     }
 
     fn into_cloneable(self) -> Self::Cloneable {
-        (match self {
+        match self {
             Either::Left(left) => Either::Left(left.into_cloneable()),
             Either::Right(right) => Either::Right(right.into_cloneable()),
-        },)
+        }
     }
 
     fn into_cloneable_owned(self) -> Self::CloneableOwned {
-        (match self {
+        match self {
             Either::Left(left) => Either::Left(left.into_cloneable_owned()),
             Either::Right(right) => Either::Right(right.into_cloneable_owned()),
-        },)
+        }
     }
 
     fn dry_resolve(&mut self) {
@@ -253,10 +253,10 @@ where
     }
 
     async fn resolve(self) -> Self::AsyncOutput {
-        (match self {
+        match self {
             Either::Left(left) => Either::Left(left.resolve().await),
             Either::Right(right) => Either::Right(right.resolve().await),
-        },)
+        }
     }
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/leptos-rs/leptos/issues/3556#issuecomment-2646165698 by @luxalpa, the changes I introduced in #3556 broke the `--cfg=erase_components` mode.