### PR TITLE
fix(CI): switch to stable in semver for most compatibility

### DIFF
--- a/.github/workflows/ci-semver.yml
+++ b/.github/workflows/ci-semver.yml
@@ -29,5 +29,3 @@ jobs:
         uses: actions/checkout@v4
       - name: Semver Checks
         uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          rust-toolchain: nightly-2025-03-05


### PR DESCRIPTION
JSON document v40 is not supported in cargo semver. For most compatibility, advised to use the latest stable:

> It's also possible that support for some nightly versions may be dropped even while older stable versions are still supported. This usually happens when a rustdoc format gets superseded by a newer version before becoming part of any stable Rust. In that case, we may drop support for that format to conserve maintenance bandwidth and speed up compile times. For example, cargo-semver-checks v0.24 [supported](https://github.com/obi1kenobi/cargo-semver-checks/blob/93baddc2a65a5055117ca670fe156dc761403fa5/Cargo.toml#L18) rustdoc formats v24, v26, and v27, but did not support the nightly-only v25 format.