### PR TITLE
feat: add patch http method codec

### DIFF
--- a/server_fn/src/codec/cbor.rs
+++ b/server_fn/src/codec/cbor.rs
@@ -1,3 +1,4 @@
+use super::Patch;
 use super::Post;
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
@@ -36,3 +37,5 @@ where
 
 /// Pass arguments and receive responses using `cbor` in a `POST` request.
 pub type Cbor = Post<CborEncoding>;
+/// Pass arguments and receive responses using `cbor` in a `PATCH` request.
+pub type PatchCbor = Patch<CborEncoding>;

--- a/server_fn/src/codec/cbor.rs
+++ b/server_fn/src/codec/cbor.rs
@@ -1,5 +1,4 @@
-use super::Patch;
-use super::Post;
+use super::{Patch, Post};
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -34,4 +34,5 @@ where
 
 /// Pass arguments and receive responses as JSON in the body of a `POST` request.
 pub type Json = Post<JsonEncoding>;
+/// Pass arguments and receive responses as JSON in the body of a `PATCH` request.
 pub type PatchJson = Patch<JsonEncoding>;

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -1,3 +1,4 @@
+use super::Patch;
 use super::Post;
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
@@ -34,3 +35,4 @@ where
 
 /// Pass arguments and receive responses as JSON in the body of a `POST` request.
 pub type Json = Post<JsonEncoding>;
+pub type PatchJson = Patch<JsonEncoding>;

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -1,5 +1,4 @@
-use super::Patch;
-use super::Post;
+use super::{Patch, Post};
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};

--- a/server_fn/src/codec/mod.rs
+++ b/server_fn/src/codec/mod.rs
@@ -52,6 +52,8 @@ pub use postcard::*;
 
 mod post;
 pub use post::*;
+mod patch;
+pub use patch::*;
 mod stream;
 use crate::ContentType;
 use futures::Future;

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -33,3 +36,5 @@ where
 
 /// Pass arguments and receive responses as MessagePack in a `POST` request.
 pub type MsgPack = Post<MsgPackEncoding>;
+/// Pass arguments and receive responses as MessagePack in a `PATCH` request.
+pub type PatchMsgPack = Patch<MsgPackEncoding>;

--- a/server_fn/src/codec/patch.rs
+++ b/server_fn/src/codec/patch.rs
@@ -1,0 +1,86 @@
+use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
+use crate::{
+    error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
+    request::{ClientReq, Req},
+    response::{ClientRes, TryRes},
+    ContentType, Decodes, Encodes,
+};
+use std::marker::PhantomData;
+
+/// A codec that encodes the data in the `PATCH` body.
+/// **Note**: Browser support for sending `PATCH` requests without JS/WASM
+/// may be poor.  If you want to support functionality without JS/WASM then
+/// consider using [`Post`](super::Post) instead.
+pub struct Patch<Codec>(PhantomData<Codec>);
+
+impl<Codec: ContentType> ContentType for Patch<Codec> {
+    const CONTENT_TYPE: &'static str = Codec::CONTENT_TYPE;
+}
+
+impl<Codec: ContentType> Encoding for Patch<Codec> {
+    const METHOD: http::Method = http::Method::PATCH;
+}
+
+impl<E, T, Encoding, Request> IntoReq<Patch<Encoding>, Request, E> for T
+where
+    Request: ClientReq<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_patch_bytes(
+            path,
+            accepts,
+            Encoding::CONTENT_TYPE,
+            data,
+        )
+    }
+}
+
+impl<E, T, Request, Encoding> FromReq<Patch<Encoding>, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let data = req.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}
+
+impl<E, Response, Encoding, T> IntoRes<Patch<Encoding>, Response, E> for T
+where
+    Response: TryRes<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError + Send,
+    T: Send,
+{
+    async fn into_res(self) -> Result<Response, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Response::try_from_bytes(Encoding::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, Encoding, Response, T> FromRes<Patch<Encoding>, Response, E> for T
+where
+    Response: ClientRes<E> + Send,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_res(res: Response) -> Result<Self, E> {
+        let data = res.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}

--- a/server_fn/src/codec/postcard.rs
+++ b/server_fn/src/codec/postcard.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -33,3 +36,5 @@ where
 
 /// Pass arguments and receive responses with postcard in a `POST` request.
 pub type Postcard = Post<PostcardEncoding>;
+/// Pass arguments and receive responses with postcard in a `PATCH` request.
+pub type PatchPostcard = Patch<PostcardEncoding>;

--- a/server_fn/src/codec/rkyv.rs
+++ b/server_fn/src/codec/rkyv.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use rkyv::{
     api::high::{HighDeserializer, HighSerializer, HighValidator},
@@ -52,3 +55,5 @@ where
 
 /// Pass arguments and receive responses as `rkyv` in a `POST` request.
 pub type Rkyv = Post<RkyvEncoding>;
+/// Pass arguments and receive responses as `rkyv` in a `PATCH` request.
+pub type PatchRkyv = Patch<RkyvEncoding>;

--- a/server_fn/src/codec/serde_lite.rs
+++ b/server_fn/src/codec/serde_lite.rs
@@ -1,5 +1,7 @@
 use crate::{
-    codec::Post, error::ServerFnErrorErr, ContentType, Decodes, Encodes,
+    codec::{Patch, Post},
+    error::ServerFnErrorErr,
+    ContentType, Decodes, Encodes,
 };
 use bytes::Bytes;
 use serde_lite::{Deserialize, Serialize};
@@ -46,3 +48,5 @@ where
 
 /// Pass arguments and receive responses as JSON in the body of a `POST` request.
 pub type SerdeLite = Post<SerdeLiteEncoding>;
+/// Pass arguments and receive responses as JSON in the body of a `PATCH` request.
+pub type PatchSerdeLite = Patch<SerdeLiteEncoding>;

--- a/server_fn/src/codec/url.rs
+++ b/server_fn/src/codec/url.rs
@@ -13,6 +13,9 @@ pub struct GetUrl;
 /// Pass arguments as the URL-encoded body of a `POST` request.
 pub struct PostUrl;
 
+/// Pass arguments as the URL-encoded body of a `PATCH` request.
+pub struct PatchUrl;
+
 impl ContentType for GetUrl {
     const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
 }
@@ -75,6 +78,45 @@ where
 }
 
 impl<E, T, Request> FromReq<PostUrl, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    T: DeserializeOwned,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let string_data = req.try_into_string().await?;
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(&string_data)
+            .map_err(|e| {
+                ServerFnErrorErr::Args(e.to_string()).into_app_error()
+            })?;
+        Ok(args)
+    }
+}
+
+impl ContentType for PatchUrl {
+    const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+}
+
+impl Encoding for PatchUrl {
+    const METHOD: Method = Method::PATCH;
+}
+
+impl<E, T, Request> IntoReq<PatchUrl, Request, E> for T
+where
+    Request: ClientReq<E>,
+    T: Serialize + Send,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let qs = serde_qs::to_string(&self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_patch(path, accepts, PatchUrl::CONTENT_TYPE, qs)
+    }
+}
+
+impl<E, T, Request> FromReq<PatchUrl, Request, E> for T
 where
     Request: Req<E> + Send + 'static,
     T: DeserializeOwned,

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -71,6 +71,30 @@ where
         content_type: &str,
         body: impl Stream<Item = Bytes> + Send + 'static,
     ) -> Result<Self, E>;
+
+    /// Attempts to construct a new `PATCH` request with a text body.
+    fn try_new_patch(
+        path: &str,
+        content_type: &str,
+        accepts: &str,
+        body: String,
+    ) -> Result<Self, E>;
+
+    /// Attempts to construct a new `PATCH` request with a binary body.
+    fn try_new_patch_bytes(
+        path: &str,
+        content_type: &str,
+        accepts: &str,
+        body: Bytes,
+    ) -> Result<Self, E>;
+
+    /// Attempts to construct a new `PATCH` request with form data as the body.
+    fn try_new_patch_form_data(
+        path: &str,
+        accepts: &str,
+        content_type: &str,
+        body: Self::FormData,
+    ) -> Result<Self, E>;
 }
 
 /// Represents the request as received by the server.

--- a/server_fn/src/request/reqwest.rs
+++ b/server_fn/src/request/reqwest.rs
@@ -112,6 +112,59 @@ where
             })
     }
 
+    fn try_new_patch(
+        path: &str,
+        content_type: &str,
+        accepts: &str,
+        body: String,
+    ) -> Result<Self, E> {
+        let url = format!("{}{}", get_server_url(), path);
+        CLIENT
+            .patch(url)
+            .header(CONTENT_TYPE, content_type)
+            .header(ACCEPT, accepts)
+            .body(body)
+            .build()
+            .map_err(|e| {
+                ServerFnErrorErr::Request(e.to_string()).into_app_error()
+            })
+    }
+
+    fn try_new_patch_bytes(
+        path: &str,
+        content_type: &str,
+        accepts: &str,
+        body: Bytes,
+    ) -> Result<Self, E> {
+        let url = format!("{}{}", get_server_url(), path);
+        CLIENT
+            .patch(url)
+            .header(CONTENT_TYPE, content_type)
+            .header(ACCEPT, accepts)
+            .body(body)
+            .build()
+            .map_err(|e| {
+                ServerFnErrorErr::Request(e.to_string()).into_app_error()
+            })
+    }
+
+    fn try_new_patch_form_data(
+        path: &str,
+        accepts: &str,
+        content_type: &str,
+        body: Self::FormData,
+    ) -> Result<Self, E> {
+        CLIENT
+            .patch(path)
+            .header(CONTENT_TYPE, content_type)
+            .header(ACCEPT, accepts)
+            .multipart(body)
+            .build()
+            .map_err(|e| {
+                ServerFnErrorErr::Request(e.to_string()).into_app_error()
+            })
+    }
+
     fn try_new_streaming(
         path: &str,
         accepts: &str,


### PR DESCRIPTION
# Description
Adds `PATCH` method support for `#[server]` functions via a `Patch` codec.  Includes a note about potential browser support issues when JS/WASM is not enabled.  Useful when defining `REST` apis via `#[server]` functions.  

# Why do we need this?
Per the current Leptos documentation:

> Isomorphic: Leptos provides primitives to write isomorphic [server functions](https://docs.rs/leptos_server/0.2.5/leptos_server/index.html), i.e., functions that can be called with the “same shape” on the client or server, but only run on the server. This means you can write your server-only logic (database requests, authentication etc.) alongside the client-side components that will consume it, and call server functions as if they were running in the browser, without needing to create and maintain a separate REST or other API.
Web: Leptos is built on the Web platform and Web standards. The [router](https://docs.rs/leptos_router/latest/leptos_router/) is designed to use Web fundamentals (like links and forms) and build on top of them rather than trying to replace them.

However, in the current implementation you *must* maintain a separate REST API if you want to define your server functions with `#[server]` *and* provide a RESTful API.  It also encourages non-Web standard practices such as using `POST` for requests that are clearly not suited for that method, such as fetching data or updating existing resources.  Since this imposes duplication on the backend public API and does not adhere to web standards, we should provide tools so that the use of `#[server]` functions can leverage existing RESTful apis.

## What about graceful degradation?
A concern with supporting `PATCH`, `PUT`, `DELETE`, etc. for `#[server]` functions is their limited support in the case the browser does not have JS/WASM enabled.  This is a real concern, but the current library's choice not to provide these methods is severely limiting on the backend side, forcing duplication of API endpoints and not allowing the backend to adhere to web standards for defining its public APIs.  Ultimately, it should be up to the developer to decide if they need their functionality to require working without JS/WASM.  The defaults are not changed, so existing applications are not affected, and a note has been provided that use of `PATCH` on a `#[server]` function may require JS/WASM to be enabled to function.