### PR TITLE
test: regression from #3502

### DIFF
--- a/examples/suspense_tests/e2e/features/check_instrumented_issue_3719.feature
+++ b/examples/suspense_tests/e2e/features/check_instrumented_issue_3719.feature
@@ -1,0 +1,99 @@
+@check_instrumented_issue_3719
+Feature: Using instrumented counters to test regression from #3502.
+    Check that the suspend/suspense and the underlying resources are
+    called with the expected number of times.  If this was already in
+    place by #3502 (5c43c18) it should have caught this regression.
+    For a better minimum demonstration see #3719.
+
+    Background:
+
+        Given I see the app
+        And I select the mode Instrumented
+
+    Scenario: follow all paths via CSR avoids #3502
+        Given I select the following links
+            | Item Listing         |
+            | Item 1               |
+            | Inspect path2        |
+            | Inspect path2/field3 |
+        And I click on Reset CSR Counters
+        When I select the following links
+            | Inspect path2/field1 |
+            | Inspect path2/field2 |
+        And I go check the Counters
+        Then I see the following counters under section
+            | Suspend Calls      |   |
+            | item_listing       | 0 |
+            | item_overview      | 0 |
+            | item_inspect       | 2 |
+        And the following counters under section
+            | Server Calls (CSR) |   |
+            | list_items         | 0 |
+            | get_item           | 0 |
+            | inspect_item_root  | 0 |
+            | inspect_item_field | 2 |
+
+    # To show that starting directly from within a param will simply
+    # cause the problem.
+    Scenario: Quicker way to demonstrate regression caused by #3502
+        Given I select the link Target 123
+        # And I click on Reset CSR Counters
+        When I select the following links
+            | Inspect path2/field1 |
+            | Inspect path2/field2 |
+        And I go check the Counters
+        Then I see the following counters under section
+            | Suspend Calls      |   |
+            | item_listing       | 0 |
+            | item_overview      | 0 |
+            | item_inspect       | 3 |
+        And the following counters under section
+            | Server Calls (CSR) |   |
+            | list_items         | 1 |
+            | get_item           | 1 |
+            | inspect_item_root  | 0 |
+            | inspect_item_field | 4 |
+
+    Scenario: Follow paths ordinarily down to a target
+        Given I select the following links
+            | Item Listing         |
+            | Item 1               |
+        And I click on Reset CSR Counters
+        When I select the following links
+            | Target 4## |
+            | Target 3## |
+        And I go check the Counters
+        Then I see the following counters under section
+            | Suspend Calls      |   |
+            | item_listing       | 0 |
+            | item_overview      | 2 |
+            | item_inspect       | 0 |
+        And the following counters under section
+            | Server Calls (CSR) |   |
+            | list_items         | 0 |
+            | get_item           | 2 |
+            | inspect_item_root  | 0 |
+            | inspect_item_field | 0 |
+
+    Scenario: Same as above, but add a refresh to test hydration
+        Given I select the following links
+            | Item Listing         |
+            | Item 1               |
+        And I refresh the page
+        And I click on Reset CSR Counters
+        When I select the following links
+            | Target 4## |
+            | Target 3## |
+        And I go check the Counters
+        Then I see the following counters under section
+            | Suspend Calls      |   |
+            | item_listing       | 0 |
+            | item_overview      | 2 |
+            | item_inspect       | 0 |
+        And the following counters under section
+            | Server Calls (CSR) |   |
+            | list_items         | 0 |
+            | get_item           | 2 |
+            | inspect_item_root  | 0 |
+            | inspect_item_field | 0 |
+

--- a/examples/suspense_tests/e2e/tests/app_suite.rs
+++ b/examples/suspense_tests/e2e/tests/app_suite.rs
@@ -3,12 +3,28 @@ mod fixtures;
 use anyhow::Result;
 use cucumber::World;
 use fixtures::world::AppWorld;
+use std::{ffi::OsStr, fs::read_dir};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    AppWorld::cucumber()
-        .fail_on_skipped()
-        .run_and_exit("./features")
-        .await;
+    // Normally the below is done, but it's now gotten to the point of
+    // having a sufficient number of tests where the resource contention
+    // of the concurrently running browsers will cause failures on CI.
+    // AppWorld::cucumber()
+    //     .fail_on_skipped()
+    //     .run_and_exit("./features")
+    //     .await;
+
+    // Mitigate the issue by manually stepping through each feature,
+    // rather than letting cucumber glob them and dispatch all at once.
+    for entry in read_dir("./features")? {
+        let path = entry?.path();
+        if path.extension() == Some(OsStr::new("feature")) {
+            AppWorld::cucumber()
+                .fail_on_skipped()
+                .run_and_exit(path)
+                .await;
+        }
+    }
     Ok(())
 }

--- a/examples/suspense_tests/src/instrumented.rs
+++ b/examples/suspense_tests/src/instrumented.rs
@@ -492,8 +492,9 @@ fn ItemInspect() -> impl IntoView {
             // result
         },
     );
-    on_cleanup(|| {
-        if let Some(c) = use_context::<WriteSignal<Option<FieldNavCtx>>>() {
+    let ws = use_context::<WriteSignal<Option<FieldNavCtx>>>();
+    on_cleanup(move || {
+        if let Some(c) = ws {
             c.set(None);
         }
     });

--- a/examples/suspense_tests/src/instrumented.rs
+++ b/examples/suspense_tests/src/instrumented.rs
@@ -4,7 +4,7 @@ use leptos_router::{
     hooks::use_params,
     nested_router::Outlet,
     params::Params,
-    MatchNestedRoutes, ParamSegment, SsrMode, StaticSegment, WildcardSegment,
+    ParamSegment, SsrMode, StaticSegment, WildcardSegment,
 };
 
 #[cfg(feature = "ssr")]
@@ -21,6 +21,7 @@ pub(super) mod counter {
     pub struct Counter(AtomicU32);
 
     impl Counter {
+        #[allow(dead_code)]
         pub const fn new() -> Self {
             Self(AtomicU32::new(0))
         }
@@ -203,20 +204,20 @@ pub struct SuspenseCounters {
 }
 
 #[component]
-pub fn InstrumentedRoutes() -> impl MatchNestedRoutes + Clone {
+pub fn InstrumentedRoutes() -> impl leptos_router::MatchNestedRoutes + Clone {
     // TODO should make this mode configurable via feature flag?
     let ssr = SsrMode::Async;
     view! {
         <ParentRoute path=StaticSegment("instrumented") view=InstrumentedRoot ssr>
-            <Route path=StaticSegment("/") view=InstrumentedTop/>
+            <Route path=StaticSegment("/") view=InstrumentedTop />
             <ParentRoute path=StaticSegment("item") view=ItemRoot>
-                <Route path=StaticSegment("/") view=ItemListing/>
+                <Route path=StaticSegment("/") view=ItemListing />
                 <ParentRoute path=ParamSegment("id") view=ItemTop>
-                    <Route path=StaticSegment("/") view=ItemOverview/>
-                    <Route path=WildcardSegment("path") view=ItemInspect/>
+                    <Route path=StaticSegment("/") view=ItemOverview />
+                    <Route path=WildcardSegment("path") view=ItemInspect />
                 </ParentRoute>
             </ParentRoute>
-            <Route path=StaticSegment("counters") view=ShowCounters/>
+            <Route path=StaticSegment("counters") view=ShowCounters />
         </ParentRoute>
     }
     .into_inner()
@@ -279,32 +280,41 @@ fn InstrumentedRoot() -> impl IntoView {
         <section id="instrumented">
             <nav>
                 <a href="/">"Site Root"</a>
-                <A href="./" exact=true>"Instrumented Root"</A>
-                <A href="item/" strict_trailing_slash=true>"Item Listing"</A>
-                <A href="counters" strict_trailing_slash=true>"Counters"</A>
+                <A href="./" exact=true>
+                    "Instrumented Root"
+                </A>
+                <A href="item/" strict_trailing_slash=true>
+                    "Item Listing"
+                </A>
+                <A href="counters" strict_trailing_slash=true>
+                    "Counters"
+                </A>
             </nav>
-            <FieldNavPortlet/>
-            <Outlet/>
-            <Suspense>{
-                move || Suspend::new(async move {
+            <FieldNavPortlet />
+            <Outlet />
+            <Suspense>
+                {move || Suspend::new(async move {
                     let clear_suspense_counters = move |_| {
                         counters.update(|c| *c = SuspenseCounters::default());
                     };
-                    csr_ticket.get().map(|ticket| {
-                        let ticket = ticket.0;
-                        view! {
-                            <ActionForm action=reset_counters>
-                                <input type="hidden" name="ticket" value=format!("{ticket}") />
-                                <input
-                                    id="reset-csr-counters"
-                                    type="submit"
-                                    value="Reset CSR Counters"
-                                    on:click=clear_suspense_counters/>
-                            </ActionForm>
-                        }
-                    })
-                })
-            }</Suspense>
+                    csr_ticket
+                        .get()
+                        .map(|ticket| {
+                            let ticket = ticket.0;
+                            view! {
+                                <ActionForm action=reset_counters>
+                                    <input type="hidden" name="ticket" value=format!("{ticket}") />
+                                    <input
+                                        id="reset-csr-counters"
+                                        type="submit"
+                                        value="Reset CSR Counters"
+                                        on:click=clear_suspense_counters
+                                    />
+                                </ActionForm>
+                            }
+                        })
+                })}
+            </Suspense>
             <footer>
                 <nav>
                     <A href="item/3/">"Target 3##"</A>
@@ -323,11 +333,17 @@ fn InstrumentedRoot() -> impl IntoView {
 fn InstrumentedTop() -> impl IntoView {
     view! {
         <h1>"Instrumented Tests"</h1>
-        <p>"These tests validates the number of invocations of server functions and suspenses per access."</p>
+        <p>
+            "These tests validates the number of invocations of server functions and suspenses per access."
+        </p>
         <ul>
             // not using `A` because currently some bugs with artix
-            <li><a href="item/">"Item Listing"</a></li>
-            <li><a href="item/4/path1/">"Target 41#"</a></li>
+            <li>
+                <a href="item/">"Item Listing"</a>
+            </li>
+            <li>
+                <a href="item/4/path1/">"Target 41#"</a>
+            </li>
         </ul>
     }
 }
@@ -342,7 +358,7 @@ fn ItemRoot() -> impl IntoView {
 
     view! {
         <h2>"<ItemRoot/>"</h2>
-        <Outlet/>
+        <Outlet />
     }
 }
 
@@ -360,7 +376,9 @@ fn ItemListing() -> impl IntoView {
                 // adding an extra `/` in artix; manually construct `a` instead.
                 // <li><A href=format!("./{item}/")>"Item "{item}</A></li>
                 view! {
-                    <li><a href=format!("/instrumented/item/{item}/")>"Item "{item}</a></li>
+                    <li>
+                        <a href=format!("/instrumented/item/{item}/")>"Item "{item}</a>
+                    </li>
                 }
             )
             .collect_view()
@@ -373,9 +391,7 @@ fn ItemListing() -> impl IntoView {
     view! {
         <h3>"<ItemListing/>"</h3>
         <ul>
-        <Suspense>
-            {item_listing}
-        </Suspense>
+            <Suspense>{item_listing}</Suspense>
         </ul>
     }
 }
@@ -402,7 +418,7 @@ fn ItemTop() -> impl IntoView {
     ));
     view! {
         <h4>"<ItemTop/>"</h4>
-        <Outlet/>
+        <Outlet />
     }
 }
 
@@ -412,24 +428,29 @@ fn ItemOverview() -> impl IntoView {
     let resource = expect_context::<Resource<Option<GetItemResult>>>();
     let item_view = move || {
         Suspend::new(async move {
-            let result = resource.await.map(|GetItemResult(item, names)| view! {
-            <p>{format!("Viewing {item:?}")}</p>
-            <ul>{
-                names.into_iter()
-                    .map(|name| {
-                        // FIXME seems like relative link isn't working, it is currently
-                        // adding an extra `/` in artix; manually construct `a` instead.
-                        // <li><A href=format!("./{name}/")>{format!("Inspect {name}")}</A></li>
-                        let id = item.id;
-                        view! {
-                            <li><a href=format!("/instrumented/item/{id}/{name}/")>
-                                "Inspect "{name.clone()}
-                            </a></li>
-                        }
-                    })
-                    .collect_view()
-            }</ul>
-        });
+            let result = resource.await.map(|GetItemResult(item, names)| {
+                view! {
+                    <p>{format!("Viewing {item:?}")}</p>
+                    <ul>
+                        {names
+                            .into_iter()
+                            .map(|name| {
+                                let id = item.id;
+                                // FIXME seems like relative link isn't working, it is currently
+                                // adding an extra `/` in artix; manually construct `a` instead.
+                                // <li><A href=format!("./{name}/")>{format!("Inspect {name}")}</A></li>
+                                view! {
+                                    <li>
+                                        <a href=format!(
+                                            "/instrumented/item/{id}/{name}/",
+                                        )>"Inspect "{name.clone()}</a>
+                                    </li>
+                                }
+                            })
+                            .collect_view()}
+                    </ul>
+                }
+            });
             suspense_counters.update_untracked(|c| c.item_overview += 1);
             result
         })
@@ -437,9 +458,7 @@ fn ItemOverview() -> impl IntoView {
 
     view! {
         <h5>"<ItemOverview/>"</h5>
-        <Suspense>
-            {item_view}
-        </Suspense>
+        <Suspense>{item_view}</Suspense>
     }
 }
 
@@ -496,23 +515,26 @@ fn ItemInspect() -> impl IntoView {
                 ));
                 view! {
                     <p>{format!("Inspecting {item:?}")}</p>
-                    <ul>{
-                        fields.iter()
+                    <ul>
+                        {fields
+                            .iter()
                             .map(|field| {
                                 // FIXME seems like relative link to root for a wildcard isn't
                                 // working as expected, so manually construct `a` instead.
                                 // let text = format!("Inspect {name}/{field}");
                                 // view! {
-                                //     <li><A href=format!("{field}")>{text}</A></li>
+                                // <li><A href=format!("{field}")>{text}</A></li>
                                 // }
                                 view! {
-                                    <li><a href=format!("/instrumented/item/{id}/{name}/{field}")>{
-                                        format!("Inspect {name}/{field}")
-                                    }</a></li>
+                                    <li>
+                                        <a href=format!(
+                                            "/instrumented/item/{id}/{name}/{field}",
+                                        )>{format!("Inspect {name}/{field}")}</a>
+                                    </li>
                                 }
                             })
-                            .collect_view()
-                    }</ul>
+                            .collect_view()}
+                    </ul>
                 }
             });
             suspense_counters.update_untracked(|c| c.item_inspect += 1);
@@ -527,9 +549,7 @@ fn ItemInspect() -> impl IntoView {
 
     view! {
         <h5>"<ItemInspect/>"</h5>
-        <Suspense>
-            {inspect_view}
-        </Suspense>
+        <Suspense>{inspect_view}</Suspense>
     }
 }
 
@@ -590,7 +610,8 @@ fn ShowCounters() -> impl IntoView {
                             id="reset-counters"
                             type="submit"
                             value="Reset Counters"
-                            on:click=clear_suspense_counters/>
+                            on:click=clear_suspense_counters
+                        />
                     </ActionForm>
                 }
             })
@@ -601,20 +622,23 @@ fn ShowCounters() -> impl IntoView {
         <h2>"Counters"</h2>
 
         <h3 id="suspend-calls">"Suspend Calls"</h3>
-        {move || suspense_counters.with(|c| view! {
-            <dl>
-                <dt>"item_listing"</dt>
-                <dd id="item_listing">{c.item_listing}</dd>
-                <dt>"item_overview"</dt>
-                <dd id="item_overview">{c.item_overview}</dd>
-                <dt>"item_inspect"</dt>
-                <dd id="item_inspect">{c.item_inspect}</dd>
-            </dl>
-        })}
+        {move || {
+            suspense_counters
+                .with(|c| {
+                    view! {
+                        <dl>
+                            <dt>"item_listing"</dt>
+                            <dd id="item_listing">{c.item_listing}</dd>
+                            <dt>"item_overview"</dt>
+                            <dd id="item_overview">{c.item_overview}</dd>
+                            <dt>"item_inspect"</dt>
+                            <dd id="item_inspect">{c.item_inspect}</dd>
+                        </dl>
+                    }
+                })
+        }}
 
-        <Suspense>
-            {counter_view}
-        </Suspense>
+        <Suspense>{counter_view}</Suspense>
     }
 }
 
@@ -642,17 +666,17 @@ pub fn FieldNavPortlet() -> impl IntoView {
             view! {
                 <div id="FieldNavPortlet">
                     <span>"FieldNavPortlet:"</span>
-                    <nav>{
-                        ctx.0.map(|ctx| {
-                            ctx.into_iter()
-                                .map(|FieldNavItem { href, text }| {
-                                    view! {
-                                        <A href=href>{text}</A>
-                                    }
-                                })
-                                .collect_view()
-                        })
-                    }</nav>
+                    <nav>
+                        {ctx
+                            .0
+                            .map(|ctx| {
+                                ctx.into_iter()
+                                    .map(|FieldNavItem { href, text }| {
+                                        view! { <A href=href>{text}</A> }
+                                    })
+                                    .collect_view()
+                            })}
+                    </nav>
                 </div>
             }
         })


### PR DESCRIPTION
Also as reported in #3719, which has an actual minimum example.

To provided additional detail that I missed there (even though I mentioned this briefly in #3699), these tests in this pull request should have flagged #3502 which the cdee2a9476109b10f5d8da268684bd1257c6ce9b being the first source of the regression, and that this following patch is as close to the source of the issue as I can find:

```patch
diff --git a/router/src/nested_router.rs b/router/src/nested_router.rs
index 27269b3c..3fa6ed0e 100644
--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -655,8 +655,8 @@ where
                                         ScopedFuture::new(view.choose()),
                                     );
                                     let view = view.await;
-                                    let view =
-                                        MatchedRoute(matched.0.get(), view);
+                                    // let view =
+                                    //     MatchedRoute(matched.0.get(), view);
                                     OwnedView::new(view).into_any()
                                 })
                                     as Pin<
```

Obviously that's not the fix as the router in islands mode probably depends on that, I thought I should at least narrow down the source of this regression to as close as possible.

I am setting the merge base to `main` as that probably will have the immediate benefit, and that these tests should hopefully pass as I feel getting a pass from this first from CI and then pulling the resulting `main` into `leptos_0.8` to see the test failures may be better from a provenance standpoint. (Also maybe the final merge can be a 3-way merge sourced from `main` (with these tests), `leptos_0.8` plus the pull request branch that will provide the fix, if we want to make this fancy, I don't mind either way.)