### PR TITLE
feat: add support for more HTTP methods in server fn codecs

### DIFF
--- a/server_fn/src/codec/cbor.rs
+++ b/server_fn/src/codec/cbor.rs
@@ -1,4 +1,4 @@
-use super::Post;
+use super::{Patch, Post, Put};
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -36,3 +36,13 @@ where
 
 /// Pass arguments and receive responses using `cbor` in a `POST` request.
 pub type Cbor = Post<CborEncoding>;
+
+/// Pass arguments and receive responses using `cbor` in the body of a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchCbor = Patch<CborEncoding>;
+
+/// Pass arguments and receive responses using `cbor` in the body of a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutCbor = Put<CborEncoding>;

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -1,4 +1,4 @@
-use super::Post;
+use super::{Patch, Post, Put};
 use crate::{ContentType, Decodes, Encodes};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -34,3 +34,13 @@ where
 
 /// Pass arguments and receive responses as JSON in the body of a `POST` request.
 pub type Json = Post<JsonEncoding>;
+
+/// Pass arguments and receive responses as JSON in the body of a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchJson = Patch<JsonEncoding>;
+
+/// Pass arguments and receive responses as JSON in the body of a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutJson = Put<JsonEncoding>;

--- a/server_fn/src/codec/mod.rs
+++ b/server_fn/src/codec/mod.rs
@@ -50,8 +50,12 @@ mod postcard;
 #[cfg(feature = "postcard")]
 pub use postcard::*;
 
+mod patch;
+pub use patch::*;
 mod post;
 pub use post::*;
+mod put;
+pub use put::*;
 mod stream;
 use crate::ContentType;
 use futures::Future;

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post, Put},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -33,3 +36,13 @@ where
 
 /// Pass arguments and receive responses as MessagePack in a `POST` request.
 pub type MsgPack = Post<MsgPackEncoding>;
+
+/// Pass arguments and receive responses as MessagePack in the body of a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchMsgPack = Patch<MsgPackEncoding>;
+
+/// Pass arguments and receive responses as MessagePack in the body of a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutMsgPack = Put<MsgPackEncoding>;

--- a/server_fn/src/codec/multipart.rs
+++ b/server_fn/src/codec/multipart.rs
@@ -66,7 +66,7 @@ where
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
         let multi = self.into();
-        Request::try_new_multipart(
+        Request::try_new_post_multipart(
             path,
             accepts,
             multi.into_client_data().unwrap(),

--- a/server_fn/src/codec/patch.rs
+++ b/server_fn/src/codec/patch.rs
@@ -1,0 +1,83 @@
+use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
+use crate::{
+    error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
+    request::{ClientReq, Req},
+    response::{ClientRes, TryRes},
+    ContentType, Decodes, Encodes,
+};
+use std::marker::PhantomData;
+
+/// A codec that encodes the data in the patch body
+pub struct Patch<Codec>(PhantomData<Codec>);
+
+impl<Codec: ContentType> ContentType for Patch<Codec> {
+    const CONTENT_TYPE: &'static str = Codec::CONTENT_TYPE;
+}
+
+impl<Codec: ContentType> Encoding for Patch<Codec> {
+    const METHOD: http::Method = http::Method::PATCH;
+}
+
+impl<E, T, Encoding, Request> IntoReq<Patch<Encoding>, Request, E> for T
+where
+    Request: ClientReq<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_patch_bytes(
+            path,
+            accepts,
+            Encoding::CONTENT_TYPE,
+            data,
+        )
+    }
+}
+
+impl<E, T, Request, Encoding> FromReq<Patch<Encoding>, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let data = req.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}
+
+impl<E, Response, Encoding, T> IntoRes<Patch<Encoding>, Response, E> for T
+where
+    Response: TryRes<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError + Send,
+    T: Send,
+{
+    async fn into_res(self) -> Result<Response, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Response::try_from_bytes(Encoding::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, Encoding, Response, T> FromRes<Patch<Encoding>, Response, E> for T
+where
+    Response: ClientRes<E> + Send,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_res(res: Response) -> Result<Self, E> {
+        let data = res.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}

--- a/server_fn/src/codec/postcard.rs
+++ b/server_fn/src/codec/postcard.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post, Put},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -33,3 +36,13 @@ where
 
 /// Pass arguments and receive responses with postcard in a `POST` request.
 pub type Postcard = Post<PostcardEncoding>;
+
+/// Pass arguments and receive responses with postcard in a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchPostcard = Patch<PostcardEncoding>;
+
+/// Pass arguments and receive responses with postcard in a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutPostcard = Put<PostcardEncoding>;

--- a/server_fn/src/codec/put.rs
+++ b/server_fn/src/codec/put.rs
@@ -1,0 +1,78 @@
+use super::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
+use crate::{
+    error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
+    request::{ClientReq, Req},
+    response::{ClientRes, TryRes},
+    ContentType, Decodes, Encodes,
+};
+use std::marker::PhantomData;
+
+/// A codec that encodes the data in the put body
+pub struct Put<Codec>(PhantomData<Codec>);
+
+impl<Codec: ContentType> ContentType for Put<Codec> {
+    const CONTENT_TYPE: &'static str = Codec::CONTENT_TYPE;
+}
+
+impl<Codec: ContentType> Encoding for Put<Codec> {
+    const METHOD: http::Method = http::Method::PUT;
+}
+
+impl<E, T, Encoding, Request> IntoReq<Put<Encoding>, Request, E> for T
+where
+    Request: ClientReq<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_put_bytes(path, accepts, Encoding::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, T, Request, Encoding> FromReq<Put<Encoding>, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let data = req.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}
+
+impl<E, Response, Encoding, T> IntoRes<Put<Encoding>, Response, E> for T
+where
+    Response: TryRes<E>,
+    Encoding: Encodes<T>,
+    E: FromServerFnError + Send,
+    T: Send,
+{
+    async fn into_res(self) -> Result<Response, E> {
+        let data = Encoding::encode(self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Response::try_from_bytes(Encoding::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, Encoding, Response, T> FromRes<Put<Encoding>, Response, E> for T
+where
+    Response: ClientRes<E> + Send,
+    Encoding: Decodes<T>,
+    E: FromServerFnError,
+{
+    async fn from_res(res: Response) -> Result<Self, E> {
+        let data = res.try_into_bytes().await?;
+        let s = Encoding::decode(data).map_err(|e| {
+            ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
+        })?;
+        Ok(s)
+    }
+}

--- a/server_fn/src/codec/rkyv.rs
+++ b/server_fn/src/codec/rkyv.rs
@@ -1,4 +1,7 @@
-use crate::{codec::Post, ContentType, Decodes, Encodes};
+use crate::{
+    codec::{Patch, Post, Put},
+    ContentType, Decodes, Encodes,
+};
 use bytes::Bytes;
 use rkyv::{
     api::high::{HighDeserializer, HighSerializer, HighValidator},
@@ -52,3 +55,13 @@ where
 
 /// Pass arguments and receive responses as `rkyv` in a `POST` request.
 pub type Rkyv = Post<RkyvEncoding>;
+
+/// Pass arguments and receive responses as `rkyv` in a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchRkyv = Patch<RkyvEncoding>;
+
+/// Pass arguments and receive responses as `rkyv` in a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutRkyv = Put<RkyvEncoding>;

--- a/server_fn/src/codec/serde_lite.rs
+++ b/server_fn/src/codec/serde_lite.rs
@@ -1,5 +1,7 @@
 use crate::{
-    codec::Post, error::ServerFnErrorErr, ContentType, Decodes, Encodes,
+    codec::{Patch, Post, Put},
+    error::ServerFnErrorErr,
+    ContentType, Decodes, Encodes,
 };
 use bytes::Bytes;
 use serde_lite::{Deserialize, Serialize};
@@ -46,3 +48,13 @@ where
 
 /// Pass arguments and receive responses as JSON in the body of a `POST` request.
 pub type SerdeLite = Post<SerdeLiteEncoding>;
+
+/// Pass arguments and receive responses as JSON in the body of a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PatchSerdeLite = Patch<SerdeLiteEncoding>;
+
+/// Pass arguments and receive responses as JSON in the body of a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub type PutSerdeLite = Put<SerdeLiteEncoding>;

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -38,7 +38,12 @@ where
     T: Stream<Item = Bytes> + Send + Sync + 'static,
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
-        Request::try_new_streaming(path, accepts, Streaming::CONTENT_TYPE, self)
+        Request::try_new_post_streaming(
+            path,
+            accepts,
+            Streaming::CONTENT_TYPE,
+            self,
+        )
     }
 }
 
@@ -201,7 +206,7 @@ where
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
         let data = self.into();
-        Request::try_new_streaming(
+        Request::try_new_post_streaming(
             path,
             accepts,
             Streaming::CONTENT_TYPE,

--- a/server_fn/src/codec/url.rs
+++ b/server_fn/src/codec/url.rs
@@ -13,6 +13,21 @@ pub struct GetUrl;
 /// Pass arguments as the URL-encoded body of a `POST` request.
 pub struct PostUrl;
 
+/// Pass arguments as the URL-encoded body of a `DELETE` request.
+/// **Note**: Browser support for `DELETE` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub struct DeleteUrl;
+
+/// Pass arguments as the URL-encoded body of a `PATCH` request.
+/// **Note**: Browser support for `PATCH` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub struct PatchUrl;
+
+/// Pass arguments as the URL-encoded body of a `PUT` request.
+/// **Note**: Browser support for `PUT` requests without JS/WASM may be poor.
+/// Consider using a `POST` request if functionality without JS/WASM is required.
+pub struct PutUrl;
+
 impl ContentType for GetUrl {
     const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
 }
@@ -84,6 +99,123 @@ where
         let string_data = req.try_into_string().await?;
         let args = serde_qs::Config::new(5, false)
             .deserialize_str::<Self>(&string_data)
+            .map_err(|e| {
+                ServerFnErrorErr::Args(e.to_string()).into_app_error()
+            })?;
+        Ok(args)
+    }
+}
+
+impl ContentType for DeleteUrl {
+    const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+}
+
+impl Encoding for DeleteUrl {
+    const METHOD: Method = Method::DELETE;
+}
+
+impl<E, T, Request> IntoReq<DeleteUrl, Request, E> for T
+where
+    Request: ClientReq<E>,
+    T: Serialize + Send,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_qs::to_string(&self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_delete(path, accepts, GetUrl::CONTENT_TYPE, &data)
+    }
+}
+
+impl<E, T, Request> FromReq<DeleteUrl, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    T: DeserializeOwned,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let string_data = req.as_query().unwrap_or_default();
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(string_data)
+            .map_err(|e| {
+                ServerFnErrorErr::Args(e.to_string()).into_app_error()
+            })?;
+        Ok(args)
+    }
+}
+
+impl ContentType for PatchUrl {
+    const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+}
+
+impl Encoding for PatchUrl {
+    const METHOD: Method = Method::PATCH;
+}
+
+impl<E, T, Request> IntoReq<PatchUrl, Request, E> for T
+where
+    Request: ClientReq<E>,
+    T: Serialize + Send,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_qs::to_string(&self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_patch(path, accepts, GetUrl::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, T, Request> FromReq<PatchUrl, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    T: DeserializeOwned,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let string_data = req.as_query().unwrap_or_default();
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(string_data)
+            .map_err(|e| {
+                ServerFnErrorErr::Args(e.to_string()).into_app_error()
+            })?;
+        Ok(args)
+    }
+}
+
+impl ContentType for PutUrl {
+    const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+}
+
+impl Encoding for PutUrl {
+    const METHOD: Method = Method::PUT;
+}
+
+impl<E, T, Request> IntoReq<PutUrl, Request, E> for T
+where
+    Request: ClientReq<E>,
+    T: Serialize + Send,
+    E: FromServerFnError,
+{
+    fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
+        let data = serde_qs::to_string(&self).map_err(|e| {
+            ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
+        })?;
+        Request::try_new_put(path, accepts, GetUrl::CONTENT_TYPE, data)
+    }
+}
+
+impl<E, T, Request> FromReq<PutUrl, Request, E> for T
+where
+    Request: Req<E> + Send + 'static,
+    T: DeserializeOwned,
+    E: FromServerFnError,
+{
+    async fn from_req(req: Request) -> Result<Self, E> {
+        let string_data = req.as_query().unwrap_or_default();
+        let args = serde_qs::Config::new(5, false)
+            .deserialize_str::<Self>(string_data)
             .map_err(|e| {
                 ServerFnErrorErr::Args(e.to_string()).into_app_error()
             })?;

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -282,6 +282,9 @@ where
                 ServerFnError::MissingArg(value)
             }
             ServerFnErrorErr::Response(value) => ServerFnError::Response(value),
+            ServerFnErrorErr::UnsupportedRequestMethod(value) => {
+                ServerFnError::Request(value)
+            }
         }
     }
 
@@ -377,6 +380,9 @@ pub enum ServerFnErrorErr {
     /// Error while trying to register the server function (only occurs in case of poisoned RwLock).
     #[error("error while trying to register the server function: {0}")]
     Registration(String),
+    /// Occurs on the client if trying to use an unsupported `HTTP` method when building a request.
+    #[error("error trying to build `HTTP` method request: {0}")]
+    UnsupportedRequestMethod(String),
     /// Occurs on the client if there is a network error while trying to run function on server.
     #[error("error reaching server to call server function: {0}")]
     Request(String),


### PR DESCRIPTION
# Description

Adds `PATCH`, `PUT`, `DELETE`, and limited `HEAD` method support for `#[server]` functions. Includes a note about potential browser support issues when JS/WASM is not enabled. Useful when defining REST apis via `#[server]` functions.

See #3733 for previous discussion on this topic.