### PR TITLE
fix: add `FromServerFnError` to `leptos::prelude::*`

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -174,7 +174,7 @@ pub mod prelude {
         };
         pub use server_fn::{
             self,
-            error::{FromServerFnError, ServerFnError},
+            error::{FromServerFnError, ServerFnError, ServerFnErrorErr},
         };
         pub use tachys::{
             reactive_graph::{bind::BindAttribute, node_ref::*, Suspend},

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -172,7 +172,10 @@ pub mod prelude {
             actions::*, computed::*, effect::*, graph::untrack, owner::*,
             signal::*, wrappers::read::*,
         };
-        pub use server_fn::{self, error::ServerFnError};
+        pub use server_fn::{
+            self,
+            error::{FromServerFnError, ServerFnError},
+        };
         pub use tachys::{
             reactive_graph::{bind::BindAttribute, node_ref::*, Suspend},
             view::{fragment::Fragment, template::ViewTemplate},


### PR DESCRIPTION
### Description

Make `FromServerFnError` public in the `leptos::prelude` module.

In my opinion this is an ease of life enhancement.