### PR TITLE
 fix: send/receive websocket data

### DIFF
--- a/examples/server_fns_axum/src/app.rs
+++ b/examples/server_fns_axum/src/app.rs
@@ -945,9 +945,7 @@ pub fn CustomClientExample() -> impl IntoView {
                             Item = Result<server_fn::Bytes, server_fn::Bytes>,
                         > + Send
                         + 'static,
-                    impl Sink<Result<server_fn::Bytes, server_fn::Bytes>>
-                        + Send
-                        + 'static,
+                    impl Sink<server_fn::Bytes> + Send + 'static,
                 ),
                 E,
             >,

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -132,14 +132,10 @@ pub mod browser {
                 let (sink, stream) = websocket.split();
 
                 let stream = stream.map(|message| match message {
-                    Ok(message) => {
-                        crate::deserialize_result::<OutputStreamError>(
-                            match message {
-                                Message::Text(text) => Bytes::from(text),
-                                Message::Bytes(bytes) => Bytes::from(bytes),
-                            },
-                        )
-                    }
+                    Ok(message) => Ok(match message {
+                        Message::Text(text) => Bytes::from(text),
+                        Message::Bytes(bytes) => Bytes::from(bytes),
+                    }),
                     Err(err) => {
                         web_sys::console::error_1(&err.to_string().into());
                         Err(OutputStreamError::from_server_fn_error(
@@ -281,9 +277,7 @@ pub mod reqwest {
 
             Ok((
                 read.map(|msg| match msg {
-                    Ok(msg) => crate::deserialize_result::<OutputStreamError>(
-                        msg.into_data(),
-                    ),
+                    Ok(msg) => Ok(msg.into_data()),
                     Err(e) => Err(OutputStreamError::from_server_fn_error(
                         ServerFnErrorErr::Request(e.to_string()),
                     )

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -201,14 +201,17 @@ pub mod browser {
                             Ok(message) => Ok(Message::Bytes(message.into())),
                             Err(err) => {
                                 let err = InputStreamError::de(err);
+                                let formatted_err = format!("{:?}", err);
                                 web_sys::console::error_1(
-                                    &js_sys::JsString::from(err.to_string()),
+                                    &js_sys::JsString::from(
+                                        formatted_err.clone(),
+                                    ),
                                 );
                                 const CLOSE_CODE_ERROR: u16 = 1011;
                                 Err(WebSocketError::ConnectionClose(
                                     CloseEvent {
                                         code: CLOSE_CODE_ERROR,
-                                        reason: err.to_string(),
+                                        reason: formatted_err,
                                         was_clean: true,
                                     },
                                 ))
@@ -303,7 +306,7 @@ pub mod reqwest {
                         Err(err) => {
                             let err = E::de(err);
                             Err(tokio_tungstenite::tungstenite::Error::Io(
-                                std::io::Error::other(err.to_string()),
+                                std::io::Error::other(format!("{:?}", err)),
                             ))
                         }
                     }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -561,9 +561,7 @@ impl<E: FromServerFnError> FromStr for ServerFnErrorWrapper<E> {
 }
 
 /// A trait for types that can be returned from a server function.
-pub trait FromServerFnError:
-    std::fmt::Debug + Sized + Display + 'static
-{
+pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// The encoding strategy used to serialize and deserialize this error type. Must implement the [`Encodes`](server_fn::Encodes) trait for references to the error type.
     type Encoder: Encodes<Self> + Decodes<Self>;
 

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -747,7 +747,7 @@ where
 /// - Tag 0: Ok variant
 /// - Tag 1: Err variant
 #[allow(dead_code)]
-pub(crate) fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
+pub fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
     match result {
         Ok(bytes) => {
             let mut buf = BytesMut::with_capacity(1 + bytes.len());
@@ -766,7 +766,7 @@ pub(crate) fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
 
 /// Deserializes a Bytes instance back into a Result<Bytes, Bytes>.
 #[allow(dead_code)]
-pub(crate) fn deserialize_result<E: FromServerFnError>(
+pub fn deserialize_result<E: FromServerFnError>(
     bytes: Bytes,
 ) -> Result<Bytes, Bytes> {
     if bytes.is_empty() {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -774,8 +774,7 @@ fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
     }
 }
 
-/// Deserializes a Bytes instance back into a Result<Bytes, Bytes>.
-#[allow(dead_code)]
+// Deserializes a Bytes instance back into a Result<Bytes, Bytes>.
 fn deserialize_result<E: FromServerFnError>(
     bytes: Bytes,
 ) -> Result<Bytes, Bytes> {

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -136,6 +136,7 @@ use base64::{engine::general_purpose::STANDARD_NO_PAD, DecodeError, Engine};
 // re-exported to make it possible to implement a custom Client without adding a separate
 // dependency on `bytes`
 pub use bytes::Bytes;
+use bytes::{BufMut, BytesMut};
 use client::Client;
 use codec::{Encoding, FromReq, FromRes, IntoReq, IntoRes};
 #[doc(hidden)]
@@ -656,14 +657,17 @@ where
 
         let output = server_fn(input.into()).await?;
 
-        let output = output.stream.map(|output| match output {
-            Ok(output) => OutputEncoding::encode(&output).map_err(|e| {
-                OutputStreamError::from_server_fn_error(
-                    ServerFnErrorErr::Serialization(e.to_string()),
-                )
-                .ser()
-            }),
-            Err(err) => Err(err.ser()),
+        let output = output.stream.map(|output| {
+            let result = match output {
+                Ok(output) => OutputEncoding::encode(&output).map_err(|e| {
+                    OutputStreamError::from_server_fn_error(
+                        ServerFnErrorErr::Serialization(e.to_string()),
+                    )
+                    .ser()
+                }),
+                Err(err) => Err(err.ser()),
+            };
+            serialize_result(result)
         });
 
         Server::spawn(async move {
@@ -695,23 +699,21 @@ where
                 pin_mut!(input);
                 pin_mut!(sink);
                 while let Some(input) = input.stream.next().await {
-                    if sink
-                        .send(
-                            input
-                                .and_then(|input| {
-                                    InputEncoding::encode(&input).map_err(|e| {
-                                        InputStreamError::from_server_fn_error(
-                                            ServerFnErrorErr::Serialization(
-                                                e.to_string(),
-                                            ),
-                                        )
-                                    })
-                                })
-                                .map_err(|e| e.ser()),
-                        )
-                        .await
-                        .is_err()
-                    {
+                    let result = match input {
+                        Ok(input) => {
+                            InputEncoding::encode(&input).map_err(|e| {
+                                InputStreamError::from_server_fn_error(
+                                    ServerFnErrorErr::Serialization(
+                                        e.to_string(),
+                                    ),
+                                )
+                                .ser()
+                            })
+                        }
+                        Err(err) => Err(err.ser()),
+                    };
+                    let result = serialize_result(result);
+                    if sink.send(result).await.is_err() {
                         break;
                     }
                 }
@@ -737,6 +739,53 @@ where
             let output = BoxedStream { stream: boxed };
             Ok(output)
         }
+    }
+}
+
+/// Serializes a Result<Bytes, Bytes> into a single Bytes instance.
+/// Format: [tag: u8][content: Bytes]
+/// - Tag 0: Ok variant
+/// - Tag 1: Err variant
+pub(crate) fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
+    match result {
+        Ok(bytes) => {
+            let mut buf = BytesMut::with_capacity(1 + bytes.len());
+            buf.put_u8(0); // Tag for Ok variant
+            buf.extend_from_slice(&bytes);
+            buf.freeze()
+        }
+        Err(bytes) => {
+            let mut buf = BytesMut::with_capacity(1 + bytes.len());
+            buf.put_u8(1); // Tag for Err variant
+            buf.extend_from_slice(&bytes);
+            buf.freeze()
+        }
+    }
+}
+
+/// Deserializes a Bytes instance back into a Result<Bytes, Bytes>.
+pub(crate) fn deserialize_result<E: FromServerFnError>(
+    bytes: Bytes,
+) -> Result<Bytes, Bytes> {
+    if bytes.is_empty() {
+        return Err(E::from_server_fn_error(
+            ServerFnErrorErr::Deserialization("Data is empty".into()),
+        )
+        .ser());
+    }
+
+    let tag = bytes[0];
+    let content = bytes.slice(1..);
+
+    match tag {
+        0 => Ok(content),
+        1 => Err(content),
+        _ => {
+            return Err(E::from_server_fn_error(
+                ServerFnErrorErr::Deserialization("Invalid data tag".into()),
+            )
+            .ser())
+        } // Invalid tag
     }
 }
 
@@ -1216,5 +1265,47 @@ pub mod mock {
         ) -> Result<(), Error> {
             unreachable!()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::codec::JsonEncoding;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    enum TestError {
+        ServerFnError(ServerFnErrorErr),
+    }
+
+    impl FromServerFnError for TestError {
+        type Encoder = JsonEncoding;
+
+        fn from_server_fn_error(value: ServerFnErrorErr) -> Self {
+            Self::ServerFnError(value)
+        }
+    }
+    #[test]
+    fn test_result_serialization() {
+        // Test Ok variant
+        let ok_result: Result<Bytes, Bytes> =
+            Ok(Bytes::from_static(b"success data"));
+        let serialized = serialize_result(ok_result);
+        let deserialized = deserialize_result::<TestError>(serialized);
+        assert!(deserialized.is_ok());
+        assert_eq!(deserialized.unwrap(), Bytes::from_static(b"success data"));
+
+        // Test Err variant
+        let err_result: Result<Bytes, Bytes> =
+            Err(Bytes::from_static(b"error details"));
+        let serialized = serialize_result(err_result);
+        let deserialized = deserialize_result::<TestError>(serialized);
+        assert!(deserialized.is_err());
+        assert_eq!(
+            deserialized.unwrap_err(),
+            Bytes::from_static(b"error details")
+        );
     }
 }

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -746,6 +746,7 @@ where
 /// Format: [tag: u8][content: Bytes]
 /// - Tag 0: Ok variant
 /// - Tag 1: Err variant
+#[allow(dead_code)]
 pub(crate) fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
     match result {
         Ok(bytes) => {
@@ -764,6 +765,7 @@ pub(crate) fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
 }
 
 /// Deserializes a Bytes instance back into a Result<Bytes, Bytes>.
+#[allow(dead_code)]
 pub(crate) fn deserialize_result<E: FromServerFnError>(
     bytes: Bytes,
 ) -> Result<Bytes, Bytes> {
@@ -780,12 +782,10 @@ pub(crate) fn deserialize_result<E: FromServerFnError>(
     match tag {
         0 => Ok(content),
         1 => Err(content),
-        _ => {
-            return Err(E::from_server_fn_error(
-                ServerFnErrorErr::Deserialization("Invalid data tag".into()),
-            )
-            .ser())
-        } // Invalid tag
+        _ => Err(E::from_server_fn_error(ServerFnErrorErr::Deserialization(
+            "Invalid data tag".into(),
+        ))
+        .ser()), // Invalid tag
     }
 }
 

--- a/server_fn/src/request/actix.rs
+++ b/server_fn/src/request/actix.rs
@@ -159,11 +159,11 @@ where
                             Ok(Message::Binary(bytes)) => {
                                 _ = response_stream_tx
                                     .start_send(
-                                        crate::deserialize_result::<InputStreamError>(bytes),
+                                        Ok(bytes),
                                     );
                             }
                             Ok(Message::Text(text)) => {
-                                _ = response_stream_tx.start_send(crate::deserialize_result::<InputStreamError>(text.into_bytes()));
+                                _ = response_stream_tx.start_send(Ok(text.into_bytes()));
                             }
                             Ok(_other) => {
                             }

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -146,11 +146,11 @@ where
                             Ok(Message::Binary(bytes)) => {
                                 _ = outgoing_tx
                                     .start_send(
-                                        crate::deserialize_result::<InputStreamError>(bytes),
+                                        Ok(bytes),
                                     );
                             }
                             Ok(Message::Text(text)) => {
-                                _ = outgoing_tx.start_send(crate::deserialize_result::<InputStreamError>(Bytes::from(text)));
+                                _ = outgoing_tx.start_send(Ok(Bytes::from(text)));
                             }
                             Ok(Message::Ping(bytes)) => {
                                 if session.send(Message::Pong(bytes)).await.is_err() {

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -159,7 +159,6 @@ where
                             }
                             Ok(_other) => {}
                             Err(e) => {
-                                println!("2");
                                 _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser()));
                             }
                         }

--- a/server_fn/src/request/generic.rs
+++ b/server_fn/src/request/generic.rs
@@ -79,7 +79,7 @@ where
     ) -> Result<
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
-            impl Sink<Result<Bytes, Bytes>> + Send + 'static,
+            impl Sink<Bytes> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -87,7 +87,7 @@ where
         Err::<
             (
                 futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
-                futures::sink::Drain<Result<Bytes, Bytes>>,
+                futures::sink::Drain<Bytes>,
                 Self::WebsocketResponse,
             ),
             _,

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -360,7 +360,7 @@ where
         Output = Result<
             (
                 impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
-                impl Sink<Result<Bytes, Bytes>> + Send + 'static,
+                impl Sink<Bytes> + Send + 'static,
                 Self::WebsocketResponse,
             ),
             Error,
@@ -415,7 +415,7 @@ where
     ) -> Result<
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
-            impl Sink<Result<Bytes, Bytes>> + Send + 'static,
+            impl Sink<Bytes> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -424,7 +424,7 @@ where
         Err::<
             (
                 futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
-                futures::sink::Drain<Result<Bytes, Bytes>>,
+                futures::sink::Drain<Bytes>,
                 Self::WebsocketResponse,
             ),
             _,


### PR DESCRIPTION
With the current implementation, you are not able to send errors over WebSockets and you will be trapped into an infinite loop. This PR solves it and you can properly send stream data over WebSocket. As an effect, there is no longer a requirement to have `Display` bound on the `FromServerFnError` trait as we are no longer using it.

Supersedes: #3847

PR origin: #3656