### PR TITLE
Fix some island-routing issues

### DIFF
--- a/examples/islands_router/Cargo.toml
+++ b/examples/islands_router/Cargo.toml
@@ -10,7 +10,11 @@ crate-type = ["cdylib", "rlib"]
 console_error_panic_hook = "0.1.7"
 futures = "0.3.30"
 http = "1.1"
-leptos = { path = "../../leptos", features = ["tracing", "islands"] }
+leptos = { path = "../../leptos", features = [
+  "tracing",
+  "islands",
+  "islands-router",
+] }
 leptos_router = { path = "../../router" }
 server_fn = { path = "../../server_fn", features = ["serde-lite"] }
 leptos_axum = { path = "../../integrations/axum", features = [

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -99,6 +99,7 @@ trace-component-props = [
   "leptos_dom/trace-component-props",
 ]
 delegation = ["tachys/delegation"]
+islands-router = ["tachys/mark_branches"]
 
 [build-dependencies]
 rustc_version = "0.4.1"

--- a/leptos/src/hydration/islands_routing.js
+++ b/leptos/src/hydration/islands_routing.js
@@ -180,6 +180,7 @@ function diffRange(oldDocument, oldRoot, newDocument, newRoot, oldEnd, newEnd) {
 	while (oldDocWalker.nextNode() && newDocWalker.nextNode()) {
 		oldNode = oldDocWalker.currentNode;
 		newNode = newDocWalker.currentNode;
+		console.log("in loop", oldNode, newNode);
 
 		if (oldNode == oldEnd || newNode == newEnd) {
 			break;

--- a/leptos/src/hydration/islands_routing.js
+++ b/leptos/src/hydration/islands_routing.js
@@ -180,7 +180,6 @@ function diffRange(oldDocument, oldRoot, newDocument, newRoot, oldEnd, newEnd) {
 	while (oldDocWalker.nextNode() && newDocWalker.nextNode()) {
 		oldNode = oldDocWalker.currentNode;
 		newNode = newDocWalker.currentNode;
-		console.log("in loop", oldNode, newNode);
 
 		if (oldNode == oldEnd || newNode == newEnd) {
 			break;

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -107,21 +107,19 @@ pub fn HydrationScripts(
         .unwrap_or_default();
 
     let root = root.unwrap_or_default();
-    use_context::<IslandsRouterNavigation>().is_none().then(|| {
-        view! {
-            <link rel="modulepreload" href=format!("{root}/{pkg_path}/{js_file_name}.js") nonce=nonce.clone()/>
-            <link
-                rel="preload"
-                href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
-                r#as="fetch"
-                r#type="application/wasm"
-                crossorigin=nonce.clone().unwrap_or_default()
-            />
-            <script type="module" nonce=nonce>
-                {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?});{islands_router}")}
-            </script>
-        }
-    })
+    view! {
+        <link rel="modulepreload" href=format!("{root}/{pkg_path}/{js_file_name}.js") nonce=nonce.clone()/>
+        <link
+            rel="preload"
+            href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
+            r#as="fetch"
+            r#type="application/wasm"
+            crossorigin=nonce.clone().unwrap_or_default()
+        />
+        <script type="module" nonce=nonce>
+            {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?});{islands_router}")}
+        </script>
+    }
 }
 
 /// If this is provided via context, it means that you are using the islands router and

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -357,24 +357,37 @@ impl ToTokens for Model {
 
         // add island wrapper if island
         let component = if is_island {
+            let is_server = cfg!(feature = "ssr");
             let hydrate_fn_name = hydrate_fn_name.as_ref().unwrap();
-            quote! {
-                {
-                    if ::leptos::context::use_context::<::leptos::reactive::owner::IsHydrating>()
-                        .map(|h| h.0)
-                        .unwrap_or(false) {
-                        ::leptos::either::Either::Left(
-                            #component
-                        )
-                    } else {
-                        ::leptos::either::Either::Right(
-                            ::leptos::tachys::html::islands::Island::new(
-                                stringify!(#hydrate_fn_name),
+            if is_server {
+                quote! {
+                    {
+                        // if we're on the server, and inside another island already,
+                        // *don't* add a <leptos-island> (this will hydrate them both separately)
+                        if ::leptos::context::use_context::<::leptos::reactive::owner::IsHydrating>()
+                            .map(|h| h.0)
+                            .unwrap_or(false) {
+                            ::leptos::either::Either::Left(
                                 #component
                             )
-                             #island_serialized_props
-                        )
+                        } else {
+                            ::leptos::either::Either::Right(
+                                ::leptos::tachys::html::islands::Island::new(
+                                    stringify!(#hydrate_fn_name),
+                                    #component
+                                )
+                                 #island_serialized_props
+                            )
+                        }
                     }
+                }
+            } else {
+                quote! {
+                    ::leptos::tachys::html::islands::Island::new(
+                        stringify!(#hydrate_fn_name),
+                        #component
+                    )
+                    #island_serialized_props
                 }
             }
         } else {

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -418,7 +418,7 @@ impl RenderHtml for MatchedRoute {
         mark_branches: bool,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        if mark_branches {
+        if mark_branches && escape {
             buf.open_branch(&self.0);
         }
         self.1.to_html_with_buf(
@@ -428,7 +428,7 @@ impl RenderHtml for MatchedRoute {
             mark_branches,
             extra_attrs,
         );
-        if mark_branches {
+        if mark_branches && escape {
             buf.close_branch(&self.0);
         }
     }
@@ -443,7 +443,7 @@ impl RenderHtml for MatchedRoute {
     ) where
         Self: Sized,
     {
-        if mark_branches {
+        if mark_branches && escape {
             buf.open_branch(&self.0);
         }
         self.1.to_html_async_with_buf::<OUT_OF_ORDER>(
@@ -453,7 +453,7 @@ impl RenderHtml for MatchedRoute {
             mark_branches,
             extra_attrs,
         );
-        if mark_branches {
+        if mark_branches && escape {
             buf.close_branch(&self.0);
         }
     }

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -186,6 +186,7 @@ reactive_graph = ["dep:reactive_graph", "dep:any_spawner"]
 reactive_stores = ["reactive_graph", "dep:reactive_stores"]
 sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils"]
 tracing = ["dep:tracing"]
+mark_branches = []
 
 [package.metadata.cargo-all-features]
 denylist = ["tracing", "sledgehammer"]

--- a/tachys/src/hydration.rs
+++ b/tachys/src/hydration.rs
@@ -84,22 +84,27 @@ where
         *self.0.borrow_mut() = node;
     }
 
-    /// Advances to the next placeholder node.
+    /// Advances to the next placeholder node and returns it
     pub fn next_placeholder(
         &self,
         position: &PositionState,
     ) -> crate::renderer::types::Placeholder {
         //crate::dom::log("looking for placeholder after");
         //Rndr::log_node(&self.current());
+        self.advance_to_placeholder(position);
+        let marker = self.current();
+        crate::renderer::types::Placeholder::cast_from(marker.clone())
+            .unwrap_or_else(|| failed_to_cast_marker_node(marker))
+    }
+
+    /// Advances to the next placeholder node.
+    pub fn advance_to_placeholder(&self, position: &PositionState) {
         if position.get() == Position::FirstChild {
             self.child();
         } else {
             self.sibling();
         }
-        let marker = self.current();
         position.set(Position::NextChild);
-        crate::renderer::types::Placeholder::cast_from(marker.clone())
-            .unwrap_or_else(|| failed_to_cast_marker_node(marker))
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -436,6 +436,12 @@ impl RenderHtml for AnyView {
     {
         #[cfg(feature = "ssr")]
         if OUT_OF_ORDER {
+            let type_id = mark_branches
+                .then(|| format!("{:?}", self.type_id))
+                .unwrap_or_default();
+            if mark_branches {
+                buf.open_branch(&type_id);
+            }
             (self.to_html_async_ooo)(
                 self.value,
                 buf,
@@ -444,6 +450,9 @@ impl RenderHtml for AnyView {
                 mark_branches,
                 extra_attrs,
             );
+            if mark_branches {
+                buf.close_branch(&type_id);
+            }
         } else {
             let type_id = mark_branches
                 .then(|| format!("{:?}", self.type_id))

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -498,13 +498,23 @@ impl RenderHtml for AnyView {
         position: &PositionState,
     ) -> Self::State {
         #[cfg(feature = "hydrate")]
-        if FROM_SERVER {
-            (self.hydrate_from_server)(self.value, cursor, position)
-        } else {
-            panic!(
-                "hydrating AnyView from inside a ViewTemplate is not \
-                 supported."
-            );
+        {
+            if FROM_SERVER {
+                if cfg!(feature = "mark_branches") {
+                    cursor.advance_to_placeholder(position);
+                }
+                let state =
+                    (self.hydrate_from_server)(self.value, cursor, position);
+                if cfg!(feature = "mark_branches") {
+                    cursor.advance_to_placeholder(position);
+                }
+                state
+            } else {
+                panic!(
+                    "hydrating AnyView from inside a ViewTemplate is not \
+                     supported."
+                );
+            }
         }
         #[cfg(not(feature = "hydrate"))]
         {

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -392,9 +392,11 @@ impl RenderHtml for AnyView {
     ) {
         #[cfg(feature = "ssr")]
         {
-            let type_id = mark_branches
-                .then(|| format!("{:?}", self.type_id))
-                .unwrap_or_default();
+            let type_id = if mark_branches {
+                format!("{:?}", self.type_id)
+            } else {
+                Default::default()
+            };
             if mark_branches {
                 buf.open_branch(&type_id);
             }
@@ -436,9 +438,11 @@ impl RenderHtml for AnyView {
     {
         #[cfg(feature = "ssr")]
         if OUT_OF_ORDER {
-            let type_id = mark_branches
-                .then(|| format!("{:?}", self.type_id))
-                .unwrap_or_default();
+            let type_id = if mark_branches {
+                format!("{:?}", self.type_id)
+            } else {
+                Default::default()
+            };
             if mark_branches {
                 buf.open_branch(&type_id);
             }
@@ -454,9 +458,11 @@ impl RenderHtml for AnyView {
                 buf.close_branch(&type_id);
             }
         } else {
-            let type_id = mark_branches
-                .then(|| format!("{:?}", self.type_id))
-                .unwrap_or_default();
+            let type_id = if mark_branches {
+                format!("{:?}", self.type_id)
+            } else {
+                Default::default()
+            };
             if mark_branches {
                 buf.open_branch(&type_id);
             }

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -392,12 +392,12 @@ impl RenderHtml for AnyView {
     ) {
         #[cfg(feature = "ssr")]
         {
-            let type_id = if mark_branches {
+            let type_id = if mark_branches && escape {
                 format!("{:?}", self.type_id)
             } else {
                 Default::default()
             };
-            if mark_branches {
+            if mark_branches && escape {
                 buf.open_branch(&type_id);
             }
             (self.to_html)(
@@ -408,7 +408,7 @@ impl RenderHtml for AnyView {
                 mark_branches,
                 extra_attrs,
             );
-            if mark_branches {
+            if mark_branches && escape {
                 buf.close_branch(&type_id);
             }
         }
@@ -438,12 +438,12 @@ impl RenderHtml for AnyView {
     {
         #[cfg(feature = "ssr")]
         if OUT_OF_ORDER {
-            let type_id = if mark_branches {
+            let type_id = if mark_branches && escape {
                 format!("{:?}", self.type_id)
             } else {
                 Default::default()
             };
-            if mark_branches {
+            if mark_branches && escape {
                 buf.open_branch(&type_id);
             }
             (self.to_html_async_ooo)(
@@ -454,16 +454,16 @@ impl RenderHtml for AnyView {
                 mark_branches,
                 extra_attrs,
             );
-            if mark_branches {
+            if mark_branches && escape {
                 buf.close_branch(&type_id);
             }
         } else {
-            let type_id = if mark_branches {
+            let type_id = if mark_branches && escape {
                 format!("{:?}", self.type_id)
             } else {
                 Default::default()
             };
-            if mark_branches {
+            if mark_branches && escape {
                 buf.open_branch(&type_id);
             }
             (self.to_html_async)(
@@ -474,7 +474,7 @@ impl RenderHtml for AnyView {
                 mark_branches,
                 extra_attrs,
             );
-            if mark_branches {
+            if mark_branches && escape {
                 buf.close_branch(&type_id);
             }
         }

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -389,14 +389,21 @@ where
         cursor: &Cursor,
         position: &PositionState,
     ) -> Self::State {
-        match self {
+        if cfg!(feature = "mark_branches") {
+            cursor.advance_to_placeholder(position);
+        }
+        let state = match self {
             Either::Left(left) => {
                 Either::Left(left.hydrate::<FROM_SERVER>(cursor, position))
             }
             Either::Right(right) => {
                 Either::Right(right.hydrate::<FROM_SERVER>(cursor, position))
             }
+        };
+        if cfg!(feature = "mark_branches") {
+            cursor.advance_to_placeholder(position);
         }
+        state
     }
 
     fn into_owned(self) -> Self::Owned {
@@ -888,11 +895,17 @@ macro_rules! tuples {
                     cursor: &Cursor,
                     position: &PositionState,
                 ) -> Self::State {
+                    if cfg!(feature = "mark_branches") {
+                        cursor.advance_to_placeholder(position);
+                    }
                     let state = match self {
                         $([<EitherOf $num>]::$ty(this) => {
                             [<EitherOf $num>]::$ty(this.hydrate::<FROM_SERVER>(cursor, position))
                         })*
                     };
+                    if cfg!(feature = "mark_branches") {
+                        cursor.advance_to_placeholder(position);
+                    }
 
                     Self::State { state }
                 }

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -308,7 +308,7 @@ where
     ) {
         match self {
             Either::Left(left) => {
-                if mark_branches {
+                if mark_branches && escape {
                     buf.open_branch("0");
                 }
                 left.to_html_with_buf(
@@ -318,12 +318,12 @@ where
                     mark_branches,
                     extra_attrs,
                 );
-                if mark_branches {
+                if mark_branches && escape {
                     buf.close_branch("0");
                 }
             }
             Either::Right(right) => {
-                if mark_branches {
+                if mark_branches && escape {
                     buf.open_branch("1");
                 }
                 right.to_html_with_buf(
@@ -333,7 +333,7 @@ where
                     mark_branches,
                     extra_attrs,
                 );
-                if mark_branches {
+                if mark_branches && escape {
                     buf.close_branch("1");
                 }
             }
@@ -352,7 +352,7 @@ where
     {
         match self {
             Either::Left(left) => {
-                if mark_branches {
+                if mark_branches && escape {
                     buf.open_branch("0");
                 }
                 left.to_html_async_with_buf::<OUT_OF_ORDER>(
@@ -362,12 +362,12 @@ where
                     mark_branches,
                     extra_attrs,
                 );
-                if mark_branches {
+                if mark_branches && escape {
                     buf.close_branch("0");
                 }
             }
             Either::Right(right) => {
-                if mark_branches {
+                if mark_branches && escape {
                     buf.open_branch("1");
                 }
                 right.to_html_async_with_buf::<OUT_OF_ORDER>(
@@ -377,7 +377,7 @@ where
                     mark_branches,
                     extra_attrs,
                 );
-                if mark_branches {
+                if mark_branches && escape {
                     buf.close_branch("1");
                 }
             }
@@ -849,11 +849,11 @@ macro_rules! tuples {
                 ) {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            if mark_branches {
+                            if mark_branches && escape {
                                 buf.open_branch(stringify!($ty));
                             }
                             this.to_html_with_buf(buf, position, escape, mark_branches, extra_attrs);
-                            if mark_branches {
+                            if mark_branches && escape {
                                 buf.close_branch(stringify!($ty));
                             }
                         })*
@@ -872,11 +872,11 @@ macro_rules! tuples {
                 {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            if mark_branches {
+                            if mark_branches && escape {
                                 buf.open_branch(stringify!($ty));
                             }
                             this.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches, extra_attrs);
-                            if mark_branches {
+                            if mark_branches && escape {
                                 buf.close_branch(stringify!($ty));
                             }
                         })*

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -252,12 +252,12 @@ where
         mark_branches: bool,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        if mark_branches {
+        if mark_branches && escape {
             buf.open_branch("for");
         }
         for (index, item) in self.items.into_iter().enumerate() {
             let (_, item) = (self.view_fn)(index, item);
-            if mark_branches {
+            if mark_branches && escape {
                 buf.open_branch("item");
             }
             item.to_html_with_buf(
@@ -267,12 +267,12 @@ where
                 mark_branches,
                 extra_attrs.clone(),
             );
-            if mark_branches {
+            if mark_branches && escape {
                 buf.close_branch("item");
             }
             *position = Position::NextChild;
         }
-        if mark_branches {
+        if mark_branches && escape {
             buf.close_branch("for");
         }
         buf.push_str("<!>");
@@ -286,7 +286,7 @@ where
         mark_branches: bool,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        if mark_branches {
+        if mark_branches && escape {
             buf.open_branch("for");
         }
         for (index, item) in self.items.into_iter().enumerate() {
@@ -296,7 +296,7 @@ where
                 format!("item-{key}")
             });
             let (_, item) = (self.view_fn)(index, item);
-            if mark_branches {
+            if mark_branches && escape {
                 buf.open_branch(branch_name.as_ref().unwrap());
             }
             item.to_html_async_with_buf::<OUT_OF_ORDER>(
@@ -306,12 +306,12 @@ where
                 mark_branches,
                 extra_attrs.clone(),
             );
-            if mark_branches {
+            if mark_branches && escape {
                 buf.close_branch(branch_name.as_ref().unwrap());
             }
             *position = Position::NextChild;
         }
-        if mark_branches {
+        if mark_branches && escape {
             buf.close_branch("for");
         }
         buf.push_sync("<!>");

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -322,6 +322,10 @@ where
         cursor: &Cursor,
         position: &PositionState,
     ) -> Self::State {
+        if cfg!(feature = "mark_branches") {
+            cursor.advance_to_placeholder(position);
+        }
+
         // get parent and position
         let current = cursor.current();
         let parent = if position.get() == Position::FirstChild {
@@ -342,11 +346,22 @@ where
         for (index, item) in items.enumerate() {
             hashed_items.insert((self.key_fn)(&item));
             let (set_index, view) = (self.view_fn)(index, item);
+            if cfg!(feature = "mark_branches") {
+                cursor.advance_to_placeholder(position);
+            }
             let item = view.hydrate::<FROM_SERVER>(cursor, position);
+            if cfg!(feature = "mark_branches") {
+                cursor.advance_to_placeholder(position);
+            }
             rendered_items.push(Some((set_index, item)));
         }
         let marker = cursor.next_placeholder(position);
         position.set(Position::NextChild);
+
+        if cfg!(feature = "mark_branches") {
+            cursor.advance_to_placeholder(position);
+        }
+
         KeyedState {
             parent: Some(parent),
             marker,


### PR DESCRIPTION
Looking at #3896 raised a few overlapping issues with out-of-order rendering, type-erasure, and island hydration when using the new/semi-experimental islands-routing feature. The commits in this PR return it to a working state, in and out of `erase_components` mode.