### PR TITLE
docs: update example tailwind input css to v4

### DIFF
--- a/examples/tailwind_actix/style/tailwind.css
+++ b/examples/tailwind_actix/style/tailwind.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";

--- a/examples/tailwind_axum/style/tailwind.css
+++ b/examples/tailwind_axum/style/tailwind.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";


### PR DESCRIPTION
See https://github.com/leptos-rs/leptos/issues/3688

Note that example_csr still holds style.css of tailwind v3, which still seems to works using trunk instead of cargo-leptos.