### PR TITLE
Strange marker node bug

### DIFF
--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -7,8 +7,9 @@ use crate::{
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, any_view::AnyView, IntoRender, Mountable,
-        Position, PositionState, Render, RenderHtml, ToTemplate,
+        add_attr::AddAnyAttr, any_view::AnyView, iterators::StaticVec,
+        IntoRender, Mountable, Position, PositionState, Render, RenderHtml,
+        ToTemplate,
     },
 };
 use const_str_slice_concat::{
@@ -106,7 +107,7 @@ where
     NewChild: IntoRender,
     NewChild::Output: RenderHtml,
 {
-    type Output = HtmlElement<E, At, Vec<AnyView>>;
+    type Output = HtmlElement<E, At, StaticVec<AnyView>>;
 
     fn child(self, child: NewChild) -> Self::Output {
         use crate::view::any_view::IntoAny;
@@ -125,29 +126,29 @@ where
 
 // #[cfg(erase_components)]
 trait NextChildren {
-    fn next_children(self, child: AnyView) -> Vec<AnyView>;
+    fn next_children(self, child: AnyView) -> StaticVec<AnyView>;
 }
 
 // #[cfg(erase_components)]
 impl NextChildren for () {
-    fn next_children(self, child: AnyView) -> Vec<AnyView> {
-        vec![child]
+    fn next_children(self, child: AnyView) -> StaticVec<AnyView> {
+        vec![child].into()
     }
 }
 
 // #[cfg(erase_components)]
 impl<T: RenderHtml> NextChildren for (T,) {
-    fn next_children(self, child: AnyView) -> Vec<AnyView> {
+    fn next_children(self, child: AnyView) -> StaticVec<AnyView> {
         use crate::view::any_view::IntoAny;
 
-        vec![self.0.into_owned().into_any(), child]
+        vec![self.0.into_owned().into_any(), child].into()
     }
 }
 
 // #[cfg(erase_components)]
-impl NextChildren for Vec<AnyView> {
-    fn next_children(mut self, child: AnyView) -> Vec<AnyView> {
-        self.push(child);
+impl NextChildren for StaticVec<AnyView> {
+    fn next_children(mut self, child: AnyView) -> StaticVec<AnyView> {
+        self.0.push(child);
         self
     }
 }

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -7,15 +7,14 @@ use crate::{
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{
-        add_attr::AddAnyAttr, IntoRender, Mountable, Position, PositionState,
-        Render, RenderHtml, ToTemplate,
+        add_attr::AddAnyAttr, any_view::AnyView, IntoRender, Mountable,
+        Position, PositionState, Render, RenderHtml, ToTemplate,
     },
 };
 use const_str_slice_concat::{
     const_concat, const_concat_with_prefix, str_from_buffer,
 };
 use futures::future::join;
-use next_tuple::NextTuple;
 use std::ops::Deref;
 
 mod custom;
@@ -71,33 +70,85 @@ where
     }
 }*/
 
+// #[cfg(not(erase_components))]
+// impl<E, At, Ch, NewChild> ElementChild<NewChild> for HtmlElement<E, At, Ch>
+// where
+//     E: ElementWithChildren,
+//     Ch: RenderHtml + next_tuple::NextTuple,
+//     <Ch as next_tuple::NextTuple>::Output<NewChild::Output>: Render,
+
+//     NewChild: IntoRender,
+//     NewChild::Output: RenderHtml,
+// {
+//     type Output = HtmlElement<
+//         E,
+//         At,
+//         <Ch as next_tuple::NextTuple>::Output<NewChild::Output>,
+//     >;
+
+//     fn child(self, child: NewChild) -> Self::Output {
+//         HtmlElement {
+//             #[cfg(any(debug_assertions, leptos_debuginfo))]
+//             defined_at: self.defined_at,
+//             tag: self.tag,
+//             attributes: self.attributes,
+//             children: self.children.next_tuple(child.into_render()),
+//         }
+//     }
+// }
+
+// #[cfg(erase_components)]
 impl<E, At, Ch, NewChild> ElementChild<NewChild> for HtmlElement<E, At, Ch>
 where
     E: ElementWithChildren,
-    Ch: Render + NextTuple,
-    <Ch as NextTuple>::Output<NewChild::Output>: Render,
+    Ch: RenderHtml + NextChildren,
 
     NewChild: IntoRender,
-    NewChild::Output: Render,
+    NewChild::Output: RenderHtml,
 {
-    type Output =
-        HtmlElement<E, At, <Ch as NextTuple>::Output<NewChild::Output>>;
+    type Output = HtmlElement<E, At, Vec<AnyView>>;
 
     fn child(self, child: NewChild) -> Self::Output {
-        let HtmlElement {
-            #[cfg(any(debug_assertions, leptos_debuginfo))]
-            defined_at,
-            tag,
-            attributes,
-            children,
-        } = self;
+        use crate::view::any_view::IntoAny;
+
         HtmlElement {
             #[cfg(any(debug_assertions, leptos_debuginfo))]
-            defined_at,
-            tag,
-            attributes,
-            children: children.next_tuple(child.into_render()),
+            defined_at: self.defined_at,
+            tag: self.tag,
+            attributes: self.attributes,
+            children: self
+                .children
+                .next_children(child.into_render().into_any()),
         }
+    }
+}
+
+// #[cfg(erase_components)]
+trait NextChildren {
+    fn next_children(self, child: AnyView) -> Vec<AnyView>;
+}
+
+// #[cfg(erase_components)]
+impl NextChildren for () {
+    fn next_children(self, child: AnyView) -> Vec<AnyView> {
+        vec![child]
+    }
+}
+
+// #[cfg(erase_components)]
+impl<T: RenderHtml> NextChildren for (T,) {
+    fn next_children(self, child: AnyView) -> Vec<AnyView> {
+        use crate::view::any_view::IntoAny;
+
+        vec![self.0.into_owned().into_any(), child]
+    }
+}
+
+// #[cfg(erase_components)]
+impl NextChildren for Vec<AnyView> {
+    fn next_children(mut self, child: AnyView) -> Vec<AnyView> {
+        self.push(child);
+        self
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -163,7 +163,6 @@ impl<T> IntoAny for T
 where
     T: Send,
     T: RenderHtml,
-    T::State: 'static,
 {
     fn into_any(self) -> AnyView {
         #[cfg(feature = "ssr")]

--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -327,7 +327,10 @@ where
                 extra_attrs.clone(),
             );
         }
-        buf.push_str("<!>");
+        if escape {
+            buf.push_str("<!>");
+            *position = Position::NextChild;
+        }
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
@@ -359,7 +362,10 @@ where
                 extra_attrs.clone(),
             );
         }
-        buf.push_sync("<!>");
+        if escape {
+            buf.push_sync("<!>");
+            *position = Position::NextChild;
+        }
     }
 
     fn hydrate<const FROM_SERVER: bool>(
@@ -373,6 +379,7 @@ where
             .collect();
 
         let marker = cursor.next_placeholder(position);
+        position.set(Position::NextChild);
 
         VecState { states, marker }
     }

--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -364,8 +364,8 @@ where
         }
         if escape {
             buf.push_sync("<!>");
-            *position = Position::NextChild;
         }
+        *position = Position::NextChild;
     }
 
     fn hydrate<const FROM_SERVER: bool>(
@@ -388,6 +388,198 @@ where
         self.into_iter()
             .map(RenderHtml::into_owned)
             .collect::<Vec<_>>()
+    }
+}
+
+/// A container used for ErasedMode. It's slightly better than a raw Vec<> because the rendering traits don't have to worry about the length of the Vec changing, therefore no marker traits etc.
+pub struct StaticVec<T>(pub(crate) Vec<T>);
+
+impl<T> From<Vec<T>> for StaticVec<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self(vec)
+    }
+}
+
+impl<T> From<StaticVec<T>> for Vec<T> {
+    fn from(static_vec: StaticVec<T>) -> Self {
+        static_vec.0
+    }
+}
+
+/// Retained view state for a `StaticVec<Vec<_>>`.
+pub struct StaticVecState<T>
+where
+    T: Mountable,
+{
+    states: Vec<T>,
+}
+
+impl<T> Mountable for StaticVecState<T>
+where
+    T: Mountable,
+{
+    fn unmount(&mut self) {
+        self.states.iter_mut().for_each(Mountable::unmount);
+    }
+
+    fn mount(
+        &mut self,
+        parent: &crate::renderer::types::Element,
+        marker: Option<&crate::renderer::types::Node>,
+    ) {
+        for state in self.states.iter_mut() {
+            state.mount(parent, marker);
+        }
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        if let Some(first) = self.states.first() {
+            first.insert_before_this(child)
+        } else {
+            false
+        }
+    }
+
+    fn elements(&self) -> Vec<crate::renderer::types::Element> {
+        self.states
+            .iter()
+            .flat_map(|item| item.elements())
+            .collect()
+    }
+}
+
+impl<T> Render for StaticVec<T>
+where
+    T: Render,
+{
+    type State = StaticVecState<T::State>;
+
+    fn build(self) -> Self::State {
+        Self::State {
+            states: self.0.into_iter().map(T::build).collect(),
+        }
+    }
+
+    fn rebuild(self, state: &mut Self::State) {
+        let Self::State { states } = state;
+        let old = states;
+        // this is an unkeyed diff
+        self.0
+            .into_iter()
+            .zip(old.iter_mut())
+            .for_each(|(new, old)| T::rebuild(new, old));
+    }
+}
+
+impl<T> AddAnyAttr for StaticVec<T>
+where
+    T: AddAnyAttr,
+{
+    type Output<SomeNewAttr: Attribute> =
+        StaticVec<<T as AddAnyAttr>::Output<SomeNewAttr::Cloneable>>;
+
+    fn add_any_attr<NewAttr: Attribute>(
+        self,
+        attr: NewAttr,
+    ) -> Self::Output<NewAttr>
+    where
+        Self::Output<NewAttr>: RenderHtml,
+    {
+        let attr = attr.into_cloneable();
+        self.0
+            .into_iter()
+            .map(|n| n.add_any_attr(attr.clone()))
+            .collect::<Vec<_>>()
+            .into()
+    }
+}
+
+impl<T> RenderHtml for StaticVec<T>
+where
+    T: RenderHtml,
+{
+    type AsyncOutput = StaticVec<T::AsyncOutput>;
+    type Owned = StaticVec<T::Owned>;
+
+    const MIN_LENGTH: usize = 0;
+
+    fn dry_resolve(&mut self) {
+        for inner in self.0.iter_mut() {
+            inner.dry_resolve();
+        }
+    }
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        futures::future::join_all(self.0.into_iter().map(T::resolve))
+            .await
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    fn html_len(&self) -> usize {
+        self.0.iter().map(RenderHtml::html_len).sum::<usize>()
+    }
+
+    fn to_html_with_buf(
+        self,
+        buf: &mut String,
+        position: &mut Position,
+        escape: bool,
+        mark_branches: bool,
+        extra_attrs: Vec<AnyAttribute>,
+    ) {
+        for child in self.0.into_iter() {
+            child.to_html_with_buf(
+                buf,
+                position,
+                escape,
+                mark_branches,
+                extra_attrs.clone(),
+            );
+        }
+    }
+
+    fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
+        self,
+        buf: &mut StreamBuilder,
+        position: &mut Position,
+        escape: bool,
+        mark_branches: bool,
+        extra_attrs: Vec<AnyAttribute>,
+    ) where
+        Self: Sized,
+    {
+        for child in self.0.into_iter() {
+            child.to_html_async_with_buf::<OUT_OF_ORDER>(
+                buf,
+                position,
+                escape,
+                mark_branches,
+                extra_attrs.clone(),
+            );
+        }
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        cursor: &Cursor,
+        position: &PositionState,
+    ) -> Self::State {
+        let states = self
+            .0
+            .into_iter()
+            .map(|child| child.hydrate::<FROM_SERVER>(cursor, position))
+            .collect();
+        Self::State { states }
+    }
+
+    fn into_owned(self) -> Self::Owned {
+        self.0
+            .into_iter()
+            .map(RenderHtml::into_owned)
+            .collect::<Vec<_>>()
+            .into()
     }
 }
 

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -286,6 +286,7 @@ where
             rendered_items.push(Some((set_index, item)));
         }
         let marker = cursor.next_placeholder(position);
+        position.set(Position::NextChild);
         KeyedState {
             parent: Some(parent),
             marker,


### PR DESCRIPTION
This is a rather unorthodox bug report, but I thought this would be the easiest way to review and checkout locally. 

Whilst adding erasure, I think I've stumbled on a bug, or something very weird. 

It seems having `HtmlElement` extend it's children as `Vec<AnyView>`  breaks leptos somehow. With this PR, running `counter_isomorphic` `cargo leptos watch` and checking out the site, console shows: 
```
(index):419 Uncaught SyntaxError: Unexpected token '>' (at (index):419:21)
(index):427 Uncaught SyntaxError: Unexpected token '>' (at (index):427:58)
```
Which is a random `<!>` marker in the html in the second line of this snippet:
```
ws.onclose = () => console.warn('Live-reload stopped. Manual reload necessary.');
 })(3001, 'ws://')<!></script><link rel="modulepreload" href="/pkg/counter_isomorphic.js" nonce="nRIE4NM7UA2nhEng5NCK0g"><link rel="preload" href="/pkg/counter_isomorphic.wasm" as="fetch" type="application/wasm" crossorigin="nRIE4NM7UA2nhEng5NCK0g"><script type="module" nonce="nRIE4NM7UA2nhEng5NCK0g">(function (root, pkg_path, output_name, wasm_output_name) {
	import(`${root}/${pkg_path}/${output_name}.js`)
		.then(mod => {
			mod.default({module_or_path: `${root}/${pkg_path}/${wasm_output_name}.wasm`}).then(() => {
				mod.hydrate();
			});
		})
})
```

I'm pretty confused how it could be anything wrong with this diff, and I've un erased flagged it so this is verifiable in normal mode. Any ideas @gbj? 

I also checked patching 0.8 branch with the solution to #3583, but doesn't help.