### PR TITLE
fix: do not track anything inside the `async` block of a `Resource` (closes #4060)

### DIFF
--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -518,7 +518,9 @@ impl<T: 'static> ArcAsyncDerived<T> {
     {
         let fun = move || {
             let fut = fun();
-            async move { SendOption::new(Some(fut.await)) }
+            ScopedFuture::new_untracked(async move {
+                SendOption::new(Some(fut.await))
+            })
         };
         let initial_value = SendOption::new(initial_value);
         let (this, _) = spawn_derived!(

--- a/reactive_graph/src/computed/async_derived/mod.rs
+++ b/reactive_graph/src/computed/async_derived/mod.rs
@@ -42,6 +42,18 @@ impl<Fut> ScopedFuture<Fut> {
             fut,
         }
     }
+
+    /// Wraps the given `Future` by taking the current [`Owner`] re-setting it as the
+    /// active owner every time the inner `Future` is polled. Always untracks, i.e., clears
+    /// the active [`Observer`] when polled.
+    pub fn new_untracked(fut: Fut) -> Self {
+        let owner = Owner::current().unwrap_or_default();
+        Self {
+            owner,
+            observer: None,
+            fut,
+        }
+    }
 }
 
 impl<Fut: Future> Future for ScopedFuture<Fut> {


### PR DESCRIPTION
Resources are not supposed to track anything inside the `async` block: rather, anything you need to track is tracked in the first argument. This allows us to only track the first argument on the client, and not run the `async` block again until something in the first argument has changed.

However, #4060 shows that when you read from another resource via `.await`, and that first resource is not actually ready, it was actually getting tracked and causing the second (dependent) resource to re-run when the first resource completed, which is not correct.

This corrects that behavior, fixing the problem in #4060.

I think this falls into the awkward category in which it 1) fixes a bug, 2) doesn't change the type/won't break compilation of existing code, but 3) could hypothetically break (incorrect-but-compiling) existing code that depends on the bugged behavior. However I think it's worth making the fix (assuming I didn't break something else obvious), because you almost certainly don't actually want to trigger those `async` blocks multiple times unnecessarily, as they are typically used for something that has real side effects (like calling a server function, etc.)