### PR TITLE
enhance: handle ../ in aria-current for A tags

### DIFF
--- a/router/src/link.rs
+++ b/router/src/link.rs
@@ -133,16 +133,14 @@ where
         let is_active = {
             let href = href.clone();
             move || {
-                href.read().as_deref().is_some_and(|to| {
-                    let path = normalize_path(to);
-                    current_url.with(|loc| {
-                        let loc = loc.path();
-                        if exact {
-                            loc == path
-                        } else {
-                            is_active_for(&path, loc, strict_trailing_slash)
-                        }
-                    })
+                let path = normalize_path(&href.read());
+                current_url.with(|loc| {
+                    let loc = loc.path();
+                    if exact {
+                        loc == path
+                    } else {
+                        is_active_for(&path, loc, strict_trailing_slash)
+                    }
                 })
             }
         };


### PR DESCRIPTION
This correctly sets the aria-current attribute on a tags when the provided href matches the current location after resolving the href for page back navigations (`../`).

Rust playground suggests this to be around a 1.5 ms performance hit for a vector of 100000 elements, but that probably doesn't mirror real world examples. This could be made faster by replacing the `insert_str` with `push_str` and reversing the iterator before the fold again, but that break the filter.