### PR TITLE
Fix context issues with nesting routing

### DIFF
--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -167,6 +167,7 @@ impl Owner {
                     .map(|parent| parent.read().or_poisoned().arena.clone())
                     .unwrap_or_default(),
                 paused: false,
+                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context,
@@ -201,6 +202,7 @@ impl Owner {
                 #[cfg(feature = "sandboxed-arenas")]
                 arena: Default::default(),
                 paused: false,
+                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context,
@@ -226,6 +228,7 @@ impl Owner {
                 #[cfg(feature = "sandboxed-arenas")]
                 arena,
                 paused,
+                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context: self.shared_context.clone(),
@@ -455,6 +458,7 @@ pub(crate) struct OwnerInner {
     #[cfg(feature = "sandboxed-arenas")]
     arena: Arc<RwLock<ArenaMap>>,
     paused: bool,
+    joined_owners: Vec<Owner>,
 }
 
 impl Debug for OwnerInner {

--- a/reactive_graph/src/owner/context.rs
+++ b/reactive_graph/src/owner/context.rs
@@ -3,9 +3,19 @@ use or_poisoned::OrPoisoned;
 use std::{
     any::{Any, TypeId},
     collections::VecDeque,
+    sync::Arc,
 };
 
 impl Owner {
+    #[doc(hidden)]
+    pub fn join_contexts(&self, other: &Owner) {
+        self.inner
+            .write()
+            .or_poisoned()
+            .joined_owners
+            .push(other.clone());
+    }
+
     fn provide_context<T: Send + Sync + 'static>(&self, value: T) {
         self.inner
             .write()
@@ -26,17 +36,26 @@ impl Owner {
         if let Some(context) = contexts.remove(&ty) {
             context.downcast::<T>().ok().map(|n| *n)
         } else {
-            while let Some(ref this_parent) = parent.clone() {
-                let mut this_parent = this_parent.write().or_poisoned();
-                let contexts = &mut this_parent.contexts;
-                let value = contexts.remove(&ty);
-                let downcast =
-                    value.and_then(|context| context.downcast::<T>().ok());
-                if let Some(value) = downcast {
-                    return Some(*value);
-                } else {
-                    parent =
-                        this_parent.parent.as_ref().and_then(|p| p.upgrade());
+            let parent = inner.parent.as_ref().and_then(|p| p.upgrade());
+            let joined = inner
+                .joined_owners
+                .iter()
+                .map(|owner| Arc::clone(&owner.inner));
+            for parent in parent.into_iter().chain(joined) {
+                while let Some(ref this_parent) = parent.clone() {
+                    let mut this_parent = this_parent.write().or_poisoned();
+                    let contexts = &mut this_parent.contexts;
+                    let value = contexts.remove(&ty);
+                    let downcast =
+                        value.and_then(|context| context.downcast::<T>().ok());
+                    if let Some(value) = downcast {
+                        return Some(*value);
+                    } else {
+                        parent = this_parent
+                            .parent
+                            .as_ref()
+                            .and_then(|p| p.upgrade());
+                    }
                 }
             }
             None
@@ -49,22 +68,31 @@ impl Owner {
     ) -> Option<R> {
         let ty = TypeId::of::<T>();
         let inner = self.inner.read().or_poisoned();
-        let mut parent = inner.parent.as_ref().and_then(|p| p.upgrade());
         let contexts = &inner.contexts;
         let reference = if let Some(context) = contexts.get(&ty) {
             context.downcast_ref::<T>()
         } else {
-            while let Some(ref this_parent) = parent.clone() {
-                let this_parent = this_parent.read().or_poisoned();
-                let contexts = &this_parent.contexts;
-                let value = contexts.get(&ty);
-                let downcast =
-                    value.and_then(|context| context.downcast_ref::<T>());
-                if let Some(value) = downcast {
-                    return Some(cb(value));
-                } else {
-                    parent =
-                        this_parent.parent.as_ref().and_then(|p| p.upgrade());
+            let parent = inner.parent.as_ref().and_then(|p| p.upgrade());
+            let joined = inner
+                .joined_owners
+                .iter()
+                .map(|owner| Arc::clone(&owner.inner));
+            for parent in parent.into_iter().chain(joined) {
+                let mut parent = Some(parent);
+                while let Some(ref this_parent) = parent.clone() {
+                    let this_parent = this_parent.read().or_poisoned();
+                    let contexts = &this_parent.contexts;
+                    let value = contexts.get(&ty);
+                    let downcast =
+                        value.and_then(|context| context.downcast_ref::<T>());
+                    if let Some(value) = downcast {
+                        return Some(cb(value));
+                    } else {
+                        parent = this_parent
+                            .parent
+                            .as_ref()
+                            .and_then(|p| p.upgrade());
+                    }
                 }
             }
             None
@@ -83,17 +111,26 @@ impl Owner {
         let reference = if let Some(context) = contexts.get_mut(&ty) {
             context.downcast_mut::<T>()
         } else {
-            while let Some(ref this_parent) = parent.clone() {
-                let mut this_parent = this_parent.write().or_poisoned();
-                let contexts = &mut this_parent.contexts;
-                let value = contexts.get_mut(&ty);
-                let downcast =
-                    value.and_then(|context| context.downcast_mut::<T>());
-                if let Some(value) = downcast {
-                    return Some(cb(value));
-                } else {
-                    parent =
-                        this_parent.parent.as_ref().and_then(|p| p.upgrade());
+            let parent = inner.parent.as_ref().and_then(|p| p.upgrade());
+            let joined = inner
+                .joined_owners
+                .iter()
+                .map(|owner| Arc::clone(&owner.inner));
+            for parent in parent.into_iter().chain(joined) {
+                while let Some(ref this_parent) = parent.clone() {
+                    let mut this_parent = this_parent.write().or_poisoned();
+                    let contexts = &mut this_parent.contexts;
+                    let value = contexts.get_mut(&ty);
+                    let downcast =
+                        value.and_then(|context| context.downcast_mut::<T>());
+                    if let Some(value) = downcast {
+                        return Some(cb(value));
+                    } else {
+                        parent = this_parent
+                            .parent
+                            .as_ref()
+                            .and_then(|p| p.upgrade());
+                    }
                 }
             }
             None


### PR DESCRIPTION
@benwis provided me another reproduction similar to the issue #3042, which I simplified to this:
```rust
#[component]
pub fn App() -> impl IntoView {
    view! {
        <Router>
            <main>
                <Routes fallback=|| "Not found">
                    <ParentRoute path=StaticSegment("") view=|| view! {
                        <Provider value=42i32>
                            <Outlet/>
                        </Provider>
                    }>
                        <Route path=StaticSegment("") view=HomePage/>
                    </ParentRoute>
                </Routes>
            </main>
        </Router>
    }
}

#[component]
fn HomePage() -> impl IntoView {
    let value = use_context::<i32>();

    view! {
        <p>{format!("{value:?}")}</p>
    }
}
```

The issue here is that currently an `Outlet` is slotted into the ownership tree as the child of its parent's `view`, not in the location where the `Outlet` itself is consumed. This is important to the way `Outlet` itself works, because it uses context to determine which route it's supposed to be rendering. But it causes the issue that context provided inside something like a `Provider` or a `move || Suspend::new()` does not reach the `Outlet`, because the `Outlet` is a child of the parent `view`. So you would expect the tree to be
```
parent view
|_ Provider
  |_ Outlet
```
but really it is
```
parent view
|_ Provider
|_ Outlet
```

This PR adds a new concept to the ownership model, which is the idea of "joining owners" solely for the sake of context. All this does is allow you to add additional owners that will be searched for context. 

I then used this to join together the two owners here: the owner of the route itself, and the owner where it is used. This means that context will as you expect it, even in cases where you conditionally/dynamically render the `Outlet`, which is much better.

This would benefit from further testing but I'm about to log off to eat dinner!

cc: @benwis @zakstucke 