### PR TITLE
Fix deprecated parameters js warning

### DIFF
--- a/leptos/src/hydration/island_script.js
+++ b/leptos/src/hydration/island_script.js
@@ -55,7 +55,7 @@
 	idle(() => {
 		import(`${root}/${pkg_path}/${output_name}.js`)
 			.then(mod => {
-				mod.default(`${root}/${pkg_path}/${wasm_output_name}.wasm`).then(() => {
+				mod.default({module_or_path: `${root}/${pkg_path}/${wasm_output_name}.wasm`}).then(() => {
 					mod.hydrate();
 					hydrateIslands(document.body, mod);
 				});


### PR DESCRIPTION
Nothing but copy/paste of this fix [PR](https://github.com/leptos-rs/leptos/pull/3219). In 0.8.2 with turned on islands we have the same warning as in the PR