### PR TITLE
More information in "outside reactive tracking context" warning.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "wasm_backtrace",
  "web-sys",
 ]
 
@@ -4273,6 +4274,16 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasm_backtrace"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba01d353899b9d98dc4c7ac7624d35500c1090af911d6919eb806bef43335e"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { version = "0.1.41", optional = true }
 guardian = "1.2"
 async-lock = "3.4.0"
 send_wrapper = { version = "0.6.0", features = ["futures"] }
+wasm_backtrace = "0.1.1"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 web-sys = { version = "0.3.72", features = ["console"] }

--- a/reactive_graph/src/traits.rs
+++ b/reactive_graph/src/traits.rs
@@ -123,6 +123,7 @@ impl<T: Source + ToAnySource + DefinedAt> Track for T {
                 use crate::diagnostics::SpecialNonReactiveZone;
 
                 if !SpecialNonReactiveZone::is_inside() {
+                    let backtrace = wasm_backtrace::backtrace();
                     let called_at = Location::caller();
                     let ty = std::any::type_name::<T>();
                     let defined_at = self
@@ -143,7 +144,8 @@ impl<T: Source + ToAnySource + DefinedAt> Track for T {
                          let y = x.get() * 2\n  ✅ YES let y = move || \
                          x.get() * 2.\n\n3. If you’re *trying* to access the \
                          value without tracking, use `.get_untracked()` or \
-                         `.with_untracked()` instead."
+                         `.with_untracked()` instead.\n\nComplete backtrace \
+                         of the call site:\n{backtrace}"
                     ));
                 }
             }


### PR DESCRIPTION
As of now, the "outside reactive tracking context" warning often only points to internals of `reactive_graph`, making it hard to figure out where in the user code this was caused. This commit adds a backtrace that is printed after the warning. It has the caveat that it is a WASM backtrace, and hence contains less information than a Rust backtrace. However, [it is currently impossible to get a nice Rust backtrace out of WASM](https://users.rust-lang.org/t/what-is-the-current-state-of-backtraces-in-wasm/128002/2?u=isibboi), hence this seems to be the best option.