### PR TITLE
Minor: clippy - Replace mem::replace with Option::replace

### DIFF
--- a/any_error/src/lib.rs
+++ b/any_error/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
     error,
     fmt::{self, Display},
     future::Future,
-    mem, ops,
+    ops,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -109,7 +109,7 @@ pub fn get_error_hook() -> Option<Arc<dyn ErrorHook>> {
 /// Sets the current thread-local error hook, which will be invoked when [`throw`] is called.
 pub fn set_error_hook(hook: Arc<dyn ErrorHook>) -> ResetErrorHookOnDrop {
     ResetErrorHookOnDrop(
-        ERROR_HOOK.with_borrow_mut(|this| mem::replace(this, Some(hook))),
+        ERROR_HOOK.with_borrow_mut(|this| Option::replace(this, hook)),
     )
 }
 

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -208,9 +208,7 @@ impl Owner {
     /// Runs the given function with this as the current `Owner`.
     pub fn with<T>(&self, fun: impl FnOnce() -> T) -> T {
         let prev = {
-            OWNER.with(|o| {
-                mem::replace(&mut *o.borrow_mut(), Some(self.clone()))
-            })
+            OWNER.with(|o| Option::replace(&mut *o.borrow_mut(), self.clone()))
         };
         #[cfg(feature = "sandboxed-arenas")]
         Arena::set(&self.inner.read().or_poisoned().arena);

--- a/reactive_graph/src/transition.rs
+++ b/reactive_graph/src/transition.rs
@@ -37,9 +37,9 @@ impl AsyncTransition {
         let (tx, rx) = mpsc::channel();
         let global_transition = global_transition();
         let inner = TransitionInner { tx };
-        let prev = std::mem::replace(
+        let prev = Option::replace(
             &mut *global_transition.write().or_poisoned(),
-            Some(inner.clone()),
+            inner.clone(),
         );
         let value = action().await;
         _ = std::mem::replace(


### PR DESCRIPTION
all changes are of the form

```rust
-        ERROR_HOOK.with_borrow_mut(|this| mem::replace(this, Some(hook))),
+        ERROR_HOOK.with_borrow_mut(|this| Option::replace(this, hook)),
```

In this example there is no need to wrap "hook" as "Some(hook)".