### PR TITLE
Minor: examples/server_fns_axum - Bumped various packages (not axum).

### DIFF
--- a/examples/server_fns_axum/Cargo.toml
+++ b/examples/server_fns_axum/Cargo.toml
@@ -22,20 +22,20 @@ log = "0.4.22"
 simple_logger = "5.0"
 serde = { version = "1.0", features = ["derive"] }
 axum = { version = "0.7.5", optional = true }
-tower = { version = "0.4.13", optional = true }
-tower-http = { version = "0.5.2", features = [
+tower = { version = "0.5.2", optional = true }
+tower-http = { version = "0.6.2", features = [
   "fs",
   "tracing",
   "trace",
 ], optional = true }
 tokio = { version = "1.39", features = ["full"], optional = true }
-thiserror = "1.0"
+thiserror = "2.0.11"
 wasm-bindgen = "0.2.93"
 serde_toml = "0.0.1"
 toml = "0.8.19"
 web-sys = { version = "0.3.70", features = ["FileList", "File"] }
-strum = { version = "0.26.3", features = ["strum_macros", "derive"] }
-notify = { version = "6.1", optional = true }
+strum = { version = "0.27.1", features = ["strum_macros", "derive"] }
+notify = { version = "8.0", optional = true }
 pin-project-lite = "0.2.14"
 dashmap = { version = "6.0", optional = true }
 once_cell = { version = "1.19", optional = true }


### PR DESCRIPTION
crates updated :- 

    tower-http
    tower
    thiserror
    strum
    notify

server_fn_axum is a great resource, so I want to keep the dependencies upto date.

I want to isolate the axum changes in a PR I am currenlty writing ...

