### PR TITLE
Implement several into traits for store fields

### DIFF
--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -14,17 +14,22 @@ use crate::{
     renderer::{types::Element, RemoveEventHandler},
     view::{Position, ToTemplate},
 };
-#[cfg(feature = "reactive_stores")]
-use reactive_graph::owner::Storage;
 use reactive_graph::{
     signal::{ReadSignal, RwSignal, WriteSignal},
     traits::{Get, Update},
     wrappers::read::Signal,
 };
-#[cfg(feature = "reactive_stores")]
-use reactive_stores::{ArcField, Field, KeyedSubfield, Subfield};
 use send_wrapper::SendWrapper;
 use wasm_bindgen::JsValue;
+#[cfg(feature = "reactive_stores")]
+use {
+    reactive_graph::owner::Storage,
+    reactive_stores::{
+        ArcField, AtIndex, AtKeyed, DerefedField, Field, KeyedSubfield,
+        StoreField, Subfield,
+    },
+    std::ops::{Deref, DerefMut, IndexMut},
+};
 
 /// `group` attribute used for radio inputs with `bind`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -387,6 +392,57 @@ where
     for<'a> &'a T: IntoIterator,
 {
     type Value = T;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<Inner, Prev, K, T> IntoSplitSignal for AtKeyed<Inner, Prev, K, T>
+where
+    Self: Get<Value = T> + Update<Value = T> + Clone,
+    for<'a> &'a T: IntoIterator,
+{
+    type Value = T;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<Inner, Prev> IntoSplitSignal for AtIndex<Inner, Prev>
+where
+    Prev: Send + Sync + IndexMut<usize> + 'static,
+    Inner: Send + Sync + Clone + 'static,
+    Self: Get<Value = Prev::Output> + Update<Value = Prev::Output> + Clone,
+    Prev::Output: Sized,
+{
+    type Value = Prev::Output;
+    type Read = Self;
+    type Write = Self;
+
+    fn into_split_signal(self) -> (Self::Read, Self::Write) {
+        (self.clone(), self.clone())
+    }
+}
+
+#[cfg(feature = "reactive_stores")]
+impl<S> IntoSplitSignal for DerefedField<S>
+where
+    Self: Get<Value = <S::Value as Deref>::Target>
+        + Update<Value = <S::Value as Deref>::Target>
+        + Clone,
+    S: Clone + StoreField + Send + Sync + 'static,
+    <S as StoreField>::Value: Deref + DerefMut,
+    <S::Value as Deref>::Target: Sized,
+{
+    type Value = <S::Value as Deref>::Target;
     type Read = Self;
     type Write = Self;
 

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -1095,6 +1095,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! class_store_field {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
@@ -1220,6 +1221,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! tuple_class_store_field {
         ($name:ident, <$($impl_gen:ident),*>, <$($gen:ident),*> , $v:ty, $( $where_clause:tt )*) => {
             impl<$($impl_gen),*>  IntoClass for (&'static str, $name<$($gen),*>)
@@ -1397,12 +1399,16 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use reactive_stores::{
-        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
-        KeyedSubfield, Store, StoreField, Subfield,
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
     };
-    use std::ops::{Deref, DerefMut, Index, IndexMut};
 
+    #[cfg(feature = "reactive_stores")]
     class_store_field!(
         Subfield,
         <Inner, Prev, V>,
@@ -1411,6 +1417,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     class_store_field!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -1421,6 +1429,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     class_store_field!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -1431,6 +1441,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     class_store_field!(
         DerefedField,
         <S>,
@@ -1439,6 +1451,7 @@ mod stable {
         <S as StoreField>::Value: Deref + DerefMut
     );
 
+    #[cfg(feature = "reactive_stores")]
     class_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -1448,6 +1461,7 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     tuple_class_store_field!(
         Subfield,
         <Inner, Prev>,
@@ -1457,6 +1471,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_class_store_field!(
         AtKeyed,
         <Inner, Prev, K>,
@@ -1468,6 +1484,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a bool: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_class_store_field!(
         KeyedSubfield,
         <Inner, Prev, K>,
@@ -1479,6 +1497,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a bool: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_class_store_field!(
         DerefedField,
         <S>,
@@ -1488,6 +1508,7 @@ mod stable {
         <S as StoreField>::Value: Deref<Target = bool> + DerefMut
     );
 
+    #[cfg(feature = "reactive_stores")]
     tuple_class_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -1498,14 +1519,18 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     class_signal_arena!(Store);
+    #[cfg(feature = "reactive_stores")]
     class_signal_arena!(Field);
     class_signal_arena!(RwSignal);
     class_signal_arena!(ReadSignal);
     class_signal_arena!(Memo);
     class_signal_arena!(Signal);
     class_signal_arena!(MaybeSignal);
+    #[cfg(feature = "reactive_stores")]
     class_signal!(ArcStore);
+    #[cfg(feature = "reactive_stores")]
     class_signal!(ArcField);
     class_signal!(ArcRwSignal);
     class_signal!(ArcReadSignal);

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -605,8 +605,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -635,7 +635,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -894,8 +894,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -924,7 +924,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -529,7 +529,7 @@ mod stable {
                 C::State: 'static,
             {
                 type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
+                type State = RenderEffect<Option<C::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -538,7 +538,7 @@ mod stable {
                 }
 
                 fn to_html(self, class: &mut String) {
-                    let value = self.get();
+                    let value = self.try_get();
                     value.to_html(class);
                 }
 
@@ -546,18 +546,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el)
+                    // TODO FROM_SERVER vs template
+                    let el = el.clone();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).build(el)
+                    let el = el.to_owned();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.build(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    (move || self.get()).rebuild(state)
+                    let prev_value = state.take_value();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -576,13 +629,13 @@ mod stable {
 
                 fn reset(state: &mut Self::State) {
                     *state = RenderEffect::new_with_value(
-                        move |prev| {
-                            if let Some(mut state) = prev {
+                        move |prev| match (prev) {
+                            Some(Some(mut state)) => {
                                 C::reset(&mut state);
-                                state
-                            } else {
-                                unreachable!()
+                                Some(state)
                             }
+                            Some(None) => None,
+                            None => None,
                         },
                         state.take_value(),
                     );
@@ -610,7 +663,7 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.get();
+                    let include = f.try_get().unwrap_or(false);
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -620,9 +673,31 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::hydrate::<FROM_SERVER>(
-                        (self.0, move || self.1.get()),
-                        el,
+                    // TODO FROM_SERVER vs template
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                if let Some((class_list, prev)) = prev {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
                     )
                 }
 
@@ -630,11 +705,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::build((self.0, move || self.1.get()), el)
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                match prev {
+                                    Some((class_list, prev)) => {
+                                        if include {
+                                            if !prev {
+                                                Rndr::add_class(
+                                                    &class_list,
+                                                    name,
+                                                );
+                                            }
+                                        } else if prev {
+                                            Rndr::remove_class(
+                                                &class_list,
+                                                name,
+                                            );
+                                        }
+                                    }
+                                    None => {
+                                        if include {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
+                    )
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    IntoClass::rebuild((self.0, move || self.1.get()), state)
+                    let (name, f) = self;
+                    // Name might've updated:
+                    state.name = name;
+                    state.effect = RenderEffect::new_with_value(
+                        move |prev| {
+                            let include = f.try_get().unwrap_or(false);
+                            match prev {
+                                Some((class_list, prev)) => {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                    (class_list.clone(), include)
+                                }
+                                None => {
+                                    unreachable!()
+                                }
+                            }
+                        },
+                        state.effect.take_value(),
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -683,7 +818,7 @@ mod stable {
                 C::State: 'static,
             {
                 type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
+                type State = RenderEffect<Option<C::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -692,7 +827,7 @@ mod stable {
                 }
 
                 fn to_html(self, class: &mut String) {
-                    let value = self.get();
+                    let value = self.try_get();
                     value.to_html(class);
                 }
 
@@ -700,18 +835,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el)
+                    // TODO FROM_SERVER vs template
+                    let el = el.clone();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    (move || self.get()).build(el)
+                    let el = el.to_owned();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.build(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    (move || self.get()).rebuild(state)
+                    let prev_value = state.take_value();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {
@@ -730,13 +918,13 @@ mod stable {
 
                 fn reset(state: &mut Self::State) {
                     *state = RenderEffect::new_with_value(
-                        move |prev| {
-                            if let Some(mut state) = prev {
+                        move |prev| match (prev) {
+                            Some(Some(mut state)) => {
                                 C::reset(&mut state);
-                                state
-                            } else {
-                                unreachable!()
+                                Some(state)
                             }
+                            Some(None) => None,
+                            None => None,
                         },
                         state.take_value(),
                     );
@@ -761,7 +949,7 @@ mod stable {
 
                 fn to_html(self, class: &mut String) {
                     let (name, f) = self;
-                    let include = f.get();
+                    let include = f.try_get().unwrap_or(false);
                     if include {
                         <&str as IntoClass>::to_html(name, class);
                     }
@@ -771,9 +959,31 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::hydrate::<FROM_SERVER>(
-                        (self.0, move || self.1.get()),
-                        el,
+                    // TODO FROM_SERVER vs template
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                if let Some((class_list, prev)) = prev {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
                     )
                 }
 
@@ -781,11 +991,71 @@ mod stable {
                     self,
                     el: &crate::renderer::types::Element,
                 ) -> Self::State {
-                    IntoClass::build((self.0, move || self.1.get()), el)
+                    let (name, f) = self;
+                    let class_list = Rndr::class_list(el);
+                    let name = Rndr::intern(name);
+
+                    RenderEffectWithClassName::new(
+                        name,
+                        RenderEffect::new(
+                            move |prev: Option<(
+                                crate::renderer::types::ClassList,
+                                bool,
+                            )>| {
+                                let include = f.try_get().unwrap_or(false);
+                                match prev {
+                                    Some((class_list, prev)) => {
+                                        if include {
+                                            if !prev {
+                                                Rndr::add_class(
+                                                    &class_list,
+                                                    name,
+                                                );
+                                            }
+                                        } else if prev {
+                                            Rndr::remove_class(
+                                                &class_list,
+                                                name,
+                                            );
+                                        }
+                                    }
+                                    None => {
+                                        if include {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    }
+                                }
+                                (class_list.clone(), include)
+                            },
+                        ),
+                    )
                 }
 
                 fn rebuild(self, state: &mut Self::State) {
-                    IntoClass::rebuild((self.0, move || self.1.get()), state)
+                    let (name, f) = self;
+                    // Name might've updated:
+                    state.name = name;
+                    state.effect = RenderEffect::new_with_value(
+                        move |prev| {
+                            let include = f.try_get().unwrap_or(false);
+                            match prev {
+                                Some((class_list, prev)) => {
+                                    if include {
+                                        if !prev {
+                                            Rndr::add_class(&class_list, name);
+                                        }
+                                    } else if prev {
+                                        Rndr::remove_class(&class_list, name);
+                                    }
+                                    (class_list.clone(), include)
+                                }
+                                None => {
+                                    unreachable!()
+                                }
+                            }
+                        },
+                        state.effect.take_value(),
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {

--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -99,11 +99,14 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use reactive_stores::{
-        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
-        KeyedSubfield, Store, StoreField, Subfield,
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
     };
-    use std::ops::{Deref, DerefMut, Index, IndexMut};
 
     macro_rules! inner_html_signal {
         ($sig:ident) => {
@@ -336,6 +339,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! inner_html_store_field {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
@@ -451,6 +455,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         Subfield,
         <Inner, Prev, V>,
@@ -459,6 +464,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -469,6 +476,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+    
+    #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -479,6 +488,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         DerefedField,
         <S>,
@@ -486,6 +497,8 @@ mod stable {
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
+    
+    #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -495,14 +508,18 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     inner_html_signal_arena!(Store);
+    #[cfg(feature = "reactive_stores")]
     inner_html_signal_arena!(Field);
     inner_html_signal_arena!(RwSignal);
     inner_html_signal_arena!(ReadSignal);
     inner_html_signal_arena!(Memo);
     inner_html_signal_arena!(Signal);
     inner_html_signal_arena!(MaybeSignal);
+    #[cfg(feature = "reactive_stores")]
     inner_html_signal!(ArcStore);
+    #[cfg(feature = "reactive_stores")]
     inner_html_signal!(ArcField);
     inner_html_signal!(ArcRwSignal);
     inner_html_signal!(ArcReadSignal);

--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -476,7 +476,7 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
-    
+
     #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         KeyedSubfield,
@@ -497,7 +497,7 @@ mod stable {
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
-    
+
     #[cfg(feature = "reactive_stores")]
     inner_html_store_field!(
         AtIndex,

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -526,13 +526,14 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use std::sync::Arc;
-
     use reactive_stores::{
         ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
         KeyedSubfield, Store, StoreField, Subfield,
     };
-    use std::ops::{Deref, DerefMut, Index, IndexMut};
+    use std::{
+        ops::{Deref, DerefMut, Index, IndexMut},
+        sync::Arc,
+    };
 
     macro_rules! signal_impl {
         ($sig:ident $dry_resolve:literal) => {

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -526,13 +526,14 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use reactive_stores::{
-        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
-        KeyedSubfield, Store, StoreField, Subfield,
-    };
-    use std::{
-        ops::{Deref, DerefMut, Index, IndexMut},
-        sync::Arc,
+    use std::sync::Arc;
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
     };
 
     macro_rules! signal_impl {
@@ -1113,6 +1114,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! store_field_impl {
         ($name:ident, <$($gen:ident),*>, $v:ty, $dry_resolve:literal, $( $where_clause:tt )*) =>
         {
@@ -1399,6 +1401,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     store_field_impl!(
         Subfield,
         <Inner, Prev, V>,
@@ -1408,6 +1411,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     store_field_impl!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -1419,6 +1424,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     store_field_impl!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -1430,6 +1437,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     store_field_impl!(
         DerefedField,
         <S>,
@@ -1438,6 +1447,8 @@ mod stable {
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
+
+    #[cfg(feature = "reactive_stores")]
     store_field_impl!(
         AtIndex,
         <Inner, Prev>,
@@ -1448,14 +1459,18 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     signal_impl_arena!(Store false);
+    #[cfg(feature = "reactive_stores")]
     signal_impl_arena!(Field false);
     signal_impl_arena!(RwSignal false);
     signal_impl_arena!(ReadSignal false);
     signal_impl_arena!(Memo true);
     signal_impl_arena!(Signal true);
     signal_impl_arena!(MaybeSignal true);
+    #[cfg(feature = "reactive_stores")]
     signal_impl!(ArcStore false);
+    #[cfg(feature = "reactive_stores")]
     signal_impl!(ArcField false);
     signal_impl!(ArcRwSignal false);
     signal_impl!(ArcReadSignal false);

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -506,10 +506,10 @@ where
 #[cfg(not(feature = "nightly"))]
 mod stable {
     use super::RenderEffectState;
-    use crate::renderer::Rndr;
     use crate::{
         html::attribute::{Attribute, AttributeValue},
         hydration::Cursor,
+        renderer::Rndr,
         ssr::StreamBuilder,
         view::{
             add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -786,8 +786,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -1081,8 +1081,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -457,7 +457,7 @@ mod stable {
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
-    
+
     #[cfg(feature = "reactive_stores")]
     property_store_field!(
         AtIndex,

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -178,8 +178,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -284,8 +284,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -92,11 +92,14 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use reactive_stores::{
-        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
-        KeyedSubfield, Store, StoreField, Subfield,
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
     };
-    use std::ops::{Deref, DerefMut, Index, IndexMut};
 
     macro_rules! property_signal {
         ($sig:ident) => {
@@ -308,6 +311,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! property_store_field {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
@@ -411,6 +415,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     property_store_field!(
         Subfield,
         <Inner, Prev, V>,
@@ -419,6 +424,8 @@ mod stable {
         Prev: 'static,
         Inner: Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     property_store_field!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -429,6 +436,8 @@ mod stable {
         K: std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     property_store_field!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -439,6 +448,8 @@ mod stable {
         K: std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     property_store_field!(
         DerefedField,
         <S>,
@@ -446,6 +457,8 @@ mod stable {
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
+    
+    #[cfg(feature = "reactive_stores")]
     property_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -456,14 +469,18 @@ mod stable {
         Inner: Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     property_signal_arena!(Store);
+    #[cfg(feature = "reactive_stores")]
     property_signal_arena!(Field);
     property_signal_arena!(RwSignal);
     property_signal_arena!(ReadSignal);
     property_signal_arena!(Memo);
     property_signal_arena!(Signal);
     property_signal_arena!(MaybeSignal);
+    #[cfg(feature = "reactive_stores")]
     property_signal!(ArcStore);
+    #[cfg(feature = "reactive_stores")]
     property_signal!(ArcField);
     property_signal!(ArcRwSignal);
     property_signal!(ArcReadSignal);

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -101,7 +101,7 @@ mod stable {
                 V: IntoProperty + Send + Sync + Clone + 'static,
                 V::State: 'static,
             {
-                type State = RenderEffect<V::State>;
+                type State = RenderEffect<Option<V::State>>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -110,7 +110,31 @@ mod stable {
                     el: &crate::renderer::types::Element,
                     key: &str,
                 ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el, key)
+                    let key = Rndr::intern(key);
+                    let key = key.to_owned();
+                    let el = el.to_owned();
+
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state, &key);
+                                Some(state)
+                            }
+                            (None, Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            }
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.hydrate::<FROM_SERVER>(&el, &key))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn build(
@@ -118,11 +142,48 @@ mod stable {
                     el: &crate::renderer::types::Element,
                     key: &str,
                 ) -> Self::State {
-                    (move || self.get()).build(el, key)
+                    let key = Rndr::intern(key);
+                    let key = key.to_owned();
+                    let el = el.to_owned();
+
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state, &key);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el, &key)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => {
+                                Some(value.build(&el, &key))
+                            }
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
                 }
 
                 fn rebuild(self, state: &mut Self::State, key: &str) {
-                    (move || self.get()).rebuild(state, key)
+                    let prev_value = state.take_value();
+                    let key = key.to_owned();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state, &key);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None,
+                                (None, None) => None,
+                            }
+                        },
+                        prev_value,
+                    );
                 }
 
                 fn into_cloneable(self) -> Self::Cloneable {

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -329,8 +329,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -358,7 +358,8 @@ mod stable {
                                 C::reset(&mut state);
                                 Some(state)
                             }
-                            _ => None,
+                            Some(None) => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -581,8 +582,8 @@ mod stable {
                                 (Some(Some(state)), None) => Some(state),
                                 (Some(None), Some(_)) => None,
                                 (Some(None), None) => None,
-                                (None, Some(_)) => None,
-                                (None, None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
                             }
                         },
                         prev_value,
@@ -611,7 +612,7 @@ mod stable {
                                 Some(state)
                             }
                             Some(None) => None,
-                            None => None,
+                            None => None, // unreachable!()
                         },
                         state.take_value(),
                     );
@@ -760,7 +761,6 @@ mod stable {
             }
         };
     }
-
 
     use super::RenderEffect;
     use crate::html::style::IntoStyle;

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -769,6 +769,264 @@ mod stable {
         };
     }
 
+    macro_rules! style_store_field {
+        ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+        {
+            impl<$($gen),*> IntoStyle for $name<$($gen),*>
+            where
+                $v: IntoStyle + Clone + Send + Sync + 'static,
+                <$v as IntoStyle>::State: 'static,
+                $($where_clause)*
+            {
+                type AsyncOutput = Self;
+                type State = RenderEffect<Option<<$v as IntoStyle>::State>>;
+                type Cloneable = Self;
+                type CloneableOwned = Self;
+
+                fn to_html(self, style: &mut String) {
+                    let value = self.try_get();
+                    value.to_html(style);
+                }
+
+                fn hydrate<const FROM_SERVER: bool>(
+                    self,
+                    el: &crate::renderer::types::Element,
+                ) -> Self::State {
+                    // TODO FROM_SERVER vs template
+                    let el = el.clone();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        // Outer Some means there was a previous state
+                        // Inner Some means the previous state was valid
+                        // (i.e., the signal was successfully accessed)
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.hydrate::<FROM_SERVER>(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
+                }
+
+                fn build(self, el: &crate::renderer::types::Element) -> Self::State {
+                    let el = el.to_owned();
+                    RenderEffect::new(move |prev| {
+                        let value = self.try_get();
+                        match (prev, value) {
+                            (Some(Some(mut state)), Some(value)) => {
+                                value.rebuild(&mut state);
+                                Some(state)
+                            }
+                            (None, Some(value)) => Some(value.build(&el)),
+                            (Some(Some(state)), None) => Some(state),
+                            (Some(None), Some(value)) => Some(value.build(&el)),
+                            (Some(None), None) => None,
+                            (None, None) => None,
+                        }
+                    })
+                }
+
+                fn rebuild(self, state: &mut Self::State) {
+                    let prev_value = state.take_value();
+                    *state = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = self.try_get();
+                            match (prev, value) {
+                                (Some(Some(mut state)), Some(value)) => {
+                                    value.rebuild(&mut state);
+                                    Some(state)
+                                }
+                                (Some(Some(state)), None) => Some(state),
+                                (Some(None), Some(_)) => None,
+                                (Some(None), None) => None,
+                                (None, Some(_)) => None, // unreachable!()
+                                (None, None) => None,    // unreachable!()
+                            }
+                        },
+                        prev_value,
+                    );
+                }
+
+                fn into_cloneable(self) -> Self::Cloneable {
+                    self
+                }
+
+                fn into_cloneable_owned(self) -> Self::CloneableOwned {
+                    self
+                }
+
+                fn dry_resolve(&mut self) {}
+
+                async fn resolve(self) -> Self::AsyncOutput {
+                    self
+                }
+
+                fn reset(state: &mut Self::State) {
+                    *state = RenderEffect::new_with_value(
+                        move |prev| match (prev) {
+                            Some(Some(mut state)) => {
+                                <$v>::reset(&mut state);
+                                Some(state)
+                            }
+                            Some(None) => None,
+                            None => None, // unreachable!()
+                        },
+                        state.take_value(),
+                    );
+                }
+            }
+        };
+    }
+
+    macro_rules! tuple_style_store_field {
+        ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+        {
+            impl<$($gen),*> IntoStyle for (&'static str, $name<$($gen),*>)
+            where
+                $v: Into<Cow<'static, str>> + Send + Sync + Clone + 'static,
+                $($where_clause)*
+            {
+                type AsyncOutput = Self;
+                type State = crate::reactive_graph::style::RenderEffectWithCssStyleName<(
+                    CssStyleDeclaration,
+                    Option<Cow<'static, str>>,
+                )>;
+                type Cloneable = Self;
+                type CloneableOwned = Self;
+
+                fn to_html(self, style: &mut String) {
+                    let (name, f) = self;
+                    let value = f.try_get();
+                    if let Some(value) = value {
+                        style.push_str(name);
+                        style.push(':');
+                        style.push_str(&value.into());
+                        style.push(';');
+                    }
+                }
+
+                fn hydrate<const FROM_SERVER: bool>(self, el: &crate::renderer::types::Element) -> Self::State {
+                    let (name, f) = self;
+                    let name = Rndr::intern(name);
+                    // TODO FROM_SERVER vs template
+                    let style = Rndr::style(el);
+                    RenderEffectWithCssStyleName::new(
+                        name,
+                        RenderEffect::new(move |prev| {
+                            let value = f.try_get().map(Into::into);
+                            match (prev, value) {
+                                (Some((style, Some(mut prev))), Some(value)) => {
+                                    if value != prev {
+                                        Rndr::set_css_property(&style, name, &value);
+                                    }
+                                    prev = value;
+                                    (style, Some(prev))
+                                }
+                                (None, Some(value)) => {
+                                    if !FROM_SERVER {
+                                        Rndr::set_css_property(&style, name, &value);
+                                    }
+                                    (style.clone(), Some(value))
+                                }
+                                _ => (style.clone(), None),
+                            }
+                        }),
+                    )
+                }
+
+                fn build(self, el: &crate::renderer::types::Element) -> Self::State {
+                    let (name, f) = self;
+                    let name = Rndr::intern(name);
+                    // TODO FROM_SERVER vs template
+                    let style = Rndr::style(el);
+                    RenderEffectWithCssStyleName::new(
+                        name,
+                        RenderEffect::new(move |prev| {
+                            let value = f.try_get().map(Into::into);
+                            match (prev, value) {
+                                (Some((style, Some(mut prev))), Some(value)) => {
+                                    if value != prev {
+                                        Rndr::set_css_property(&style, name, &value);
+                                    }
+                                    prev = value;
+                                    (style, Some(prev))
+                                }
+                                (None, Some(value)) => {
+                                    // always set the style initially without checking
+                                    Rndr::set_css_property(&style, name, &value);
+                                    (style.clone(), Some(value))
+                                }
+                                _ => (style.clone(), None),
+                            }
+                        }),
+                    )
+                }
+
+                fn rebuild(self, state: &mut Self::State) {
+                    let (name, f) = self;
+                    // Name might've updated:
+                    state.name = name;
+                    state.effect = RenderEffect::new_with_value(
+                        move |prev| {
+                            let value = f.try_get().map(Into::into);
+                            match (prev, value) {
+                                (Some((style, Some(mut prev))), Some(value)) => {
+                                    if value != prev {
+                                        Rndr::set_css_property(&style, name, &value);
+                                    }
+                                    prev = value;
+                                    (style, Some(prev))
+                                }
+                                (Some((style, Some(prev))), None) => (style, Some(prev)),
+                                (Some((style, None)), Some(_)) => (style, None),
+                                (Some((style, None)), None) => (style, None),
+                                (None, _) => unreachable!(),
+                            }
+                        },
+                        state.effect.take_value(),
+                    );
+                }
+
+                fn into_cloneable(self) -> Self::Cloneable {
+                    self
+                }
+
+                fn into_cloneable_owned(self) -> Self::CloneableOwned {
+                    self
+                }
+
+                fn dry_resolve(&mut self) {}
+
+                async fn resolve(self) -> Self::AsyncOutput {
+                    self
+                }
+
+                fn reset(state: &mut Self::State) {
+                    let name = state.name;
+                    *state = RenderEffectWithCssStyleName::new(
+                        state.name,
+                        RenderEffect::new_with_value(
+                            move |prev| match (prev) {
+                                Some((style, Some(mut prev))) => {
+                                    crate::reactive_graph::Rndr::remove_css_property(&style, name);
+                                    prev = Cow::Borrowed("");
+                                    (style, Some(prev))
+                                }
+                                Some((style, None)) => (style, None),
+                                None => unreachable!(),
+                            },
+                            state.effect.take_value(),
+                        ),
+                    );
+                }
+            }
+        };
+    }
     use super::RenderEffect;
     use crate::html::style::IntoStyle;
     #[allow(deprecated)]
@@ -780,13 +1038,112 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
+    use reactive_stores::{
+        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+        KeyedSubfield, Store, StoreField, Subfield,
+    };
     use std::borrow::Cow;
+    use std::ops::{Deref, DerefMut, Index, IndexMut};
 
+    style_store_field!(
+        Subfield,
+        <Inner, Prev, V>,
+        V,
+        Subfield<Inner, Prev, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+    style_store_field!(
+        AtKeyed,
+        <Inner, Prev, K, V>,
+        V,
+        AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+    style_store_field!(
+        KeyedSubfield,
+        <Inner, Prev, K, V>,
+        V,
+        KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+    style_store_field!(
+        DerefedField,
+        <S>,
+        <S::Value as Deref>::Target,
+        S: Clone + StoreField + Send + Sync + 'static,
+        <S as StoreField>::Value: Deref + DerefMut
+    );
+
+    style_store_field!(
+        AtIndex,
+        <Inner, Prev>,
+        <Prev as Index<usize>>::Output,
+        AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
+        Prev: Send + Sync + IndexMut<usize> + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+
+    tuple_style_store_field!(
+        Subfield,
+        <Inner, Prev, V>,
+        V,
+        Subfield<Inner, Prev, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+    tuple_style_store_field!(
+        AtKeyed,
+        <Inner, Prev, K, V>,
+        V,
+        AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+    tuple_style_store_field!(
+        KeyedSubfield,
+        <Inner, Prev, K, V>,
+        V,
+        KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+    tuple_style_store_field!(
+        DerefedField,
+        <S>,
+        <S::Value as Deref>::Target,
+        S: Clone + StoreField + Send + Sync + 'static,
+        <S as StoreField>::Value: Deref + DerefMut
+    );
+
+    tuple_style_store_field!(
+        AtIndex,
+        <Inner, Prev>,
+        <Prev as Index<usize>>::Output,
+        AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
+        Prev: Send + Sync + IndexMut<usize> + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+
+    style_signal_arena!(Store);
+    style_signal_arena!(Field);
     style_signal_arena!(RwSignal);
     style_signal_arena!(ReadSignal);
     style_signal_arena!(Memo);
     style_signal_arena!(Signal);
     style_signal_arena!(MaybeSignal);
+    style_signal!(ArcStore);
+    style_signal!(ArcField);
     style_signal!(ArcRwSignal);
     style_signal!(ArcReadSignal);
     style_signal!(ArcMemo);

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -254,9 +254,10 @@ where
 
 #[cfg(not(feature = "nightly"))]
 mod stable {
-    use crate::reactive_graph::style::RenderEffectWithCssStyleName;
-    use crate::renderer::types::CssStyleDeclaration;
-    use crate::renderer::Rndr;
+    use crate::{
+        reactive_graph::style::RenderEffectWithCssStyleName,
+        renderer::{types::CssStyleDeclaration, Rndr},
+    };
 
     macro_rules! style_signal {
         ($sig:ident) => {

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -769,6 +769,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! style_store_field {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
@@ -883,6 +884,7 @@ mod stable {
         };
     }
 
+    #[cfg(feature = "reactive_stores")]
     macro_rules! tuple_style_store_field {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
@@ -1038,15 +1040,17 @@ mod stable {
         traits::Get,
         wrappers::read::{ArcSignal, Signal},
     };
-    use reactive_stores::{
-        ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
-        KeyedSubfield, Store, StoreField, Subfield,
-    };
-    use std::{
-        borrow::Cow,
-        ops::{Deref, DerefMut, Index, IndexMut},
+    use std::borrow::Cow;
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
     };
 
+    #[cfg(feature = "reactive_stores")]
     style_store_field!(
         Subfield,
         <Inner, Prev, V>,
@@ -1055,6 +1059,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     style_store_field!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -1065,6 +1071,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     style_store_field!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -1075,6 +1083,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     style_store_field!(
         DerefedField,
         <S>,
@@ -1083,6 +1093,7 @@ mod stable {
         <S as StoreField>::Value: Deref + DerefMut
     );
 
+    #[cfg(feature = "reactive_stores")]
     style_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -1092,6 +1103,7 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     tuple_style_store_field!(
         Subfield,
         <Inner, Prev, V>,
@@ -1100,6 +1112,8 @@ mod stable {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_style_store_field!(
         AtKeyed,
         <Inner, Prev, K, V>,
@@ -1110,6 +1124,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_style_store_field!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
@@ -1120,6 +1136,8 @@ mod stable {
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
         for<'a> &'a V: IntoIterator,
     );
+
+    #[cfg(feature = "reactive_stores")]
     tuple_style_store_field!(
         DerefedField,
         <S>,
@@ -1128,6 +1146,7 @@ mod stable {
         <S as StoreField>::Value: Deref + DerefMut
     );
 
+    #[cfg(feature = "reactive_stores")]
     tuple_style_store_field!(
         AtIndex,
         <Inner, Prev>,
@@ -1137,14 +1156,18 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
 
+    #[cfg(feature = "reactive_stores")]
     style_signal_arena!(Store);
+    #[cfg(feature = "reactive_stores")]
     style_signal_arena!(Field);
     style_signal_arena!(RwSignal);
     style_signal_arena!(ReadSignal);
     style_signal_arena!(Memo);
     style_signal_arena!(Signal);
     style_signal_arena!(MaybeSignal);
+    #[cfg(feature = "reactive_stores")]
     style_signal!(ArcStore);
+    #[cfg(feature = "reactive_stores")]
     style_signal!(ArcField);
     style_signal!(ArcRwSignal);
     style_signal!(ArcReadSignal);

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -462,8 +462,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, _)), None) => (style.clone(), None),
-                                _ => unreachable!(),
+                                (Some((style, Some(prev))), None) => (style, Some(prev)),
+                                (Some((style, None)), Some(_)) => (style, None),
+                                (Some((style, None)), None) => (style, None),
+                                (None, _) => unreachable!(),
                             }
                         },
                         state.effect.take_value(),
@@ -495,7 +497,8 @@ mod stable {
                                     prev = Cow::Borrowed("");
                                     (style, Some(prev))
                                 }
-                                _ => unreachable!(),
+                                Some((style, None)) => (style, None),
+                                None => unreachable!(),
                             },
                             state.effect.take_value(),
                         ),
@@ -719,8 +722,10 @@ mod stable {
                                     prev = value;
                                     (style, Some(prev))
                                 }
-                                (Some((style, _)), None) => (style.clone(), None),
-                                _ => unreachable!(),
+                                (Some((style, Some(prev))), None) => (style, Some(prev)),
+                                (Some((style, None)), Some(_)) => (style, None),
+                                (Some((style, None)), None) => (style, None),
+                                (None, _) => unreachable!(),
                             }
                         },
                         state.effect.take_value(),
@@ -752,7 +757,8 @@ mod stable {
                                     prev = Cow::Borrowed("");
                                     (style, Some(prev))
                                 }
-                                _ => unreachable!(),
+                                Some((style, None)) => (style, None),
+                                None => unreachable!(),
                             },
                             state.effect.take_value(),
                         ),

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -1042,8 +1042,10 @@ mod stable {
         ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
         KeyedSubfield, Store, StoreField, Subfield,
     };
-    use std::borrow::Cow;
-    use std::ops::{Deref, DerefMut, Index, IndexMut};
+    use std::{
+        borrow::Cow,
+        ops::{Deref, DerefMut, Index, IndexMut},
+    };
 
     style_store_field!(
         Subfield,


### PR DESCRIPTION
This PR implements these traits:
- `IntoClass`
- `IntoStyle`
- `IntoProperty`
- `Render`
- `RenderHtml`
- `AttributeValue`
- `InnerHtml`

for these store fields:
- `Store`
- `ArcStore`
- `Field`
- `ArcField`
- `SubField`
- `AtKeyed`
- `KeyedSubField`
- `DerefedField`
- `AtIndex`

Implementation for `Store`, `Field`, `ArcStore`, and `ArcField` was approachable easily by existing macro rules for signals, but for other store fields, I had to write new macro rules. Maybe someone can unify them with a better design.

The implementation of `AddAnyAttr` for signals was empty and marked with `todo!()`. I also added this empty implementation to new macros.

~~I didn't put them under the "reactive_stores" feature flag. Please let me know if I should do so.~~
I put them under the "reactive_stores" feature flag.

Additionally, it implements `IntoSplitSignal` for `AtKeyed`, `AtIndex`, and `DerefedField`.

This PR is written based on the previous PR (#3569), which had rewritten the implementation of signals to use `try_get()` instead of `get()`.