### PR TITLE
Provide error message if file hashing is enabled but no hash file is …

### DIFF
--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -83,6 +83,10 @@ pub fn HydrationScripts(
                     }
                 }
             }
+        } else {
+            leptos::logging::error!(
+                "File hashing is active but no hash file was found"
+            );
         }
     } else if std::option_env!("LEPTOS_OUTPUT_NAME").is_none() {
         wasm_file_name.push_str("_bg");


### PR DESCRIPTION
If file hashing is active and one forgets to deploy the hash.txt file, no warning/error is logged. Although this can be tracked down pretty quick, a QoL improvement is to log an error.

I decided to use an error rather than a warning because the app will be basically unusable.