### PR TITLE
projects/bevy3d_ui Migrate to leptos 0.7.7

### DIFF
--- a/projects/bevy3d_ui/Cargo.toml
+++ b/projects/bevy3d_ui/Cargo.toml
@@ -8,9 +8,9 @@ codegen-units = 1
 lto = true
 
 [dependencies]
-leptos = { version = "0.6.13", features = ["csr"] }
-leptos_meta = { version = "0.6.13", features = ["csr"] }
-leptos_router = { version = "0.6.13", features = ["csr"] }
+leptos = { version = "0.7.7", features = ["csr"] }
+leptos_meta = { version = "0.7.7" }
+leptos_router = { version = "0.7.7" }
 console_log = "1.0"
 log = "0.4.22"
 console_error_panic_hook = "0.1.7"

--- a/projects/bevy3d_ui/src/main.rs
+++ b/projects/bevy3d_ui/src/main.rs
@@ -1,6 +1,6 @@
 mod demos;
 mod routes;
-use leptos::*;
+use leptos::prelude::*;
 use routes::RootPage;
 
 pub fn main() {

--- a/projects/bevy3d_ui/src/routes/demo1.rs
+++ b/projects/bevy3d_ui/src/routes/demo1.rs
@@ -2,7 +2,7 @@ use crate::demos::bevydemo1::eventqueue::events::{
     ClientInEvents, CounterEvtData,
 };
 use crate::demos::bevydemo1::scene::Scene;
-use leptos::*;
+use leptos::prelude::*;
 
 /// 3d view component
 #[component]
@@ -10,16 +10,16 @@ pub fn Demo1() -> impl IntoView {
     // Setup a Counter
     let initial_value: i32 = 0;
     let step: i32 = 1;
-    let (value, set_value) = create_signal(initial_value);
+    let (value, set_value) = signal(initial_value);
 
     // Setup a bevy 3d scene
     let scene = Scene::new("#bevy".to_string());
     let sender = scene.get_processor().sender;
-    let (sender_sig, _set_sender_sig) = create_signal(sender);
-    let (scene_sig, _set_scene_sig) = create_signal(scene);
+    let (sender_sig, _set_sender_sig) = signal(sender);
+    let (scene_sig, _set_scene_sig) = signal(scene);
 
     // We need to add the 3D view onto the canvas post render.
-    create_effect(move |_| {
+    Effect::new(move |_| {
         request_animation_frame(move || {
             scene_sig.get().setup();
         });

--- a/projects/bevy3d_ui/src/routes/mod.rs
+++ b/projects/bevy3d_ui/src/routes/mod.rs
@@ -1,23 +1,25 @@
 pub mod demo1;
 use demo1::Demo1;
-use leptos::*;
-use leptos_meta::{provide_meta_context, Meta, Stylesheet, Title};
-use leptos_router::*;
-
+use leptos::prelude::*;
+use leptos_meta::Title;
+use leptos_meta::{provide_meta_context, MetaTags, Stylesheet};
+use leptos_router::components::*;
+use leptos_router::StaticSegment;
 #[component]
 pub fn RootPage() -> impl IntoView {
     provide_meta_context();
 
     view! {
-        <Meta name="charset" content="UTF-8"/>
-        <Meta name="description" content="Leptonic CSR template"/>
-        <Meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <Meta name="theme-color" content="#e66956"/>
-        <Stylesheet href="https://fonts.googleapis.com/css?family=Roboto&display=swap"/>
+        <meta name="charset" content="UTF-8"/>
+        <meta name="description" content="Leptonic CSR template"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <meta name="theme-color" content="#e66956"/>
         <Title text="Leptos Bevy3D Example"/>
+        <Stylesheet href="https://fonts.googleapis.com/css?family=Roboto&display=swap"/>
+        <MetaTags/>
         <Router>
-            <Routes>
-                <Route path="" view=|| view! { <Demo1/> }/>
+            <Routes fallback=move || "Not found.">
+                <Route path=StaticSegment("") view=Demo1 />
             </Routes>
         </Router>
     }

--- a/projects/bevy3d_ui/src/routes/mod.rs
+++ b/projects/bevy3d_ui/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod demo1;
 use demo1::Demo1;
 use leptos::prelude::*;
+use leptos_meta::Meta;
 use leptos_meta::Title;
 use leptos_meta::{provide_meta_context, MetaTags, Stylesheet};
 use leptos_router::components::*;
@@ -10,10 +11,10 @@ pub fn RootPage() -> impl IntoView {
     provide_meta_context();
 
     view! {
-        <meta name="charset" content="UTF-8"/>
-        <meta name="description" content="Leptonic CSR template"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-        <meta name="theme-color" content="#e66956"/>
+        <Meta name="charset" content="UTF-8"/>
+        <Meta name="description" content="Leptonic CSR template"/>
+        <Meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+        <Meta name="theme-color" content="#e66956"/>
         <Title text="Leptos Bevy3D Example"/>
         <Stylesheet href="https://fonts.googleapis.com/css?family=Roboto&display=swap"/>
         <MetaTags/>


### PR DESCRIPTION
I want to keep the bevy reference design up to date ... 

This is the first PR of 2. 

PR2 Will follow the bevy migration guide ( from 0.14 to 0.16 )