### PR TITLE
Remove unnecessary "crate::" prefix in a documentation example.

### DIFF
--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -140,7 +140,7 @@
 //! # use reactive_stores::Store;
 //! // Needed to use at_unkeyed() on Vec
 //! use reactive_stores::StoreFieldIter;
-//! use crate::reactive_stores::StoreFieldIterator;
+//! use reactive_stores::StoreFieldIterator;
 //! use reactive_graph::traits::Read;
 //! use reactive_graph::traits::Get;
 //!


### PR DESCRIPTION
Minor fix for better copy-paste when reading through the docs :)