### PR TITLE
feat: implement some signal traits for tuples

### DIFF
--- a/reactive_graph/src/signal.rs
+++ b/reactive_graph/src/signal.rs
@@ -10,6 +10,7 @@ mod read;
 mod rw;
 mod subscriber_traits;
 mod trigger;
+mod tuples;
 mod write;
 
 use crate::owner::LocalStorage;

--- a/reactive_graph/src/signal/tuples.rs
+++ b/reactive_graph/src/signal/tuples.rs
@@ -1,0 +1,236 @@
+use std::{fmt, ops::Deref, panic::Location, sync::Arc};
+
+use crate::traits::{
+    DefinedAt, Dispose, IsDisposed, Notify, ReadUntracked, Set, Track,
+};
+
+const DEFINED_AT_MSG: &str = "`DefinedAt::defined_at` called on a tuple. Only the first value will be reported.";
+const PARTIAL_SET_MSG: &str =
+    "Tried to fallibly set a tuple, but only some values succeeded.";
+
+macro_rules! impl_tuple {
+    ($($T:ident, $N:tt,)*) => {
+        impl<$($T,)*> Dispose for ($($T,)*)
+        where
+            $($T: Dispose,)*
+        {
+            fn dispose(self) {
+                $(
+                    self.$N.dispose();
+                )*
+            }
+        }
+
+        impl<$($T,)*> Track for ($($T,)*)
+        where
+            $($T: Track,)*
+        {
+            fn track(&self) {
+                $(
+                    self.$N.track();
+                )*
+            }
+        }
+
+        impl<$($T,)*> DefinedAt for ($($T,)*)
+        where
+            $($T: DefinedAt,)*
+        {
+            fn defined_at(&self) -> Option<&'static Location<'static>> {
+                let locs = [$(self.$N.defined_at()),*];
+
+                crate::log_warning(format_args!(
+                    "{DEFINED_AT_MSG} All locations: [{}]",
+                    MaybeLocations { locs: &locs },
+                ));
+
+                locs[0]
+            }
+        }
+
+        impl<$($T,)*> ReadUntracked for ($($T,)*)
+        where
+            $($T: ReadUntracked,)*
+        {
+            type Value = TupleReadWrapper<($(TupleReadFieldWrapper<$T>,)*)>;
+
+            fn try_read_untracked(&self) -> Option<Self::Value> {
+                Some(TupleReadWrapper((
+                    $(TupleReadFieldWrapper::new(&self.$N)?,)*
+                )))
+            }
+        }
+
+        impl<$($T,)*> Notify for ($($T,)*)
+        where
+            $($T: Notify,)*
+        {
+            fn notify(&self) {
+                $(
+                    self.$N.notify();
+                )*
+            }
+        }
+
+        impl<$($T,)*> Set for ($($T,)*)
+        where
+            $($T: Set,)*
+        {
+            type Value = ($($T::Value,)*);
+
+            fn set(&self, value: Self::Value) {
+                $(
+                    self.$N.set(value.$N);
+                )*
+            }
+
+            fn try_set(&self, value: Self::Value) -> Option<Self::Value> {
+                let values = ($(
+                    self.$N.try_set(value.$N),
+                )*);
+
+                let all_none = $(values.$N.is_none() &&)* true;
+                let all_some = $(values.$N.is_some() &&)* true;
+                assert!(all_none || all_some, "{PARTIAL_SET_MSG}");
+
+                Some(($(values.$N?,)*))
+            }
+        }
+
+        impl<$($T,)*> IsDisposed for ($($T,)*)
+        where
+            $($T: IsDisposed,)*
+        {
+            fn is_disposed(&self) -> bool {
+                $(
+                    self.$N.is_disposed() &&
+                )*
+                true
+            }
+        }
+    };
+}
+
+#[rustfmt::skip]
+mod impl_tuples {
+    use super::*;
+
+    impl_tuple!(T0, 0,);
+    impl_tuple!(T0, 0, T1, 1,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10, T11, 11,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10, T11, 11, T12, 12,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10, T11, 11, T12, 12, T13, 13,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10, T11, 11, T12, 12, T13, 13, T14, 14,);
+    impl_tuple!(T0, 0, T1, 1, T2, 2, T3, 3, T4, 4, T5, 5, T6, 6, T7, 7, T8, 8, T9, 9, T10, 10, T11, 11, T12, 12, T13, 13, T14, 14, T15, 15,);
+}
+
+/// A wrapper around a tuple that simply [Deref]s to the tuple.
+/// This is needed because of the [Deref] bound on [ReadUntracked::Value].
+pub struct TupleReadWrapper<T>(T);
+impl<T> Deref for TupleReadWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T: fmt::Debug> fmt::Debug for TupleReadWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TupleReadWrapper").finish()
+    }
+}
+
+/// A wrapper around an [ReadUntracked::Value] that allows us to implement [Clone]
+/// on the [Deref] guard and sattisfy the blanket implementation of
+/// [GetUntracked](crate::traits::GetUntracked).
+pub struct TupleReadFieldWrapper<T: ReadUntracked> {
+    value: Arc<T::Value>,
+}
+impl<T: ReadUntracked> Deref for TupleReadFieldWrapper<T> {
+    type Target = <T::Value as Deref>::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+impl<T: ReadUntracked> TupleReadFieldWrapper<T> {
+    fn new(signal: &T) -> Option<Self> {
+        let value = signal.try_read_untracked()?;
+        Some(Self {
+            value: Arc::new(value),
+        })
+    }
+}
+impl<T: ReadUntracked> fmt::Debug for TupleReadFieldWrapper<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TupleReadFieldWrapper").finish()
+    }
+}
+impl<T: ReadUntracked + Clone> Clone for TupleReadFieldWrapper<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+        }
+    }
+}
+
+struct MaybeLocations<'a, const N: usize> {
+    locs: &'a [Option<&'static Location<'static>>; N],
+}
+impl<const N: usize> fmt::Display for MaybeLocations<'_, N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for loc in self.locs {
+            if let Some(loc) = loc {
+                write!(f, "{}", loc)?;
+            } else {
+                f.write_str("unknown")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        signal::ArcRwSignal,
+        traits::{GetUntracked, WithUntracked},
+    };
+
+    use super::*;
+
+    #[test]
+    fn compile_test() {
+        let a = ArcRwSignal::new(1);
+        let b = ArcRwSignal::new(2);
+        {
+            let tuple = (a.clone(), b.clone()).read_untracked();
+            assert_eq!(*tuple.0 .0, 1); // .0 is ambiguous in this file only as it's not public.
+            assert_eq!(*tuple.1, 2);
+        }
+        {
+            let (a, b) = (a.clone(), b.clone()).get_untracked();
+            assert_eq!(*a, 1);
+            assert_eq!(*b, 2);
+        }
+
+        (a.clone(), b.clone()).with_untracked(
+            |(a, b): &(
+                TupleReadFieldWrapper<ArcRwSignal<i32>>,
+                TupleReadFieldWrapper<ArcRwSignal<i32>>,
+            )| {
+                assert_eq!(**a, 1);
+                assert_eq!(**b, 2);
+            },
+        );
+    }
+}


### PR DESCRIPTION
This implements some signal-related traits for tuples.

- To to satisfy the `ReadUntracked::Value: Deref` bound and the `Clone` bound in the `ReadUntracked` -> `WithUntracked` -> `GetUntracked` blanket implementations I had to use a couple of wrappers.
  - This does mean that things like `.with` will not be perfect, requiring for example two `*`s to get to the value in some cases.
- I am not sure what to do about `Set`, and whether to just remove it. I don't think there is as much of an use case for it anyway.
  - Options:
    - The current implementation always panics if setting *partially* fails.
    - Alternatives are to always panic, or never panic.
    - Finally another alternative is to have `SetUntracked::Value` be a tuple of options so that the `try` variant can partially return the values.
  - I am leaning toward removing it.

---

<details><summary>Example expansion</summary>

```rust
impl<T0, T1> Dispose for (T0, T1)
where
    T0: Dispose,
    T1: Dispose,
{
    fn dispose(self) {
        self.0.dispose();
        self.1.dispose();
    }
}
impl<T0, T1> Track for (T0, T1)
where
    T0: Track,
    T1: Track,
{
    fn track(&self) {
        self.0.track();
        self.1.track();
    }
}
impl<T0, T1> DefinedAt for (T0, T1)
where
    T0: DefinedAt,
    T1: DefinedAt,
{
    fn defined_at(&self) -> Option<&'static Location<'static>> {
        let locs = [self.0.defined_at(), self.1.defined_at()];
        crate::log_warning(format_args!(
            "{DEFINED_AT_MSG} All locations: [{}]",
            MaybeLocations { locs: &locs },
        ));
        locs[0]
    }
}
impl<T0, T1> ReadUntracked for (T0, T1)
where
    T0: ReadUntracked,
    T1: ReadUntracked,
{
    type Value = TupleReadWrapper<(
        TupleReadFieldWrapper<T0>,
        TupleReadFieldWrapper<T1>,
    )>;
    fn try_read_untracked(&self) -> Option<Self::Value> {
        Some(TupleReadWrapper((
            TupleReadFieldWrapper::new(&self.0)?,
            TupleReadFieldWrapper::new(&self.1)?,
        )))
    }
}
impl<T0, T1> Notify for (T0, T1)
where
    T0: Notify,
    T1: Notify,
{
    fn notify(&self) {
        self.0.notify();
        self.1.notify();
    }
}
impl<T0, T1> Set for (T0, T1)
where
    T0: Set,
    T1: Set,
{
    type Value = (T0::Value, T1::Value);
    fn set(&self, value: Self::Value) {
        self.0.set(value.0);
        self.1.set(value.1);
    }
    fn try_set(&self, value: Self::Value) -> Option<Self::Value> {
        let values = (self.0.try_set(value.0), self.1.try_set(value.1));
        let all_none = values.0.is_none() && values.1.is_none() && true;
        let all_some = values.0.is_some() && values.1.is_some() && true;
        {
            if !(all_none || all_some) {
                {
                    core::panicking::panic_fmt(core::const_format_args!(
                        "{PARTIAL_SET_MSG}"
                    ));
                };
            }
        };
        Some((values.0?, values.1?))
    }
}
impl<T0, T1> IsDisposed for (T0, T1)
where
    T0: IsDisposed,
    T1: IsDisposed,
{
    fn is_disposed(&self) -> bool {
        self.0.is_disposed() && self.1.is_disposed() && true
    }
}```

</details>