### PR TITLE
fix(examples): fix compilation errors in examples

### DIFF
--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -27,7 +27,6 @@ once_cell = "1.19"
 gloo-net = { version = "0.6.0" }
 wasm-bindgen = "0.2.93"
 serde = { version = "1.0", features = ["derive"] }
-simple_logger = "5.0"
 tracing = { version = "0.1.40", optional = true }
 send_wrapper = "0.6.0"
 

--- a/examples/hackernews/Cargo.toml
+++ b/examples/hackernews/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "hackernews_bin"
+path = "src/main.rs"
+
 [profile.release]
 codegen-units = 1
 opt-level = "z"

--- a/examples/hackernews/index.html
+++ b/examples/hackernews/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<link data-trunk rel="rust" data-wasm-opt="z" data-cargo-features="csr"/>
+		<link data-trunk rel="rust" data-wasm-opt="z" data-cargo-features="csr" data-bin="hackernews_bin"/>
 		<link data-trunk rel="css" href="./style.css"/>
 	</head>
 	<body></body>

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -37,11 +37,7 @@ log = { version = "0.4", optional = true }
 
 [features]
 default = ["csr"]
-csr = [
-  "leptos/csr",
-  "dep:console_log",
-  "dep:log",
-]
+csr = ["leptos/csr"]
 hydrate = ["leptos/hydrate"]
 ssr = [
   "dep:axum",

--- a/examples/hackernews_axum/Cargo.toml
+++ b/examples/hackernews_axum/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "hackernews_axum_bin"
+path = "src/main.rs"
+
 [profile.release]
 codegen-units = 1
 lto = true
@@ -28,10 +32,16 @@ http = { version = "1.1", optional = true }
 web-sys = { version = "0.3.70", features = ["AbortController", "AbortSignal"] }
 wasm-bindgen = "0.2.93"
 send_wrapper = { version = "0.6.0", features = ["futures"] }
+console_log = { version = "1", optional = true }
+log = { version = "0.4", optional = true }
 
 [features]
 default = ["csr"]
-csr = ["leptos/csr"]
+csr = [
+  "leptos/csr",
+  "dep:console_log",
+  "dep:log",
+]
 hydrate = ["leptos/hydrate"]
 ssr = [
   "dep:axum",

--- a/examples/hackernews_axum/index.html
+++ b/examples/hackernews_axum/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<link data-trunk rel="rust" data-wasm-opt="z"/>
+		<link data-trunk rel="rust" data-wasm-opt="z"  data-bin="hackernews_axum_bin"/>
 		<link data-trunk rel="css" href="/style.css"/>
 	</head>
 	<body></body>

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -35,7 +35,6 @@ pub fn main() {
     use hackernews_axum::*;
     use leptos::prelude::*;
 
-    _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();
     mount_to_body(App);
 }

--- a/examples/hackernews_axum/src/main.rs
+++ b/examples/hackernews_axum/src/main.rs
@@ -33,6 +33,7 @@ async fn main() {
 #[cfg(not(feature = "ssr"))]
 pub fn main() {
     use hackernews_axum::*;
+    use leptos::prelude::*;
 
     _ = console_log::init_with_level(log::Level::Debug);
     console_error_panic_hook::set_once();


### PR DESCRIPTION
Hi Greg,

The examples `hacknews` and `hacknews_axum`, who can be used within both `csr` and `ssr` mode, raise error during `trunk serve` with latest `cargo`:

```
2025-03-25T09:12:13.675539Z  INFO 🚀 Starting trunk 0.21.9
2025-03-25T09:12:14.274171Z  INFO 📦 starting build
warning: output filename collision.
The bin target `hackernews` in package `hackernews v0.1.0 (/home/ysun/leptos/examples/hackernews)` has the same output filename as the lib target `hackernews` in package `hackernews v0.1.0 (/home/ysun/leptos/examples/hackernews)`.
Colliding filename is: /home/ysun/leptos/examples/hackernews/target/wasm32-unknown-unknown/debug/hackernews.wasm
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
warning: output filename collision.
The bin target `hackernews` in package `hackernews v0.1.0 (/home/ysun/leptos/examples/hackernews)` has the same output filename as the lib target `hackernews` in package `hackernews v0.1.0 (/home/ysun/leptos/examples/hackernews)`.
Colliding filename is: /home/ysun/leptos/examples/hackernews/target/wasm32-unknown-unknown/debug/hackernews.wasm.dwp
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.

(Compilation details omitted...)

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: error from asset pipeline
    2: running cargo build
    3: found more than one target artifact: ["hackernews", "hackernews"]:
        * consider adding `<link data-trunk rel="rust" data-bin={bin} />` to the index.html to build only the specified binary
        * or adding `<link data-trunk rel="rust" data-target-name={artifact} />` to select the specific artifact by name
```

My output of `cargo --version`:

```
cargo 1.85.1 (d73d2caf9 2024-12-31)
```

While the error also occurs with `1.81.0-nightly(a2b58c3da 2024-07-16)`.

Though [it's raised by `trunk`](https://github.com/trunk-rs/trunk/blob/7e0a0117b4bd3c8e4b272fb342264ee4a0f61b3b/src/pipelines/rust/mod.rs#L511-L518), people believe it's a cargo problem: https://github.com/trunk-rs/trunk/issues/740.

It seems cargo used to produce duplicate artifacts but the checking rules may be changed at some time: https://github.com/rust-lang/cargo/issues/6313#issuecomment-2222146333

To fix it, I explicitly defined the binary artifact name and specified the name in `index.html`. I'm not sure if it's the best way though 😅 

Also, the `simple_logger` was removed from the example `counter_isomorphic`, which indeed was not needed before, but somehow cause another compilation error:

![2415fc6feb97a4e3c1814895bfb3fd1](https://github.com/user-attachments/assets/16595098-bf56-4ea3-bd82-7ed3042edc89)