### PR TITLE
Forward lint attributes used with #[component] macro

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -645,7 +645,9 @@ impl Parse for DummyModel {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut attrs = input.call(Attribute::parse_outer)?;
         // Drop unknown attributes like #[deprecated]
-        drain_filter(&mut attrs, |attr| !(attr.path().is_ident("doc") || attr.path().is_ident("allow")));
+        drain_filter(&mut attrs, |attr| {
+            !(attr.path().is_ident("doc") || attr.path().is_ident("allow"))
+        });
 
         let vis: Visibility = input.parse()?;
         let mut sig: Signature = input.parse()?;

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -645,7 +645,7 @@ impl Parse for DummyModel {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut attrs = input.call(Attribute::parse_outer)?;
         // Drop unknown attributes like #[deprecated]
-        drain_filter(&mut attrs, |attr| !attr.path().is_ident("doc"));
+        drain_filter(&mut attrs, |attr| !(attr.path().is_ident("doc") || attr.path().is_ident("allow")));
 
         let vis: Visibility = input.parse()?;
         let mut sig: Signature = input.parse()?;
@@ -937,6 +937,10 @@ impl UnknownAttrs {
                     if let Meta::NameValue(_) = &attr.meta {
                         return None;
                     }
+                }
+
+                if attr.path().is_ident("allow") {
+                    return None;
                 }
 
                 Some((attr.into_token_stream(), attr.span()))


### PR DESCRIPTION
Removed lint(allow) attributes from adding to component function and added it to user logic.
Fix for #3771 
