### PR TITLE
Implement several into traits for store fields (0.8)

### DIFF
--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -93,61 +93,17 @@ mod stable {
         wrappers::read::{ArcSignal, Signal},
     };
 
-    macro_rules! property_signal {
-        ($sig:ident) => {
-            impl<V> IntoProperty for $sig<V>
-            where
-                $sig<V>: Get<Value = V>,
-                V: IntoProperty + Send + Sync + Clone + 'static,
-                V::State: 'static,
-            {
-                type State = RenderEffect<V::State>;
-                type Cloneable = Self;
-                type CloneableOwned = Self;
-
-                fn hydrate<const FROM_SERVER: bool>(
-                    self,
-                    el: &crate::renderer::types::Element,
-                    key: &str,
-                ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el, key)
-                }
-
-                fn build(
-                    self,
-                    el: &crate::renderer::types::Element,
-                    key: &str,
-                ) -> Self::State {
-                    (move || self.get()).build(el, key)
-                }
-
-                fn rebuild(self, state: &mut Self::State, key: &str) {
-                    (move || self.get()).rebuild(state, key)
-                }
-
-                fn into_cloneable(self) -> Self::Cloneable {
-                    self
-                }
-
-                fn into_cloneable_owned(self) -> Self::CloneableOwned {
-                    self
-                }
-            }
-        };
-    }
-
-    macro_rules! property_signal_arena {
-        ($sig:ident) => {
+    macro_rules! property_reactive {
+        ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+        {
             #[allow(deprecated)]
-            impl<V, S> IntoProperty for $sig<V, S>
+            impl<$($gen),*> IntoProperty for $name<$($gen),*>
             where
-                $sig<V, S>: Get<Value = V>,
-                S: Send + Sync + 'static,
-                S: Storage<V> + Storage<Option<V>>,
-                V: IntoProperty + Send + Sync + Clone + 'static,
-                V::State: 'static,
+                $v: IntoProperty + Clone + Send + Sync + 'static,
+                <$v as IntoProperty>::State: 'static,
+                $($where_clause)*
             {
-                type State = RenderEffect<V::State>;
+                type State = RenderEffect<<$v as IntoProperty>::State>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -182,13 +138,132 @@ mod stable {
         };
     }
 
-    property_signal_arena!(RwSignal);
-    property_signal_arena!(ReadSignal);
-    property_signal_arena!(Memo);
-    property_signal_arena!(Signal);
-    property_signal_arena!(MaybeSignal);
-    property_signal!(ArcRwSignal);
-    property_signal!(ArcReadSignal);
-    property_signal!(ArcMemo);
-    property_signal!(ArcSignal);
+    property_reactive!(
+        RwSignal,
+        <V, S>,
+        V,
+        RwSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    property_reactive!(
+        ReadSignal,
+        <V, S>,
+        V,
+        ReadSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    property_reactive!(
+        Memo,
+        <V, S>,
+        V,
+        Memo<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    property_reactive!(
+        Signal,
+        <V, S>,
+        V,
+        Signal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    property_reactive!(
+        MaybeSignal,
+        <V, S>,
+        V,
+        MaybeSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    property_reactive!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
+    property_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
+    property_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
+    property_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
+    };
+
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        Subfield,
+        <Inner, Prev, V>,
+        V,
+        Subfield<Inner, Prev, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        AtKeyed,
+        <Inner, Prev, K, V>,
+        V,
+        AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        KeyedSubfield,
+        <Inner, Prev, K, V>,
+        V,
+        KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        DerefedField,
+        <S>,
+        <S::Value as Deref>::Target,
+        S: Clone + StoreField + Send + Sync + 'static,
+        <S as StoreField>::Value: Deref + DerefMut
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        AtIndex,
+        <Inner, Prev>,
+        <Prev as Index<usize>>::Output,
+        AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
+        Prev: Send + Sync + IndexMut<usize> + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        Store,
+        <V, S>,
+        V,
+        Store<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(
+        Field,
+        <V, S>,
+        V,
+        Field<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
+    #[cfg(feature = "reactive_stores")]
+    property_reactive!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
 }

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -208,7 +208,7 @@ where
 
 #[cfg(not(feature = "nightly"))]
 mod stable {
-    macro_rules! style_store_field {
+    macro_rules! style_reactive {
         ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
         {
             #[allow(deprecated)]
@@ -350,7 +350,7 @@ mod stable {
     };
     use std::sync::Arc;
 
-    style_store_field!(
+    style_reactive!(
         RwSignal,
         <V, S>,
         V,
@@ -358,7 +358,7 @@ mod stable {
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_store_field!(
+    style_reactive!(
         ReadSignal,
         <V, S>,
         V,
@@ -366,7 +366,7 @@ mod stable {
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_store_field!(
+    style_reactive!(
         Memo,
         <V, S>,
         V,
@@ -374,7 +374,7 @@ mod stable {
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_store_field!(
+    style_reactive!(
         Signal,
         <V, S>,
         V,
@@ -382,7 +382,7 @@ mod stable {
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_store_field!(
+    style_reactive!(
         MaybeSignal,
         <V, S>,
         V,
@@ -390,10 +390,10 @@ mod stable {
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_store_field!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
-    style_store_field!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
-    style_store_field!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
-    style_store_field!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+    style_reactive!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
+    style_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
+    style_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
+    style_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
     
     #[cfg(feature = "reactive_stores")]
     use {
@@ -405,7 +405,7 @@ mod stable {
     };
 
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         Subfield,
         <Inner, Prev, V>,
         V,
@@ -415,7 +415,7 @@ mod stable {
     );
 
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         AtKeyed,
         <Inner, Prev, K, V>,
         V,
@@ -427,7 +427,7 @@ mod stable {
     );
 
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         KeyedSubfield,
         <Inner, Prev, K, V>,
         V,
@@ -439,7 +439,7 @@ mod stable {
     );
 
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         DerefedField,
         <S>,
         <S::Value as Deref>::Target,
@@ -448,7 +448,7 @@ mod stable {
     );
 
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         AtIndex,
         <Inner, Prev>,
         <Prev as Index<usize>>::Output,
@@ -457,7 +457,7 @@ mod stable {
         Inner: Send + Sync + Clone + 'static,
     );
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         Store,
         <V, S>,
         V,
@@ -466,7 +466,7 @@ mod stable {
         S: Send + Sync + 'static,
     );
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(
+    style_reactive!(
         Field,
         <V, S>,
         V,
@@ -475,9 +475,9 @@ mod stable {
         S: Send + Sync + 'static,
     );
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
+    style_reactive!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
     #[cfg(feature = "reactive_stores")]
-    style_store_field!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
+    style_reactive!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
 }
 
 /*

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -394,7 +394,7 @@ mod stable {
     style_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
     style_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
     style_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
-    
+
     #[cfg(feature = "reactive_stores")]
     use {
         reactive_stores::{

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -208,16 +208,18 @@ where
 
 #[cfg(not(feature = "nightly"))]
 mod stable {
-    macro_rules! style_signal {
-        ($sig:ident) => {
-            impl<C> IntoStyle for $sig<C>
+    macro_rules! style_store_field {
+        ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+        {
+            #[allow(deprecated)]
+            impl<$($gen),*> IntoStyle for $name<$($gen),*>
             where
-                $sig<C>: Get<Value = C>,
-                C: IntoStyle + Clone + Send + Sync + 'static,
-                C::State: 'static,
+                $v: IntoStyle + Clone + Send + Sync + 'static,
+                <$v as IntoStyle>::State: 'static,
+                $($where_clause)*
             {
                 type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
+                type State = RenderEffect<<$v as IntoStyle>::State>;
                 type Cloneable = Self;
                 type CloneableOwned = Self;
 
@@ -262,7 +264,7 @@ mod stable {
                     *state = RenderEffect::new_with_value(
                         move |prev| {
                             if let Some(mut state) = prev {
-                                C::reset(&mut state);
+                                <$v>::reset(&mut state);
                                 state
                             } else {
                                 unreachable!()
@@ -273,15 +275,16 @@ mod stable {
                 }
             }
 
-            impl<S> IntoStyleValue for $sig<S>
+            #[allow(deprecated)]
+            impl<$($gen),*> IntoStyleValue for $name<$($gen),*>
             where
-                $sig<S>: Get<Value = S>,
-                S: IntoStyleValue + Send + Sync + Clone + 'static,
+                $v: IntoStyleValue + Send + Sync + Clone + 'static,
+                $($where_clause)*
             {
                 type AsyncOutput = Self;
-                type State = (Arc<str>, RenderEffect<S::State>);
-                type Cloneable = $sig<S>;
-                type CloneableOwned = $sig<S>;
+                type State = (Arc<str>, RenderEffect<<$v as IntoStyleValue>::State>);
+                type Cloneable = $name<$($gen),*>;
+                type CloneableOwned = $name<$($gen),*>;
 
                 fn to_html(self, name: &str, style: &mut String) {
                     IntoStyleValue::to_html(move || self.get(), name, style)
@@ -334,76 +337,6 @@ mod stable {
         };
     }
 
-    macro_rules! style_signal_arena {
-        ($sig:ident) => {
-            #[allow(deprecated)]
-            impl<C, S> IntoStyle for $sig<C, S>
-            where
-                $sig<C, S>: Get<Value = C>,
-                S: Storage<C> + Storage<Option<C>>,
-                S: Send + Sync + 'static,
-                C: IntoStyle + Send + Sync + Clone + 'static,
-                C::State: 'static,
-            {
-                type AsyncOutput = Self;
-                type State = RenderEffect<C::State>;
-                type Cloneable = Self;
-                type CloneableOwned = Self;
-
-                fn to_html(self, style: &mut String) {
-                    let value = self.get();
-                    value.to_html(style);
-                }
-
-                fn hydrate<const FROM_SERVER: bool>(
-                    self,
-                    el: &crate::renderer::types::Element,
-                ) -> Self::State {
-                    (move || self.get()).hydrate::<FROM_SERVER>(el)
-                }
-
-                fn build(
-                    self,
-                    el: &crate::renderer::types::Element,
-                ) -> Self::State {
-                    (move || self.get()).build(el)
-                }
-
-                fn rebuild(self, state: &mut Self::State) {
-                    (move || self.get()).rebuild(state)
-                }
-
-                fn into_cloneable(self) -> Self::Cloneable {
-                    self
-                }
-
-                fn into_cloneable_owned(self) -> Self::CloneableOwned {
-                    self
-                }
-
-                fn dry_resolve(&mut self) {}
-
-                async fn resolve(self) -> Self::AsyncOutput {
-                    self
-                }
-
-                fn reset(state: &mut Self::State) {
-                    *state = RenderEffect::new_with_value(
-                        move |prev| {
-                            if let Some(mut state) = prev {
-                                C::reset(&mut state);
-                                state
-                            } else {
-                                unreachable!()
-                            }
-                        },
-                        state.take_value(),
-                    );
-                }
-            }
-        };
-    }
-
     use super::RenderEffect;
     use crate::html::style::{IntoStyle, IntoStyleValue};
     #[allow(deprecated)]
@@ -417,15 +350,134 @@ mod stable {
     };
     use std::sync::Arc;
 
-    style_signal_arena!(RwSignal);
-    style_signal_arena!(ReadSignal);
-    style_signal_arena!(Memo);
-    style_signal_arena!(Signal);
-    style_signal_arena!(MaybeSignal);
-    style_signal!(ArcRwSignal);
-    style_signal!(ArcReadSignal);
-    style_signal!(ArcMemo);
-    style_signal!(ArcSignal);
+    style_store_field!(
+        RwSignal,
+        <V, S>,
+        V,
+        RwSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    style_store_field!(
+        ReadSignal,
+        <V, S>,
+        V,
+        ReadSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    style_store_field!(
+        Memo,
+        <V, S>,
+        V,
+        Memo<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    style_store_field!(
+        Signal,
+        <V, S>,
+        V,
+        Signal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    style_store_field!(
+        MaybeSignal,
+        <V, S>,
+        V,
+        MaybeSignal<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    style_store_field!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
+    style_store_field!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
+    style_store_field!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
+    style_store_field!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+    
+    #[cfg(feature = "reactive_stores")]
+    use {
+        reactive_stores::{
+            ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, Field,
+            KeyedSubfield, Store, StoreField, Subfield,
+        },
+        std::ops::{Deref, DerefMut, Index, IndexMut},
+    };
+
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        Subfield,
+        <Inner, Prev, V>,
+        V,
+        Subfield<Inner, Prev, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        AtKeyed,
+        <Inner, Prev, K, V>,
+        V,
+        AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        KeyedSubfield,
+        <Inner, Prev, K, V>,
+        V,
+        KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
+        Prev: Send + Sync + 'static,
+        Inner: Send + Sync + Clone + 'static,
+        K: Send + Sync + std::fmt::Debug + Clone + 'static,
+        for<'a> &'a V: IntoIterator,
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        DerefedField,
+        <S>,
+        <S::Value as Deref>::Target,
+        S: Clone + StoreField + Send + Sync + 'static,
+        <S as StoreField>::Value: Deref + DerefMut
+    );
+
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        AtIndex,
+        <Inner, Prev>,
+        <Prev as Index<usize>>::Output,
+        AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
+        Prev: Send + Sync + IndexMut<usize> + 'static,
+        Inner: Send + Sync + Clone + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        Store,
+        <V, S>,
+        V,
+        Store<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(
+        Field,
+        <V, S>,
+        V,
+        Field<V, S>: Get<Value = V>,
+        S: Storage<V> + Storage<Option<V>>,
+        S: Send + Sync + 'static,
+    );
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
+    #[cfg(feature = "reactive_stores")]
+    style_store_field!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
 }
 
 /*


### PR DESCRIPTION
This PR implements these traits:

- `IntoStyle`
- `IntoStyleValue`
- `IntoProperty`
- `Render`
- `RenderHtml`
- `AttributeValue`
- `InnerHtmlValue`

for these store fields:

- `Store`
- `ArcStore`
- `Field`
- `ArcField`
- `SubField`
- `AtKeyed`
- `KeyedSubField`
- `DerefedField`
- `AtIndex`

It also implements `IntoSplitSignal` for these traits:

- `AtKeyed`
- `AtIndex`
- `DerefedField`

I created a new macro rule that was flexible enough to handle the signals, so I replaced the previous macro with this new one for all signals.

I didn't implement `IntoClass` because it also had an implementation for `(&'static str, $sig<bool, S>)`, which my new macro wasn't flexible enough to handle. However, I thought that if you create something like `IntoStyleValue` for `IntoClass`, it can have a unified implementation similar to `IntoStyle`. So I waited for your response about this. (Or I can write a separate macro for this tuple.)

Another thing about `IntoStyleValue` is that you implemented it only for `Arc` signals, but in the new macro, it is implemented for all signals. I wasn't sure of the true meaning of this, but the compiler didn't complain, so I didn't touch it.

In the `mod.rs` (the implementation of `AttributeValue`, `RenderHtml`, `AddAnyAttr`, and `Render`) there was an argument for the current macros called `$dry_resolve`. I wasn't sure what value should I pass for the new store fields, so I passed `false` for them.

The implementation of `AddAnyAttr` for signals was empty and marked with `todo!()`. I also added this empty implementation to the new macros.
