### PR TITLE
Error boundary fixes

### DIFF
--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -418,7 +418,9 @@ where
                         }
                         StreamChunk::OutOfOrder { chunks } => {
                             let chunks = chunks.await;
-                            my_chunks.extend(chunks.take_chunks());
+                            my_chunks.push_back(StreamChunk::OutOfOrder {
+                                chunks: Box::pin(async move { chunks }),
+                            });
                         }
                     }
                 }

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -1,20 +1,21 @@
 use crate::{children::TypedChildren, IntoView};
+use futures::{channel::oneshot, future::join_all};
 use hydration_context::{SerializedDataId, SharedContext};
 use leptos_macro::component;
 use reactive_graph::{
     computed::ArcMemo,
     effect::RenderEffect,
-    owner::{provide_context, Owner},
+    owner::{provide_context, ArcStoredValue, Owner},
     signal::ArcRwSignal,
-    traits::{Get, Update, With, WithUntracked},
+    traits::{Get, Update, With, WithUntracked, WriteValue},
 };
 use rustc_hash::FxHashMap;
-use std::{fmt::Debug, sync::Arc};
+use std::{collections::VecDeque, fmt::Debug, mem, sync::Arc};
 use tachys::{
     html::attribute::{any_attribute::AnyAttribute, Attribute},
     hydration::Cursor,
     reactive_graph::OwnedView,
-    ssr::StreamBuilder,
+    ssr::{StreamBuilder, StreamChunk},
     view::{
         add_attr::AddAnyAttr, Mountable, Position, PositionState, Render,
         RenderHtml,
@@ -96,10 +97,12 @@ where
     let hook = hook as Arc<dyn ErrorHook>;
 
     let _guard = throw_error::set_error_hook(Arc::clone(&hook));
+    let suspended_children = ErrorBoundarySuspendedChildren::default();
 
     let owner = Owner::new();
     let children = owner.with(|| {
         provide_context(Arc::clone(&hook));
+        provide_context(suspended_children.clone());
         children.into_inner()()
     });
 
@@ -111,10 +114,14 @@ where
             children,
             errors,
             fallback,
+            suspended_children,
         },
         owner,
     )
 }
+
+pub(crate) type ErrorBoundarySuspendedChildren =
+    ArcStoredValue<Vec<oneshot::Receiver<()>>>;
 
 struct ErrorBoundaryView<Chil, FalFn> {
     hook: Arc<dyn ErrorHook>,
@@ -123,6 +130,7 @@ struct ErrorBoundaryView<Chil, FalFn> {
     children: Chil,
     fallback: FalFn,
     errors: ArcRwSignal<Errors>,
+    suspended_children: ErrorBoundarySuspendedChildren,
 }
 
 struct ErrorBoundaryViewState<Chil, Fal> {
@@ -257,6 +265,7 @@ where
             children,
             fallback,
             errors,
+            suspended_children,
         } = self;
         ErrorBoundaryView {
             hook,
@@ -265,6 +274,7 @@ where
             children: children.add_any_attr(attr.into_cloneable_owned()),
             fallback,
             errors,
+            suspended_children,
         }
     }
 }
@@ -292,6 +302,7 @@ where
             children,
             fallback,
             errors,
+            suspended_children,
             ..
         } = self;
         ErrorBoundaryView {
@@ -301,6 +312,7 @@ where
             children: children.resolve().await,
             fallback,
             errors,
+            suspended_children,
         }
     }
 
@@ -349,7 +361,8 @@ where
     ) where
         Self: Sized,
     {
-        let _hook = throw_error::set_error_hook(self.hook);
+        let _hook = throw_error::set_error_hook(Arc::clone(&self.hook));
+
         // first, attempt to serialize the children to HTML, then check for errors
         let mut new_buf = StreamBuilder::new(buf.clone_id());
         let mut new_pos = *position;
@@ -361,20 +374,74 @@ where
             extra_attrs.clone(),
         );
 
-        // any thrown errors would've been caught here
-        if self.errors.with_untracked(|map| map.is_empty()) {
-            buf.append(new_buf);
+        let suspense_children =
+            mem::take(&mut *self.suspended_children.write_value());
+
+        // not waiting for any suspended children: just render
+        if suspense_children.is_empty() {
+            // any thrown errors would've been caught here
+            if self.errors.with_untracked(|map| map.is_empty()) {
+                buf.append(new_buf);
+            } else {
+                // otherwise, serialize the fallback instead
+                let mut fallback = String::with_capacity(Fal::MIN_LENGTH);
+                (self.fallback)(self.errors).to_html_with_buf(
+                    &mut fallback,
+                    position,
+                    escape,
+                    mark_branches,
+                    extra_attrs,
+                );
+                buf.push_sync(&fallback);
+            }
         } else {
-            // otherwise, serialize the fallback instead
-            let mut fallback = String::with_capacity(Fal::MIN_LENGTH);
-            (self.fallback)(self.errors).to_html_with_buf(
-                &mut fallback,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
-            buf.push_sync(&fallback);
+            let mut position = *position;
+            // if we're waiting for suspended children, we'll first wait for them to load
+            // in this implementation, an ErrorBoundary that *contains* Suspense essentially acts
+            // like a Suspense: it will wait for (all top-level) child Suspense to load before rendering anything
+            let mut view_buf = StreamBuilder::new(new_buf.clone_id());
+            view_buf.next_id();
+            let hook = Arc::clone(&self.hook);
+            view_buf.push_async(async move {
+                let _hook = throw_error::set_error_hook(Arc::clone(&hook));
+                let _ = join_all(suspense_children).await;
+
+                let mut my_chunks = VecDeque::new();
+                for chunk in new_buf.take_chunks() {
+                    match chunk {
+                        StreamChunk::Sync(data) => {
+                            my_chunks.push_back(StreamChunk::Sync(data))
+                        }
+                        StreamChunk::Async { chunks } => {
+                            let chunks = chunks.await;
+                            my_chunks.extend(chunks);
+                        }
+                        StreamChunk::OutOfOrder { chunks } => {
+                            let chunks = chunks.await;
+                            my_chunks.extend(chunks.take_chunks());
+                        }
+                    }
+                }
+
+                if self.errors.with_untracked(|map| map.is_empty()) {
+                    // if no errors, just go ahead with the stream
+                    my_chunks
+                } else {
+                    // otherwise, serialize the fallback instead
+                    let mut fallback = String::with_capacity(Fal::MIN_LENGTH);
+                    (self.fallback)(self.errors).to_html_with_buf(
+                        &mut fallback,
+                        &mut position,
+                        escape,
+                        mark_branches,
+                        extra_attrs,
+                    );
+                    my_chunks.clear();
+                    my_chunks.push_back(StreamChunk::Sync(fallback));
+                    my_chunks
+                }
+            });
+            buf.append(view_buf);
         }
     }
 

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -1,5 +1,6 @@
 use crate::{
     children::{TypedChildren, ViewFnOnce},
+    error::ErrorBoundarySuspendedChildren,
     suspense_component::SuspenseBoundary,
     IntoView,
 };
@@ -7,7 +8,7 @@ use leptos_macro::component;
 use reactive_graph::{
     computed::{suspense::SuspenseContext, ArcMemo},
     effect::Effect,
-    owner::{provide_context, Owner},
+    owner::{provide_context, use_context, Owner},
     signal::ArcRwSignal,
     traits::{Get, Set, Track, With},
     wrappers::write::SignalSetter,
@@ -85,6 +86,8 @@ pub fn Transition<Chil>(
 where
     Chil: IntoView + Send + 'static,
 {
+    let error_boundary_parent = use_context::<ErrorBoundarySuspendedChildren>();
+
     let owner = Owner::new();
     owner.with(|| {
         let (starts_local, id) = {
@@ -123,6 +126,7 @@ where
             none_pending,
             fallback,
             children,
+            error_boundary_parent,
         })
     })
 }

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -82,6 +82,10 @@ impl StreamBuilder {
 
     /// Appends another stream to this one.
     pub fn append(&mut self, mut other: StreamBuilder) {
+        if !self.sync_buf.is_empty() {
+            self.chunks
+                .push_back(StreamChunk::Sync(mem::take(&mut self.sync_buf)));
+        }
         self.chunks.append(&mut other.chunks);
         self.sync_buf.push_str(&other.sync_buf);
     }
@@ -318,6 +322,11 @@ impl OooChunk {
             buf.push_str("close.remove();open.remove();");
         }
         buf.push_str("})()</script>");
+    }
+
+    /// Consumes this structure and returns its inner chunks of the stream.
+    pub fn take_chunks(self) -> VecDeque<StreamChunk> {
+        self.chunks
     }
 }
 

--- a/tachys/src/view/error_boundary.rs
+++ b/tachys/src/view/error_boundary.rs
@@ -33,7 +33,11 @@ where
         match (&mut state.state, self) {
             // both errors: throw the new error and replace
             (Either::Right(_), Err(new)) => {
-                state.error = Some(throw_error::throw(new.into()))
+                if let Some(old_error) =
+                    state.error.replace(throw_error::throw(new.into()))
+                {
+                    throw_error::clear(&old_error);
+                }
             }
             // both Ok: need to rebuild child
             (Either::Left(old), Ok(new)) => {


### PR DESCRIPTION
This PR should address issues #3850 (clearing the previous error when rebuilding a node from `Err(_)` to `Err(_)`) and #3851 (`ErrorBoundary` with child `Suspense` that contains a value that starts in the `Err(_)` state).

@sabify if you distilled those MREs from a larger or more complex example, please feel free to let me know if there are additional, unaddressed issues! 

The fix for #3851 in particular is a behavior change: it effectively turns any `<ErrorBoundary/>` that contains a `<Suspense/>` in its children into a `<Suspense/>` itself, so that it can wait for the children to load in order to know whether it needs to render its error fallback. It seems to work but I imagine there are also edge cases here that I have not foreseen.