### PR TITLE
Re-export the codee crate

### DIFF
--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -16,6 +16,9 @@ mod resource;
 pub use resource::*;
 mod shared;
 
+/// Re-export of the `codee` crate.
+pub use codee;
+
 use base64::{engine::general_purpose::STANDARD_NO_PAD, DecodeError, Engine};
 pub use shared::*;
 

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -16,10 +16,9 @@ mod resource;
 pub use resource::*;
 mod shared;
 
+use base64::{engine::general_purpose::STANDARD_NO_PAD, DecodeError, Engine};
 /// Re-export of the `codee` crate.
 pub use codee;
-
-use base64::{engine::general_purpose::STANDARD_NO_PAD, DecodeError, Engine};
 pub use shared::*;
 
 /// Encodes data into a string.


### PR DESCRIPTION
Prevents having to keep `codee` and `leptos` in sync because `codee` has a different versioning scheme. Used in common case of changing encoding for resources, so makes sense to be exported.