### PR TITLE
fix: reactive_graph keymap impl and clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ name = "reactive_stores"
 version = "0.2.0-rc1"
 dependencies = [
  "any_spawner",
+ "dashmap",
  "guardian",
  "itertools",
  "leptos",
@@ -2793,6 +2794,7 @@ dependencies = [
  "reactive_graph",
  "reactive_stores_macro",
  "rustc-hash 2.1.1",
+ "send_wrapper",
  "tokio",
  "tokio-test",
 ]

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -17,6 +17,8 @@ paste = "1.0"
 reactive_graph = { workspace = true }
 rustc-hash = "2.0"
 reactive_stores_macro = { workspace = true }
+dashmap = "6.1"
+send_wrapper = "0.6.0"
 
 [dev-dependencies]
 tokio = { version = "1.43", features = ["rt-multi-thread", "macros"] }

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -79,7 +79,7 @@ impl Parse for Model {
 
 #[derive(Clone)]
 enum SubfieldMode {
-    Keyed(ExprClosure, Box<Type>),
+    Keyed(Box<ExprClosure>, Box<Type>),
     Skip,
 }
 
@@ -91,7 +91,7 @@ impl Parse for SubfieldMode {
             let ty: Type = input.parse()?;
             let _eq: Token![=] = input.parse()?;
             let closure: ExprClosure = input.parse()?;
-            Ok(SubfieldMode::Keyed(closure, Box::new(ty)))
+            Ok(SubfieldMode::Keyed(Box::new(closure), Box::new(ty)))
         } else if mode == "skip" {
             Ok(SubfieldMode::Skip)
         } else {


### PR DESCRIPTION
This PR improves the `reactive_stores` `KeyMap` implementation by using concurrent `DashMap` on non-wasm and lock-free std `HashMap` on wasm. This also solves two Clippy errors, one mentioned earlier and the other was enum large stack usage.