### PR TITLE
fix: correctly handle optional parameters in `ParentRoute`

### DIFF
--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -128,6 +128,8 @@ pub trait MatchNestedRoutes {
     fn generate_routes(
         &self,
     ) -> impl IntoIterator<Item = GeneratedRouteData> + '_;
+
+    fn optional(&self) -> bool;
 }
 
 #[derive(Default, Debug, PartialEq)]

--- a/router/src/matching/nested/any_nested_route.rs
+++ b/router/src/matching/nested/any_nested_route.rs
@@ -17,6 +17,7 @@ pub struct AnyNestedRoute {
         )
             -> (Option<(RouteMatchId, AnyNestedMatch)>, &'a str),
     generate_routes: fn(&Erased) -> Vec<GeneratedRouteData>,
+    optional: fn(&Erased) -> bool,
 }
 
 impl Clone for AnyNestedRoute {
@@ -74,11 +75,18 @@ where
             value.get_ref::<T>().generate_routes().into_iter().collect()
         }
 
+        fn optional<T: MatchNestedRoutes + Send + Clone + 'static>(
+            value: &Erased,
+        ) -> bool {
+            value.get_ref::<T>().optional()
+        }
+
         AnyNestedRoute {
             value: Erased::new(self),
             clone: clone::<T>,
             match_nested: match_nested::<T>,
             generate_routes: generate_routes::<T>,
+            optional: optional::<T>,
         }
     }
 }
@@ -96,5 +104,9 @@ impl MatchNestedRoutes for AnyNestedRoute {
 
     fn generate_routes(&self) -> impl IntoIterator<Item = GeneratedRouteData> {
         (self.generate_routes)(&self.value)
+    }
+
+    fn optional(&self) -> bool {
+        (self.optional)(&self.value)
     }
 }


### PR DESCRIPTION
Consider an example like this, in which a parent route has an optional param
```
<ParentRoute path=OptionalParamSegment("lang") view=Localizer>
    <Route path=StaticSegment("about") view=AboutPage/>
</ParentRoute>
```
Currently, this matches `/en/about`, but fails to match `/about`, because it interprets `"about"` as a value for the `"lang"` param, but has then consumed the whole route so cannot match `about` because the remaining path is `""`.

This PR corrects this situation so you end up with a correct match on both `/en/about` (with params `{"lang": "en" }` and on `/about` (with no value for the `"lang"` param).

Note one edge case: if you have a fallback home page `StaticRoute("")` or similar, it will *always* match, so it will prevent the fixes here from working. So, if you need this PR for routing to work then you may just need a separate `ParentRoute` for fallback, which does work as intended:
```
<ParentRoute path=OptionalParamSegment("lang") view=...>
    <Route path=StaticSegment("about") view=AboutPage/>
    // etc.
</ParentRoute>
<ParentRoute path=OptionalParamSegment("lang") view=...>
    <Route path=StaticSegment("") view=HomePage/>
</ParentRoute>
```

I have not heard reports of this but encountered it in my own application. Given that it requires some breaking changes to public trait signatures I'll leave it in 0.8 and not try to backport.