### PR TITLE
chore(nightly): update proc-macro span file name method name

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -361,7 +361,7 @@ fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
     cfg_if::cfg_if! {
         if #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))] {
             Some(leptos_hot_reload::span_to_stable_id(
-                site.source_file().path(),
+                site.file(),
                 site.start().line()
             ))
         } else {


### PR DESCRIPTION
Latest nightly `2025-04-15` removes the [`.source_file()`](https://doc.rust-lang.org/proc_macro/struct.Span.html#method.source_file) method on `proc_macro::Span` (used in our hot-reloading code) and [splits it into `.file()` and `local_file()`](https://github.com/rust-lang/rust/issues/54725#issuecomment-2796806678). 

The bad news: this means leptos nightly no longer compiles on latest nightly.

The good news: this is a step toward stabilization for other parts of the API, which is *great*.

I've made the decision to just change to the newer method name, and require nightly users to use latest nightly.