### PR TITLE
fix: Use stabilized ClipboardEvent

### DIFF
--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -733,9 +733,9 @@ generate_event_types! {
   // =========================================================
   // DocumentAndElementEventHandlersEventMap
   // =========================================================
-  copy: Event, // ClipboardEvent is unstable
-  cut: Event, // ClipboardEvent is unstable
-  paste: Event, // ClipboardEvent is unstable
+  copy: ClipboardEvent,
+  cut: ClipboardEvent,
+  paste: ClipboardEvent,
 
   // =========================================================
   // DocumentEventMap
@@ -758,11 +758,11 @@ use super::{
 };
 #[doc(no_inline)]
 pub use web_sys::{
-    AnimationEvent, BeforeUnloadEvent, CompositionEvent, CustomEvent,
-    DeviceMotionEvent, DeviceOrientationEvent, DragEvent, ErrorEvent, Event,
-    FocusEvent, GamepadEvent, HashChangeEvent, InputEvent, KeyboardEvent,
-    MessageEvent, MouseEvent, PageTransitionEvent, PointerEvent, PopStateEvent,
-    ProgressEvent, PromiseRejectionEvent, SecurityPolicyViolationEvent,
-    StorageEvent, SubmitEvent, TouchEvent, TransitionEvent, UiEvent,
-    WheelEvent,
+    AnimationEvent, BeforeUnloadEvent, ClipboardEvent, CompositionEvent,
+    CustomEvent, DeviceMotionEvent, DeviceOrientationEvent, DragEvent,
+    ErrorEvent, Event, FocusEvent, GamepadEvent, HashChangeEvent, InputEvent,
+    KeyboardEvent, MessageEvent, MouseEvent, PageTransitionEvent, PointerEvent,
+    PopStateEvent, ProgressEvent, PromiseRejectionEvent,
+    SecurityPolicyViolationEvent, StorageEvent, SubmitEvent, TouchEvent,
+    TransitionEvent, UiEvent, WheelEvent,
 };


### PR DESCRIPTION
`ClipboardEvent` has been stabilized in `web-sys` for a while now, and is widely available according to MDN, so this PR uses `ClipboardEvent` for the appropriate events (`copy`, `cut`, `paste`).

- `web-sys` changelog: https://github.com/rustwasm/wasm-bindgen/blob/c35cc9369d5e0dc418986f7811a0dd702fb33ef9/CHANGELOG.md#changed-7
  (Note that the version number in the changelog refers to `wasm-bindgen` instead of `web-sys`, but `ClipboardEvent` is indeed stabilized in the version of `web-sys` that `tachys` uses)
- MDN page: https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent