### PR TITLE
fix: don't use `Arc::ptr_eq` for string comparison (closes #3983)

### DIFF
--- a/tachys/src/html/class.rs
+++ b/tachys/src/html/class.rs
@@ -473,7 +473,7 @@ impl IntoClass for Arc<str> {
 
     fn rebuild(self, state: &mut Self::State) {
         let (el, prev) = state;
-        if !Arc::ptr_eq(&self, prev) {
+        if self != *prev {
             Rndr::set_attribute(el, "class", &self);
         }
         *prev = self;

--- a/tachys/src/html/element/inner_html.rs
+++ b/tachys/src/html/element/inner_html.rs
@@ -292,7 +292,7 @@ impl InnerHtmlValue for Arc<str> {
     }
 
     fn rebuild(self, state: &mut Self::State) {
-        if !Arc::ptr_eq(&self, &state.1) {
+        if self != state.1 {
             Rndr::set_inner_html(&state.0, &self);
             state.1 = self;
         }

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -211,18 +211,20 @@ where
         let (name, mut f) = self;
         // Name might've updated:
         state.name = name;
+        let mut first_run = true;
         state.effect = RenderEffect::new_with_value(
             move |prev| {
                 let include = *f.invoke().borrow();
                 match prev {
                     Some((class_list, prev)) => {
                         if include {
-                            if !prev {
+                            if !prev || first_run {
                                 Rndr::add_class(&class_list, name);
                             }
                         } else if prev {
                             Rndr::remove_class(&class_list, name);
                         }
+                        first_run = false;
                         (class_list.clone(), include)
                     }
                     None => {

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -372,7 +372,7 @@ impl Render for Arc<str> {
 
     fn rebuild(self, state: &mut Self::State) {
         let ArcStrState { node, str } = state;
-        if !Arc::ptr_eq(&self, str) {
+        if self != *str {
             Rndr::set_text(node, &self);
             *str = self;
         }


### PR DESCRIPTION
Getting cute with little optimizations can lead to weird little bugs.

See further discussion in #3983.