### PR TITLE
fix(examples): incorrect routes in hackernews example (closes #3892)

### DIFF
--- a/examples/hackernews_islands_axum/src/fallback.rs
+++ b/examples/hackernews_islands_axum/src/fallback.rs
@@ -29,12 +29,14 @@ pub async fn file_and_error_handler(
     let static_result = get_static_file(uri.clone(), accept_encoding).await;
 
     match static_result {
-        Ok(res) => if res.status() == StatusCode::OK {
-            res.into_response()
-         } else {
-            (StatusCode::NOT_FOUND, "Not found.").into_response()
-        },
-        Err(e) => e.into_response()
+        Ok(res) => {
+            if res.status() == StatusCode::OK {
+                res.into_response()
+            } else {
+                (StatusCode::NOT_FOUND, "Not found.").into_response()
+            }
+        }
+        Err(e) => e.into_response(),
     }
 }
 

--- a/examples/hackernews_islands_axum/src/fallback.rs
+++ b/examples/hackernews_islands_axum/src/fallback.rs
@@ -26,12 +26,15 @@ pub async fn file_and_error_handler(
         .map(|h| h.to_str().unwrap_or("none"))
         .unwrap_or("none")
         .to_string();
-    let res = get_static_file(uri.clone(), accept_encoding).await.unwrap();
+    let static_result = get_static_file(uri.clone(), accept_encoding).await;
 
-    if res.status() == StatusCode::OK {
-        res.into_response()
-    } else {
-        (StatusCode::NOT_FOUND, "Not found.").into_response()
+    match static_result {
+        Ok(res) => if res.status() == StatusCode::OK {
+            res.into_response()
+         } else {
+            (StatusCode::NOT_FOUND, "Not found.").into_response()
+        },
+        Err(e) => e.into_response()
     }
 }
 

--- a/examples/hackernews_islands_axum/src/routes/stories.rs
+++ b/examples/hackernews_islands_axum/src/routes/stories.rs
@@ -47,7 +47,7 @@ pub fn Stories() -> impl IntoView {
     let stories = Resource::new(
         move || (page(), story_type()),
         move |(page, story_type)| async move {
-            fetch_stories(category(&story_type), page).await.ok()
+            fetch_stories(story_type, page).await.ok()
         },
     );
     let (pending, set_pending) = signal(false);


### PR DESCRIPTION
Avoid calling category() twice on the story type.