### PR TITLE
Remove getrandom

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["--cfg", "getrandom_backend=\"linux_getrandom\""]
+rustflags = ["--cfg", "getrandom_backend=\"wasm_js\""]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "getrandom_backend=\"linux_getrandom\""]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,8 +1137,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -1741,7 +1743,7 @@ dependencies = [
  "cfg-if",
  "either_of",
  "futures",
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "hydration_context",
  "leptos-spin-macro",
  "leptos_config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,10 +1137,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -1743,7 +1741,6 @@ dependencies = [
  "cfg-if",
  "either_of",
  "futures",
- "getrandom 0.3.1",
  "hydration_context",
  "leptos-spin-macro",
  "leptos_config",

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -57,7 +57,7 @@ serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.31"
 send_wrapper = "0.6.0"
-getrandom = { version = "0.2", features = ["js"], optional = true }
+getrandom = { version = "0.3.1", features = ["wasm_js"], optional = true }
 
 [features]
 hydration = [

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -57,7 +57,6 @@ serde_qs = "0.13.0"
 slotmap = "1.0"
 futures = "0.3.31"
 send_wrapper = "0.6.0"
-getrandom = { version = "0.3.1", features = ["wasm_js"], optional = true }
 
 [features]
 hydration = [
@@ -66,13 +65,12 @@ hydration = [
   "hydration_context/browser",
   "leptos_dom/hydration",
 ]
-csr = ["leptos_macro/csr", "reactive_graph/effects", "dep:getrandom"]
+csr = ["leptos_macro/csr", "reactive_graph/effects"]
 hydrate = [
   "leptos_macro/hydrate",
   "hydration",
   "tachys/hydrate",
   "reactive_graph/effects",
-  "dep:getrandom",
 ]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]


### PR DESCRIPTION
This warning 

"warning: Feature js of package getrandom has been obsolete in version 0.3.1"

Now using the feature "wasm_js"

Just a small maintence nudge