### PR TITLE
Fix some typos in the documentation/examples for reactive store.

### DIFF
--- a/examples/stores/README.md
+++ b/examples/stores/README.md
@@ -1,6 +1,6 @@
-# Leptos Counter Example
+# Stores Example
 
-This example creates a simple counter in a client side rendered app with Rust and WASM!
+This example shows how to use reactive stores, by building a client-side rendered TODO application.
 
 ## Getting Started
 

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -56,12 +56,12 @@
 //!
 //! # if false { // don't run effect in doctests
 //! Effect::new(move |_| {
-//!     // you can access individual store withs field a getter
+//!     // you can access individual store fields with a getter
 //!     println!("todos: {:?}", &*store.todos().read());
 //! });
 //! # }
 //!
-//! // won't notify the effect that listen to `todos`
+//! // won't notify the effect that listens to `todos`
 //! store.todos().write().push(Todo {
 //!     label: "Test".to_string(),
 //!     completed: false,
@@ -69,7 +69,7 @@
 //! ```
 //! ### Generated traits
 //! The [`Store`](macro@Store) macro generates traits for each `struct` to which it is applied.  When working
-//! within a single file more module, this is not an issue.  However, when working with multiple modules
+//! within a single file or module, this is not an issue.  However, when working with multiple modules
 //! or files, one needs to `use` the generated traits.  The general pattern is that for each `struct`
 //! named `Foo`, the macro generates a trait named `FooStoreFields`.  For example:
 //! ```rust


### PR DESCRIPTION
Fix some typos in the reactive store docs, and give a more specific description in the reactive store's example README.md