### PR TITLE
fix: correctly decode base64-encoded server action error messages stored in URL

### DIFF
--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -4,7 +4,7 @@ use reactive_graph::{
     traits::DefinedAt,
 };
 use server_fn::{
-    error::{FromServerFnError, ServerFnErrorErr, ServerFnErrorWrapper},
+    error::{FromServerFnError, ServerFnUrlError},
     ServerFn,
 };
 use std::{ops::Deref, panic::Location, sync::Arc};
@@ -62,19 +62,7 @@ where
     pub fn new() -> Self {
         let err = use_context::<ServerActionError>().and_then(|error| {
             (error.path() == S::PATH)
-                .then(|| {
-                    error
-                        .err()
-                        .parse::<ServerFnErrorWrapper<S::Error>>()
-                        .map(|e| e.0)
-                        .unwrap_or_else(|e| {
-                            S::Error::from_server_fn_error(
-                                ServerFnErrorErr::Deserialization(
-                                    e.to_string(),
-                                ),
-                            )
-                        })
-                })
+                .then(|| ServerFnUrlError::<S::Error>::decode_err(error.err()))
                 .map(Err)
         });
         Self {
@@ -162,19 +150,7 @@ where
     pub fn new() -> Self {
         let err = use_context::<ServerActionError>().and_then(|error| {
             (error.path() == S::PATH)
-                .then(|| {
-                    error
-                        .err()
-                        .parse::<ServerFnErrorWrapper<S::Error>>()
-                        .map(|e| e.0)
-                        .unwrap_or_else(|e| {
-                            S::Error::from_server_fn_error(
-                                ServerFnErrorErr::Deserialization(
-                                    e.to_string(),
-                                ),
-                            )
-                        })
-                })
+                .then(|| ServerFnUrlError::<S::Error>::decode_err(error.err()))
                 .map(Err)
         });
         Self {


### PR DESCRIPTION
#3811 introduced a bug when decoding `ServerAction` errors from the URL (when JS/WASM is turned off, or in islands mode), because errors were no longer decoded properly. Conveniently, fixing it along removed a bunch of code by correctly using the new helper method.