### PR TITLE
fix: call `additional_context` after providing other server context in all cases

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -352,10 +352,10 @@ pub fn handle_server_fns_with_context(
                 owner
                     .with(|| {
                         ScopedFuture::new(async move {
-                            additional_context();
                             provide_context(Request::new(&req));
                             let res_options = ResponseOptions::default();
                             provide_context(res_options.clone());
+                            additional_context();
 
                             // store Accepts and Referer in case we need them for redirect (below)
                             let accepts_html = req

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -381,10 +381,10 @@ async fn handle_server_fns_inner(
         owner
             .with(|| {
                 ScopedFuture::new(async move {
-                    additional_context();
                     provide_context(parts);
                     let res_options = ResponseOptions::default();
                     provide_context(res_options.clone());
+                    additional_context();
 
                     // store Accepts and Referer in case we need them for redirect (below)
                     let accepts_html = req
@@ -2053,8 +2053,8 @@ where
                 } else {
                     let mut res = handle_response_inner(
                         move || {
-                            additional_context();
                             provide_context(state.clone());
+                            additional_context();
                         },
                         move || shell(options),
                         req,


### PR DESCRIPTION
Currently, `additional_context()` is called after we provide other server context (like the request `Parts` in Axum) for ordinary routes, but before the other context for server functions. That's just an oversight; correcting it allows you to access the request data in your `additional_context` function, which can be useful!