### PR TITLE
feat: enhancing server_fn errors

### DIFF
--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -6,13 +6,13 @@ use server_fn::{
     client::{browser::BrowserClient, Client},
     codec::{
         Encoding, FromReq, FromRes, GetUrl, IntoReq, IntoRes, MultipartData,
-        MultipartFormData, Postcard, Rkyv, SerdeLite, StreamingText,
-        TextStream,
+        MultipartFormData, Postcard, Rkyv, RkyvEncoding, SerdeLite,
+        StreamingText, TextStream,
     },
     error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
     request::{browser::BrowserRequest, ClientReq, Req},
     response::{browser::BrowserResponse, ClientRes, TryRes},
-    ContentType,
+    ContentType, Format, FormatType,
 };
 use std::future::Future;
 #[cfg(feature = "ssr")]
@@ -29,16 +29,16 @@ pub fn shell(options: LeptosOptions) -> impl IntoView {
         <!DOCTYPE html>
         <html lang="en">
             <head>
-                <meta charset="utf-8"/>
-                <meta name="viewport" content="width=device-width, initial-scale=1"/>
-                <AutoReload options=options.clone()/>
-                <HydrationScripts options/>
-                <meta name="color-scheme" content="dark light"/>
-                <link rel="shortcut icon" type="image/ico" href="/favicon.ico"/>
-                <link rel="stylesheet" id="leptos" href="/pkg/server_fns_axum.css"/>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <AutoReload options=options.clone() />
+                <HydrationScripts options />
+                <meta name="color-scheme" content="dark light" />
+                <link rel="shortcut icon" type="image/ico" href="/favicon.ico" />
+                <link rel="stylesheet" id="leptos" href="/pkg/server_fns_axum.css" />
             </head>
             <body>
-                <App/>
+                <App />
             </body>
         </html>
     }
@@ -51,7 +51,7 @@ pub fn App() -> impl IntoView {
             <h1>"Server Function Demo"</h1>
         </header>
         <main>
-            <HomePage/>
+            <HomePage />
         </main>
     }
 }
@@ -60,20 +60,20 @@ pub fn App() -> impl IntoView {
 pub fn HomePage() -> impl IntoView {
     view! {
         <h2>"Some Simple Server Functions"</h2>
-        <SpawnLocal/>
-        <WithAnAction/>
-        <WithActionForm/>
+        <SpawnLocal />
+        <WithAnAction />
+        <WithActionForm />
         <h2>"Custom Error Types"</h2>
-        <CustomErrorTypes/>
+        <CustomErrorTypes />
         <h2>"Alternative Encodings"</h2>
-        <ServerFnArgumentExample/>
-        <RkyvExample/>
-        <PostcardExample/>
-        <FileUpload/>
-        <FileUploadWithProgress/>
-        <FileWatcher/>
-        <CustomEncoding/>
-        <CustomClientExample/>
+        <ServerFnArgumentExample />
+        <RkyvExample />
+        <PostcardExample />
+        <FileUpload />
+        <FileUploadWithProgress />
+        <FileWatcher />
+        <CustomEncoding />
+        <CustomClientExample />
     }
 }
 
@@ -109,7 +109,7 @@ pub fn SpawnLocal() -> impl IntoView {
             " in an event listener. "
             "Clicking this button should alert with the uppercase version of the input."
         </p>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let value = input_ref.get().unwrap().value();
             spawn_local(async move {
@@ -188,7 +188,7 @@ pub fn WithAnAction() -> impl IntoView {
             "Some server functions are conceptually \"mutations,\", which change something on the server. "
             "These often work well as actions."
         </p>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let text = input_ref.get().unwrap().value();
             action.dispatch(text.into());
@@ -278,9 +278,9 @@ pub fn ServerFnArgumentExample() -> impl IntoView {
         <ul>
             <li>Specific server function <strong>paths</strong></li>
             <li>Mixing and matching input and output <strong>encodings</strong></li>
-            <li>Adding custom <strong>middleware</strong> on a per-server-fn basis</li>
+            <li>Adding custom <strong>middleware</strong>on a per-server-fn basis</li>
         </ul>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let value = input_ref.get().unwrap().value();
             spawn_local(async move {
@@ -318,8 +318,8 @@ pub fn RkyvExample() -> impl IntoView {
     let rkyv_result = Resource::new(move || input.get(), rkyv_example);
 
     view! {
-        <h3>Using <code>rkyv</code> encoding</h3>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <h3>Using <code>rkyv</code>encoding</h3>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let value = input_ref.get().unwrap().value();
             set_input.set(value);
@@ -379,8 +379,8 @@ pub fn FileUpload() -> impl IntoView {
             let form_data = FormData::new_with_form(&target).unwrap();
             upload_action.dispatch_local(form_data);
         }>
-            <input type="file" name="file_to_upload"/>
-            <input type="submit"/>
+            <input type="file" name="file_to_upload" />
+            <input type="submit" />
         </form>
         <p>
             {move || {
@@ -552,8 +552,8 @@ pub fn FileUploadWithProgress() -> impl IntoView {
         <p>A file upload with progress can be handled with two separate server functions.</p>
         <aside>See the doc comment on the component for an explanation.</aside>
         <form on:submit=on_submit>
-            <input type="file" name="file_to_upload"/>
-            <input type="submit"/>
+            <input type="file" name="file_to_upload" />
+            <input type="submit" />
         </form>
         {move || filename.get().map(|filename| view! { <p>Uploading {filename}</p> })}
         {move || {
@@ -683,14 +683,35 @@ pub async fn ascii_uppercase_classic(
 }
 
 // The EnumString and Display derive macros are provided by strum
-#[derive(Debug, Clone, Display, EnumString, Serialize, Deserialize)]
+#[derive(
+    thiserror::Error,
+    Debug,
+    Clone,
+    Display,
+    EnumString,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub enum InvalidArgument {
     TooShort,
     TooLong,
     NotAscii,
 }
 
-#[derive(Debug, Clone, Display, Serialize, Deserialize)]
+#[derive(
+    thiserror::Error,
+    Debug,
+    Clone,
+    Display,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+)]
 pub enum MyErrors {
     InvalidArgument(InvalidArgument),
     ServerFnError(ServerFnErrorErr),
@@ -710,6 +731,8 @@ impl From<String> for MyErrors {
 }
 
 impl FromServerFnError for MyErrors {
+    type Encoder = RkyvEncoding;
+
     fn from_server_fn_error(value: ServerFnErrorErr) -> Self {
         MyErrors::ServerFnError(value)
     }
@@ -730,7 +753,7 @@ pub fn CustomErrorTypes() -> impl IntoView {
             "Try typing a message that is between 5 and 15 characters of ASCII text below. Then try breaking \
             the rules!"
         </p>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let value = input_ref.get().unwrap().value();
             spawn_local(async move {
@@ -764,6 +787,10 @@ pub struct TomlEncoded<T>(T);
 
 impl ContentType for Toml {
     const CONTENT_TYPE: &'static str = "application/toml";
+}
+
+impl FormatType for Toml {
+    const FORMAT_TYPE: Format = Format::Text;
 }
 
 impl Encoding for Toml {
@@ -859,7 +886,7 @@ pub fn CustomEncoding() -> impl IntoView {
         <p>
             "This example creates a custom encoding that sends server fn data using TOML. Why? Well... why not?"
         </p>
-        <input node_ref=input_ref placeholder="Type something here."/>
+        <input node_ref=input_ref placeholder="Type something here." />
         <button on:click=move |_| {
             let value = input_ref.get().unwrap().value();
             spawn_local(async move {
@@ -914,10 +941,13 @@ pub fn CustomClientExample() -> impl IntoView {
         ) -> impl Future<
             Output = Result<
                 (
-                    impl Stream<Item = Result<server_fn::Bytes, OS>>
+                    impl Stream<
+                            Item = Result<server_fn::Bytes, server_fn::Bytes>,
+                        > + Send
+                        + 'static,
+                    impl Sink<Result<server_fn::Bytes, server_fn::Bytes>>
                         + Send
                         + 'static,
-                    impl Sink<Result<server_fn::Bytes, IS>> + Send + 'static,
                 ),
                 E,
             >,
@@ -1000,16 +1030,14 @@ pub fn PostcardExample() -> impl IntoView {
     );
 
     view! {
-        <h3>Using <code>postcard</code> encoding</h3>
+        <h3>Using <code>postcard</code>encoding</h3>
         <p>"This example demonstrates using Postcard for efficient binary serialization."</p>
         <button on:click=move |_| {
-            // Update the input data when the button is clicked
-            set_input.update(|data| {
-                data.age += 1;
-            });
-        }>
-            "Increment Age"
-        </button>
+            set_input
+                .update(|data| {
+                    data.age += 1;
+                });
+        }>"Increment Age"</button>
         // Display the current input data
         <p>"Input: " {move || format!("{:?}", input.get())}</p>
         <Transition>

--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -952,11 +952,11 @@ pub fn CustomClientExample() -> impl IntoView {
                 E,
             >,
         > + Send {
-            BrowserClient::open_websocket(path)
+            <BrowserClient as Client<E, IS, OS>>::open_websocket(path)
         }
 
         fn spawn(future: impl Future<Output = ()> + Send + 'static) {
-            <BrowserClient as Client<E>>::spawn(future)
+            <BrowserClient as Client<E, IS, OS>>::spawn(future)
         }
     }
 

--- a/server_fn/src/codec/cbor.rs
+++ b/server_fn/src/codec/cbor.rs
@@ -1,5 +1,5 @@
 use super::{Patch, Post, Put};
-use crate::{ContentType, Decodes, Encodes};
+use crate::{ContentType, Decodes, Encodes, Format, FormatType};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -10,15 +10,19 @@ impl ContentType for CborEncoding {
     const CONTENT_TYPE: &'static str = "application/cbor";
 }
 
+impl FormatType for CborEncoding {
+    const FORMAT_TYPE: Format = Format::Binary;
+}
+
 impl<T> Encodes<T> for CborEncoding
 where
     T: Serialize,
 {
     type Error = ciborium::ser::Error<std::io::Error>;
 
-    fn encode(value: T) -> Result<Bytes, Self::Error> {
+    fn encode(value: &T) -> Result<Bytes, Self::Error> {
         let mut buffer: Vec<u8> = Vec::new();
-        ciborium::ser::into_writer(&value, &mut buffer)?;
+        ciborium::ser::into_writer(value, &mut buffer)?;
         Ok(Bytes::from(buffer))
     }
 }

--- a/server_fn/src/codec/json.rs
+++ b/server_fn/src/codec/json.rs
@@ -1,5 +1,5 @@
 use super::{Patch, Post, Put};
-use crate::{ContentType, Decodes, Encodes};
+use crate::{ContentType, Decodes, Encodes, Format, FormatType};
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -10,14 +10,18 @@ impl ContentType for JsonEncoding {
     const CONTENT_TYPE: &'static str = "application/json";
 }
 
+impl FormatType for JsonEncoding {
+    const FORMAT_TYPE: Format = Format::Text;
+}
+
 impl<T> Encodes<T> for JsonEncoding
 where
     T: Serialize,
 {
     type Error = serde_json::Error;
 
-    fn encode(output: T) -> Result<Bytes, Self::Error> {
-        serde_json::to_vec(&output).map(Bytes::from)
+    fn encode(output: &T) -> Result<Bytes, Self::Error> {
+        serde_json::to_vec(output).map(Bytes::from)
     }
 }
 

--- a/server_fn/src/codec/msgpack.rs
+++ b/server_fn/src/codec/msgpack.rs
@@ -1,6 +1,6 @@
 use crate::{
     codec::{Patch, Post, Put},
-    ContentType, Decodes, Encodes,
+    ContentType, Decodes, Encodes, Format, FormatType,
 };
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -12,14 +12,18 @@ impl ContentType for MsgPackEncoding {
     const CONTENT_TYPE: &'static str = "application/msgpack";
 }
 
+impl FormatType for MsgPackEncoding {
+    const FORMAT_TYPE: Format = Format::Binary;
+}
+
 impl<T> Encodes<T> for MsgPackEncoding
 where
     T: Serialize,
 {
     type Error = rmp_serde::encode::Error;
 
-    fn encode(value: T) -> Result<Bytes, Self::Error> {
-        rmp_serde::to_vec(&value).map(Bytes::from)
+    fn encode(value: &T) -> Result<Bytes, Self::Error> {
+        rmp_serde::to_vec(value).map(Bytes::from)
     }
 }
 

--- a/server_fn/src/codec/patch.rs
+++ b/server_fn/src/codec/patch.rs
@@ -25,7 +25,7 @@ where
     E: FromServerFnError,
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Request::try_new_patch_bytes(
@@ -60,7 +60,7 @@ where
     T: Send,
 {
     async fn into_res(self) -> Result<Response, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Response::try_from_bytes(Encoding::CONTENT_TYPE, data)

--- a/server_fn/src/codec/post.rs
+++ b/server_fn/src/codec/post.rs
@@ -25,7 +25,7 @@ where
     E: FromServerFnError,
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Request::try_new_post_bytes(path, accepts, Encoding::CONTENT_TYPE, data)
@@ -55,7 +55,7 @@ where
     T: Send,
 {
     async fn into_res(self) -> Result<Response, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Response::try_from_bytes(Encoding::CONTENT_TYPE, data)

--- a/server_fn/src/codec/postcard.rs
+++ b/server_fn/src/codec/postcard.rs
@@ -1,6 +1,6 @@
 use crate::{
     codec::{Patch, Post, Put},
-    ContentType, Decodes, Encodes,
+    ContentType, Decodes, Encodes, Format, FormatType,
 };
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -12,14 +12,18 @@ impl ContentType for PostcardEncoding {
     const CONTENT_TYPE: &'static str = "application/x-postcard";
 }
 
+impl FormatType for PostcardEncoding {
+    const FORMAT_TYPE: Format = Format::Binary;
+}
+
 impl<T> Encodes<T> for PostcardEncoding
 where
     T: Serialize,
 {
     type Error = postcard::Error;
 
-    fn encode(value: T) -> Result<Bytes, Self::Error> {
-        postcard::to_allocvec(&value).map(Bytes::from)
+    fn encode(value: &T) -> Result<Bytes, Self::Error> {
+        postcard::to_allocvec(value).map(Bytes::from)
     }
 }
 

--- a/server_fn/src/codec/put.rs
+++ b/server_fn/src/codec/put.rs
@@ -25,7 +25,7 @@ where
     E: FromServerFnError,
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Request::try_new_put_bytes(path, accepts, Encoding::CONTENT_TYPE, data)
@@ -55,7 +55,7 @@ where
     T: Send,
 {
     async fn into_res(self) -> Result<Response, E> {
-        let data = Encoding::encode(self).map_err(|e| {
+        let data = Encoding::encode(&self).map_err(|e| {
             ServerFnErrorErr::Serialization(e.to_string()).into_app_error()
         })?;
         Response::try_from_bytes(Encoding::CONTENT_TYPE, data)

--- a/server_fn/src/codec/rkyv.rs
+++ b/server_fn/src/codec/rkyv.rs
@@ -1,6 +1,6 @@
 use crate::{
     codec::{Patch, Post, Put},
-    ContentType, Decodes, Encodes,
+    ContentType, Decodes, Encodes, Format, FormatType,
 };
 use bytes::Bytes;
 use rkyv::{
@@ -24,6 +24,10 @@ impl ContentType for RkyvEncoding {
     const CONTENT_TYPE: &'static str = "application/rkyv";
 }
 
+impl FormatType for RkyvEncoding {
+    const FORMAT_TYPE: Format = Format::Binary;
+}
+
 impl<T> Encodes<T> for RkyvEncoding
 where
     T: Archive + for<'a> Serialize<RkyvSerializer<'a>>,
@@ -32,8 +36,8 @@ where
 {
     type Error = rancor::Error;
 
-    fn encode(value: T) -> Result<Bytes, Self::Error> {
-        let encoded = rkyv::to_bytes::<rancor::Error>(&value)?;
+    fn encode(value: &T) -> Result<Bytes, Self::Error> {
+        let encoded = rkyv::to_bytes::<rancor::Error>(value)?;
         Ok(Bytes::copy_from_slice(encoded.as_ref()))
     }
 }

--- a/server_fn/src/codec/serde_lite.rs
+++ b/server_fn/src/codec/serde_lite.rs
@@ -1,7 +1,7 @@
 use crate::{
     codec::{Patch, Post, Put},
     error::ServerFnErrorErr,
-    ContentType, Decodes, Encodes,
+    ContentType, Decodes, Encodes, Format, FormatType,
 };
 use bytes::Bytes;
 use serde_lite::{Deserialize, Serialize};
@@ -13,13 +13,17 @@ impl ContentType for SerdeLiteEncoding {
     const CONTENT_TYPE: &'static str = "application/json";
 }
 
+impl FormatType for SerdeLiteEncoding {
+    const FORMAT_TYPE: Format = Format::Text;
+}
+
 impl<T> Encodes<T> for SerdeLiteEncoding
 where
     T: Serialize,
 {
     type Error = ServerFnErrorErr;
 
-    fn encode(value: T) -> Result<Bytes, Self::Error> {
+    fn encode(value: &T) -> Result<Bytes, Self::Error> {
         serde_json::to_vec(
             &value
                 .serialize()

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq, FromRes, IntoReq};
 use crate::{
-    error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
+    error::{FromServerFnError, ServerFnErrorErr},
     request::{ClientReq, Req},
     response::{ClientRes, TryRes},
     ContentType, IntoRes, ServerFnError,
@@ -50,7 +50,7 @@ where
 impl<E, T, Request> FromReq<Streaming, Request, E> for T
 where
     Request: Req<E> + Send + 'static,
-    T: From<ByteStream<E>> + 'static,
+    T: From<ByteStream> + 'static,
 {
     async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
@@ -71,34 +71,37 @@ where
 /// end before the output will begin.
 ///
 /// Streaming requests are only allowed over HTTP2 or HTTP3.
-pub struct ByteStream<E>(Pin<Box<dyn Stream<Item = Result<Bytes, E>> + Send>>);
+pub struct ByteStream(Pin<Box<dyn Stream<Item = Result<Bytes, Bytes>> + Send>>);
 
-impl<E> ByteStream<E> {
+impl ByteStream {
     /// Consumes the wrapper, returning a stream of bytes.
-    pub fn into_inner(self) -> impl Stream<Item = Result<Bytes, E>> + Send {
+    pub fn into_inner(self) -> impl Stream<Item = Result<Bytes, Bytes>> + Send {
         self.0
     }
 }
 
-impl<E> Debug for ByteStream<E> {
+impl Debug for ByteStream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ByteStream").finish()
     }
 }
 
-impl<E> ByteStream<E> {
+impl ByteStream {
     /// Creates a new `ByteStream` from the given stream.
-    pub fn new<T>(
+    pub fn new<T, E>(
         value: impl Stream<Item = Result<T, E>> + Send + 'static,
     ) -> Self
     where
         T: Into<Bytes>,
+        E: Into<Bytes>,
     {
-        Self(Box::pin(value.map(|value| value.map(Into::into))))
+        Self(Box::pin(
+            value.map(|value| value.map(Into::into).map_err(Into::into)),
+        ))
     }
 }
 
-impl<E, S, T> From<S> for ByteStream<E>
+impl<S, T> From<S> for ByteStream
 where
     S: Stream<Item = T> + Send + 'static,
     T: Into<Bytes>,
@@ -108,7 +111,7 @@ where
     }
 }
 
-impl<E, Response> IntoRes<Streaming, Response, E> for ByteStream<E>
+impl<E, Response> IntoRes<Streaming, Response, E> for ByteStream
 where
     Response: TryRes<E>,
     E: 'static,
@@ -118,7 +121,7 @@ where
     }
 }
 
-impl<E, Response> FromRes<Streaming, Response, E> for ByteStream<E>
+impl<E, Response> FromRes<Streaming, Response, E> for ByteStream
 where
     Response: ClientRes<E> + Send,
 {
@@ -166,13 +169,13 @@ pub struct TextStream<E = ServerFnError>(
     Pin<Box<dyn Stream<Item = Result<String, E>> + Send>>,
 );
 
-impl<E> Debug for TextStream<E> {
+impl<E: FromServerFnError> Debug for TextStream<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("TextStream").finish()
     }
 }
 
-impl<E> TextStream<E> {
+impl<E: FromServerFnError> TextStream<E> {
     /// Creates a new `ByteStream` from the given stream.
     pub fn new(
         value: impl Stream<Item = Result<String, E>> + Send + 'static,
@@ -181,7 +184,7 @@ impl<E> TextStream<E> {
     }
 }
 
-impl<E> TextStream<E> {
+impl<E: FromServerFnError> TextStream<E> {
     /// Consumes the wrapper, returning a stream of text.
     pub fn into_inner(self) -> impl Stream<Item = Result<String, E>> + Send {
         self.0
@@ -192,6 +195,7 @@ impl<E, S, T> From<S> for TextStream<E>
 where
     S: Stream<Item = T> + Send + 'static,
     T: Into<String>,
+    E: FromServerFnError,
 {
     fn from(value: S) -> Self {
         Self(Box::pin(value.map(|data| Ok(data.into()))))
@@ -202,7 +206,7 @@ impl<E, T, Request> IntoReq<StreamingText, Request, E> for T
 where
     Request: ClientReq<E>,
     T: Into<TextStream<E>>,
-    E: 'static,
+    E: FromServerFnError,
 {
     fn into_req(self, path: &str, accepts: &str) -> Result<Request, E> {
         let data = self.into();
@@ -223,13 +227,16 @@ where
 {
     async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
-        let s = TextStream::new(data.map(|chunk| {
-            chunk.and_then(|bytes| {
-                String::from_utf8(bytes.to_vec()).map_err(|e| {
-                    ServerFnErrorErr::Deserialization(e.to_string())
-                        .into_app_error()
-                })
-            })
+        let s = TextStream::new(data.map(|chunk| match chunk {
+            Ok(bytes) => {
+                let de = String::from_utf8(bytes.to_vec()).map_err(|e| {
+                    E::from_server_fn_error(ServerFnErrorErr::Deserialization(
+                        e.to_string(),
+                    ))
+                })?;
+                Ok(de)
+            }
+            Err(bytes) => Err(E::de(bytes)),
         }));
         Ok(s.into())
     }
@@ -238,12 +245,13 @@ where
 impl<E, Response> IntoRes<StreamingText, Response, E> for TextStream<E>
 where
     Response: TryRes<E>,
-    E: 'static,
+    E: FromServerFnError,
 {
     async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(
             Streaming::CONTENT_TYPE,
-            self.into_inner().map(|stream| stream.map(Into::into)),
+            self.into_inner()
+                .map(|stream| stream.map(Into::into).map_err(|e| e.ser())),
         )
     }
 }
@@ -255,13 +263,16 @@ where
 {
     async fn from_res(res: Response) -> Result<Self, E> {
         let stream = res.try_into_stream()?;
-        Ok(TextStream(Box::pin(stream.map(|chunk| {
-            chunk.and_then(|bytes| {
-                String::from_utf8(bytes.into()).map_err(|e| {
-                    ServerFnErrorErr::Deserialization(e.to_string())
-                        .into_app_error()
-                })
-            })
+        Ok(TextStream(Box::pin(stream.map(|chunk| match chunk {
+            Ok(bytes) => {
+                let de = String::from_utf8(bytes.into()).map_err(|e| {
+                    E::from_server_fn_error(ServerFnErrorErr::Deserialization(
+                        e.to_string(),
+                    ))
+                })?;
+                Ok(de)
+            }
+            Err(bytes) => Err(E::de(bytes)),
         }))))
     }
 }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -3,7 +3,7 @@
 use crate::{ContentType, Decodes, Encodes, Format, FormatType};
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use bytes::Bytes;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display, Write},
     str::FromStr,
@@ -263,13 +263,7 @@ impl FormatType for ServerFnErrorEncoding {
 
 impl<CustErr> Encodes<ServerFnError<CustErr>> for ServerFnErrorEncoding
 where
-    CustErr: std::fmt::Debug
-        + Display
-        + Serialize
-        + DeserializeOwned
-        + 'static
-        + FromStr
-        + Display,
+    CustErr: Display,
 {
     type Error = std::fmt::Error;
 
@@ -311,13 +305,7 @@ where
 
 impl<CustErr> Decodes<ServerFnError<CustErr>> for ServerFnErrorEncoding
 where
-    CustErr: std::fmt::Debug
-        + Display
-        + Serialize
-        + DeserializeOwned
-        + 'static
-        + FromStr
-        + Display,
+    CustErr: FromStr,
 {
     type Error = String;
 
@@ -361,13 +349,7 @@ where
 
 impl<CustErr> FromServerFnError for ServerFnError<CustErr>
 where
-    CustErr: std::fmt::Debug
-        + Display
-        + Serialize
-        + DeserializeOwned
-        + 'static
-        + FromStr
-        + Display,
+    CustErr: std::fmt::Debug + Display + FromStr + 'static,
 {
     type Encoder = ServerFnErrorEncoding;
 

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -580,7 +580,7 @@ impl<E: FromServerFnError> FromStr for ServerFnErrorWrapper<E> {
 
 /// A trait for types that can be returned from a server function.
 pub trait FromServerFnError:
-    std::fmt::Debug + Serialize + DeserializeOwned + Display + 'static
+    std::fmt::Debug + Sized + Display + 'static
 {
     /// The encoding strategy used to serialize and deserialize this error type. Must implement the [`Encodes`](server_fn::Encodes) trait for references to the error type.
     type Encoder: Encodes<Self> + Decodes<Self>;

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -474,7 +474,7 @@ where
         let location = res.location();
         let has_redirect_header = res.has_redirect();
 
-        // if it returns an error status, deserialize the error using FromStr
+        // if it returns an error status, deserialize the error using the error's decoder.
         let res = if (400..=599).contains(&status) {
             Err(E::de(res.try_into_bytes().await?))
         } else {

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 use crate::error::ServerFnErrorErr;
+use bytes::Bytes;
 use std::{future::Future, pin::Pin};
 
 /// An abstraction over a middleware layer, which can be used to add additional
@@ -11,7 +12,7 @@ pub trait Layer<Req, Res>: Send + Sync + 'static {
 /// A type-erased service, which takes an HTTP request and returns a response.
 pub struct BoxedService<Req, Res> {
     /// A function that converts a [`ServerFnErrorErr`] into a string.
-    pub ser: fn(ServerFnErrorErr) -> String,
+    pub ser: fn(ServerFnErrorErr) -> Bytes,
     /// The inner service.
     pub service: Box<dyn Service<Req, Res> + Send>,
 }
@@ -19,7 +20,7 @@ pub struct BoxedService<Req, Res> {
 impl<Req, Res> BoxedService<Req, Res> {
     /// Constructs a type-erased service from this service.
     pub fn new(
-        ser: fn(ServerFnErrorErr) -> String,
+        ser: fn(ServerFnErrorErr) -> Bytes,
         service: impl Service<Req, Res> + Send + 'static,
     ) -> Self {
         Self {
@@ -43,7 +44,7 @@ pub trait Service<Request, Response> {
     fn run(
         &mut self,
         req: Request,
-        ser: fn(ServerFnErrorErr) -> String,
+        ser: fn(ServerFnErrorErr) -> Bytes,
     ) -> Pin<Box<dyn Future<Output = Response> + Send>>;
 }
 
@@ -52,6 +53,7 @@ mod axum {
     use super::{BoxedService, Service};
     use crate::{error::ServerFnErrorErr, response::Res, ServerFnError};
     use axum::body::Body;
+    use bytes::Bytes;
     use http::{Request, Response};
     use std::{future::Future, pin::Pin};
 
@@ -64,7 +66,7 @@ mod axum {
         fn run(
             &mut self,
             req: Request<Body>,
-            ser: fn(ServerFnErrorErr) -> String,
+            ser: fn(ServerFnErrorErr) -> Bytes,
         ) -> Pin<Box<dyn Future<Output = Response<Body>> + Send>> {
             let path = req.uri().path().to_string();
             let inner = self.call(req);
@@ -129,6 +131,7 @@ mod actix {
         response::{actix::ActixResponse, Res},
     };
     use actix_web::{HttpRequest, HttpResponse};
+    use bytes::Bytes;
     use std::{future::Future, pin::Pin};
 
     impl<S> super::Service<HttpRequest, HttpResponse> for S
@@ -140,7 +143,7 @@ mod actix {
         fn run(
             &mut self,
             req: HttpRequest,
-            ser: fn(ServerFnErrorErr) -> String,
+            ser: fn(ServerFnErrorErr) -> Bytes,
         ) -> Pin<Box<dyn Future<Output = HttpResponse> + Send>> {
             let path = req.uri().path().to_string();
             let inner = self.call(req);
@@ -163,7 +166,7 @@ mod actix {
         fn run(
             &mut self,
             req: ActixRequest,
-            ser: fn(ServerFnErrorErr) -> String,
+            ser: fn(ServerFnErrorErr) -> Bytes,
         ) -> Pin<Box<dyn Future<Output = ActixResponse> + Send>> {
             let path = req.0 .0.uri().path().to_string();
             let inner = self.call(req.0.take().0);

--- a/server_fn/src/request/generic.rs
+++ b/server_fn/src/request/generic.rs
@@ -45,7 +45,7 @@ where
 
     fn try_into_stream(
         self,
-    ) -> Result<impl Stream<Item = Result<Bytes, Error>> + Send + 'static, Error>
+    ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, Error>
     {
         Ok(stream::iter(self.into_body())
             .ready_chunks(16)
@@ -78,18 +78,16 @@ where
         self,
     ) -> Result<
         (
-            impl Stream<Item = Result<Bytes, InputStreamError>> + Send + 'static,
-            impl Sink<Result<Bytes, OutputStreamError>> + Send + 'static,
+            impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
+            impl Sink<Result<Bytes, Bytes>> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
     > {
         Err::<
             (
-                futures::stream::Once<
-                    std::future::Ready<Result<Bytes, InputStreamError>>,
-                >,
-                futures::sink::Drain<Result<Bytes, OutputStreamError>>,
+                futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
+                futures::sink::Drain<Result<Bytes, Bytes>>,
                 Self::WebsocketResponse,
             ),
             _,

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -350,7 +350,7 @@ where
     /// Attempts to convert the body of the request into a stream of bytes.
     fn try_into_stream(
         self,
-    ) -> Result<impl Stream<Item = Result<Bytes, Error>> + Send + 'static, Error>;
+    ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, Error>;
 
     /// Attempts to convert the body of the request into a websocket handle.
     #[allow(clippy::type_complexity)]
@@ -359,8 +359,8 @@ where
     ) -> impl Future<
         Output = Result<
             (
-                impl Stream<Item = Result<Bytes, InputStreamError>> + Send + 'static,
-                impl Sink<Result<Bytes, OutputStreamError>> + Send + 'static,
+                impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
+                impl Sink<Result<Bytes, Bytes>> + Send + 'static,
                 Self::WebsocketResponse,
             ),
             Error,
@@ -406,7 +406,7 @@ where
 
     fn try_into_stream(
         self,
-    ) -> Result<impl Stream<Item = Result<Bytes, Error>> + Send, Error> {
+    ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send, Error> {
         Ok(futures::stream::once(async { unreachable!() }))
     }
 
@@ -414,8 +414,8 @@ where
         self,
     ) -> Result<
         (
-            impl Stream<Item = Result<Bytes, InputStreamError>> + Send + 'static,
-            impl Sink<Result<Bytes, OutputStreamError>> + Send + 'static,
+            impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
+            impl Sink<Result<Bytes, Bytes>> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -423,10 +423,8 @@ where
         #[allow(unreachable_code)]
         Err::<
             (
-                futures::stream::Once<
-                    std::future::Ready<Result<Bytes, InputStreamError>>,
-                >,
-                futures::sink::Drain<Result<Bytes, OutputStreamError>>,
+                futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
+                futures::sink::Drain<Result<Bytes, Bytes>>,
                 Self::WebsocketResponse,
             ),
             _,

--- a/server_fn/src/request/spin.rs
+++ b/server_fn/src/request/spin.rs
@@ -51,13 +51,14 @@ where
 
     fn try_into_stream(
         self,
-    ) -> Result<
-        impl Stream<Item = Result<Bytes, ServerFnError>> + Send + 'static,
-        E,
-    > {
+    ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, E>
+    {
         Ok(self.into_body().into_data_stream().map(|chunk| {
             chunk.map_err(|e| {
-                ServerFnErrorErr::Deserialization(e.to_string()).into()
+                E::from_server_fn_error(ServerFnErrorErr::Deserialization(
+                    e.to_string(),
+                ))
+                .ser()
             })
         }))
     }

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -36,9 +36,10 @@ where
 
     fn try_from_stream(
         content_type: &str,
-        data: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+        data: impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
     ) -> Result<Self, E> {
-        let body = Body::from_stream(data.map_err(|e| ServerFnErrorWrapper(e)));
+        let body =
+            Body::from_stream(data.map_err(|e| ServerFnErrorWrapper(E::de(e))));
         let builder = http::Response::builder();
         builder
             .status(200)
@@ -51,7 +52,7 @@ where
 }
 
 impl Res for Response<Body> {
-    fn error_response(path: &str, err: String) -> Self {
+    fn error_response(path: &str, err: Bytes) -> Self {
         Response::builder()
             .status(http::StatusCode::INTERNAL_SERVER_ERROR)
             .header(SERVER_FN_ERROR_HEADER, path)

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -31,14 +31,14 @@ where
     /// Attempts to convert a stream of bytes into an HTTP response.
     fn try_from_stream(
         content_type: &str,
-        data: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+        data: impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
     ) -> Result<Self, E>;
 }
 
 /// Represents the response as created by the server;
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
-    fn error_response(path: &str, err: String) -> Self;
+    fn error_response(path: &str, err: Bytes) -> Self;
 
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
@@ -55,7 +55,10 @@ pub trait ClientRes<E> {
     /// Attempts to extract a binary stream from an HTTP response.
     fn try_into_stream(
         self,
-    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + Sync + 'static, E>;
+    ) -> Result<
+        impl Stream<Item = Result<Bytes, Bytes>> + Send + Sync + 'static,
+        E,
+    >;
 
     /// HTTP status code of the response.
     fn status(&self) -> u16;
@@ -89,14 +92,14 @@ impl<E> TryRes<E> for BrowserMockRes {
 
     fn try_from_stream(
         _content_type: &str,
-        _data: impl Stream<Item = Result<Bytes, E>>,
+        _data: impl Stream<Item = Result<Bytes, Bytes>>,
     ) -> Result<Self, E> {
         unreachable!()
     }
 }
 
 impl Res for BrowserMockRes {
-    fn error_response(_path: &str, _err: String) -> Self {
+    fn error_response(_path: &str, _err: Bytes) -> Self {
         unreachable!()
     }
 

--- a/server_fn/src/response/reqwest.rs
+++ b/server_fn/src/response/reqwest.rs
@@ -19,9 +19,11 @@ impl<E: FromServerFnError> ClientRes<E> for Response {
 
     fn try_into_stream(
         self,
-    ) -> Result<impl Stream<Item = Result<Bytes, E>> + Send + 'static, E> {
+    ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, E>
+    {
         Ok(self.bytes_stream().map_err(|e| {
-            ServerFnErrorErr::Response(e.to_string()).into_app_error()
+            E::from_server_fn_error(ServerFnErrorErr::Response(e.to_string()))
+                .ser()
         }))
     }
 

--- a/server_fn/tests/invalid/not_result.rs
+++ b/server_fn/tests/invalid/not_result.rs
@@ -1,7 +1,12 @@
+use server_fn::{
+    codec::JsonEncoding,
+    error::{FromServerFnError, ServerFnErrorErr},
+};
 use server_fn_macro_default::server;
-use server_fn::error::{FromServerFnError, ServerFnErrorErr};
 
-#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub enum CustomError {
     #[error("error a")]
     A,
@@ -10,6 +15,8 @@ pub enum CustomError {
 }
 
 impl FromServerFnError for CustomError {
+    type Encoder = JsonEncoding;
+
     fn from_server_fn_error(_: ServerFnErrorErr) -> Self {
         Self::A
     }

--- a/server_fn/tests/invalid/not_result.stderr
+++ b/server_fn/tests/invalid/not_result.stderr
@@ -1,7 +1,7 @@
 error[E0277]: CustomError is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
-  --> tests/invalid/not_result.rs:18:1
+  --> tests/invalid/not_result.rs:25:1
    |
-18 | #[server]
+25 | #[server]
    | ^^^^^^^^^ Must return a `Result` or aliased `Result`.
    |
    = help: the trait `ServerFnMustReturnResult` is not implemented for `CustomError`
@@ -9,9 +9,9 @@ error[E0277]: CustomError is not a `Result` or aliased `Result`. Server function
    = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
 
 error[E0271]: expected `impl Future<Output = CustomError>` to be a future that resolves to `Result<_, _>`, but it resolves to `CustomError`
-  --> tests/invalid/not_result.rs:18:1
+  --> tests/invalid/not_result.rs:25:1
    |
-18 | #[server]
+25 | #[server]
    | ^^^^^^^^^ expected `Result<_, _>`, found `CustomError`
    |
    = note: expected enum `Result<_, _>`
@@ -23,9 +23,9 @@ note: required by a bound in `ServerFn::{synthetic#0}`
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServerFn::{synthetic#0}`
 
 error[E0277]: CustomError is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
-  --> tests/invalid/not_result.rs:18:1
+  --> tests/invalid/not_result.rs:25:1
    |
-18 | #[server]
+25 | #[server]
    | ^^^^^^^^^ Must return a `Result` or aliased `Result`.
    |
    = help: the trait `ServerFnMustReturnResult` is not implemented for `CustomError`
@@ -34,9 +34,9 @@ error[E0277]: CustomError is not a `Result` or aliased `Result`. Server function
    = note: this error originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: CustomError is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
-  --> tests/invalid/not_result.rs:18:1
+  --> tests/invalid/not_result.rs:25:1
    |
-18 | #[server]
+25 | #[server]
    | ^^^^^^^^^ Must return a `Result` or aliased `Result`.
    |
    = help: the trait `ServerFnMustReturnResult` is not implemented for `CustomError`
@@ -44,14 +44,14 @@ error[E0277]: CustomError is not a `Result` or aliased `Result`. Server function
    = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
 
 error[E0308]: mismatched types
-  --> tests/invalid/not_result.rs:18:1
+  --> tests/invalid/not_result.rs:25:1
    |
-18 | #[server]
+25 | #[server]
    | ^^^^^^^^^ expected `CustomError`, found `Result<_, _>`
    |
    = note: expected enum `CustomError`
               found enum `Result<_, _>`
 help: consider using `Result::expect` to unwrap the `Result<_, _>` value, panicking if the value is a `Result::Err`
    |
-18 | #[server].expect("REASON")
+25 | #[server].expect("REASON")
    |          +++++++++++++++++

--- a/server_fn/tests/valid/custom_error_aliased_return_full.rs
+++ b/server_fn/tests/valid/custom_error_aliased_return_full.rs
@@ -1,7 +1,12 @@
+use server_fn::{
+    codec::JsonEncoding,
+    error::{FromServerFnError, ServerFnErrorErr},
+};
 use server_fn_macro_default::server;
-use server_fn::error::{FromServerFnError, ServerFnErrorErr};
 
-#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub enum CustomError {
     #[error("error a")]
     ErrorA,
@@ -10,6 +15,8 @@ pub enum CustomError {
 }
 
 impl FromServerFnError for CustomError {
+    type Encoder = JsonEncoding;
+
     fn from_server_fn_error(_: ServerFnErrorErr) -> Self {
         Self::ErrorA
     }

--- a/server_fn/tests/valid/custom_error_aliased_return_none.rs
+++ b/server_fn/tests/valid/custom_error_aliased_return_none.rs
@@ -1,7 +1,12 @@
+use server_fn::{
+    codec::JsonEncoding,
+    error::{FromServerFnError, ServerFnErrorErr},
+};
 use server_fn_macro_default::server;
-use server_fn::error::{FromServerFnError, ServerFnErrorErr};
 
-#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub enum CustomError {
     #[error("error a")]
     ErrorA,
@@ -10,6 +15,8 @@ pub enum CustomError {
 }
 
 impl FromServerFnError for CustomError {
+    type Encoder = JsonEncoding;
+
     fn from_server_fn_error(_: ServerFnErrorErr) -> Self {
         Self::ErrorA
     }

--- a/server_fn/tests/valid/custom_error_aliased_return_part.rs
+++ b/server_fn/tests/valid/custom_error_aliased_return_part.rs
@@ -1,7 +1,12 @@
+use server_fn::{
+    codec::JsonEncoding,
+    error::{FromServerFnError, ServerFnErrorErr},
+};
 use server_fn_macro_default::server;
-use server_fn::error::{FromServerFnError, ServerFnErrorErr};
 
-#[derive(Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, thiserror::Error, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub enum CustomError {
     #[error("error a")]
     ErrorA,
@@ -10,6 +15,8 @@ pub enum CustomError {
 }
 
 impl FromServerFnError for CustomError {
+    type Encoder = JsonEncoding;
+
     fn from_server_fn_error(_: ServerFnErrorErr) -> Self {
         Self::ErrorA
     }


### PR DESCRIPTION
This PR provides custom encoding and decoding for returned error types from server_fns.

The new syntax:
```rust
#[derive(
    thiserror::Error,
    Debug,
    Clone,
    Display,
    Serialize,
    Deserialize,
    rkyv::Archive,
    rkyv::Serialize,
    rkyv::Deserialize,
)]
pub enum MyErrors {
    ServerFnError(ServerFnErrorErr),
    Other(String),
}


impl FromServerFnError for MyErrors {
    type Encoder = RkyvEncoding;

    fn from_server_fn_error(value: ServerFnErrorErr) -> Self {
        MyErrors::ServerFnError(value)
    }
}
```