### PR TITLE
fix: remove `Display` requirement from `FromServerFnError`

### DIFF
--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -202,13 +202,15 @@ pub mod browser {
                             Err(err) => {
                                 let err = InputStreamError::de(err);
                                 web_sys::console::error_1(
-                                    &js_sys::JsString::from(err.to_string()),
+                                    &js_sys::JsString::from(
+                                        err.websocket_error_reason(),
+                                    ),
                                 );
                                 const CLOSE_CODE_ERROR: u16 = 1011;
                                 Err(WebSocketError::ConnectionClose(
                                     CloseEvent {
                                         code: CLOSE_CODE_ERROR,
-                                        reason: err.to_string(),
+                                        reason: err.websocket_error_reason(),
                                         was_clean: true,
                                     },
                                 ))
@@ -303,7 +305,9 @@ pub mod reqwest {
                         Err(err) => {
                             let err = E::de(err);
                             Err(tokio_tungstenite::tungstenite::Error::Io(
-                                std::io::Error::other(err.to_string()),
+                                std::io::Error::other(
+                                    err.websocket_error_reason(),
+                                ),
                             ))
                         }
                     }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -561,9 +561,7 @@ impl<E: FromServerFnError> FromStr for ServerFnErrorWrapper<E> {
 }
 
 /// A trait for types that can be returned from a server function.
-pub trait FromServerFnError:
-    std::fmt::Debug + Sized + Display + 'static
-{
+pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// The encoding strategy used to serialize and deserialize this error type. Must implement the [`Encodes`](server_fn::Encodes) trait for references to the error type.
     type Encoder: Encodes<Self> + Decodes<Self>;
 
@@ -588,6 +586,20 @@ pub trait FromServerFnError:
         Self::Encoder::decode(data).unwrap_or_else(|e| {
             ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()
         })
+    }
+
+    /// Reason for the error, used for errors in WebSocket connections.
+    ///
+    /// **Note**: Ideally, this method would default to using `Display` if implemented, falling back
+    /// to `Debug` otherwise. However, due to limitations in Rust's type system (notably the lack of
+    /// specialization or conditional trait detection), it's not currently possible to implement
+    /// that behavior in a sound and automatic way in Rust.
+    ///
+    /// The current Debug-based fallback is a safe default. If a type implements Display and/or more
+    /// customized output is desired, we recommend overriding this method explicitly with the better
+    /// error message(s).
+    fn websocket_error_reason(&self) -> String {
+        format!("{self:?}")
     }
 }
 


### PR DESCRIPTION
As I lamented @ https://github.com/leptos-rs/leptos/pull/3811#pullrequestreview-2766764718 I find the returned requirement of `Display` on all `FromServerFnError` implementations problematic. It turns out that it's there only so that `to_string()` can be called in a few places where web sockets are involved.

Since I don't use websockets and I don't ever display error messages "verbatim" to my end users, this `Display` requirement is just extra churn and noise for me.

We don't necessarily have to go with the exact solution I've provided here, but I'm opening this PR to at least "force" a discussion on the matter.