### PR TITLE
refactor: make `shell` parameter in `file_and_error_handler*` generic

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1988,7 +1988,7 @@ where
 #[cfg(feature = "default")]
 pub fn file_and_error_handler_with_context<S, IV>(
     additional_context: impl Fn() + 'static + Clone + Send,
-    shell: fn(LeptosOptions) -> IV,
+    shell: impl Fn(LeptosOptions) -> IV + 'static + Clone + Send,
 ) -> impl Fn(
     Uri,
     State<S>,
@@ -2005,6 +2005,7 @@ where
     move |uri: Uri, State(state): State<S>, req: Request<Body>| {
         Box::pin({
             let additional_context = additional_context.clone();
+            let shell = shell.clone();
             async move {
                 let options = LeptosOptions::from_ref(&state);
                 let res =
@@ -2048,7 +2049,7 @@ where
 /// simply reuse the source code of this function in your own application.
 #[cfg(feature = "default")]
 pub fn file_and_error_handler<S, IV>(
-    shell: fn(LeptosOptions) -> IV,
+    shell: impl Fn(LeptosOptions) -> IV + 'static + Clone + Send,
 ) -> impl Fn(
     Uri,
     State<S>,


### PR DESCRIPTION
This is more consistent with the other Axum integration functions, which are also generic. This also allows passing a closure.

The reason I made this PR is that I'm trying to create a private library that wraps the Leptos Axum integration, but the function pointer is giving me a lot of trouble.