### PR TITLE
Minor: drop create_signal form the landing page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use leptos::*;
 #[component]
 pub fn SimpleCounter(initial_value: i32) -> impl IntoView {
     // create a reactive signal with the initial value
-    let (value, set_value) = create_signal(initial_value);
+    let (value, set_value) = signal(initial_value);
 
     // create event handlers for our buttons
     // note that `value` and `set_value` are `Copy`, so it's super easy to move them into closures
@@ -46,7 +46,7 @@ pub fn SimpleCounter(initial_value: i32) -> impl IntoView {
 pub fn SimpleCounterWithBuilder(initial_value: i32) -> impl IntoView {
     use leptos::html::*;
 
-    let (value, set_value) = create_signal(initial_value);
+    let (value, set_value) = signal(initial_value);
     let clear = move |_| set_value(0);
     let decrement = move |_| set_value.update(|value| *value -= 1);
     let increment = move |_| set_value.update(|value| *value += 1);


### PR DESCRIPTION

I don't look at the landing page often ... but this goofy mistake made me chuckle.
