### PR TITLE
fix: memory leak introduced by #4015

### DIFF
--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -484,7 +484,10 @@ impl<T: 'static> ArcAsyncDerived<T> {
     {
         let fun = move || {
             let fut = fun();
-            async move { SendOption::new(Some(fut.await)) }
+            let fut = async move { SendOption::new(Some(fut.await)) };
+            #[cfg(feature = "sandboxed-arenas")]
+            let fut = Sandboxed::new(fut);
+            fut
         };
         let initial_value = SendOption::new(initial_value);
         let (this, _) = spawn_derived!(
@@ -518,9 +521,12 @@ impl<T: 'static> ArcAsyncDerived<T> {
     {
         let fun = move || {
             let fut = fun();
-            ScopedFuture::new_untracked(async move {
+            let fut = ScopedFuture::new_untracked(async move {
                 SendOption::new(Some(fut.await))
-            })
+            });
+            #[cfg(feature = "sandboxed-arenas")]
+            let fut = Sandboxed::new(fut);
+            fut
         };
         let initial_value = SendOption::new(initial_value);
         let (this, _) = spawn_derived!(
@@ -562,7 +568,10 @@ impl<T: 'static> ArcAsyncDerived<T> {
     {
         let fun = move || {
             let fut = fun();
-            async move { SendOption::new_local(Some(fut.await)) }
+            let fut = async move { SendOption::new_local(Some(fut.await)) };
+            #[cfg(feature = "sandboxed-arenas")]
+            let fut = Sandboxed::new(fut);
+            fut
         };
         let initial_value = SendOption::new_local(initial_value);
         let (this, _) = spawn_derived!(
@@ -598,7 +607,10 @@ impl<T: 'static> ArcAsyncDerived<T> {
         let initial = SendOption::new_local(None::<T>);
         let fun = move || {
             let fut = fun();
-            async move { SendOption::new_local(Some(fut.await)) }
+            let fut = async move { SendOption::new_local(Some(fut.await)) };
+            #[cfg(feature = "sandboxed-arenas")]
+            let fut = Sandboxed::new(fut);
+            fut
         };
         let (this, _) = spawn_derived!(
             crate::spawn_local,

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -458,7 +458,7 @@ pub(crate) struct OwnerInner {
     #[cfg(feature = "sandboxed-arenas")]
     arena: Arc<RwLock<ArenaMap>>,
     paused: bool,
-    joined_owners: Vec<Owner>,
+    joined_owners: Vec<WeakOwner>,
 }
 
 impl Debug for OwnerInner {

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -291,12 +291,18 @@ impl Owner {
     /// fill the same need as an "on unmount" function in other UI approaches, etc.
     pub fn on_cleanup(fun: impl FnOnce() + Send + Sync + 'static) {
         if let Some(owner) = Owner::current() {
-            owner
-                .inner
-                .write()
-                .or_poisoned()
-                .cleanups
-                .push(Box::new(fun));
+            let mut inner = owner.inner.write().or_poisoned();
+
+            #[cfg(feature = "sandboxed-arenas")]
+            let fun = {
+                let arena = Arc::clone(&inner.arena);
+                move || {
+                    Arena::set(&arena);
+                    fun()
+                }
+            };
+
+            inner.cleanups.push(Box::new(fun));
         }
     }
 

--- a/reactive_graph/src/owner/context.rs
+++ b/reactive_graph/src/owner/context.rs
@@ -3,7 +3,6 @@ use or_poisoned::OrPoisoned;
 use std::{
     any::{Any, TypeId},
     collections::VecDeque,
-    sync::Arc,
 };
 
 impl Owner {
@@ -13,7 +12,7 @@ impl Owner {
             .write()
             .or_poisoned()
             .joined_owners
-            .push(other.clone());
+            .push(other.downgrade());
     }
 
     fn provide_context<T: Send + Sync + 'static>(&self, value: T) {
@@ -39,7 +38,7 @@ impl Owner {
             let joined = inner
                 .joined_owners
                 .iter()
-                .map(|owner| Arc::clone(&owner.inner));
+                .flat_map(|owner| owner.upgrade().map(|owner| owner.inner));
             for parent in parent.into_iter().chain(joined) {
                 let mut parent = Some(parent);
                 while let Some(ref this_parent) = parent.clone() {
@@ -76,7 +75,7 @@ impl Owner {
             let joined = inner
                 .joined_owners
                 .iter()
-                .map(|owner| Arc::clone(&owner.inner));
+                .flat_map(|owner| owner.upgrade().map(|owner| owner.inner));
             for parent in parent.into_iter().chain(joined) {
                 let mut parent = Some(parent);
                 while let Some(ref this_parent) = parent.clone() {
@@ -114,7 +113,7 @@ impl Owner {
             let joined = inner
                 .joined_owners
                 .iter()
-                .map(|owner| Arc::clone(&owner.inner));
+                .flat_map(|owner| owner.upgrade().map(|owner| owner.inner));
             for parent in parent.into_iter().chain(joined) {
                 let mut parent = Some(parent);
                 while let Some(ref this_parent) = parent.clone() {


### PR DESCRIPTION
Kind of a good news/bad news situation here.

This seems to fix the memory leak reported [here](https://github.com/leptos-rs/leptos/pull/4015#issuecomment-2957748006), by only storing `WeakOwner` rather than a regular `Owner` when joining two context tree together.

On the other hand, it reintroduces the panic described in #3729. Which suggests to me that the problem was being "solved" by accidentally leaking the `Owner` by storing it in a cyclical data structure. Now, it's getting disposed properly again which means those panics are occurring again.

This will require a bit more investigation on my part to fix #3729 properly. (For now, I'm going to bed.)