### PR TITLE
More flexible server fn macro api

### DIFF
--- a/projects/ory-kratos/app/src/auth/login.rs
+++ b/projects/ory-kratos/app/src/auth/login.rs
@@ -79,12 +79,11 @@ impl IntoView for LoginResponse {
 
 #[tracing::instrument]
 #[server]
-pub async fn login(body: HashMap<String, String>) -> Result<LoginResponse, ServerFnError> {
+pub async fn login(mut body: HashMap<String, String>) -> Result<LoginResponse, ServerFnError> {
     use ory_kratos_client::models::error_browser_location_change_required::ErrorBrowserLocationChangeRequired;
     use ory_kratos_client::models::generic_error::GenericError;
     use reqwest::StatusCode;
 
-    let mut body = body;
     let action = body
         .remove("action")
         .ok_or(ServerFnError::new("Can't find action on body."))?;

--- a/projects/ory-kratos/app/src/auth/recovery.rs
+++ b/projects/ory-kratos/app/src/auth/recovery.rs
@@ -83,13 +83,12 @@ pub async fn init_recovery_flow() -> Result<ViewableRecoveryFlow, ServerFnError>
 #[tracing::instrument(ret)]
 #[server]
 pub async fn process_recovery(
-    body: HashMap<String, String>,
+    mut body: HashMap<String, String>,
 ) -> Result<ViewableRecoveryFlow, ServerFnError> {
     use ory_kratos_client::models::error_browser_location_change_required::ErrorBrowserLocationChangeRequired;
     use ory_kratos_client::models::generic_error::GenericError;
     use reqwest::StatusCode;
 
-    let mut body = body;
     let action = body
         .remove("action")
         .ok_or(ServerFnError::new("Can't find action on body."))?;

--- a/projects/ory-kratos/app/src/auth/registration.rs
+++ b/projects/ory-kratos/app/src/auth/registration.rs
@@ -89,7 +89,7 @@ pub async fn init_registration() -> Result<RegistrationResponse, ServerFnError> 
 #[tracing::instrument(err)]
 #[server]
 pub async fn register(
-    body: HashMap<String, String>,
+    mut body: HashMap<String, String>,
 ) -> Result<RegistrationResponse, ServerFnError> {
     use ory_kratos_client::models::error_browser_location_change_required::ErrorBrowserLocationChangeRequired;
     use ory_kratos_client::models::generic_error::GenericError;
@@ -97,7 +97,6 @@ pub async fn register(
 
     let pool = leptos_axum::extract::<axum::Extension<sqlx::SqlitePool>>().await?;
 
-    let mut body = body;
     let action = body
         .remove("action")
         .ok_or(ServerFnError::new("Can't find action on body."))?;

--- a/projects/ory-kratos/app/src/auth/settings.rs
+++ b/projects/ory-kratos/app/src/auth/settings.rs
@@ -140,7 +140,7 @@ pub async fn init_settings_flow(
 #[server]
 pub async fn update_settings(
     flow_id: String,
-    body: HashMap<String, String>,
+    mut body: HashMap<String, String>,
 ) -> Result<ViewableSettingsFlow, ServerFnError> {
     use ory_kratos_client::models::{
         ErrorBrowserLocationChangeRequired, ErrorGeneric, GenericError,
@@ -148,7 +148,6 @@ pub async fn update_settings(
     use reqwest::StatusCode;
     let session = leptos_axum::extract::<extractors::ExtractSession>().await?.0;
     tracing::error!("{session:#?}");
-    let mut body = body;
     let action = body
         .remove("action")
         .ok_or(ServerFnError::new("Can't find action on body."))?;

--- a/projects/ory-kratos/app/src/auth/verification.rs
+++ b/projects/ory-kratos/app/src/auth/verification.rs
@@ -54,9 +54,8 @@ pub async fn init_verification(
 #[tracing::instrument]
 #[server]
 pub async fn verify(
-    body: HashMap<String, String>,
+    mut body: HashMap<String, String>,
 ) -> Result<Option<ViewableVerificationFlow>, ServerFnError> {
-    let mut body = body;
     let action = body
         .remove("action")
         .ok_or(ServerFnError::new("Can't find action on body."))?;

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -98,7 +98,7 @@
 //! # fn main() {
 //! # }
 //! ```
-//!
+//! 
 //! ### Additional field types
 //!
 //! Most of the time, your structs will have fields as in the example above: the struct is comprised

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -98,7 +98,7 @@
 //! # fn main() {
 //! # }
 //! ```
-//! 
+//!
 //! ### Additional field types
 //!
 //! Most of the time, your structs will have fields as in the example above: the struct is comprised

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -35,6 +35,7 @@ impl ServerFnCall {
     /// #[proc_macro_attribute]
     /// pub fn server(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     ///     match ServerFnCall::parse(
+    ///         "/api",
     ///         args.into(),
     ///         s.into(),
     ///     ) {

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -81,6 +81,26 @@ impl ServerFnCall {
         Ok(myself)
     }
 
+    /// Get a reference to the server function arguments.
+    pub fn get_args(&self) -> &ServerFnArgs {
+        &self.args
+    }
+
+    /// Get a mutable reference to the server function arguments.
+    pub fn get_args_mut(&mut self) -> &mut ServerFnArgs {
+        &mut self.args
+    }
+
+    /// Get a reference to the server function body.
+    pub fn get_body(&self) -> &ServerFnBody {
+        &self.body
+    }
+
+    /// Get a mutable reference to the server function body.
+    pub fn get_body_mut(&mut self) -> &mut ServerFnBody {
+        &mut self.body
+    }
+
     /// Set the path to the server function crate.
     pub fn default_server_fn_path(mut self, path: Option<Path>) -> Self {
         self.server_fn_path = path;
@@ -840,8 +860,9 @@ fn type_from_ident(ident: Ident) -> Type {
     })
 }
 
+/// Middleware for a server function.
 #[derive(Debug, Clone)]
-struct Middleware {
+pub struct Middleware {
     expr: syn::Expr,
 }
 
@@ -906,21 +927,36 @@ fn err_type(return_ty: &Type) -> Result<Option<&Type>> {
     ))
 }
 
+/// The arguments to the `server` macro.
 #[derive(Debug)]
-struct ServerFnArgs {
-    struct_name: Option<Ident>,
-    prefix: Option<LitStr>,
-    input: Option<Type>,
-    input_derive: Option<ExprTuple>,
-    output: Option<Type>,
-    fn_path: Option<LitStr>,
-    server: Option<Type>,
-    client: Option<Type>,
-    custom_wrapper: Option<Path>,
+#[non_exhaustive]
+pub struct ServerFnArgs {
+    /// The name of the struct that will implement the server function trait
+    /// and be submitted to inventory.
+    pub struct_name: Option<Ident>,
+    /// The prefix to use for the server function URL.
+    pub prefix: Option<LitStr>,
+    /// The input http encoding to use for the server function.
+    pub input: Option<Type>,
+    /// Additional traits to derive on the input struct for the server function.
+    pub input_derive: Option<ExprTuple>,
+    /// The output http encoding to use for the server function.
+    pub output: Option<Type>,
+    /// The path to the server function crate.
+    pub fn_path: Option<LitStr>,
+    /// The server type to use for the server function.
+    pub server: Option<Type>,
+    /// The client type to use for the server function.
+    pub client: Option<Type>,
+    /// The custom wrapper to use for the server function struct.
+    pub custom_wrapper: Option<Path>,
+    /// If the generated input type should implement `From` the only field in the input
+    pub impl_from: Option<LitBool>,
+    /// If the generated input type should implement `Deref` to the only field in the input
+    pub impl_deref: Option<LitBool>,
+    /// The protocol to use for the server function implementation.
+    pub protocol: Option<Type>,
     builtin_encoding: bool,
-    impl_from: Option<LitBool>,
-    impl_deref: Option<LitBool>,
-    protocol: Option<Type>,
 }
 
 impl Parse for ServerFnArgs {
@@ -1173,9 +1209,12 @@ impl Parse for ServerFnArgs {
     }
 }
 
+/// An argument type in a server function.
 #[derive(Debug, Clone)]
-struct ServerFnArg {
+pub struct ServerFnArg {
+    /// The attributes on the server function argument.
     server_fn_attributes: Vec<Attribute>,
+    /// The type of the server function argument.
     arg: syn::PatType,
 }
 
@@ -1314,22 +1353,34 @@ impl Parse for ServerFnArg {
     }
 }
 
+/// The body of a server function.
 #[derive(Debug, Clone)]
-struct ServerFnBody {
+pub struct ServerFnBody {
+    /// The attributes on the server function.
     pub attrs: Vec<Attribute>,
+    /// The visibility of the server function.
     pub vis: syn::Visibility,
-    pub async_token: Token![async],
-    pub fn_token: Token![fn],
+    async_token: Token![async],
+    fn_token: Token![fn],
+    /// The name of the server function.
     pub ident: Ident,
+    /// The generics of the server function.
     pub generics: Generics,
-    pub _paren_token: token::Paren,
+    _paren_token: token::Paren,
+    /// The arguments to the server function.
     pub inputs: Punctuated<ServerFnArg, Token![,]>,
-    pub output_arrow: Token![->],
+    output_arrow: Token![->],
+    /// The return type of the server function.
     pub return_ty: syn::Type,
+    /// The Ok output type of the server function.
     pub output_ty: syn::GenericArgument,
+    /// The error output type of the server function.
     pub error_ty: Option<syn::Type>,
+    /// The body of the server function.
     pub block: TokenStream2,
+    /// The documentation of the server function.
     pub docs: Vec<(String, Span)>,
+    /// The middleware attributes applied to the server function.
     pub middlewares: Vec<Middleware>,
 }
 

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -687,7 +687,7 @@ impl ServerFnCall {
         }
     }
 
-    fn from_impl(&self) -> TokenStream2 {
+    fn impl_from(&self) -> TokenStream2 {
         let impl_from = self
             .args
             .impl_from
@@ -785,7 +785,7 @@ impl ToTokens for ServerFnCall {
         // only emit the dummy (unmodified server-only body) for the server build
         let dummy = cfg!(feature = "ssr").then(|| body.to_dummy_output());
 
-        let from_impl = self.from_impl();
+        let impl_from = self.impl_from();
 
         let deref_impl = self.deref_impl();
 
@@ -800,7 +800,7 @@ impl ToTokens for ServerFnCall {
         tokens.extend(quote! {
             #struct_tokens
 
-            #from_impl
+            #impl_from
 
             #deref_impl
 

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -1355,6 +1355,7 @@ impl Parse for ServerFnArg {
 
 /// The body of a server function.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ServerFnBody {
     /// The attributes on the server function.
     pub attrs: Vec<Attribute>,

--- a/server_fn_macro/src/lib.rs
+++ b/server_fn_macro/src/lib.rs
@@ -318,7 +318,7 @@ impl ServerFnCall {
         let fn_name_as_str = self.fn_name_as_str();
         let link_to_server_fn = format!(
             "Serialized arguments for the [`{fn_name_as_str}`] server \
-         function.\n\n"
+             function.\n\n"
         );
         let args_docs = quote! {
             #[doc = #link_to_server_fn]
@@ -483,7 +483,7 @@ impl ServerFnCall {
             .unwrap_or_else(|| LitStr::new("", Span::call_site()));
         let fn_path = fn_path.value();
         // Remove any leading slashes, then add one slash back
-        let fn_path = "/".to_string() + &fn_path.trim_start_matches('/');
+        let fn_path = "/".to_string() + fn_path.trim_start_matches('/');
 
         let enable_server_fn_mod_path =
             option_env!("SERVER_FN_MOD_PATH").is_some();
@@ -1321,8 +1321,8 @@ impl Parse for ServerFnArg {
                         _ => Err(Error::new(
                             attr.span(),
                             "Unrecognized #[server] attribute, expected \
-                         #[server(default)] or #[server(rename = \
-                         \"fieldName\")]",
+                             #[server(default)] or #[server(rename = \
+                             \"fieldName\")]",
                         )),
                     }
                 } else if attr.path().is_ident("doc") {


### PR DESCRIPTION
This PR refactors the server function macro implementation into a struct that can be parsed and converted to tokens. The struct has more modular methods for derived values like the protocol based on the default configuration and the parsed arguments. This should make it both easier to maintain in the long run and easier to modify for Dioxus. I did make some fields of the server function arguments and body public to make them easier to read and modify externally. This introduces some additional semvar requirements. I have marked the newly public structs as non exhaustive so we can add fields in minor releases. Let me know if you would rather expose getters and setters or if the API surface is too broad

There are two small potentially breaking changes in this PR:
1) Some arguments like `prefix` now only accept `StrLit` instead of any `Literal`. This makes parsing the contents easier since we don't need to rely on the display implementation and strip the quotes manually.
2) The hashing logic is slightly different: instead of hashing the file, column, and row. This PR hashes the module path and function name. It should still be unique as enforced by the compiler, but it is slightly more stable