### PR TITLE
fix: add namespace to g in svg portals (closes #3958)

### DIFF
--- a/leptos/src/portal.rs
+++ b/leptos/src/portal.rs
@@ -42,11 +42,15 @@ where
         let children = children.into_inner();
 
         Effect::new(move |_| {
-            let tag = if is_svg { "g" } else { "div" };
-
-            let container = document()
-                .create_element(tag)
-                .expect("element creation to work");
+            let container = if is_svg {
+                document()
+                    .create_element_ns(Some("http://www.w3.org/2000/svg"), "g")
+                    .expect("SVG element creation to work")
+            } else {
+                document()
+                    .create_element("div")
+                    .expect("HTML element creation to work")
+            };
 
             let render_root = if use_shadow {
                 container


### PR DESCRIPTION
Should fix the issue with invisible `<g>` elements created by Portals #3958