### PR TITLE
Put serde_json in the root workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ or_poisoned = { path = "./or_poisoned", version = "0.1.0" }
 reactive_graph = { path = "./reactive_graph", version = "0.1.7" }
 reactive_stores = { path = "./reactive_stores", version = "0.1.7" }
 reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.1.7" }
+serde_json = "1.0.0"
 server_fn = { path = "./server_fn", version = "0.7.7" }
 server_fn_macro = { path = "./server_fn_macro", version = "0.7.7" }
 server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.7.7" }

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -21,7 +21,7 @@ leptos_macro = { workspace = true, features = ["actix"] }
 leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 server_fn = { workspace = true, features = ["actix"] }
-serde_json = "1.0"
+serde_json = { workspace = true }
 parking_lot = "0.12.3"
 tracing = { version = "0.1", optional = true }
 tokio = { version = "1.43", features = ["rt", "fs"] }

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -27,7 +27,7 @@ send_wrapper = "0.6"
 serde = { version = "1.0" }
 js-sys = { version = "0.3.74", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }
-serde_json = { version = "1.0" }
+serde_json = { workspace = true }
 
 [features]
 ssr = []

--- a/oco/Cargo.toml
+++ b/oco/Cargo.toml
@@ -13,4 +13,4 @@ serde = "1.0"
 thiserror = "2.0"
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -42,7 +42,7 @@ multer = { version = "3.1", optional = true }
 
 ## output encodings
 # serde
-serde_json = "1.0"
+serde_json = { workspace = true }
 serde-lite = { version = "0.5.0", features = ["derive"], optional = true }
 futures = "0.3.31"
 http = { version = "1.1" }


### PR DESCRIPTION
serde_json is common to

integrations/actix
leptos/server
oco
server_fn

This is a defensive PR - Putting the crate definition into the root workspcace makes it less likely to get difficult to trace version slip bugs.

This does not help where sede_json is optional so care manual review is required.