### PR TITLE
Backport: Use Span::file() for nightly compatibility (for v0.8.0-rc1) | Ref chore(nightly): update proc-macro span file name method name (#3852)

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -361,7 +361,7 @@ fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
     cfg_if::cfg_if! {
         if #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))] {
             Some(leptos_hot_reload::span_to_stable_id(
-                site.source_file().path(),
+                site.file(),
                 site.start().line()
             ))
         } else {


### PR DESCRIPTION
This pull request cherry-picks commit 8f38559aa2a4ed0c1d308b0693c509a1d63e098b from `main` to address compatibility with recent nightly Rust changes. It replaces the deprecated `Span::source_file().path()` with the newer `Span::file()` method in `leptos_macro/src/lib.rs`.

Intended for inclusion in the `v0.8.0-rc1` release. Please advise on the appropriate process if a separate release branch is preferred.
