### PR TITLE
Revert "Remove getrandom (#3589)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "cfg-if",
  "either_of",
  "futures",
+ "getrandom 0.2.15",
  "hydration_context",
  "leptos-spin-macro",
  "leptos_config",

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -29,6 +29,9 @@ oco_ref = { workspace = true }
 or_poisoned = { workspace = true }
 paste = "1.0"
 rand = { version = "0.8.5", optional = true }
+# NOTE: While not used directly, `getrandom`'s `js` feature is needed when `rand` is used on WASM to
+#       avoid a compilation error
+getrandom = { version = "0.2", optional = true }
 reactive_graph = { workspace = true, features = ["serde"] }
 rustc-hash = "2.0"
 tachys = { workspace = true, features = [
@@ -61,12 +64,13 @@ hydration = [
   "hydration_context/browser",
   "leptos_dom/hydration",
 ]
-csr = ["leptos_macro/csr", "reactive_graph/effects"]
+csr = ["leptos_macro/csr", "reactive_graph/effects", "getrandom?/js"]
 hydrate = [
   "leptos_macro/hydrate",
   "hydration",
   "tachys/hydrate",
   "reactive_graph/effects",
+  "getrandom?/js",
 ]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]
@@ -87,7 +91,7 @@ tracing = [
   "leptos_dom/tracing",
   "leptos_server/tracing",
 ]
-nonce = ["base64", "rand"]
+nonce = ["base64", "rand", "dep:getrandom"]
 spin = ["leptos-spin-macro"]
 islands = ["leptos_macro/islands", "dep:serde_json"]
 trace-component-props = [


### PR DESCRIPTION
Restores `getrandom` dependency to avoid compilation error when compiling for WASM with the `nonce` feature.