### PR TITLE
Reduce use local signals for `Action::new_local` and similar primitives

### DIFF
--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -384,12 +384,12 @@ pub fn FileUpload() -> impl IntoView {
         </form>
         <p>
             {move || {
-                if upload_action.input_local().read().is_none() && upload_action.value().read().is_none()
+                if upload_action.input().read().is_none() && upload_action.value().read().is_none()
                 {
                     "Upload a file.".to_string()
                 } else if upload_action.pending().get() {
                     "Uploading...".to_string()
-                } else if let Some(Ok(value)) = upload_action.value().get() {
+                } else if let Some(Ok(value)) = *upload_action.value().get() {
                     value.to_string()
                 } else {
                     format!("{:?}", upload_action.value().get())

--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -365,8 +365,10 @@ pub fn FileUpload() -> impl IntoView {
         Ok(count)
     }
 
-    let pending = RwSignal::new(false);
-    let result = RwSignal::new(None);
+    let upload_action = Action::new_local(|data: &FormData| {
+        // `MultipartData` implements `From<FormData>`
+        file_length(data.clone().into())
+    });
 
     view! {
         <h3>File Upload</h3>
@@ -375,26 +377,22 @@ pub fn FileUpload() -> impl IntoView {
             ev.prevent_default();
             let target = ev.target().unwrap().unchecked_into::<HtmlFormElement>();
             let form_data = FormData::new_with_form(&target).unwrap();
-            pending.set(true);
-            spawn_local(async move {
-                result.set(Some(file_length(form_data.into()).await));
-                pending.set(false);
-            });
+            upload_action.dispatch_local(form_data);
         }>
             <input type="file" name="file_to_upload"/>
             <input type="submit"/>
         </form>
         <p>
             {move || {
-                if !pending.get() && result.read().is_none()
+                if upload_action.input_local().read().is_none() && upload_action.value().read().is_none()
                 {
                     "Upload a file.".to_string()
-                } else if pending.get() {
+                } else if upload_action.pending().get() {
                     "Uploading...".to_string()
-                } else if let Some(Ok(value)) = result.get() {
+                } else if let Some(Ok(value)) = upload_action.value().get() {
                     value.to_string()
                 } else {
-                    format!("{:?}", result.get())
+                    format!("{:?}", upload_action.value().get())
                 }
             }}
 

--- a/leptos/src/form.rs
+++ b/leptos/src/form.rs
@@ -125,10 +125,13 @@ where
                         "Error converting form field into server function \
                          arguments: {err:?}"
                     );
-                    value.set(Some(Err(ServerFnErrorErr::Serialization(
-                        err.to_string(),
-                    )
-                    .into_app_error())));
+                    value.set(
+                        Some(Err(ServerFnErrorErr::Serialization(
+                            err.to_string(),
+                        )
+                        .into_app_error()))
+                        .into(),
+                    );
                     version.update(|n| *n += 1);
                 }
             }

--- a/reactive_graph/src/send_wrapper_ext.rs
+++ b/reactive_graph/src/send_wrapper_ext.rs
@@ -42,6 +42,15 @@ where
     }
 }
 
+impl<T> From<Option<T>> for MaybeSendWrapperOption<T>
+where
+    T: Send + Sync,
+{
+    fn from(value: Option<T>) -> Self {
+        Self::new(value)
+    }
+}
+
 impl<T> MaybeSendWrapperOption<T> {
     /// Create a new non-threadsafe value.
     pub fn new_local(value: Option<T>) -> Self {


### PR DESCRIPTION
A better fix for #3746 and addresses @benwis's comment [here](https://github.com/leptos-rs/leptos/pull/3749#issuecomment-2743413942). There's a bit of API leakage but because `MaybeSendWrapperOption<T>` (should maybe rename this?) implements Deref/DerefMut to `Option<T>` it is usually pretty easy to work with it.

The same thing can be done for other primitives that are built in similar ways.