### PR TITLE
Allow LocalResource sync methods to be used outside Suspense

### DIFF
--- a/leptos_server/src/local_resource.rs
+++ b/leptos_server/src/local_resource.rs
@@ -172,12 +172,6 @@ where
     fn try_read_untracked(&self) -> Option<Self::Value> {
         if let Some(mut notifier) = use_context::<LocalResourceNotifier>() {
             notifier.notify();
-        } else if cfg!(feature = "ssr") {
-            panic!(
-                "Reading from a LocalResource outside Suspense in `ssr` mode \
-                 will cause the response to hang, because LocalResources are \
-                 always pending on the server."
-            );
         }
         self.data.try_read_untracked()
     }
@@ -364,12 +358,6 @@ where
     fn try_read_untracked(&self) -> Option<Self::Value> {
         if let Some(mut notifier) = use_context::<LocalResourceNotifier>() {
             notifier.notify();
-        } else if cfg!(feature = "ssr") {
-            panic!(
-                "Reading from a LocalResource outside Suspense in `ssr` mode \
-                 will cause the response to hang, because LocalResources are \
-                 always pending on the server."
-            );
         }
         self.data.try_read_untracked()
     }


### PR DESCRIPTION
`LocalResource`'s, unlike `Resource` cannot currently be used outside `Suspense`. 

This allows `.get()` and friends to be used outside `Suspense`, this doesn't affect `.await`, which would still panic, these would now all just return `None` on the server.