### PR TITLE
projects/bevy3d_ui: Bevy - Bugfix, clippy and crate bump

### DIFF
--- a/projects/bevy3d_ui/Cargo.toml
+++ b/projects/bevy3d_ui/Cargo.toml
@@ -18,9 +18,9 @@ bevy = "0.15.2"
 crossbeam-channel = "0.5.13"
 
 [dev-dependencies]
-wasm-bindgen = "0.2.92"
-wasm-bindgen-test = "0.3.42"
-web-sys = "0.3.69"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-test = "0.3.50"
+web-sys = "0.3.77"
 
 [workspace]
 # The empty workspace here is to keep rust-analyzer satisfied

--- a/projects/bevy3d_ui/src/demos/bevydemo1/eventqueue/plugin.rs
+++ b/projects/bevy3d_ui/src/demos/bevydemo1/eventqueue/plugin.rs
@@ -17,7 +17,7 @@ impl DuplexEventsPlugin {
         let (bevy_sender, client_receiver) = crossbeam_channel::bounded(50);
         // For sending message from the client to bevy
         let (client_sender, bevy_receiver) = crossbeam_channel::bounded(50);
-        let instance = DuplexEventsPlugin {
+        DuplexEventsPlugin {
             client_processor: EventProcessor {
                 sender: client_sender,
                 receiver: client_receiver,
@@ -26,8 +26,7 @@ impl DuplexEventsPlugin {
                 sender: bevy_sender,
                 receiver: bevy_receiver,
             },
-        };
-        instance
+        }
     }
 
     /// Get the client event processor

--- a/projects/bevy3d_ui/src/demos/bevydemo1/scene.rs
+++ b/projects/bevy3d_ui/src/demos/bevydemo1/scene.rs
@@ -23,14 +23,13 @@ impl Scene {
     /// Create a new instance
     pub fn new(canvas_id: String) -> Scene {
         let plugin = DuplexEventsPlugin::new();
-        let instance = Scene {
+        Scene {
             is_setup: false,
-            canvas_id: canvas_id,
+            canvas_id,
             evt_plugin: plugin.clone(),
             shared_state: SharedState::new(),
             processor: plugin.get_processor(),
-        };
-        instance
+        }
     }
 
     /// Get the shared state
@@ -47,7 +46,7 @@ impl Scene {
 
     /// Setup and attach the bevy instance to the html canvas element
     pub fn setup(&mut self) {
-        if self.is_setup == true {
+        if self.is_setup {
             return;
         };
         App::new()

--- a/projects/bevy3d_ui/src/routes/demo1.rs
+++ b/projects/bevy3d_ui/src/routes/demo1.rs
@@ -21,7 +21,7 @@ pub fn Demo1() -> impl IntoView {
     // We need to add the 3D view onto the canvas post render.
     Effect::new(move |_| {
         request_animation_frame(move || {
-            scene_sig.get().setup();
+            scene_sig.get_untracked().setup();
         });
     });
 


### PR DESCRIPTION
The bugfix is related to access to a signal

"
bevy3d_ui-b20a0a6a298e7144.js:2637 At src/routes/demo1.rs:24:23, you access a reactive_graph::signal::read::ReadSignal<bevy3d_ui::demos::bevydemo1::scene::Scene> (defined at src/routes/demo1.rs:19:39) outside a reactive tracking context. This might mean your app is not responding to changes in signal values in the way you expect. "

The solution is to use .get_untracked() inside an "effect" block.

Lots of small clippy fixes.

Also here are the crates that have been bumped

-wasm-bindgen = "0.2.92"
-wasm-bindgen-test = "0.3.42"
-web-sys = "0.3.69"
+wasm-bindgen = "0.2.100"
+wasm-bindgen-test = "0.3.50"
+web-sys = "0.3.77"