### PR TITLE
Bugfixes to `reactive_stores`

### DIFF
--- a/reactive_stores/src/store_field.rs
+++ b/reactive_stores/src/store_field.rs
@@ -64,7 +64,7 @@ pub trait StoreField: Sized {
 
         // build a list of triggers, starting with the full path to this node and ending with the root
         // this will mean that the root is the final item, and this path is first
-        let mut triggers = Vec::with_capacity(full_path.len());
+        let mut triggers = Vec::with_capacity(full_path.len() + 2);
         triggers.push(trigger.this.clone());
         triggers.push(trigger.children.clone());
         loop {

--- a/reactive_stores/src/store_field.rs
+++ b/reactive_stores/src/store_field.rs
@@ -60,20 +60,16 @@ pub trait StoreField: Sized {
     fn triggers_for_path(&self, path: StorePath) -> Vec<ArcTrigger> {
         let trigger = self.get_trigger(path.clone());
         let mut full_path = path;
-        full_path.pop();
 
         // build a list of triggers, starting with the full path to this node and ending with the root
         // this will mean that the root is the final item, and this path is first
         let mut triggers = Vec::with_capacity(full_path.len() + 2);
         triggers.push(trigger.this.clone());
         triggers.push(trigger.children.clone());
-        loop {
+        while !full_path.is_empty() {
+            full_path.pop();
             let inner = self.get_trigger(full_path.clone());
             triggers.push(inner.children.clone());
-            if full_path.is_empty() {
-                break;
-            }
-            full_path.pop();
         }
 
         // when the WriteGuard is dropped, each trigger will be notified, in order

--- a/reactive_stores/src/subfield.rs
+++ b/reactive_stores/src/subfield.rs
@@ -114,21 +114,19 @@ where
     #[track_caller]
     fn track_field(&self) {
         let mut full_path = self.path().into_iter().collect::<StorePath>();
+        let trigger = self.get_trigger(self.path().into_iter().collect());
+        trigger.this.track();
+        trigger.children.track();
+
         // tracks `this` for all ancestors: i.e., it will track any change that is made
         // directly to one of its ancestors, but not a change made to a *child* of an ancestor
         // (which would end up with every subfield tracking its own siblings, because they are
         // children of its parent)
-        loop {
+        while !full_path.is_empty() {
+            full_path.pop();
             let inner = self.get_trigger(full_path.clone());
             inner.this.track();
-            if full_path.is_empty() {
-                break;
-            }
-            full_path.pop();
         }
-        let trigger = self.get_trigger(self.path().into_iter().collect());
-        trigger.this.track();
-        trigger.children.track();
     }
 }
 


### PR DESCRIPTION
Fixes the following:
- `StoreField::triggers_for_path`: Too small vec capacity calculation potentially causing reallocations
- `StoreField::triggers_for_path`: Duplicate trigger when path is empty
- `Subfield::track_field`: Duplicate track on `this` trigger

Also rewrites `Subfield::track_field` to skip 1 `get_trigger`