### PR TITLE
fix: allow custom status codes or redirects for route fallbacks

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -2061,7 +2061,15 @@ where
                         },
                     )
                     .await;
-                    *res.status_mut() = StatusCode::NOT_FOUND;
+
+                    // set the status to 404
+                    // but if the status was already set (for example, to a 302 redirect) don't
+                    // overwrite it
+                    let status = res.status_mut();
+                    if *status == StatusCode::OK {
+                        *res.status_mut() = StatusCode::NOT_FOUND;
+                    }
+
                     res
                 }
             }


### PR DESCRIPTION
At present, the Axum integration `file_and_error_handler` sets a 404 if it renders the fallback route. This PR changes this behavior to only set the status code to 404 (Not Found) if the status code is currently 200 (Ok), which is the default. It will be 200 unless you have overwritten it in the `fallback` of your `Router`, in which case we'll preserve that status code. 

This is especially important because it allows you to use `<Redirect/>` in the `fallback` and preserve the 302 redirect code, which is necessary for correct behavior.