### PR TITLE
Update `session_auth_axum` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "tachys"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "any_spawner",
  "async-trait",

--- a/projects/session_auth_axum/Cargo.toml
+++ b/projects/session_auth_axum/Cargo.toml
@@ -19,9 +19,9 @@ leptos_router = { path = "../../router" }
 log = "0.4.0"
 simple_logger = "5.0"
 serde = { version = "1.0", features = ["derive"] }
-axum = { version = "0.7.0", optional = true, features = ["macros"] }
-tower = { version = "0.4.0", optional = true }
-tower-http = { version = "0.5.0", features = ["fs"], optional = true }
+axum = { version = "0.8.0", optional = true, features = ["macros"] }
+tower = { version = "0.5.0", optional = true }
+tower-http = { version = "0.6.0", features = ["fs"], optional = true }
 tokio = { version = "1.0", features = ["full"], optional = true }
 http = { version = "1.0" }
 sqlx = { version = "0.8.0", features = [
@@ -30,10 +30,13 @@ sqlx = { version = "0.8.0", features = [
 ], optional = true }
 thiserror = "1.0"
 wasm-bindgen = "0.2.0"
-axum_session_auth = { version = "0.14.0", features = [], optional = true }
-axum_session = { version = "0.14.0", features = [], optional = true }
-axum_session_sqlx = { version = "0.3.0", features = [ "sqlite", "tls-rustls"], optional = true }
-bcrypt = { version = "0.15.0", optional = true }
+axum_session_auth = { version = "0.16.0", features = [], optional = true }
+axum_session = { version = "0.16.0", features = [], optional = true }
+axum_session_sqlx = { version = "0.5.0", features = [
+  "sqlite",
+  "tls-rustls",
+], optional = true }
+bcrypt = { version = "0.17.0", optional = true }
 async-trait = { version = "0.1.0", optional = true }
 
 [features]

--- a/projects/session_auth_axum/src/auth.rs
+++ b/projects/session_auth_axum/src/auth.rs
@@ -185,7 +185,7 @@ pub async fn foo() -> Result<String, ServerFnError> {
 pub async fn get_user() -> Result<Option<User>, ServerFnError> {
     use crate::todo::ssr::auth;
 
-    let auth = auth()?;
+    let auth = auth().await?;
 
     Ok(auth.current_user)
 }
@@ -199,7 +199,7 @@ pub async fn login(
     use self::ssr::*;
 
     let pool = pool()?;
-    let auth = auth()?;
+    let auth = auth().await?;
 
     let (user, UserPasshash(expected_passhash)) =
         User::get_from_username_with_passhash(username, &pool)
@@ -229,7 +229,7 @@ pub async fn signup(
     use self::ssr::*;
 
     let pool = pool()?;
-    let auth = auth()?;
+    let auth = auth().await?;
 
     if password != password_confirmation {
         return Err(ServerFnError::ServerError(
@@ -264,7 +264,7 @@ pub async fn signup(
 pub async fn logout() -> Result<(), ServerFnError> {
     use self::ssr::*;
 
-    let auth = auth()?;
+    let auth = auth().await?;
 
     auth.logout_user();
     leptos_axum::redirect("/");

--- a/projects/session_auth_axum/src/main.rs
+++ b/projects/session_auth_axum/src/main.rs
@@ -109,7 +109,7 @@ async fn main() {
     // build our application with a route
     let app = Router::new()
         .route(
-            "/api/*fn_name",
+            "/api/{fn_name}",
             get(server_fn_handler).post(server_fn_handler),
         )
         .leptos_routes_with_handler(routes, get(leptos_routes_handler))

--- a/projects/session_auth_axum/src/main.rs
+++ b/projects/session_auth_axum/src/main.rs
@@ -1,61 +1,11 @@
-use axum::{
-    body::Body as AxumBody,
-    extract::{Path, State},
-    http::Request,
-    response::{IntoResponse, Response},
-    routing::get,
-    Router,
-};
+use axum::Router;
 use axum_session::{SessionConfig, SessionLayer, SessionStore};
 use axum_session_auth::{AuthConfig, AuthSessionLayer};
 use axum_session_sqlx::SessionSqlitePool;
-use leptos::{
-    config::get_configuration, logging::log, prelude::provide_context,
-};
-use leptos_axum::{
-    generate_route_list, handle_server_fns_with_context, LeptosRoutes,
-};
-use session_auth_axum::{
-    auth::{ssr::AuthSession, User},
-    state::AppState,
-    todo::*,
-};
+use leptos::{config::get_configuration, logging::log};
+use leptos_axum::{generate_route_list, LeptosRoutes};
+use session_auth_axum::{auth::User, state::AppState, todo::*};
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
-
-async fn server_fn_handler(
-    State(app_state): State<AppState>,
-    auth_session: AuthSession,
-    path: Path<String>,
-    request: Request<AxumBody>,
-) -> impl IntoResponse {
-    log!("{:?}", path);
-
-    handle_server_fns_with_context(
-        move || {
-            provide_context(auth_session.clone());
-            provide_context(app_state.pool.clone());
-        },
-        request,
-    )
-    .await
-}
-
-async fn leptos_routes_handler(
-    auth_session: AuthSession,
-    state: State<AppState>,
-    req: Request<AxumBody>,
-) -> Response {
-    let State(app_state) = state.clone();
-    let handler = leptos_axum::render_route_with_context(
-        app_state.routes.clone(),
-        move || {
-            provide_context(auth_session.clone());
-            provide_context(app_state.pool.clone());
-        },
-        move || shell(app_state.leptos_options.clone()),
-    );
-    handler(state, req).await.into_response()
-}
 
 #[tokio::main]
 async fn main() {
@@ -82,18 +32,6 @@ async fn main() {
         eprintln!("{e:?}");
     }
 
-    // Explicit server function registration is no longer required
-    // on the main branch. On 0.3.0 and earlier, uncomment the lines
-    // below to register the server functions.
-    // _ = GetTodos::register();
-    // _ = AddTodo::register();
-    // _ = DeleteTodo::register();
-    // _ = Login::register();
-    // _ = Logout::register();
-    // _ = Signup::register();
-    // _ = GetUser::register();
-    // _ = Foo::register();
-
     // Setting this to None means we'll be using cargo-leptos and its env vars
     let conf = get_configuration(None).unwrap();
     let leptos_options = conf.leptos_options;
@@ -108,11 +46,10 @@ async fn main() {
 
     // build our application with a route
     let app = Router::new()
-        .route(
-            "/api/{fn_name}",
-            get(server_fn_handler).post(server_fn_handler),
-        )
-        .leptos_routes_with_handler(routes, get(leptos_routes_handler))
+        .leptos_routes(&app_state, routes, {
+            let options = app_state.leptos_options.clone();
+            move || shell(options.clone())
+        })
         .fallback(leptos_axum::file_and_error_handler::<AppState, _>(shell))
         .layer(
             AuthSessionLayer::<User, i64, SessionSqlitePool, SqlitePool>::new(

--- a/projects/session_auth_axum/src/todo.rs
+++ b/projects/session_auth_axum/src/todo.rs
@@ -16,19 +16,21 @@ pub struct Todo {
 #[cfg(feature = "ssr")]
 pub mod ssr {
     use super::Todo;
-    use crate::auth::{ssr::AuthSession, User};
+    use crate::{
+        auth::{ssr::AuthSession, User},
+        state::AppState,
+    };
     use leptos::prelude::*;
     use sqlx::SqlitePool;
 
     pub fn pool() -> Result<SqlitePool, ServerFnError> {
-        use_context::<SqlitePool>()
+        with_context::<AppState, _>(|state| state.pool.clone())
             .ok_or_else(|| ServerFnError::ServerError("Pool missing.".into()))
     }
 
-    pub fn auth() -> Result<AuthSession, ServerFnError> {
-        use_context::<AuthSession>().ok_or_else(|| {
-            ServerFnError::ServerError("Auth session missing.".into())
-        })
+    pub async fn auth() -> Result<AuthSession, ServerFnError> {
+        let auth = leptos_axum::extract().await?;
+        Ok(auth)
     }
 
     #[derive(sqlx::FromRow, Clone)]
@@ -165,7 +167,7 @@ pub fn TodoApp() -> impl IntoView {
                                         ", "
                                         <A href="/login">"Login"</A>
                                         ", "
-                                        <span>{format!("Login error: {}", e)}</span>
+                                        <span>{format!("Login error: {e}")}</span>
                                     }
                                         .into_any()
                                 }

--- a/projects/session_auth_axum/src/todo.rs
+++ b/projects/session_auth_axum/src/todo.rs
@@ -1,7 +1,7 @@
 use crate::{auth::*, error_template::ErrorTemplate};
 use leptos::prelude::*;
 use leptos_meta::*;
-use leptos_router::{components::*, *};
+use leptos_router::{components::*, path};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
There's a bunch of ceremony in the current version of the example that is no longer necessary in the present version of the framework: specifically the custom handlers are not needed. 