### PR TITLE
RenderHtml::into_owned

### DIFF
--- a/leptos/src/attribute_interceptor.rs
+++ b/leptos/src/attribute_interceptor.rs
@@ -43,7 +43,7 @@ pub fn AttributeInterceptor<Chil, T>(
 ) -> impl IntoView
 where
     Chil: Fn(AnyAttribute) -> T + Send + Sync + 'static,
-    T: IntoView,
+    T: IntoView + 'static,
 {
     AttributeInterceptorInner::new(children)
 }
@@ -86,7 +86,7 @@ impl<T: IntoView, A: Attribute> Render for AttributeInterceptorInner<T, A> {
     }
 }
 
-impl<T: IntoView, A> AddAnyAttr for AttributeInterceptorInner<T, A>
+impl<T: IntoView + 'static, A> AddAnyAttr for AttributeInterceptorInner<T, A>
 where
     A: Attribute,
 {
@@ -114,8 +114,11 @@ where
     }
 }
 
-impl<T: IntoView, A: Attribute> RenderHtml for AttributeInterceptorInner<T, A> {
+impl<T: IntoView + 'static, A: Attribute> RenderHtml
+    for AttributeInterceptorInner<T, A>
+{
     type AsyncOutput = T::AsyncOutput;
+    type Owned = AttributeInterceptorInner<T, A::CloneableOwned>;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -152,5 +155,13 @@ impl<T: IntoView, A: Attribute> RenderHtml for AttributeInterceptorInner<T, A> {
         position: &leptos::tachys::view::PositionState,
     ) -> Self::State {
         self.children.hydrate::<FROM_SERVER>(cursor, position)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        AttributeInterceptorInner {
+            children_builder: self.children_builder,
+            children: self.children,
+            attributes: self.attributes.into_cloneable_owned(),
+        }
     }
 }

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -276,6 +276,7 @@ where
     Fal: RenderHtml + Send + 'static,
 {
     type AsyncOutput = ErrorBoundaryView<Chil::AsyncOutput, FalFn>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = Chil::MIN_LENGTH;
 
@@ -436,6 +437,10 @@ where
                 }
             },
         )
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -87,6 +87,7 @@ impl<T: Render> Render for View<T> {
 
 impl<T: RenderHtml> RenderHtml for View<T> {
     type AsyncOutput = T::AsyncOutput;
+    type Owned = View<T::Owned>;
 
     const MIN_LENGTH: usize = <T as RenderHtml>::MIN_LENGTH;
 
@@ -164,6 +165,14 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         position: &PositionState,
     ) -> Self::State {
         self.inner.hydrate::<FROM_SERVER>(cursor, position)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        View {
+            inner: self.inner.into_owned(),
+            #[cfg(debug_assertions)]
+            view_marker: self.view_marker,
+        }
     }
 }
 

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -247,6 +247,7 @@ where
     // i.e., if this is the child of another Suspense during SSR, don't wait for it: it will handle
     // itself
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = Chil::MIN_LENGTH;
 
@@ -473,6 +474,10 @@ where
             }
         })
     }
+
+    fn into_owned(self) -> Self::Owned {
+        self
+    }
 }
 
 /// A wrapper that prevents [`Suspense`] from waiting for any resource reads that happen inside
@@ -525,6 +530,7 @@ where
     T: RenderHtml + 'static,
 {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -576,5 +582,9 @@ where
         position: &PositionState,
     ) -> Self::State {
         (self.0)().hydrate::<FROM_SERVER>(cursor, position)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -135,6 +135,7 @@ mod view_implementations {
         Ser: Send + 'static,
     {
         type AsyncOutput = Option<T>;
+        type Owned = Self;
 
         const MIN_LENGTH: usize = 0;
 
@@ -190,6 +191,10 @@ mod view_implementations {
         ) -> Self::State {
             (move || Suspend::new(async move { self.await }))
                 .hydrate::<FROM_SERVER>(cursor, position)
+        }
+
+        fn into_owned(self) -> Self::Owned {
+            self
         }
     }
 }

--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -103,6 +103,7 @@ where
     At: Attribute,
 {
     type AsyncOutput = BodyView<At::AsyncOutput>;
+    type Owned = BodyView<At::CloneableOwned>;
 
     const MIN_LENGTH: usize = At::MIN_LENGTH;
 
@@ -145,6 +146,12 @@ where
         let attributes = self.attributes.hydrate::<FROM_SERVER>(&el);
 
         BodyViewState { attributes }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        BodyView {
+            attributes: self.attributes.into_cloneable_owned(),
+        }
     }
 }
 

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -103,6 +103,7 @@ where
     At: Attribute,
 {
     type AsyncOutput = HtmlView<At::AsyncOutput>;
+    type Owned = HtmlView<At::CloneableOwned>;
 
     const MIN_LENGTH: usize = At::MIN_LENGTH;
 
@@ -148,6 +149,12 @@ where
         let attributes = self.attributes.hydrate::<FROM_SERVER>(&el);
 
         HtmlViewState { attributes }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        HtmlView {
+            attributes: self.attributes.into_cloneable_owned(),
+        }
     }
 }
 

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -430,6 +430,7 @@ where
     Ch: RenderHtml + Send,
 {
     type AsyncOutput = Self;
+    type Owned = RegisteredMetaTag<E, At::CloneableOwned, Ch::Owned>;
 
     const MIN_LENGTH: usize = 0;
 
@@ -469,6 +470,12 @@ where
             &PositionState::new(Position::NextChild),
         );
         RegisteredMetaTagState { state }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        RegisteredMetaTag {
+            el: self.el.map(|inner| inner.into_owned()),
+        }
     }
 }
 
@@ -547,6 +554,7 @@ impl AddAnyAttr for MetaTagsView {
 
 impl RenderHtml for MetaTagsView {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -572,6 +580,10 @@ impl RenderHtml for MetaTagsView {
         _cursor: &Cursor,
         _position: &PositionState,
     ) -> Self::State {
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -234,6 +234,7 @@ impl AddAnyAttr for TitleView {
 
 impl RenderHtml for TitleView {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -282,6 +283,10 @@ impl RenderHtml for TitleView {
             }
         });
         TitleViewState { effect }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -348,7 +348,7 @@ impl<Loc, Defs, FalFn, Fal> AddAnyAttr for FlatRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
     Defs: MatchNestedRoutes + Send + 'static,
-    FalFn: FnOnce() -> Fal + Send,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type Output<SomeNewAttr: leptos::attr::Attribute> =
@@ -421,10 +421,11 @@ impl<Loc, Defs, FalFn, Fal> RenderHtml for FlatRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
     Defs: MatchNestedRoutes + Send + 'static,
-    FalFn: FnOnce() -> Fal + Send,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = <Either<Fal, AnyView> as RenderHtml>::MIN_LENGTH;
 
@@ -617,5 +618,9 @@ where
                 }
             }
         }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -228,8 +228,8 @@ where
 impl<Loc, Defs, Fal, FalFn> AddAnyAttr for NestedRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
-    Defs: MatchNestedRoutes + Send,
-    FalFn: FnOnce() -> Fal + Send,
+    Defs: MatchNestedRoutes + Send + 'static,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type Output<SomeNewAttr: leptos::attr::Attribute> =
@@ -249,11 +249,12 @@ where
 impl<Loc, Defs, FalFn, Fal> RenderHtml for NestedRoutesView<Loc, Defs, FalFn>
 where
     Loc: LocationProvider + Send,
-    Defs: MatchNestedRoutes + Send,
-    FalFn: FnOnce() -> Fal + Send,
+    Defs: MatchNestedRoutes + Send + 'static,
+    FalFn: FnOnce() -> Fal + Send + 'static,
     Fal: RenderHtml + 'static,
 {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0; // TODO
 
@@ -464,6 +465,10 @@ where
             outlets,
             view,
         }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -222,6 +222,7 @@ where
     Ch: RenderHtml + Send,
 {
     type AsyncOutput = HtmlElement<E, At::AsyncOutput, Ch::AsyncOutput>;
+    type Owned = HtmlElement<E, At::CloneableOwned, Ch::Owned>;
 
     const MIN_LENGTH: usize = if E::SELF_CLOSING {
         3 // < ... />
@@ -404,6 +405,16 @@ where
             el,
             attrs,
             children,
+        }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        HtmlElement {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: self.defined_at,
+            tag: self.tag,
+            attributes: self.attributes.into_cloneable_owned(),
+            children: self.children.into_owned(),
         }
     }
 }

--- a/tachys/src/html/islands.rs
+++ b/tachys/src/html/islands.rs
@@ -100,6 +100,7 @@ where
     View: RenderHtml,
 {
     type AsyncOutput = Island<View::AsyncOutput>;
+    type Owned = Island<View::Owned>;
 
     const MIN_LENGTH: usize = ISLAND_TAG.len() * 2
         + "<>".len()
@@ -187,6 +188,14 @@ where
 
         self.view.hydrate::<FROM_SERVER>(cursor, position)
     }
+
+    fn into_owned(self) -> Self::Owned {
+        Island {
+            component: self.component,
+            props_json: self.props_json,
+            view: self.view.into_owned(),
+        }
+    }
 }
 
 /// The children that will be projected into an [`Island`].
@@ -267,6 +276,7 @@ where
     View: RenderHtml,
 {
     type AsyncOutput = IslandChildren<View::AsyncOutput>;
+    type Owned = IslandChildren<View::Owned>;
 
     const MIN_LENGTH: usize = ISLAND_CHILDREN_TAG.len() * 2
         + "<>".len()
@@ -370,6 +380,13 @@ where
                 &wasm_bindgen::JsValue::from_str("$$on_hydrate"),
                 &cb.into_js_value(),
             );
+        }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        IslandChildren {
+            view: self.view.into_owned(),
+            on_hydrate: self.on_hydrate,
         }
     }
 }

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -53,6 +53,7 @@ no_attrs!(Doctype);
 
 impl RenderHtml for Doctype {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = "<!DOCTYPE html>".len();
 
@@ -80,6 +81,10 @@ impl RenderHtml for Doctype {
         _cursor: &Cursor,
         _position: &PositionState,
     ) -> Self::State {
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 
@@ -155,6 +160,7 @@ impl AddAnyAttr for InertElement {
 
 impl RenderHtml for InertElement {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -195,5 +201,9 @@ impl RenderHtml for InertElement {
             .unwrap();
         position.set(Position::NextChild);
         InertElementState(self.html, el)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }

--- a/tachys/src/oco.rs
+++ b/tachys/src/oco.rs
@@ -39,6 +39,7 @@ no_attrs!(Oco<'static, str>);
 
 impl RenderHtml for Oco<'static, str> {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -76,6 +77,10 @@ impl RenderHtml for Oco<'static, str> {
             this, cursor, position,
         );
         OcoStrState { node, str: self }
+    }
+
+    fn into_owned(self) -> <Self as RenderHtml>::Owned {
+        self
     }
 }
 

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -135,6 +135,7 @@ where
     V::State: 'static,
 {
     type AsyncOutput = V::AsyncOutput;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -209,6 +210,10 @@ where
             }
         })
         .into()
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 
@@ -605,6 +610,7 @@ mod stable {
                 V::State: 'static,
             {
                 type AsyncOutput = Self;
+                type Owned = Self;
 
                 const MIN_LENGTH: usize = 0;
 
@@ -667,6 +673,10 @@ mod stable {
                 ) -> Self::State {
                     (move || self.get())
                         .hydrate::<FROM_SERVER>(cursor, position)
+                }
+
+                fn into_owned(self) -> Self::Owned {
+                    self
                 }
             }
 
@@ -788,6 +798,7 @@ mod stable {
                 V::State: 'static,
             {
                 type AsyncOutput = Self;
+                type Owned = Self;
 
                 const MIN_LENGTH: usize = 0;
 
@@ -850,6 +861,10 @@ mod stable {
                 ) -> Self::State {
                     (move || self.get())
                         .hydrate::<FROM_SERVER>(cursor, position)
+                }
+
+                fn into_owned(self) -> Self::Owned {
+                    self
                 }
             }
 

--- a/tachys/src/reactive_graph/owned.rs
+++ b/tachys/src/reactive_graph/owned.rs
@@ -92,6 +92,7 @@ where
 {
     // TODO
     type AsyncOutput = OwnedView<T::AsyncOutput>;
+    type Owned = OwnedView<T::Owned>;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -162,6 +163,13 @@ where
 
     fn dry_resolve(&mut self) {
         self.owner.with(|| self.view.dry_resolve());
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        OwnedView {
+            owner: self.owner,
+            view: self.view.into_owned(),
+        }
     }
 }
 

--- a/tachys/src/reactive_graph/suspense.rs
+++ b/tachys/src/reactive_graph/suspense.rs
@@ -288,6 +288,7 @@ where
     T: RenderHtml + Sized + 'static,
 {
     type AsyncOutput = Option<T>;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -471,5 +472,9 @@ where
             self.inner = Box::pin(async move { inner })
                 as Pin<Box<dyn Future<Output = T> + Send>>;
         }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }

--- a/tachys/src/view/error_boundary.rs
+++ b/tachys/src/view/error_boundary.rs
@@ -136,6 +136,7 @@ where
     E: Into<AnyError> + Send + 'static,
 {
     type AsyncOutput = Result<T::AsyncOutput, E>;
+    type Owned = Result<T::Owned, E>;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -227,5 +228,12 @@ where
             }
         };
         ResultState { state, error, hook }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        match self {
+            Ok(view) => Ok(view.into_owned()),
+            Err(e) => Err(e),
+        }
     }
 }

--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -60,6 +60,7 @@ where
     T: RenderHtml,
 {
     type AsyncOutput = Option<T::AsyncOutput>;
+    type Owned = Option<T::Owned>;
 
     const MIN_LENGTH: usize = T::MIN_LENGTH;
 
@@ -138,6 +139,10 @@ where
             None => Either::Right(()),
         }
         .hydrate::<FROM_SERVER>(cursor, position)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self.map(RenderHtml::into_owned)
     }
 }
 
@@ -273,6 +278,7 @@ where
     T: RenderHtml,
 {
     type AsyncOutput = Vec<T::AsyncOutput>;
+    type Owned = Vec<T::Owned>;
 
     const MIN_LENGTH: usize = 0;
 
@@ -370,6 +376,12 @@ where
 
         VecState { states, marker }
     }
+
+    fn into_owned(self) -> Self::Owned {
+        self.into_iter()
+            .map(RenderHtml::into_owned)
+            .collect::<Vec<_>>()
+    }
 }
 
 impl<T, const N: usize> Render for [T; N]
@@ -459,6 +471,7 @@ where
     T: RenderHtml,
 {
     type AsyncOutput = [T::AsyncOutput; N];
+    type Owned = [T::Owned; N];
 
     const MIN_LENGTH: usize = 0;
 
@@ -529,5 +542,13 @@ where
         let states =
             self.map(|child| child.hydrate::<FROM_SERVER>(cursor, position));
         ArrayState { states }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self.into_iter()
+            .map(RenderHtml::into_owned)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap_or_else(|_| unreachable!())
     }
 }

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -131,9 +131,9 @@ where
 
 impl<T, I, K, KF, VF, VFS, V> AddAnyAttr for Keyed<T, I, K, KF, VF, VFS, V>
 where
-    I: IntoIterator<Item = T> + Send,
+    I: IntoIterator<Item = T> + Send + 'static,
     K: Eq + Hash + 'static,
-    KF: Fn(&T) -> K + Send,
+    KF: Fn(&T) -> K + Send + 'static,
     V: RenderHtml,
     V: 'static,
     VF: Fn(usize, T) -> (VFS, V) + Send + 'static,
@@ -184,15 +184,16 @@ where
 
 impl<T, I, K, KF, VF, VFS, V> RenderHtml for Keyed<T, I, K, KF, VF, VFS, V>
 where
-    I: IntoIterator<Item = T> + Send,
+    I: IntoIterator<Item = T> + Send + 'static,
     K: Eq + Hash + 'static,
-    KF: Fn(&T) -> K + Send,
+    KF: Fn(&T) -> K + Send + 'static,
     V: RenderHtml + 'static,
     VF: Fn(usize, T) -> (VFS, V) + Send + 'static,
     VFS: Fn(usize) + 'static,
     T: 'static,
 {
     type AsyncOutput = Vec<V::AsyncOutput>; // TODO
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -291,6 +292,10 @@ where
             hashed_items,
             rendered_items,
         }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -99,6 +99,9 @@ where
     /// The type of the view after waiting for all asynchronous data to load.
     type AsyncOutput: RenderHtml;
 
+    /// An equivalent value that is `'static`.
+    type Owned: RenderHtml + 'static;
+
     /// The minimum length of HTML created when this view is rendered.
     const MIN_LENGTH: usize;
 
@@ -298,6 +301,9 @@ where
         let position = PositionState::new(position);
         self.hydrate::<FROM_SERVER>(&cursor, &position)
     }
+
+    /// Convert into the equivalent value that is `'static`.
+    fn into_owned(self) -> Self::Owned;
 }
 
 /// Allows a type to be mounted to the DOM.

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -70,6 +70,7 @@ macro_rules! render_primitive {
 			impl RenderHtml for $child_type
 			{
 				type AsyncOutput = Self;
+				type Owned = Self;
 
 				const MIN_LENGTH: usize = 0;
 
@@ -114,6 +115,10 @@ macro_rules! render_primitive {
 					position.set(Position::NextChildAfterText);
 
 					[<$child_type:camel State>](node, self)
+				}
+
+				fn into_owned(self) -> Self::Owned {
+					self
 				}
 			}
 

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -159,6 +159,7 @@ where
 
 impl<const V: &'static str> RenderHtml for Static<V> {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = V.len();
 
@@ -220,6 +221,10 @@ impl<const V: &'static str> RenderHtml for Static<V> {
         position.set(Position::NextChildAfterText);
 
         Some(node)
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -39,6 +39,7 @@ impl<'a> Render for &'a str {
 
 impl RenderHtml for &str {
     type AsyncOutput = Self;
+    type Owned = String;
 
     const MIN_LENGTH: usize = 0;
 
@@ -103,6 +104,10 @@ impl RenderHtml for &str {
         position.set(Position::NextChildAfterText);
 
         StrState { node, str: self }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self.to_string()
     }
 }
 
@@ -172,6 +177,7 @@ impl Render for String {
 impl RenderHtml for String {
     const MIN_LENGTH: usize = 0;
     type AsyncOutput = Self;
+    type Owned = Self;
 
     fn dry_resolve(&mut self) {}
 
@@ -209,6 +215,10 @@ impl RenderHtml for String {
         let StrState { node, .. } =
             self.as_str().hydrate::<FROM_SERVER>(cursor, position);
         StringState { node, str: self }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 
@@ -371,6 +381,7 @@ impl Render for Arc<str> {
 
 impl RenderHtml for Arc<str> {
     type AsyncOutput = Self;
+    type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
 
@@ -411,6 +422,10 @@ impl RenderHtml for Arc<str> {
         let StrState { node, .. } =
             this.hydrate::<FROM_SERVER>(cursor, position);
         ArcStrState { node, str: self }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self
     }
 }
 
@@ -477,6 +492,7 @@ impl<'a> Render for Cow<'a, str> {
 
 impl RenderHtml for Cow<'_, str> {
     type AsyncOutput = Self;
+    type Owned = String;
 
     const MIN_LENGTH: usize = 0;
 
@@ -517,6 +533,10 @@ impl RenderHtml for Cow<'_, str> {
         let StrState { node, .. } =
             this.hydrate::<FROM_SERVER>(cursor, position);
         CowStrState { node, str: self }
+    }
+
+    fn into_owned(self) -> <Self as RenderHtml>::Owned {
+        self.into_owned()
     }
 }
 

--- a/tachys/src/view/template.rs
+++ b/tachys/src/view/template.rs
@@ -76,6 +76,7 @@ where
     V::State: Mountable,
 {
     type AsyncOutput = V::AsyncOutput;
+    type Owned = V::Owned;
 
     const MIN_LENGTH: usize = V::MIN_LENGTH;
 
@@ -110,6 +111,10 @@ where
 
     async fn resolve(self) -> Self::AsyncOutput {
         self.view.resolve().await
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self.view.into_owned()
     }
 }
 

--- a/tachys/src/view/tuples.rs
+++ b/tachys/src/view/tuples.rs
@@ -23,6 +23,7 @@ impl Render for () {
 
 impl RenderHtml for () {
     type AsyncOutput = ();
+    type Owned = ();
 
     const MIN_LENGTH: usize = 3;
     const EXISTS: bool = false;
@@ -52,6 +53,8 @@ impl RenderHtml for () {
     async fn resolve(self) -> Self::AsyncOutput {}
 
     fn dry_resolve(&mut self) {}
+
+    fn into_owned(self) -> Self::Owned {}
 }
 
 impl AddAnyAttr for () {
@@ -117,6 +120,7 @@ where
     A: RenderHtml,
 {
     type AsyncOutput = (A::AsyncOutput,);
+    type Owned = (A::Owned,);
 
     const MIN_LENGTH: usize = A::MIN_LENGTH;
 
@@ -174,6 +178,10 @@ where
 
     fn dry_resolve(&mut self) {
         self.0.dry_resolve();
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        (self.0.into_owned(),)
     }
 }
 
@@ -247,6 +255,7 @@ macro_rules! impl_view_for_tuples {
 
 		{
             type AsyncOutput = ($first::AsyncOutput, $($ty::AsyncOutput,)*);
+            type Owned = ($first::Owned, $($ty::Owned,)*);
 
             const MIN_LENGTH: usize = $first::MIN_LENGTH $(+ $ty::MIN_LENGTH)*;
 
@@ -310,6 +319,15 @@ macro_rules! impl_view_for_tuples {
                 let ($first, $($ty,)*) = self;
                 $first.dry_resolve();
                 $($ty.dry_resolve());*
+            }
+
+            fn into_owned(self) -> Self::Owned {
+                #[allow(non_snake_case)]
+                let ($first, $($ty,)*) = self;
+                (
+                    $first.into_owned(),
+                    $($ty.into_owned()),*
+                )
             }
 		}
 


### PR DESCRIPTION
As discussed [here](https://github.com/leptos-rs/leptos/pull/3562#issuecomment-2646745564) this allows removing the static requirement from `IntoAny` to prevent compile errors on switching to erased mode.