### PR TITLE
feat: switch `extract()` helper to use `ServerFnErrorErr` (closes #3745)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -41,8 +41,10 @@ use leptos_router::{
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use send_wrapper::SendWrapper;
-use server_fn::error::ServerFnErrorErr;
-use server_fn::{redirect::REDIRECT_HEADER, request::actix::ActixRequest};
+use server_fn::{
+    error::ServerFnErrorErr, redirect::REDIRECT_HEADER,
+    request::actix::ActixRequest,
+};
 use std::{
     collections::HashSet,
     fmt::{Debug, Display},

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -72,8 +72,7 @@ use leptos_router::{
 #[cfg(feature = "default")]
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use server_fn::error::ServerFnErrorErr;
-use server_fn::redirect::REDIRECT_HEADER;
+use server_fn::{error::ServerFnErrorErr, redirect::REDIRECT_HEADER};
 #[cfg(feature = "default")]
 use std::path::Path;
 use std::{collections::HashSet, fmt::Debug, io, pin::Pin, sync::Arc};


### PR DESCRIPTION
This provides much better compatibility with server functions using custom errors while still working as before with server functions using `ServerFnError`.

This can be verified with the `server_fns_axum` which uses the `extract()` function and a `ServerFnError` without needing to be edited in any way, and I've also tested it against my own server functions that use a custom error and that also works as expected with the `?` operator.

Resolves #3745