### PR TITLE
fix: smooshed static segments no longer matches the path #3968

### DIFF
--- a/router/src/matching/horizontal/mod.rs
+++ b/router/src/matching/horizontal/mod.rs
@@ -14,6 +14,22 @@ pub use static_segment::*;
 pub trait PossibleRouteMatch {
     fn optional(&self) -> bool;
 
+    /// Checks if this segment matches beginning of the path 
+    /// 
+    /// 
+    /// # Arguments
+    /// 
+    /// * path - unmatched reminder of the path. 
+    /// 
+    /// # Returns
+    /// 
+    /// If segment doesn't match a path then returns `None`. In case of a match returns the
+    /// information about which part of the path was matched.
+    /// 
+    /// 1. Paths which are empty `""` or just `"/"` should match.
+    /// 2. If you match just a path `"/"`, you should preserve the starting slash
+    ///    in the [remaining](PartialPathMatch::remaining) part, so other segments which will be 
+    ///    tested can detect wherever they are matching from the beginning of the given path segment.
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>>;
 
     fn generate_path(&self, path: &mut Vec<PathSegment>);

--- a/router/src/matching/horizontal/mod.rs
+++ b/router/src/matching/horizontal/mod.rs
@@ -14,21 +14,21 @@ pub use static_segment::*;
 pub trait PossibleRouteMatch {
     fn optional(&self) -> bool;
 
-    /// Checks if this segment matches beginning of the path 
-    /// 
-    /// 
+    /// Checks if this segment matches beginning of the path
+    ///
+    ///
     /// # Arguments
-    /// 
-    /// * path - unmatched reminder of the path. 
-    /// 
+    ///
+    /// * path - unmatched reminder of the path.
+    ///
     /// # Returns
-    /// 
+    ///
     /// If segment doesn't match a path then returns `None`. In case of a match returns the
     /// information about which part of the path was matched.
-    /// 
+    ///
     /// 1. Paths which are empty `""` or just `"/"` should match.
     /// 2. If you match just a path `"/"`, you should preserve the starting slash
-    ///    in the [remaining](PartialPathMatch::remaining) part, so other segments which will be 
+    ///    in the [remaining](PartialPathMatch::remaining) part, so other segments which will be
     ///    tested can detect wherever they are matching from the beginning of the given path segment.
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>>;
 

--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -69,7 +69,7 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
         let mut has_matched =
             self.0.as_path().is_empty() || self.0.as_path() == "/";
 
-        // match an initial / 
+        // match an initial /
         if let Some('/') = test.peek() {
             test.next();
 
@@ -80,8 +80,7 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
             {
                 this.next();
             }
-        }
-        else if !path.is_empty() {
+        } else if !path.is_empty() {
             // Path must start with `/` otherwise we are not certain about being at the beginning of the segment in the path
             return None;
         }
@@ -116,12 +115,12 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
         }
 
         // build the match object
-        let (matched, remaining) = if matched_len == 1 && path.starts_with('/') {
+        let (matched, remaining) = if matched_len == 1 && path.starts_with('/')
+        {
             // If only thing that matched is `/` we can't eat it, otherwise next invocation of the
             // test function will not be able to tell that we are matching from the beginning of the path segment
             ("/", path)
-        }
-        else {
+        } else {
             // the remaining is built from the path in, with the slice moved
             // by the length of this match
             path.split_at(matched_len)

--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -69,7 +69,7 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
         let mut has_matched =
             self.0.as_path().is_empty() || self.0.as_path() == "/";
 
-        // match an initial /
+        // match an initial / 
         if let Some('/') = test.peek() {
             test.next();
 
@@ -80,6 +80,10 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
             {
                 this.next();
             }
+        }
+        else if !path.is_empty() {
+            // Path must start with `/` otherwise we are not certain about being at the beginning of the segment in the path
+            return None;
         }
 
         for char in test {
@@ -112,9 +116,16 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
         }
 
         // build the match object
-        // the remaining is built from the path in, with the slice moved
-        // by the length of this match
-        let (matched, remaining) = path.split_at(matched_len);
+        let (matched, remaining) = if matched_len == 1 && path.starts_with('/') {
+            // If only thing that matched is `/` we can't eat it, otherwise next invocation of the
+            // test function will not be able to tell that we are matching from the beginning of the path segment
+            ("/", path)
+        }
+        else {
+            // the remaining is built from the path in, with the slice moved
+            // by the length of this match
+            path.split_at(matched_len)
+        };
         has_matched.then(|| PartialPathMatch::new(remaining, vec![], matched))
     }
 
@@ -226,6 +237,17 @@ mod tests {
     }
 
     #[test]
+    fn allow_empty_match() {
+        let path = "";
+        let def = StaticSegment("");
+        let matched = def.test(path).expect("couldn't match route");
+        assert_eq!(matched.matched(), "");
+        assert_eq!(matched.remaining(), "");
+        let params = matched.params();
+        assert!(params.is_empty());
+    }
+
+    #[test]
     fn tuple_static_mismatch() {
         let path = "/foo/baz";
         let def = (StaticSegment("foo"), StaticSegment("bar"));
@@ -235,6 +257,13 @@ mod tests {
     #[test]
     fn tuple_static_mismatch_on_enum() {
         let path = "/foo/baz";
+        let def = (StaticSegment(Foo), StaticSegment(Bar));
+        assert!(def.test(path).is_none());
+    }
+
+    #[test]
+    fn dont_match_smooshed_segments() {
+        let path = "/foobar";
         let def = (StaticSegment(Foo), StaticSegment(Bar));
         assert!(def.test(path).is_none());
     }

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -67,7 +67,7 @@ where
                 };
                 path.strip_prefix(base)?
             }
-        };        
+        };
 
         let (matched, remaining) = self.children.match_nested(path);
         let matched = matched?;
@@ -121,15 +121,15 @@ pub trait MatchNestedRoutes {
     type Match: MatchInterface + MatchParams;
 
     /// Matches nested routes
-    /// 
-    /// # Arguments 
-    /// 
+    ///
+    /// # Arguments
+    ///
     /// * path - A path which is being navigated to
-    /// 
+    ///
     /// # Returns
-    /// 
-    /// Tuple where 
-    /// 
+    ///
+    /// Tuple where
+    ///
     /// * 0 - If match has been found `Some` containing tuple where
     ///     * 0 - [RouteMatchId] identifying the matching route
     ///     * 1 - [Self::Match] matching route

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -67,7 +67,7 @@ where
                 };
                 path.strip_prefix(base)?
             }
-        };
+        };        
 
         let (matched, remaining) = self.children.match_nested(path);
         let matched = matched?;
@@ -120,6 +120,20 @@ pub trait MatchNestedRoutes {
     type Data;
     type Match: MatchInterface + MatchParams;
 
+    /// Matches nested routes
+    /// 
+    /// # Arguments 
+    /// 
+    /// * path - A path which is being navigated to
+    /// 
+    /// # Returns
+    /// 
+    /// Tuple where 
+    /// 
+    /// * 0 - If match has been found `Some` containing tuple where
+    ///     * 0 - [RouteMatchId] identifying the matching route
+    ///     * 1 - [Self::Match] matching route
+    /// * 1 - Remaining path
     fn match_nested<'a>(
         &'a self,
         path: &'a str,
@@ -147,7 +161,7 @@ mod tests {
         matching::MatchParams, MatchInterface, PathSegment, StaticSegment,
         WildcardSegment,
     };
-    use either_of::Either;
+    use either_of::{Either, EitherOf4};
 
     #[test]
     pub fn matches_single_root_route() {
@@ -324,12 +338,38 @@ mod tests {
         let params = matched.to_params();
         assert_eq!(params, vec![("any".into(), "foobar".into())]);
     }
+
+    #[test]
+    pub fn dont_match_smooshed_static_segments() {
+        let routes = RouteDefs::<_>::new((
+            NestedRoute::new(StaticSegment(""), || ()),
+            NestedRoute::new(StaticSegment("users"), || ()),
+            NestedRoute::new(
+                (StaticSegment("users"), StaticSegment("id")),
+                || (),
+            ),
+            NestedRoute::new(WildcardSegment("any"), || ()),
+        ));
+
+        let matched = routes.match_route("/users");
+        assert!(matches!(matched, Some(EitherOf4::B(..))));
+
+        let matched = routes.match_route("/users/id");
+        assert!(matches!(matched, Some(EitherOf4::C(..))));
+
+        let matched = routes.match_route("/usersid");
+        assert!(matches!(matched, Some(EitherOf4::D(..))));
+    }
 }
 
+/// Successful result of [testing](PossibleRouteMatch::test) a single segment in the route path
 #[derive(Debug)]
 pub struct PartialPathMatch<'a> {
+    /// unmatched yet part of the path
     pub(crate) remaining: &'a str,
+    /// value of parameters encoded inside of the path
     pub(crate) params: Vec<(Cow<'static, str>, String)>,
+    /// part of the original path that was matched by segment
     pub(crate) matched: &'a str,
 }
 


### PR DESCRIPTION
Fixes matching the path containing a smooshed static segments. 

`/barbaz` will no longer match `path!("/bar/baz")`