### PR TITLE
Erased routing, codegen opts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1731451909bde27714eacba19c2566362a7f35224f52b153d3f42cf60f72472"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3434,6 +3440,7 @@ dependencies = [
  "drain_filter_polyfill",
  "dyn-clone",
  "either_of",
+ "erased",
  "futures",
  "html-escape",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,12 +871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,7 +3432,6 @@ dependencies = [
  "async-trait",
  "const_str_slice_concat",
  "drain_filter_polyfill",
- "dyn-clone",
  "either_of",
  "erased",
  "futures",

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -170,8 +170,14 @@ pub(crate) fn component_to_tokens(
         .collect::<Vec<_>>();
 
     let spreads = (!(spreads.is_empty())).then(|| {
-        quote! {
-            .add_any_attr((#(#spreads,)*).into_attr())
+        if cfg!(erase_components) {
+            quote! {
+                .add_any_attr(vec![#(#spreads.into_attr().into_any_attr(),)*])
+            }
+        } else {
+            quote! {
+                .add_any_attr((#(#spreads,)*).into_attr())
+            }
         }
     });
 

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -426,7 +426,7 @@ fn element_children_to_tokens(
     } else if cfg!(erase_components) {
         Some(quote! {
             .child(
-                leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_erased()),*])
+                leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_maybe_erased()),*])
             )
         })
     } else if children.len() > 16 {
@@ -476,7 +476,7 @@ fn fragment_to_tokens(
         children.into_iter().next()
     } else if cfg!(erase_components) {
         Some(quote! {
-            leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_erased()),*])
+            leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_maybe_erased()),*])
         })
     } else if children.len() > 16 {
         // implementations of various traits used in routing and rendering are implemented for

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -423,6 +423,12 @@ fn element_children_to_tokens(
                 { #child }
             )
         })
+    } else if cfg!(erase_components) {
+        Some(quote! {
+            .child(
+                leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_erased()),*])
+            )
+        })
     } else if children.len() > 16 {
         // implementations of various traits used in routing and rendering are implemented for
         // tuples of sizes 0, 1, 2, 3, ... N. N varies but is > 16. The traits are also implemented
@@ -468,6 +474,10 @@ fn fragment_to_tokens(
         None
     } else if children.len() == 1 {
         children.into_iter().next()
+    } else if cfg!(erase_components) {
+        Some(quote! {
+            leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_erased()),*])
+        })
     } else if children.len() > 16 {
         // implementations of various traits used in routing and rendering are implemented for
         // tuples of sizes 0, 1, 2, 3, ... N. N varies but is > 16. The traits are also implemented
@@ -752,10 +762,18 @@ pub(crate) fn element_to_tokens(
                 }
             }
         }
-        Some(quote! {
-            (#(#attributes,)*)
-            #(.add_any_attr(#additions))*
-        })
+
+        if cfg!(erase_components) {
+            Some(quote! {
+                vec![#(#attributes.into_attr().into_any_attr(),)*]
+                #(.add_any_attr(#additions))*
+            })
+        } else {
+            Some(quote! {
+                (#(#attributes,)*)
+                #(.add_any_attr(#additions))*
+            })
+        }
     } else {
         let tag = name.to_string();
         // collect close_tag name to emit semantic information for IDE.

--- a/reactive_graph/src/computed/inner.rs
+++ b/reactive_graph/src/computed/inner.rs
@@ -8,7 +8,7 @@ use crate::{
 use or_poisoned::OrPoisoned;
 use std::{
     fmt::Debug,
-    sync::{Arc, RwLock},
+    sync::{Arc, RwLock, RwLockWriteGuard},
 };
 
 pub struct MemoInner<T, S>
@@ -72,17 +72,21 @@ where
     }
 
     fn mark_check(&self) {
-        {
-            let mut lock = self.reactivity.write().or_poisoned();
-            if lock.state != ReactiveNodeState::Dirty {
-                lock.state = ReactiveNodeState::Check;
+        /// codegen optimisation:
+        fn inner(reactivity: &RwLock<MemoInnerReactivity>) {
+            {
+                let mut lock = reactivity.write().or_poisoned();
+                if lock.state != ReactiveNodeState::Dirty {
+                    lock.state = ReactiveNodeState::Check;
+                }
+            }
+            for sub in
+                (&reactivity.read().or_poisoned().subscribers).into_iter()
+            {
+                sub.mark_check();
             }
         }
-        for sub in
-            (&self.reactivity.read().or_poisoned().subscribers).into_iter()
-        {
-            sub.mark_check();
-        }
+        inner(&self.reactivity);
     }
 
     fn mark_subscribers_check(&self) {
@@ -93,64 +97,87 @@ where
     }
 
     fn update_if_necessary(&self) -> bool {
-        let (state, sources) = {
-            let inner = self.reactivity.read().or_poisoned();
-            (inner.state, inner.sources.clone())
-        };
+        /// codegen optimisation:
+        fn needs_update(reactivity: &RwLock<MemoInnerReactivity>) -> bool {
+            let (state, sources) = {
+                let inner = reactivity.read().or_poisoned();
+                (inner.state, inner.sources.clone())
+            };
+            match state {
+                ReactiveNodeState::Clean => false,
+                ReactiveNodeState::Dirty => true,
+                ReactiveNodeState::Check => {
+                    (&sources).into_iter().any(|source| {
+                        source.update_if_necessary()
+                            || reactivity.read().or_poisoned().state
+                                == ReactiveNodeState::Dirty
+                    })
+                }
+            }
+        }
 
-        let needs_update = match state {
-            ReactiveNodeState::Clean => false,
-            ReactiveNodeState::Dirty => true,
-            ReactiveNodeState::Check => (&sources).into_iter().any(|source| {
-                source.update_if_necessary()
-                    || self.reactivity.read().or_poisoned().state
-                        == ReactiveNodeState::Dirty
-            }),
-        };
-
-        if needs_update {
-            let fun = self.fun.clone();
-            let owner = self.owner.clone();
+        if needs_update(&self.reactivity) {
             // No deadlock risk, because we only hold the value lock.
             let value = self.value.write().or_poisoned().take();
 
-            let any_subscriber =
-                { self.reactivity.read().or_poisoned().any_subscriber.clone() };
-            any_subscriber.clear_sources(&any_subscriber);
-            let (new_value, changed) = owner.with_cleanup(|| {
+            /// codegen optimisation:
+            fn inner_1(
+                reactivity: &RwLock<MemoInnerReactivity>,
+            ) -> AnySubscriber {
+                let any_subscriber =
+                    reactivity.read().or_poisoned().any_subscriber.clone();
+                any_subscriber.clear_sources(&any_subscriber);
                 any_subscriber
-                    .with_observer(|| fun(value.map(StorageAccess::into_taken)))
+            }
+            let any_subscriber = inner_1(&self.reactivity);
+
+            let (new_value, changed) = self.owner.with_cleanup(|| {
+                any_subscriber.with_observer(|| {
+                    (self.fun)(value.map(StorageAccess::into_taken))
+                })
             });
 
             // Two locks are aquired, so order matters.
-            let mut reactivity_lock = self.reactivity.write().or_poisoned();
+            let reactivity_lock = self.reactivity.write().or_poisoned();
             {
                 // Safety: Can block endlessly if the user is has a ReadGuard on the value
                 let mut value_lock = self.value.write().or_poisoned();
                 *value_lock = Some(S::wrap(new_value));
             }
-            reactivity_lock.state = ReactiveNodeState::Clean;
 
-            if changed {
-                let subs = reactivity_lock.subscribers.clone();
-                drop(reactivity_lock);
-                for sub in subs {
-                    // don't trigger reruns of effects/memos
-                    // basically: if one of the observers has triggered this memo to
-                    // run, it doesn't need to be re-triggered because of this change
-                    if !Observer::is(&sub) {
-                        sub.mark_dirty();
+            /// codegen optimisation:
+            fn inner_2(
+                changed: bool,
+                mut reactivity_lock: RwLockWriteGuard<'_, MemoInnerReactivity>,
+            ) {
+                reactivity_lock.state = ReactiveNodeState::Clean;
+
+                if changed {
+                    let subs = reactivity_lock.subscribers.clone();
+                    drop(reactivity_lock);
+                    for sub in subs {
+                        // don't trigger reruns of effects/memos
+                        // basically: if one of the observers has triggered this memo to
+                        // run, it doesn't need to be re-triggered because of this change
+                        if !Observer::is(&sub) {
+                            sub.mark_dirty();
+                        }
                     }
+                } else {
+                    drop(reactivity_lock);
                 }
-            } else {
-                drop(reactivity_lock);
             }
+            inner_2(changed, reactivity_lock);
 
             changed
         } else {
-            let mut lock = self.reactivity.write().or_poisoned();
-            lock.state = ReactiveNodeState::Clean;
-            false
+            /// codegen optimisation:
+            fn inner(reactivity: &RwLock<MemoInnerReactivity>) -> bool {
+                let mut lock = reactivity.write().or_poisoned();
+                lock.state = ReactiveNodeState::Clean;
+                false
+            }
+            inner(&self.reactivity)
         }
     }
 }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -66,3 +66,9 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]
 denylist = ["tracing"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(leptos_debuginfo)',
+  'cfg(erase_components)',
+] }

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -344,12 +344,14 @@ pub fn Route<Segments, View>(
     /// Defaults to out-of-order streaming.
     #[prop(optional)]
     ssr: SsrMode,
-) -> <NestedRoute<Segments, (), (), View> as IntoErased>::Output
+) -> <NestedRoute<Segments, (), (), View> as IntoMaybeErased>::Output
 where
     View: ChooseView + Clone + 'static,
     Segments: PossibleRouteMatch + Debug + Clone + Send + 'static,
 {
-    NestedRoute::new(path, view).ssr_mode(ssr).into_erased()
+    NestedRoute::new(path, view)
+        .ssr_mode(ssr)
+        .into_maybe_erased()
 }
 
 /// Describes a portion of the nested layout of the app, specifying the route it should match
@@ -369,7 +371,7 @@ pub fn ParentRoute<Segments, View, Children>(
     /// Defaults to out-of-order streaming.
     #[prop(optional)]
     ssr: SsrMode,
-) -> <NestedRoute<Segments, Children, (), View> as IntoErased>::Output
+) -> <NestedRoute<Segments, Children, (), View> as IntoMaybeErased>::Output
 where
     View: ChooseView + Clone + 'static,
     Children: MatchNestedRoutes + Send + Clone + 'static,
@@ -379,10 +381,10 @@ where
     NestedRoute::new(path, view)
         .ssr_mode(ssr)
         .child(children)
-        .into_erased()
+        .into_maybe_erased()
 }
 
-/// With the `impl Fn` in the return signature, IntoErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
+/// With the `impl Fn` in the return signature, IntoMaybeErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
 macro_rules! define_protected_route {
     ($ret:ty) => {
         /// Describes a route that is guarded by a certain condition. This works the same way as
@@ -446,7 +448,7 @@ macro_rules! define_protected_route {
                 })
                 .into_any()
             };
-            NestedRoute::new(path, view).ssr_mode(ssr).into_erased()
+            NestedRoute::new(path, view).ssr_mode(ssr).into_maybe_erased()
         }
     };
 }
@@ -456,7 +458,7 @@ define_protected_route!(crate::any_nested_route::AnyNestedRoute);
 #[cfg(not(erase_components))]
 define_protected_route!(NestedRoute<Segments, (), (), impl Fn() -> AnyView + Send + Clone>);
 
-/// With the `impl Fn` in the return signature, IntoErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
+/// With the `impl Fn` in the return signature, IntoMaybeErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
 macro_rules! define_protected_parent_route {
     ($ret:ty) => {
         #[component(transparent)]
@@ -539,7 +541,7 @@ macro_rules! define_protected_parent_route {
             NestedRoute::new(path, view)
                 .ssr_mode(ssr)
                 .child(children)
-                .into_erased()
+                .into_maybe_erased()
         }
     };
 }

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -3,18 +3,20 @@ pub use super::{form::*, link::*};
 use crate::location::RequestUrl;
 pub use crate::nested_router::Outlet;
 use crate::{
+    any_nested_route::AnyNestedRoute,
     flat_router::FlatRoutesView,
     hooks::use_navigate,
     location::{
         BrowserUrl, Location, LocationChange, LocationProvider, State, Url,
     },
     navigate::NavigateOptions,
-    nested_router::NestedRoutesView,
+    nested_router::{NestedRoutesView, OutletProps},
     resolve_path::resolve_path,
-    ChooseView, MatchNestedRoutes, NestedRoute, RouteDefs, SsrMode,
+    ChooseView, MatchNestedRoutes, NestedRoute, PossibleRouteMatch, RouteDefs,
+    SsrMode,
 };
 use either_of::EitherOf3;
-use leptos::{children, prelude::*};
+use leptos::{children, html::Output, prelude::*};
 use reactive_graph::{
     owner::{provide_context, use_context, Owner},
     signal::ArcRwSignal,
@@ -24,6 +26,7 @@ use reactive_graph::{
 use std::{
     borrow::Cow,
     fmt::{Debug, Display},
+    marker::PhantomData,
     mem,
     sync::Arc,
     time::Duration,
@@ -344,11 +347,12 @@ pub fn Route<Segments, View>(
     /// Defaults to out-of-order streaming.
     #[prop(optional)]
     ssr: SsrMode,
-) -> NestedRoute<Segments, (), (), View>
+) -> <NestedRoute<Segments, (), (), View> as IntoErased>::Output
 where
-    View: ChooseView,
+    View: ChooseView + Clone + 'static,
+    Segments: PossibleRouteMatch + Debug + Clone + Send + 'static,
 {
-    NestedRoute::new(path, view).ssr_mode(ssr)
+    NestedRoute::new(path, view).ssr_mode(ssr).into_erased()
 }
 
 /// Describes a portion of the nested layout of the app, specifying the route it should match
@@ -368,145 +372,185 @@ pub fn ParentRoute<Segments, View, Children>(
     /// Defaults to out-of-order streaming.
     #[prop(optional)]
     ssr: SsrMode,
-) -> NestedRoute<Segments, Children, (), View>
+) -> <NestedRoute<Segments, Children, (), View> as IntoErased>::Output
 where
-    View: ChooseView,
+    View: ChooseView + Clone + 'static,
+    Children: MatchNestedRoutes + Send + Clone + 'static,
+    Segments: PossibleRouteMatch + Debug + Clone + Send + 'static,
 {
     let children = children.into_inner();
-    NestedRoute::new(path, view).ssr_mode(ssr).child(children)
+    NestedRoute::new(path, view)
+        .ssr_mode(ssr)
+        .child(children)
+        .into_erased()
 }
 
-/// Describes a route that is guarded by a certain condition. This works the same way as
-/// [`<Route/>`], except that if the `condition` function evaluates to `Some(false)`, it
-/// redirects to `redirect_path` instead of displaying its `view`.
-#[component(transparent)]
-pub fn ProtectedRoute<Segments, ViewFn, View, C, PathFn, P>(
-    /// The path fragment that this route should match. This can be created using the
-    /// [`path`](crate::path) macro, or path segments ([`StaticSegment`](crate::StaticSegment),
-    /// [`ParamSegment`](crate::ParamSegment), [`WildcardSegment`](crate::WildcardSegment), and
-    /// [`OptionalParamSegment`](crate::OptionalParamSegment)).
-    path: Segments,
-    /// The view for this route.
-    view: ViewFn,
-    /// A function that returns `Option<bool>`, where `Some(true)` means that the user can access
-    /// the page, `Some(false)` means the user cannot access the page, and `None` means this
-    /// information is still loading.
-    condition: C,
-    /// The path that will be redirected to if the condition is `Some(false)`.
-    redirect_path: PathFn,
-    /// Will be displayed while the condition is pending. By default this is the empty view.
-    #[prop(optional, into)]
-    fallback: children::ViewFn,
-    /// The mode that this route prefers during server-side rendering.
-    /// Defaults to out-of-order streaming.
-    #[prop(optional)]
-    ssr: SsrMode,
-) -> NestedRoute<Segments, (), (), impl Fn() -> AnyView + Send + Clone>
-where
-    ViewFn: Fn() -> View + Send + Clone + 'static,
-    View: IntoView + 'static,
-    C: Fn() -> Option<bool> + Send + Clone + 'static,
-    PathFn: Fn() -> P + Send + Clone + 'static,
-    P: Display + 'static,
-{
-    let fallback = move || fallback.run();
-    let view = move || {
-        let condition = condition.clone();
-        let redirect_path = redirect_path.clone();
-        let view = view.clone();
-        let fallback = fallback.clone();
-        (view! {
-            <Transition fallback=fallback.clone()>
-                {move || {
-                    let condition = condition();
-                    let view = view.clone();
-                    let redirect_path = redirect_path.clone();
-                    let fallback = fallback.clone();
-                    Unsuspend::new(move || match condition {
-                        Some(true) => EitherOf3::A(view()),
-                        #[allow(clippy::unit_arg)]
-                        Some(false) => {
-                            EitherOf3::B(view! { <Redirect path=redirect_path()/> }.into_inner())
-                        }
-                        None => EitherOf3::C(fallback()),
-                    })
-                }}
-
-            </Transition>
-        })
-        .into_any()
-    };
-    NestedRoute::new(path, view).ssr_mode(ssr)
-}
-
-#[component(transparent)]
-pub fn ProtectedParentRoute<Segments, ViewFn, View, C, PathFn, P, Children>(
-    /// The path fragment that this route should match. This can be created using the
-    /// [`path`](crate::path) macro, or path segments ([`StaticSegment`](crate::StaticSegment),
-    /// [`ParamSegment`](crate::ParamSegment), [`WildcardSegment`](crate::WildcardSegment), and
-    /// [`OptionalParamSegment`](crate::OptionalParamSegment)).
-    path: Segments,
-    /// The view for this route.
-    view: ViewFn,
-    /// A function that returns `Option<bool>`, where `Some(true)` means that the user can access
-    /// the page, `Some(false)` means the user cannot access the page, and `None` means this
-    /// information is still loading.
-    condition: C,
-    /// Will be displayed while the condition is pending. By default this is the empty view.
-    #[prop(optional, into)]
-    fallback: children::ViewFn,
-    /// The path that will be redirected to if the condition is `Some(false)`.
-    redirect_path: PathFn,
-    /// Nested child routes.
-    children: RouteChildren<Children>,
-    /// The mode that this route prefers during server-side rendering.
-    /// Defaults to out-of-order streaming.
-    #[prop(optional)]
-    ssr: SsrMode,
-) -> NestedRoute<Segments, Children, (), impl Fn() -> AnyView + Send + Clone>
-where
-    ViewFn: Fn() -> View + Send + Clone + 'static,
-    View: IntoView + 'static,
-    C: Fn() -> Option<bool> + Send + Clone + 'static,
-    PathFn: Fn() -> P + Send + Clone + 'static,
-    P: Display + 'static,
-{
-    let fallback = move || fallback.run();
-    let children = children.into_inner();
-    let view = move || {
-        let condition = condition.clone();
-        let redirect_path = redirect_path.clone();
-        let fallback = fallback.clone();
-        let view = view.clone();
-        let owner = Owner::current().unwrap();
-        let view = {
-            let fallback = fallback.clone();
-            move || {
-                let condition = condition();
+/// With the `impl Fn` in the return signature, IntoErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
+macro_rules! define_protected_route {
+    ($ret:ty) => {
+        /// Describes a route that is guarded by a certain condition. This works the same way as
+        /// [`<Route/>`], except that if the `condition` function evaluates to `Some(false)`, it
+        /// redirects to `redirect_path` instead of displaying its `view`.
+        #[component(transparent)]
+        pub fn ProtectedRoute<Segments, ViewFn, View, C, PathFn, P>(
+            /// The path fragment that this route should match. This can be created using the
+            /// [`path`](crate::path) macro, or path segments ([`StaticSegment`](crate::StaticSegment),
+            /// [`ParamSegment`](crate::ParamSegment), [`WildcardSegment`](crate::WildcardSegment), and
+            /// [`OptionalParamSegment`](crate::OptionalParamSegment)).
+            path: Segments,
+            /// The view for this route.
+            view: ViewFn,
+            /// A function that returns `Option<bool>`, where `Some(true)` means that the user can access
+            /// the page, `Some(false)` means the user cannot access the page, and `None` means this
+            /// information is still loading.
+            condition: C,
+            /// The path that will be redirected to if the condition is `Some(false)`.
+            redirect_path: PathFn,
+            /// Will be displayed while the condition is pending. By default this is the empty view.
+            #[prop(optional, into)]
+            fallback: children::ViewFn,
+            /// The mode that this route prefers during server-side rendering.
+            /// Defaults to out-of-order streaming.
+            #[prop(optional)]
+            ssr: SsrMode,
+        ) -> $ret
+        where
+            Segments: PossibleRouteMatch + Debug + Clone + Send + 'static,
+            ViewFn: Fn() -> View + Send + Clone + 'static,
+            View: IntoView + 'static,
+            C: Fn() -> Option<bool> + Send + Clone + 'static,
+            PathFn: Fn() -> P + Send + Clone + 'static,
+            P: Display + 'static,
+        {
+            let fallback = move || fallback.run();
+            let view = move || {
+                let condition = condition.clone();
+                let redirect_path = redirect_path.clone();
                 let view = view.clone();
+                let fallback = fallback.clone();
+                (view! {
+                    <Transition fallback=fallback.clone()>
+                        {move || {
+                            let condition = condition();
+                            let view = view.clone();
+                            let redirect_path = redirect_path.clone();
+                            let fallback = fallback.clone();
+                            Unsuspend::new(move || match condition {
+                                Some(true) => EitherOf3::A(view()),
+                                #[allow(clippy::unit_arg)]
+                                Some(false) => {
+                                    EitherOf3::B(view! { <Redirect path=redirect_path()/> }.into_inner())
+                                }
+                                None => EitherOf3::C(fallback()),
+                            })
+                        }}
+
+                    </Transition>
+                })
+                .into_any()
+            };
+            NestedRoute::new(path, view).ssr_mode(ssr).into_erased()
+        }
+    };
+}
+
+#[cfg(erase_components)]
+define_protected_route!(AnyNestedRoute);
+#[cfg(not(erase_components))]
+define_protected_route!(NestedRoute<Segments, (), (), impl Fn() -> AnyView + Send + Clone>);
+
+/// With the `impl Fn` in the return signature, IntoErased::Output isn't accepted by the compiler, so changing return type depending on the erasure flag.
+macro_rules! define_protected_parent_route {
+    ($ret:ty) => {
+        #[component(transparent)]
+        pub fn ProtectedParentRoute<
+            Segments,
+            ViewFn,
+            View,
+            C,
+            PathFn,
+            P,
+            Children,
+        >(
+            /// The path fragment that this route should match. This can be created using the
+            /// [`path`](crate::path) macro, or path segments ([`StaticSegment`](crate::StaticSegment),
+            /// [`ParamSegment`](crate::ParamSegment), [`WildcardSegment`](crate::WildcardSegment), and
+            /// [`OptionalParamSegment`](crate::OptionalParamSegment)).
+            path: Segments,
+            /// The view for this route.
+            view: ViewFn,
+            /// A function that returns `Option<bool>`, where `Some(true)` means that the user can access
+            /// the page, `Some(false)` means the user cannot access the page, and `None` means this
+            /// information is still loading.
+            condition: C,
+            /// Will be displayed while the condition is pending. By default this is the empty view.
+            #[prop(optional, into)]
+            fallback: children::ViewFn,
+            /// The path that will be redirected to if the condition is `Some(false)`.
+            redirect_path: PathFn,
+            /// Nested child routes.
+            children: RouteChildren<Children>,
+            /// The mode that this route prefers during server-side rendering.
+            /// Defaults to out-of-order streaming.
+            #[prop(optional)]
+            ssr: SsrMode,
+        ) -> $ret
+        where
+            Segments: PossibleRouteMatch + Debug + Clone + Send + 'static,
+            Children: MatchNestedRoutes + Send + Clone + 'static,
+            ViewFn: Fn() -> View + Send + Clone + 'static,
+            View: IntoView + 'static,
+            C: Fn() -> Option<bool> + Send + Clone + 'static,
+            PathFn: Fn() -> P + Send + Clone + 'static,
+            P: Display + 'static,
+        {
+            let fallback = move || fallback.run();
+            let children = children.into_inner();
+            let view = move || {
+                let condition = condition.clone();
                 let redirect_path = redirect_path.clone();
                 let fallback = fallback.clone();
-                let owner = owner.clone();
-                Unsuspend::new(move || match condition {
-                    // reset the owner so that things like providing context work
-                    // otherwise, this will be a child owner nested within the Transition, not
-                    // the parent owner of the Outlet
-                    //
-                    // clippy: not redundant, a FnOnce vs FnMut issue
-                    #[allow(clippy::redundant_closure)]
-                    Some(true) => EitherOf3::A(owner.with(|| view())),
-                    #[allow(clippy::unit_arg)]
-                    Some(false) => EitherOf3::B(
-                        view! { <Redirect path=redirect_path()/> }.into_inner(),
-                    ),
-                    None => EitherOf3::C(fallback()),
-                })
-            }
-        };
-        (view! { <Transition fallback>{view}</Transition> }).into_any()
+                let view = view.clone();
+                let owner = Owner::current().unwrap();
+                let view = {
+                    let fallback = fallback.clone();
+                    move || {
+                        let condition = condition();
+                        let view = view.clone();
+                        let redirect_path = redirect_path.clone();
+                        let fallback = fallback.clone();
+                        let owner = owner.clone();
+                        Unsuspend::new(move || match condition {
+                            // reset the owner so that things like providing context work
+                            // otherwise, this will be a child owner nested within the Transition, not
+                            // the parent owner of the Outlet
+                            //
+                            // clippy: not redundant, a FnOnce vs FnMut issue
+                            #[allow(clippy::redundant_closure)]
+                            Some(true) => EitherOf3::A(owner.with(|| view())),
+                            #[allow(clippy::unit_arg)]
+                            Some(false) => EitherOf3::B(
+                                view! { <Redirect path=redirect_path()/> }
+                                    .into_inner(),
+                            ),
+                            None => EitherOf3::C(fallback()),
+                        })
+                    }
+                };
+                (view! { <Transition fallback>{view}</Transition> }).into_any()
+            };
+            NestedRoute::new(path, view)
+                .ssr_mode(ssr)
+                .child(children)
+                .into_erased()
+        }
     };
-    NestedRoute::new(path, view).ssr_mode(ssr).child(children)
 }
+
+#[cfg(erase_components)]
+define_protected_parent_route!(AnyNestedRoute);
+#[cfg(not(erase_components))]
+define_protected_parent_route!(NestedRoute<Segments, Children, (), impl Fn() -> AnyView + Send + Clone>);
 
 /// Redirects the user to a new URL, whether on the client side or on the server
 /// side. If rendered on the server, this sets a `302` status code and sets a `Location`

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -29,7 +29,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tachys::view::any_view::AnyView;
 
 /// A wrapper that allows passing route definitions as children to a component like [`Routes`],
 /// [`FlatRoutes`], [`ParentRoute`], or [`ProtectedParentRoute`].

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -453,7 +453,7 @@ macro_rules! define_protected_route {
 }
 
 #[cfg(erase_components)]
-define_protected_route!(AnyNestedRoute);
+define_protected_route!(crate::any_nested_route::AnyNestedRoute);
 #[cfg(not(erase_components))]
 define_protected_route!(NestedRoute<Segments, (), (), impl Fn() -> AnyView + Send + Clone>);
 
@@ -546,7 +546,7 @@ macro_rules! define_protected_parent_route {
 }
 
 #[cfg(erase_components)]
-define_protected_parent_route!(AnyNestedRoute);
+define_protected_parent_route!(crate::any_nested_route::AnyNestedRoute);
 #[cfg(not(erase_components))]
 define_protected_parent_route!(NestedRoute<Segments, Children, (), impl Fn() -> AnyView + Send + Clone>);
 

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -3,20 +3,19 @@ pub use super::{form::*, link::*};
 use crate::location::RequestUrl;
 pub use crate::nested_router::Outlet;
 use crate::{
-    any_nested_route::AnyNestedRoute,
     flat_router::FlatRoutesView,
     hooks::use_navigate,
     location::{
         BrowserUrl, Location, LocationChange, LocationProvider, State, Url,
     },
     navigate::NavigateOptions,
-    nested_router::{NestedRoutesView, OutletProps},
+    nested_router::NestedRoutesView,
     resolve_path::resolve_path,
     ChooseView, MatchNestedRoutes, NestedRoute, PossibleRouteMatch, RouteDefs,
     SsrMode,
 };
 use either_of::EitherOf3;
-use leptos::{children, html::Output, prelude::*};
+use leptos::{children, prelude::*};
 use reactive_graph::{
     owner::{provide_context, use_context, Owner},
     signal::ArcRwSignal,
@@ -26,7 +25,6 @@ use reactive_graph::{
 use std::{
     borrow::Cow,
     fmt::{Debug, Display},
-    marker::PhantomData,
     mem,
     sync::Arc,
     time::Duration,

--- a/router/src/matching/any_choose_view.rs
+++ b/router/src/matching/any_choose_view.rs
@@ -1,6 +1,6 @@
 use super::ChooseView;
 use futures::FutureExt;
-use std::{any::Any, future::Future, pin::Pin};
+use std::{future::Future, pin::Pin};
 use tachys::{erased::Erased, view::any_view::AnyView};
 
 /// A type-erased [`ChooseView`].

--- a/router/src/matching/any_choose_view.rs
+++ b/router/src/matching/any_choose_view.rs
@@ -1,0 +1,47 @@
+use super::ChooseView;
+use futures::FutureExt;
+use std::{any::Any, future::Future, pin::Pin};
+use tachys::view::any_view::AnyView;
+
+/// A type-erased [`ChooseView`].
+pub struct AnyChooseView {
+    value: Box<dyn Any + Send>,
+    clone: fn(&Box<dyn Any + Send>) -> AnyChooseView,
+    choose: fn(Box<dyn Any>) -> Pin<Box<dyn Future<Output = AnyView>>>,
+    preload: for<'a> fn(
+        &'a Box<dyn Any + Send>,
+    ) -> Pin<Box<dyn Future<Output = ()> + 'a>>,
+}
+
+impl Clone for AnyChooseView {
+    fn clone(&self) -> Self {
+        (self.clone)(&self.value)
+    }
+}
+
+impl AnyChooseView {
+    pub(crate) fn new<T: ChooseView>(value: T) -> Self {
+        Self {
+            value: Box::new(value),
+            clone: |value| {
+                AnyChooseView::new(value.downcast_ref::<T>().unwrap().clone())
+            },
+            choose: |value| {
+                value.downcast::<T>().unwrap().choose().boxed_local()
+            },
+            preload: |value| {
+                value.downcast_ref::<T>().unwrap().preload().boxed_local()
+            },
+        }
+    }
+}
+
+impl ChooseView for AnyChooseView {
+    async fn choose(self) -> AnyView {
+        (self.choose)(self.value).await
+    }
+
+    async fn preload(&self) {
+        (self.preload)(&self.value).await;
+    }
+}

--- a/router/src/matching/choose_view.rs
+++ b/router/src/matching/choose_view.rs
@@ -130,3 +130,34 @@ tuples!(EitherOf13 => A, B, C, D, E, F, G, H, I, J, K, L, M);
 tuples!(EitherOf14 => A, B, C, D, E, F, G, H, I, J, K, L, M, N);
 tuples!(EitherOf15 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 tuples!(EitherOf16 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+
+/// A version of [`IntoErased`] for the [`ChooseView`] trait.
+pub trait IntoChooseViewErased {
+    /// The type of the erased view.
+    type Output: IntoChooseViewErased;
+
+    /// Erase the type of the view.
+    fn into_erased(self) -> Self::Output;
+}
+
+impl<T> IntoChooseViewErased for T
+where
+    T: ChooseView + Send + Clone + 'static,
+{
+    #[cfg(erase_components)]
+    type Output = crate::matching::any_choose_view::AnyChooseView;
+
+    #[cfg(not(erase_components))]
+    type Output = Self;
+
+    fn into_erased(self) -> Self::Output {
+        #[cfg(erase_components)]
+        {
+            crate::matching::any_choose_view::AnyChooseView::new(self)
+        }
+        #[cfg(not(erase_components))]
+        {
+            self
+        }
+    }
+}

--- a/router/src/matching/choose_view.rs
+++ b/router/src/matching/choose_view.rs
@@ -131,16 +131,16 @@ tuples!(EitherOf14 => A, B, C, D, E, F, G, H, I, J, K, L, M, N);
 tuples!(EitherOf15 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 tuples!(EitherOf16 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
-/// A version of [`IntoErased`] for the [`ChooseView`] trait.
-pub trait IntoChooseViewErased {
+/// A version of [`IntoMaybeErased`] for the [`ChooseView`] trait.
+pub trait IntoChooseViewMaybeErased {
     /// The type of the erased view.
-    type Output: IntoChooseViewErased;
+    type Output: IntoChooseViewMaybeErased;
 
     /// Erase the type of the view.
-    fn into_erased(self) -> Self::Output;
+    fn into_maybe_erased(self) -> Self::Output;
 }
 
-impl<T> IntoChooseViewErased for T
+impl<T> IntoChooseViewMaybeErased for T
 where
     T: ChooseView + Send + Clone + 'static,
 {
@@ -150,7 +150,7 @@ where
     #[cfg(not(erase_components))]
     type Output = Self;
 
-    fn into_erased(self) -> Self::Output {
+    fn into_maybe_erased(self) -> Self::Output {
         #[cfg(erase_components)]
         {
             crate::matching::any_choose_view::AnyChooseView::new(self)

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs)]
 
+mod any_choose_view;
 mod choose_view;
 mod path_segment;
 pub(crate) mod resolve_path;

--- a/router/src/matching/nested/any_nested_match.rs
+++ b/router/src/matching/nested/any_nested_match.rs
@@ -1,0 +1,105 @@
+use crate::{
+    matching::any_choose_view::AnyChooseView, ChooseView, MatchInterface,
+    MatchParams, RouteMatchId,
+};
+use std::{any::Any, borrow::Cow, fmt::Debug};
+
+/// A type-erased container for any [`MatchParams'] + [`MatchInterface`].
+pub struct AnyNestedMatch {
+    value: Box<dyn Any>,
+    to_params: fn(&dyn Any) -> Vec<(Cow<'static, str>, String)>,
+    as_id: fn(&dyn Any) -> RouteMatchId,
+    as_matched: for<'a> fn(&'a dyn Any) -> &'a str,
+    into_view_and_child:
+        fn(Box<dyn Any>) -> (AnyChooseView, Option<AnyNestedMatch>),
+}
+
+impl Debug for AnyNestedMatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnyNestedMatch").finish_non_exhaustive()
+    }
+}
+
+/// Converts anything implementing [`MatchParams'] + [`MatchInterface`] into an erased type.
+pub trait IntoAnyNestedMatch {
+    /// Wraps the nested route.
+    fn into_any_nested_match(self) -> AnyNestedMatch;
+}
+
+impl<T> IntoAnyNestedMatch for T
+where
+    T: MatchParams + MatchInterface + 'static,
+{
+    fn into_any_nested_match(self) -> AnyNestedMatch {
+        let value = Box::new(self) as Box<dyn Any>;
+        let value = match (value as Box<dyn Any>).downcast::<AnyNestedMatch>() {
+            // if it's already an AnyNestedMatch, we don't need to double-wrap it
+            Ok(any_nested_route) => return *any_nested_route,
+            Err(value) => value.downcast::<T>().unwrap(),
+        };
+
+        let to_params = |value: &dyn Any| {
+            let value = value
+                .downcast_ref::<T>()
+                .expect("AnyNestedMatch::to_params couldn't downcast");
+            value.to_params()
+        };
+
+        let as_id = |value: &dyn Any| {
+            let value = value
+                .downcast_ref::<T>()
+                .expect("AnyNestedMatch::as_id couldn't downcast");
+            value.as_id()
+        };
+
+        fn as_matched<'a, T: MatchInterface + 'static>(
+            value: &'a dyn Any,
+        ) -> &'a str {
+            let value = value
+                .downcast_ref::<T>()
+                .expect("AnyNestedMatch::as_matched couldn't downcast");
+            value.as_matched()
+        }
+
+        let into_view_and_child = |value: Box<dyn Any>| {
+            let value = value.downcast::<T>().expect(
+                "AnyNestedMatch::into_view_and_child couldn't downcast",
+            );
+            let (view, child) = value.into_view_and_child();
+            (
+                AnyChooseView::new(view),
+                child.map(|child| child.into_any_nested_match()),
+            )
+        };
+
+        AnyNestedMatch {
+            value,
+            to_params,
+            as_id,
+            as_matched: as_matched::<T>,
+            into_view_and_child,
+        }
+    }
+}
+
+impl MatchParams for AnyNestedMatch {
+    fn to_params(&self) -> Vec<(Cow<'static, str>, String)> {
+        (self.to_params)(&*self.value)
+    }
+}
+
+impl MatchInterface for AnyNestedMatch {
+    type Child = AnyNestedMatch;
+
+    fn as_id(&self) -> RouteMatchId {
+        (self.as_id)(&*self.value)
+    }
+
+    fn as_matched(&self) -> &str {
+        (self.as_matched)(&*self.value)
+    }
+
+    fn into_view_and_child(self) -> (impl ChooseView, Option<Self::Child>) {
+        (self.into_view_and_child)(self.value)
+    }
+}

--- a/router/src/matching/nested/any_nested_match.rs
+++ b/router/src/matching/nested/any_nested_match.rs
@@ -52,9 +52,7 @@ where
             value.as_id()
         };
 
-        fn as_matched<T: MatchInterface + 'static>(
-            value: &dyn Any,
-        ) -> &str {
+        fn as_matched<T: MatchInterface + 'static>(value: &dyn Any) -> &str {
             let value = value
                 .downcast_ref::<T>()
                 .expect("AnyNestedMatch::as_matched couldn't downcast");

--- a/router/src/matching/nested/any_nested_match.rs
+++ b/router/src/matching/nested/any_nested_match.rs
@@ -52,9 +52,9 @@ where
             value.as_id()
         };
 
-        fn as_matched<'a, T: MatchInterface + 'static>(
-            value: &'a dyn Any,
-        ) -> &'a str {
+        fn as_matched<T: MatchInterface + 'static>(
+            value: &dyn Any,
+        ) -> &str {
             let value = value
                 .downcast_ref::<T>()
                 .expect("AnyNestedMatch::as_matched couldn't downcast");

--- a/router/src/matching/nested/any_nested_match.rs
+++ b/router/src/matching/nested/any_nested_match.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use crate::{
     matching::any_choose_view::AnyChooseView, ChooseView, MatchInterface,
     MatchParams, RouteMatchId,

--- a/router/src/matching/nested/any_nested_route.rs
+++ b/router/src/matching/nested/any_nested_route.rs
@@ -4,7 +4,7 @@ use crate::{
     GeneratedRouteData, MatchNestedRoutes, RouteMatchId,
 };
 use std::fmt::Debug;
-use tachys::{erased::Erased, prelude::IntoErased};
+use tachys::{erased::Erased, prelude::IntoMaybeErased};
 
 /// A type-erased container for any [`MatchNestedRoutes`].
 pub struct AnyNestedRoute {
@@ -31,10 +31,10 @@ impl Debug for AnyNestedRoute {
     }
 }
 
-impl IntoErased for AnyNestedRoute {
+impl IntoMaybeErased for AnyNestedRoute {
     type Output = Self;
 
-    fn into_erased(self) -> Self::Output {
+    fn into_maybe_erased(self) -> Self::Output {
         self
     }
 }

--- a/router/src/matching/nested/any_nested_route.rs
+++ b/router/src/matching/nested/any_nested_route.rs
@@ -1,0 +1,97 @@
+use crate::{
+    matching::nested::any_nested_match::{AnyNestedMatch, IntoAnyNestedMatch},
+    GeneratedRouteData, MatchNestedRoutes, RouteMatchId,
+};
+use std::{any::Any, fmt::Debug};
+use tachys::prelude::IntoErased;
+
+/// A type-erased container for any [`MatchNestedRoutes`].
+pub struct AnyNestedRoute {
+    value: Box<dyn Any + Send>,
+    clone: fn(&Box<dyn Any + Send>) -> AnyNestedRoute,
+    match_nested:
+        for<'a> fn(
+            &'a Box<dyn Any + Send>,
+            &'a str,
+        )
+            -> (Option<(RouteMatchId, AnyNestedMatch)>, &'a str),
+    generate_routes: fn(&Box<dyn Any + Send>) -> Vec<GeneratedRouteData>,
+}
+
+impl Clone for AnyNestedRoute {
+    fn clone(&self) -> Self {
+        (self.clone)(&self.value)
+    }
+}
+
+impl Debug for AnyNestedRoute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnyNestedRoute").finish_non_exhaustive()
+    }
+}
+
+impl IntoErased for AnyNestedRoute {
+    type Output = Self;
+
+    fn into_erased(self) -> Self::Output {
+        self
+    }
+}
+
+/// Converts anything implementing [`MatchNestedRoutes`] into [`AnyNestedRoute`].
+pub trait IntoAnyNestedRoute {
+    /// Wraps the nested route.
+    fn into_any_nested_route(self) -> AnyNestedRoute;
+}
+
+impl<T> IntoAnyNestedRoute for T
+where
+    T: MatchNestedRoutes + Send + Clone + 'static,
+{
+    fn into_any_nested_route(self) -> AnyNestedRoute {
+        AnyNestedRoute {
+            value: Box::new(self),
+            clone: |value| {
+                value
+                    .downcast_ref::<T>()
+                    .unwrap()
+                    .clone()
+                    .into_any_nested_route()
+            },
+            match_nested: |value, path| {
+                let (maybe_match, path) =
+                    value.downcast_ref::<T>().unwrap().match_nested(path);
+                (
+                    maybe_match.map(|(id, matched)| {
+                        (id, matched.into_any_nested_match())
+                    }),
+                    path,
+                )
+            },
+            generate_routes: |value| {
+                value
+                    .downcast_ref::<T>()
+                    .unwrap()
+                    .generate_routes()
+                    .into_iter()
+                    .collect()
+            },
+        }
+    }
+}
+
+impl MatchNestedRoutes for AnyNestedRoute {
+    type Data = AnyNestedMatch;
+    type Match = AnyNestedMatch;
+
+    fn match_nested<'a>(
+        &'a self,
+        path: &'a str,
+    ) -> (Option<(RouteMatchId, Self::Match)>, &'a str) {
+        (self.match_nested)(&self.value, path)
+    }
+
+    fn generate_routes(&self) -> impl IntoIterator<Item = GeneratedRouteData> {
+        (self.generate_routes)(&self.value)
+    }
+}

--- a/router/src/matching/nested/any_nested_route.rs
+++ b/router/src/matching/nested/any_nested_route.rs
@@ -2,7 +2,7 @@ use crate::{
     matching::nested::any_nested_match::{AnyNestedMatch, IntoAnyNestedMatch},
     GeneratedRouteData, MatchNestedRoutes, RouteMatchId,
 };
-use std::{any::Any, fmt::Debug};
+use std::fmt::Debug;
 use tachys::{erased::Erased, prelude::IntoErased};
 
 /// A type-erased container for any [`MatchNestedRoutes`].

--- a/router/src/matching/nested/any_nested_route.rs
+++ b/router/src/matching/nested/any_nested_route.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 use crate::{
     matching::nested::any_nested_match::{AnyNestedMatch, IntoAnyNestedMatch},
     GeneratedRouteData, MatchNestedRoutes, RouteMatchId,

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    IntoChooseViewErased, MatchInterface, MatchNestedRoutes, PartialPathMatch,
-    PathSegment, PossibleRouteMatch, RouteMatchId,
+    IntoChooseViewMaybeErased, MatchInterface, MatchNestedRoutes,
+    PartialPathMatch, PathSegment, PossibleRouteMatch, RouteMatchId,
 };
 use crate::{ChooseView, GeneratedRouteData, MatchParams, Method, SsrMode};
 use core::{fmt, iter};
@@ -10,7 +10,7 @@ use std::{
     collections::HashSet,
     sync::atomic::{AtomicU16, Ordering},
 };
-use tachys::prelude::IntoErased;
+use tachys::prelude::IntoMaybeErased;
 
 pub mod any_nested_match;
 pub mod any_nested_route;
@@ -29,7 +29,7 @@ pub struct NestedRoute<Segments, Children, Data, View> {
     ssr_mode: SsrMode,
 }
 
-impl<Segments, Children, Data, View> IntoErased
+impl<Segments, Children, Data, View> IntoMaybeErased
     for NestedRoute<Segments, Children, Data, View>
 where
     Self: MatchNestedRoutes + Send + Clone + 'static,
@@ -40,7 +40,7 @@ where
     #[cfg(not(erase_components))]
     type Output = Self;
 
-    fn into_erased(self) -> Self::Output {
+    fn into_maybe_erased(self) -> Self::Output {
         #[cfg(erase_components)]
         {
             use any_nested_route::IntoAnyNestedRoute;
@@ -79,7 +79,12 @@ impl<Segments, View> NestedRoute<Segments, (), (), View> {
     pub fn new(
         path: Segments,
         view: View,
-    ) -> NestedRoute<Segments, (), (), <View as IntoChooseViewErased>::Output>
+    ) -> NestedRoute<
+        Segments,
+        (),
+        (),
+        <View as IntoChooseViewMaybeErased>::Output,
+    >
     where
         View: ChooseView,
     {
@@ -88,7 +93,7 @@ impl<Segments, View> NestedRoute<Segments, (), (), View> {
             segments: path,
             children: None,
             data: (),
-            view: view.into_erased(),
+            view: view.into_maybe_erased(),
             methods: [Method::Get].into(),
             ssr_mode: Default::default(),
         }

--- a/router/src/matching/nested/tuples.rs
+++ b/router/src/matching/nested/tuples.rs
@@ -193,7 +193,7 @@ where
         &'a self,
         path: &'a str,
     ) -> (Option<(RouteMatchId, Self::Match)>, &'a str) {
-        for (_i, item) in self.iter().enumerate() {
+        for item in self.iter() {
             if let (Some((id, matched)), remaining) = item.match_nested(path) {
                 return (Some((id, matched)), remaining);
             }

--- a/router/src/matching/nested/tuples.rs
+++ b/router/src/matching/nested/tuples.rs
@@ -3,6 +3,7 @@ use crate::{ChooseView, GeneratedRouteData, MatchParams};
 use core::iter;
 use either_of::*;
 use std::borrow::Cow;
+use tachys::view::iterators::StaticVec;
 
 impl MatchParams for () {
     fn to_params(&self) -> Vec<(Cow<'static, str>, String)> {
@@ -178,6 +179,32 @@ where
         let B = B.generate_routes().into_iter();
 
         A.chain(B)
+    }
+}
+
+impl<T> MatchNestedRoutes for StaticVec<T>
+where
+    T: MatchNestedRoutes,
+{
+    type Data = Vec<T::Data>;
+    type Match = T::Match;
+
+    fn match_nested<'a>(
+        &'a self,
+        path: &'a str,
+    ) -> (Option<(RouteMatchId, Self::Match)>, &'a str) {
+        for (_i, item) in self.iter().enumerate() {
+            if let (Some((id, matched)), remaining) = item.match_nested(path) {
+                return (Some((id, matched)), remaining);
+            }
+        }
+        (None, path)
+    }
+
+    fn generate_routes(
+        &self,
+    ) -> impl IntoIterator<Item = GeneratedRouteData> + '_ {
+        self.iter().flat_map(T::generate_routes)
     }
 }
 

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -21,9 +21,9 @@ reactive_stores = { workspace = true, optional = true }
 slotmap = { version = "1.0", optional = true }
 oco_ref = { workspace = true, optional = true }
 async-trait = "0.1.81"
-dyn-clone = "1.0.17"
 once_cell = "1.20"
 paste = "1.0"
+erased = "0.1.2"
 wasm-bindgen = "0.2.97"
 html-escape = "0.2.13"
 js-sys = "0.3.74"
@@ -162,7 +162,6 @@ sledgehammer_bindgen = { version = "0.6.0", features = [
 ], optional = true }
 sledgehammer_utils = { version = "0.3.1", optional = true }
 tracing = { version = "0.1.41", optional = true }
-erased = "0.1.2"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -162,6 +162,7 @@ sledgehammer_bindgen = { version = "0.6.0", features = [
 ], optional = true }
 sledgehammer_utils = { version = "0.3.1", optional = true }
 tracing = { version = "0.1.41", optional = true }
+erased = "0.1.2"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/tachys/src/erased.rs
+++ b/tachys/src/erased.rs
@@ -1,0 +1,61 @@
+use erased::ErasedBox;
+
+#[cfg(not(erase_components))]
+fn check(id_1: &std::any::TypeId, id_2: &std::any::TypeId) {
+    if id_1 != id_2 {
+        panic!("Erased: type mismatch")
+    }
+}
+
+macro_rules! erased {
+    ([$($new_t_params:tt)*], $name:ident) => {
+        /// A type-erased item. This is slightly more efficient than using `Box<dyn Any (+ Send)>`.
+        ///
+        /// With the caveat that T must always be correct upon retrieval.
+        /// In erased mode T retrieval is unchecked to minimise codegen, in other modes T will be verified and a panic otherwise.
+        pub struct $name {
+            #[cfg(not(erase_components))]
+            type_id: std::any::TypeId,
+            value: ErasedBox,
+        }
+
+
+        impl $name {
+            /// Create a new type-erased item.
+            pub fn new<T: $($new_t_params)*>(item: T) -> Self {
+                Self {
+                    #[cfg(not(erase_components))]
+                    type_id: std::any::TypeId::of::<T>(),
+                    value: ErasedBox::new(Box::new(item)),
+                }
+            }
+
+            /// Get a reference to the inner value.
+            pub fn get_ref<T: 'static>(&self) -> &T {
+                #[cfg(not(erase_components))]
+                check(&self.type_id, &std::any::TypeId::of::<T>());
+                unsafe { self.value.get_ref::<T>() }
+            }
+
+            /// Get a mutable reference to the inner value.
+            pub fn get_mut<T: 'static>(&mut self) -> &mut T {
+                #[cfg(not(erase_components))]
+                check(&self.type_id, &std::any::TypeId::of::<T>());
+                unsafe { self.value.get_mut::<T>() }
+            }
+
+            /// Consume the item and return the inner value.
+            pub fn into_inner<T: 'static>(self) -> Box<T> {
+                #[cfg(not(erase_components))]
+                check(&self.type_id, &std::any::TypeId::of::<T>());
+                unsafe { self.value.into_inner::<T>() }
+            }
+        }
+    };
+}
+
+erased!([Send + 'static], Erased);
+erased!(['static], ErasedLocal);
+
+/// SAFETY: `Erased::new` ensures that `T` is `Send` and `'static`.
+unsafe impl Send for Erased {}

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -72,6 +72,9 @@ pub mod oco;
 #[cfg(feature = "reactive_graph")]
 pub mod reactive_graph;
 
+/// A type-erased container.
+pub mod erased;
+
 pub(crate) trait UnwrapOrDebug {
     type Output;
 

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         renderer::{dom::Dom, Renderer},
         view::{
             add_attr::AddAnyAttr,
-            any_view::{AnyView, IntoAny, IntoErased},
+            any_view::{AnyView, IntoAny, IntoMaybeErased},
             IntoRender, Mountable, Render, RenderHtml,
         },
     };

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -14,6 +14,7 @@ pub mod prelude {
     pub use crate::{
         html::{
             attribute::{
+                any_attribute::IntoAnyAttribute,
                 aria::AriaAttributes,
                 custom::CustomAttribute,
                 global::{
@@ -30,7 +31,7 @@ pub mod prelude {
         renderer::{dom::Dom, Renderer},
         view::{
             add_attr::AddAnyAttr,
-            any_view::{AnyView, IntoAny},
+            any_view::{AnyView, IntoAny, IntoErased},
             IntoRender, Mountable, Render, RenderHtml,
         },
     };

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -118,10 +118,21 @@ impl<T> IntoErased for T
 where
     T: RenderHtml,
 {
+    #[cfg(not(erase_components))]
+    type Output = Self;
+
+    #[cfg(erase_components)]
     type Output = AnyView;
 
     fn into_erased(self) -> Self::Output {
-        self.into_owned().into_any()
+        #[cfg(not(erase_components))]
+        {
+            self
+        }
+        #[cfg(erase_components)]
+        {
+            self.into_owned().into_any()
+        }
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::type_complexity)]
 #[cfg(feature = "ssr")]
 use super::MarkBranch;
 use super::{
@@ -13,10 +14,7 @@ use crate::{
     hydration::Cursor,
     ssr::StreamBuilder,
 };
-use futures::{
-    future::{join, join_all},
-    FutureExt,
-};
+use futures::future::{join, join_all};
 use std::{any::TypeId, fmt::Debug};
 #[cfg(feature = "ssr")]
 use std::{future::Future, pin::Pin};
@@ -177,6 +175,8 @@ where
         fn resolve<T: RenderHtml + 'static>(
             value: Erased,
         ) -> Pin<Box<dyn Future<Output = AnyView> + Send>> {
+            use futures::FutureExt;
+
             async move { value.into_inner::<T>().resolve().await.into_any() }
                 .boxed()
         }

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -106,15 +106,15 @@ pub trait IntoAny {
 
 /// A more general version of [`IntoAny`] that allows into [`AnyView`],
 /// but also erasing other types that don't implement [`RenderHtml`] like routing.
-pub trait IntoErased {
+pub trait IntoMaybeErased {
     /// The type of the output.
-    type Output: IntoErased;
+    type Output: IntoMaybeErased;
 
-    /// Converts the view into a type-erased view.
-    fn into_erased(self) -> Self::Output;
+    /// Converts the view into a type-erased view if in erased mode.
+    fn into_maybe_erased(self) -> Self::Output;
 }
 
-impl<T> IntoErased for T
+impl<T> IntoMaybeErased for T
 where
     T: RenderHtml,
 {
@@ -124,7 +124,7 @@ where
     #[cfg(erase_components)]
     type Output = AnyView;
 
-    fn into_erased(self) -> Self::Output {
+    fn into_maybe_erased(self) -> Self::Output {
         #[cfg(not(erase_components))]
         {
             self

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -112,6 +112,27 @@ pub trait IntoAny {
     fn into_any(self) -> AnyView;
 }
 
+/// A more general version of [`IntoAny`] that allows into [`AnyView`],
+/// but also erasing other types that don't implement [`RenderHtml`] like routing.
+pub trait IntoErased {
+    /// The type of the output.
+    type Output;
+
+    /// Converts the view into a type-erased view.
+    fn into_erased(self) -> Self::Output;
+}
+
+impl<T> IntoErased for T
+where
+    T: RenderHtml,
+{
+    type Output = AnyView;
+
+    fn into_erased(self) -> Self::Output {
+        self.into_owned().into_any()
+    }
+}
+
 fn mount_any<T>(
     state: &mut dyn Any,
     parent: &crate::renderer::types::Element,

--- a/tachys/src/view/fragment.rs
+++ b/tachys/src/view/fragment.rs
@@ -1,9 +1,12 @@
-use super::any_view::{AnyView, IntoAny};
+use super::{
+    any_view::{AnyView, IntoAny},
+    iterators::StaticVec,
+};
 
 /// A typed-erased collection of different views.
 pub struct Fragment {
     /// The nodes contained in the fragment.
-    pub nodes: Vec<AnyView>,
+    pub nodes: StaticVec<AnyView>,
 }
 
 /// Converts some view into a type-erased collection of views.
@@ -34,11 +37,22 @@ impl Fragment {
     /// Creates a new [`Fragment`].
     #[inline(always)]
     pub fn new(nodes: Vec<AnyView>) -> Self {
-        Self { nodes }
+        Self {
+            nodes: nodes.into(),
+        }
     }
 }
 
 impl<T> IntoFragment for Vec<T>
+where
+    T: IntoAny,
+{
+    fn into_fragment(self) -> Fragment {
+        Fragment::new(self.into_iter().map(IntoAny::into_any).collect())
+    }
+}
+
+impl<T> IntoFragment for StaticVec<T>
 where
     T: IntoAny,
 {

--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -391,6 +391,28 @@ where
 /// A container used for ErasedMode. It's slightly better than a raw Vec<> because the rendering traits don't have to worry about the length of the Vec changing, therefore no marker traits etc.
 pub struct StaticVec<T>(pub(crate) Vec<T>);
 
+impl<T: Clone> Clone for StaticVec<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> IntoIterator for StaticVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T> StaticVec<T> {
+    /// Iterates over the items.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.0.iter()
+    }
+}
+
 impl<T> From<Vec<T>> for StaticVec<T> {
     fn from(vec: Vec<T>) -> Self {
         Self(vec)

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -4,8 +4,11 @@ use super::{
 };
 use crate::{
     html::attribute::{
-        any_attribute::AnyAttribute, Attribute, AttributeKey, AttributeValue,
-        NextAttribute,
+        any_attribute::AnyAttribute,
+        maybe_next_attr_erasure_macros::{
+            next_attr_combine, next_attr_output_type,
+        },
+        Attribute, AttributeKey, AttributeValue, NextAttribute,
     },
     hydration::Cursor,
     renderer::{CastFrom, Rndr},
@@ -114,13 +117,13 @@ impl<K, const V: &'static str> NextAttribute for StaticAttr<K, V>
 where
     K: AttributeKey,
 {
-    type Output<NewAttr: Attribute> = (Self, NewAttr);
+    next_attr_output_type!(Self, NewAttr);
 
     fn add_any_attr<NewAttr: Attribute>(
         self,
         new_attr: NewAttr,
     ) -> Self::Output<NewAttr> {
-        (StaticAttr::<K, V> { ty: PhantomData }, new_attr)
+        next_attr_combine!(StaticAttr::<K, V> { ty: PhantomData }, new_attr)
     }
 }
 


### PR DESCRIPTION
There's a few things in here (sorry!), to sum up: 
- Routing is erased, most importantly this should (probably) solve any remaining compile errors in rust debug/dev builds
- The `view!{}` macro now erases thoroughly
- A few more hot codegen optimisations of existing logic in traits
- erased containers define their `fn()` functions with concrete `fn foo` declarations rather than closures, TIL this is more codegen efficient
- The [erased](https://docs.rs/erased/latest/erased/) crate is used as a replacement for `Box<dyn Any>` in erased containers, which is more efficient and (I think) avoids a massive `dyn Any` vtable
- `IntoFragment` contains `StaticVec` instead of a `Vec`

This shouldn't have any breaking changes.
