### PR TITLE
Remove SendWrapper from the external interface of LocalResource

### DIFF
--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -12,9 +12,10 @@ use crate::{
         AnySource, AnySubscriber, ReactiveNode, Source, SourceSet, Subscriber,
         SubscriberSet, ToAnySource, ToAnySubscriber, WithObserver,
     },
+    maybe_send_wrapper::MaybeSendWrapper,
     owner::{use_context, Owner},
     signal::{
-        guards::{AsyncPlain, ReadGuard, WriteGuard},
+        guards::{AsyncPlain, Mapped, MappedMut, ReadGuard, WriteGuard},
         ArcTrigger,
     },
     traits::{
@@ -32,7 +33,7 @@ use send_wrapper::SendWrapper;
 use std::{
     future::Future,
     mem,
-    ops::DerefMut,
+    ops::{Deref, DerefMut},
     panic::Location,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -110,7 +111,7 @@ pub struct ArcAsyncDerived<T> {
     #[cfg(any(debug_assertions, leptos_debuginfo))]
     pub(crate) defined_at: &'static Location<'static>,
     // the current state of this signal
-    pub(crate) value: Arc<AsyncRwLock<Option<T>>>,
+    pub(crate) value: Arc<AsyncRwLock<MaybeSendWrapper<Option<T>>>>,
     // holds wakers generated when you .await this
     pub(crate) wakers: Arc<RwLock<Vec<Waker>>>,
     pub(crate) inner: Arc<RwLock<ArcAsyncDerivedInner>>,
@@ -280,7 +281,7 @@ macro_rules! spawn_derived {
                         let mut guard = this.inner.write().or_poisoned();
 
                         guard.state = AsyncDerivedState::Clean;
-                        *value.blocking_write() = Some(orig_value);
+                        *value.blocking_write() = orig_value.map(Some);
                         this.loading.store(false, Ordering::Relaxed);
                         (true, None)
                     }
@@ -405,14 +406,14 @@ macro_rules! spawn_derived {
 
 impl<T: 'static> ArcAsyncDerived<T> {
     async fn set_inner_value(
-        new_value: T,
-        value: Arc<AsyncRwLock<Option<T>>>,
+        new_value: MaybeSendWrapper<T>,
+        value: Arc<AsyncRwLock<MaybeSendWrapper<Option<T>>>>,
         wakers: Arc<RwLock<Vec<Waker>>>,
         inner: Arc<RwLock<ArcAsyncDerivedInner>>,
         loading: Arc<AtomicBool>,
         ready_tx: Option<oneshot::Sender<()>>,
     ) {
-        *value.write().await = Some(new_value);
+        **value.write().await.deref_mut() = Some(new_value.take());
         Self::notify_subs(&wakers, &inner, &loading, ready_tx);
     }
 
@@ -479,6 +480,11 @@ impl<T: 'static> ArcAsyncDerived<T> {
         T: Send + Sync + 'static,
         Fut: Future<Output = T> + Send + 'static,
     {
+        let fun = move || {
+            let fut = fun();
+            async move { MaybeSendWrapper::Threadsafe(fut.await) }
+        };
+        let initial_value = MaybeSendWrapper::Threadsafe(initial_value);
         let (this, _) = spawn_derived!(
             Executor::spawn,
             initial_value,
@@ -508,6 +514,11 @@ impl<T: 'static> ArcAsyncDerived<T> {
         Fut: Future<Output = T> + Send + 'static,
         S: Track,
     {
+        let fun = move || {
+            let fut = fun();
+            async move { MaybeSendWrapper::Threadsafe(fut.await) }
+        };
+        let initial_value = MaybeSendWrapper::Threadsafe(initial_value);
         let (this, _) = spawn_derived!(
             Executor::spawn,
             initial_value,
@@ -545,6 +556,12 @@ impl<T: 'static> ArcAsyncDerived<T> {
         T: 'static,
         Fut: Future<Output = T> + 'static,
     {
+        let fun = move || {
+            let fut = fun();
+            async move { MaybeSendWrapper::Local(SendWrapper::new(fut.await)) }
+        };
+        let initial_value =
+            MaybeSendWrapper::Local(SendWrapper::new(initial_value));
         let (this, _) = spawn_derived!(
             Executor::spawn_local,
             initial_value,
@@ -567,7 +584,7 @@ impl<T: 'static> ArcAsyncDerived<T> {
     }
 }
 
-impl<T: 'static> ArcAsyncDerived<SendWrapper<T>> {
+impl<T: 'static> ArcAsyncDerived<T> {
     #[doc(hidden)]
     #[track_caller]
     pub fn new_mock<Fut>(fun: impl Fn() -> Fut + 'static) -> Self
@@ -575,13 +592,10 @@ impl<T: 'static> ArcAsyncDerived<SendWrapper<T>> {
         T: 'static,
         Fut: Future<Output = T> + 'static,
     {
-        let initial = None::<SendWrapper<T>>;
+        let initial = MaybeSendWrapper::Local(SendWrapper::new(None::<T>));
         let fun = move || {
             let fut = fun();
-            async move {
-                let value = fut.await;
-                SendWrapper::new(value)
-            }
+            async move { MaybeSendWrapper::Local(SendWrapper::new(fut.await)) }
         };
         let (this, _) = spawn_derived!(
             Executor::spawn_local,
@@ -597,7 +611,10 @@ impl<T: 'static> ArcAsyncDerived<SendWrapper<T>> {
 }
 
 impl<T: 'static> ReadUntracked for ArcAsyncDerived<T> {
-    type Value = ReadGuard<Option<T>, AsyncPlain<Option<T>>>;
+    type Value = ReadGuard<
+        Option<T>,
+        Mapped<AsyncPlain<MaybeSendWrapper<Option<T>>>, Option<T>>,
+    >;
 
     fn try_read_untracked(&self) -> Option<Self::Value> {
         if let Some(suspense_context) = use_context::<SuspenseContext>() {
@@ -613,7 +630,9 @@ impl<T: 'static> ReadUntracked for ArcAsyncDerived<T> {
                 .suspenses
                 .push(suspense_context);
         }
-        AsyncPlain::try_new(&self.value).map(ReadGuard::new)
+        AsyncPlain::try_new(&self.value).map(|plain| {
+            ReadGuard::new(Mapped::new_with_guard(plain, |v| v.deref()))
+        })
     }
 }
 
@@ -627,13 +646,21 @@ impl<T: 'static> Write for ArcAsyncDerived<T> {
     type Value = Option<T>;
 
     fn try_write(&self) -> Option<impl UntrackableGuard<Target = Self::Value>> {
-        Some(WriteGuard::new(self.clone(), self.value.blocking_write()))
+        Some(MappedMut::new(
+            WriteGuard::new(self.clone(), self.value.blocking_write()),
+            |v| v.deref(),
+            |v| v.deref_mut(),
+        ))
     }
 
     fn try_write_untracked(
         &self,
     ) -> Option<impl DerefMut<Target = Self::Value>> {
-        Some(self.value.blocking_write())
+        Some(MappedMut::new(
+            self.value.blocking_write(),
+            |v| v.deref(),
+            |v| v.deref_mut(),
+        ))
     }
 }
 

--- a/reactive_graph/src/lib.rs
+++ b/reactive_graph/src/lib.rs
@@ -80,6 +80,7 @@ pub mod computed;
 pub mod diagnostics;
 pub mod effect;
 pub mod graph;
+pub mod maybe_send_wrapper;
 pub mod owner;
 #[cfg(feature = "serde")]
 mod serde;

--- a/reactive_graph/src/maybe_send_wrapper.rs
+++ b/reactive_graph/src/maybe_send_wrapper.rs
@@ -1,0 +1,59 @@
+//! A value that **might** be wrapped in a [`SendWrapper`] to make non-threadsafe at runtime.
+
+use std::ops::{Deref, DerefMut};
+
+use send_wrapper::SendWrapper;
+
+/// A value that might be wrapped in a [`SendWrapper`] to make non-threadsafe at runtime.
+pub enum MaybeSendWrapper<T> {
+    /// A threadsafe value.
+    Threadsafe(T),
+    /// A non-threadsafe value. If accessed from a different thread, it will panic.
+    Local(SendWrapper<T>),
+}
+
+impl<T> MaybeSendWrapper<T> {
+    /// Map from one wrapped value to another.
+    ///
+    /// # Panics
+    /// Panics if the [`MaybeSendWrapper::Local`] variant and it is called from a different thread than the one the instance has been created with.    
+    pub fn map<Out>(self, f: impl FnOnce(T) -> Out) -> MaybeSendWrapper<Out> {
+        match self {
+            Self::Threadsafe(value) => MaybeSendWrapper::Threadsafe(f(value)),
+            Self::Local(value) => {
+                MaybeSendWrapper::Local(SendWrapper::new(f(value.take())))
+            }
+        }
+    }
+
+    /// Consume the value.
+    ///
+    /// # Panics
+    /// Panics if the Local() variant and it is called from a different thread than the one the instance has been created with.
+    pub fn take(self) -> T {
+        match self {
+            Self::Threadsafe(value) => value,
+            Self::Local(value) => value.take(),
+        }
+    }
+}
+
+impl<T> Deref for MaybeSendWrapper<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Threadsafe(value) => value,
+            Self::Local(value) => value.deref(),
+        }
+    }
+}
+
+impl<T> DerefMut for MaybeSendWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Threadsafe(value) => value,
+            Self::Local(value) => value.deref_mut(),
+        }
+    }
+}


### PR DESCRIPTION
Man this was hard to figure out.. 

The tricky part is the previous setup used `Option<SendWrapper<T>>`, but these means you couldn't deref to `&Option<T>` like you need to. This now internalises a `MaybeSendWrapper` in `ArcAsyncDerived` that means it's layed out as `SendWrapper<Option<T>>`, so can be dereffed. 

Had the side effect of neatening up the internals of both `LocalResource` and `ArcAsyncDerived`.