### PR TITLE
Fix for normalized_call_site on nightly

### DIFF
--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -356,10 +356,16 @@ fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
 fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
     cfg_if::cfg_if! {
         if #[cfg(all(debug_assertions, feature = "nightly"))] {
-            Some(leptos_hot_reload::span_to_stable_id(
-                site.file().path(),
-                site.start().line()
-            ))
+            // site.file() is a String, site.local_file() is an Option<PathBuf>
+            if let Some(file) = site.local_file() {
+                Some(leptos_hot_reload::span_to_stable_id(
+                    file,
+                    site.start().line()
+                ))
+            } else {
+                // analogous to span_to_stable_id, but site.file() might not actually be stable. Y/N?
+                Some(format!("{}-{}",site.file(),site.start().line()))
+            }
         } else {
             _ = site;
             None


### PR DESCRIPTION
The previous fix from two days ago replaced the call to `site.source_file()` by `site.file()`, but the latter returns a (displayable) `String` rather than something that has a `path()`, causing compile time errors on nightly. 

There are two options that I see: 
1. `site.local_file()` returns an `Option<PathBuf>` that needs dealing with before we can defer to `span_to_stable_id()` as before.
2. Use `site.file()` and generate an ID analogous to `span_to_stable_id()` - notably though, the `String` returned by `site.file()` may or may not be stable (e.g. according to the docs, it could return something like `"<macro expansion>"`).

This PR therefore prefers 1. when `local_file().is_some()` and uses 2. otherwise, in the interest of returning `Some` if at all possible.