### PR TITLE
pass key reference to `Selector::selected`

### DIFF
--- a/examples/js-framework-benchmark/src/lib.rs
+++ b/examples/js-framework-benchmark/src/lib.rs
@@ -169,7 +169,7 @@ pub fn App() -> impl IntoView {
                             let label = row.label;
                             let is_selected = is_selected.clone();
                             template! {
-                                < tr class : danger = { move || is_selected.selected(Some(row_id)) }
+                                < tr class : danger = { move || is_selected.selected(&Some(row_id)) }
                                 > < td class = "col-md-1" > { row_id.to_string() } </ td > < td
                                 class = "col-md-4" >< a on : click = move | _ | set_selected
                                 .set(Some(row_id)) > { move || label.get() } </ a ></ td > < td

--- a/reactive_graph/src/computed/selector.rs
+++ b/reactive_graph/src/computed/selector.rs
@@ -33,28 +33,28 @@ use std::{
 /// Effect::new_isomorphic({
 ///     let is_selected = is_selected.clone();
 ///     move |_| {
-///         if is_selected.selected(5) {
+///         if is_selected.selected(&5) {
 ///             total_notifications.update_value(|n| *n += 1);
 ///         }
 ///     }
 /// });
 ///
-/// assert_eq!(is_selected.selected(5), false);
+/// assert_eq!(is_selected.selected(&5), false);
 /// assert_eq!(total_notifications.get_value(), 0);
 /// a.set(5);
 /// # any_spawner::Executor::tick().await;
 ///
-/// assert_eq!(is_selected.selected(5), true);
+/// assert_eq!(is_selected.selected(&5), true);
 /// assert_eq!(total_notifications.get_value(), 1);
 /// a.set(5);
 /// # any_spawner::Executor::tick().await;
 ///
-/// assert_eq!(is_selected.selected(5), true);
+/// assert_eq!(is_selected.selected(&5), true);
 /// assert_eq!(total_notifications.get_value(), 1);
 /// a.set(4);
 ///
 /// # any_spawner::Executor::tick().await;
-/// assert_eq!(is_selected.selected(5), false);
+/// assert_eq!(is_selected.selected(&5), false);
 /// # }).await;
 /// # });
 /// ```
@@ -117,15 +117,20 @@ where
     }
 
     /// Reactively checks whether the given key is selected.
-    pub fn selected(&self, key: T) -> bool {
+    pub fn selected(&self, key: &T) -> bool {
         let read = {
-            let mut subs = self.subs.write().or_poisoned();
-            subs.entry(key.clone())
-                .or_insert_with(|| ArcRwSignal::new(false))
-                .clone()
+            let sub = self.subs.read().or_poisoned().get(key).cloned();
+            sub.unwrap_or_else(|| {
+                let signal = ArcRwSignal::new(false);
+                self.subs
+                    .write()
+                    .or_poisoned()
+                    .insert(key.clone(), signal.clone());
+                signal
+            })
         };
         read.track();
-        (self.f)(&key, self.v.read().or_poisoned().as_ref().unwrap())
+        (self.f)(key, self.v.read().or_poisoned().as_ref().unwrap())
     }
 
     /// Removes the listener for the given key.

--- a/reactive_graph/src/computed/selector.rs
+++ b/reactive_graph/src/computed/selector.rs
@@ -121,12 +121,12 @@ where
         let read = {
             let sub = self.subs.read().or_poisoned().get(key).cloned();
             sub.unwrap_or_else(|| {
-                let signal = ArcRwSignal::new(false);
                 self.subs
                     .write()
                     .or_poisoned()
-                    .insert(key.clone(), signal.clone());
-                signal
+                    .entry(key.clone())
+                    .or_insert_with(|| ArcRwSignal::new(false))
+                    .clone()
             })
         };
         read.track();


### PR DESCRIPTION
It's a breaking change, and it avoids two possible `clone`:

* the function call
* the inner lookup

It may use `K: AsRef<T>`, but I don't think it's neccessary, and put this into v0.8 is good enough?