### PR TITLE
remove unnecessary where-clauses

### DIFF
--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -615,10 +615,7 @@ macro_rules! reactive_impl {
             fn add_any_attr<NewAttr: Attribute>(
                 self,
                 _attr: NewAttr,
-            ) -> Self::Output<NewAttr>
-            where
-                Self::Output<NewAttr>: RenderHtml,
-            {
+            ) -> Self::Output<NewAttr> {
                 todo!()
             }
         }

--- a/tachys/src/view/template.rs
+++ b/tachys/src/view/template.rs
@@ -62,10 +62,7 @@ where
     fn add_any_attr<NewAttr: Attribute>(
         self,
         _attr: NewAttr,
-    ) -> Self::Output<NewAttr>
-    where
-        Self::Output<NewAttr>: RenderHtml,
-    {
+    ) -> Self::Output<NewAttr> {
         panic!("AddAnyAttr not supported on ViewTemplate");
     }
 }


### PR DESCRIPTION
Uncovered during a crater run for `-Znext-solver` in https://github.com/rust-lang/rust/pull/133502.

These where-clauses cause `tachys` to fail with an overflow error when compiling with the next-generation trait solver right now: https://github.com/rust-lang/trait-system-refactor-initiative/issues/89. We're still unsure whether we actually have to break this when stabilizing the new solver, so it may not be an issue in the end. This breakage is a really subtle issue and quite unfortunate.

Luckily, this PR should be neutral or even desirable by itself, so I think it's fine to merge it regardless of whether it'll be actually necessary to avoid future breakage.

In case this looks good to you, it would be awesome if you could release this change as a point-release for version 0.2 and maybe even backport it to 0.1. It would really help us with our work on the new trait solver.

:rabbit: 