### PR TITLE
Fix: update wasm preload and wasm fetch to use cross-origin same-site

### DIFF
--- a/leptos/src/hydration/hydration_script.js
+++ b/leptos/src/hydration/hydration_script.js
@@ -1,7 +1,12 @@
 (function (root, pkg_path, output_name, wasm_output_name) {
 	import(`${root}/${pkg_path}/${output_name}.js`)
 		.then(mod => {
-			mod.default({module_or_path: `${root}/${pkg_path}/${wasm_output_name}.wasm`}).then(() => {
+			mod.default({
+				module_or_path: new Request(
+					`${root}/${pkg_path}/${wasm_output_name}.wasm`,
+					{ "credentials": "same-origin" }
+				)
+			}).then(() => {
 				mod.hydrate();
 			});
 		})

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -115,7 +115,8 @@ pub fn HydrationScripts(
                 href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
                 r#as="fetch"
                 r#type="application/wasm"
-                crossorigin=nonce.clone().unwrap_or_default()
+                nonce=nonce.clone().unwrap_or_default()
+                crossorigin
             />
             <script type="module" nonce=nonce>
                 {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?});{islands_router}")}


### PR DESCRIPTION
Passes a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) object instead of a string URL to [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) so that we can define the CSP as `same-origin`. 

This is done indirectly in `leptos/src/hydration/hydration_script.js` because the actual call to `fetch` is buried in code generated by `wasm-bindgen`.

Fixes #3814 

Open questions:

1. Is `same-origin` the behavior we want? Will that cause headaches for anyone hosting static files on a CDN?
2. Any additional changes needed like test coverage? I'm fairly new to leptos, but happy to follow conventions.
3. What degree should this be back ported? I've tested on 0.8 and 0.7.