### PR TITLE
enh: hygienize usages of re-exports

### DIFF
--- a/examples/directives/Cargo.toml
+++ b/examples/directives/Cargo.toml
@@ -9,8 +9,8 @@ log = "0.4.22"
 console_log = "1.0"
 console_error_panic_hook = "0.1.7"
 web-sys = { version = "0.3.70", features = ["Clipboard", "Navigator"] }
+wasm-bindgen = "0.2.93"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.42"
-wasm-bindgen = "0.2.93"
 web-sys = { version = "0.3.70", features = ["NodeList"] }

--- a/examples/directives/src/lib.rs
+++ b/examples/directives/src/lib.rs
@@ -50,7 +50,7 @@ impl From<()> for Amount {
 }
 
 pub fn add_dot(el: Element, amount: Amount) {
-    use leptos::wasm_bindgen::JsCast;
+    use wasm_bindgen::JsCast;
     let el = el.unchecked_into::<web_sys::HtmlElement>();
 
     let handle = el.clone().on(click, move |_| {

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -331,17 +331,20 @@ pub mod task {
     };
 }
 
-// these reexports are used in islands
-#[cfg(feature = "islands")]
+// Re-exports used in macros. Don't use these directly in your code.
 #[doc(hidden)]
-pub use serde;
-#[cfg(feature = "islands")]
-#[doc(hidden)]
-pub use serde_json;
-#[cfg(feature = "tracing")]
-#[doc(hidden)]
-pub use tracing;
-#[doc(hidden)]
-pub use wasm_bindgen;
-#[doc(hidden)]
-pub use web_sys;
+pub mod __reexports {
+    #[cfg(feature = "islands")]
+    #[doc(hidden)]
+    pub use serde;
+    #[cfg(feature = "islands")]
+    #[doc(hidden)]
+    pub use serde_json;
+    #[cfg(feature = "tracing")]
+    #[doc(hidden)]
+    pub use tracing;
+    #[doc(hidden)]
+    pub use wasm_bindgen;
+    #[doc(hidden)]
+    pub use web_sys;
+}

--- a/leptos_dom/src/macro_helpers/tracing_property.rs
+++ b/leptos_dom/src/macro_helpers/tracing_property.rs
@@ -4,8 +4,8 @@ use wasm_bindgen::UnwrapThrowExt;
 /// Use for tracing property
 macro_rules! tracing_props {
     () => {
-        ::leptos::tracing::span!(
-            ::leptos::tracing::Level::TRACE,
+        ::leptos::__reexports::tracing::span!(
+            ::leptos::__reexports::tracing::Level::TRACE,
             "leptos_dom::tracing_props",
             props = String::from("[]")
         );
@@ -23,8 +23,8 @@ macro_rules! tracing_props {
             )*
             props.pop();
             props.push(']');
-            ::leptos::tracing::span!(
-                ::leptos::tracing::Level::TRACE,
+            ::leptos::__reexports::tracing::span!(
+                ::leptos::__reexports::tracing::Level::TRACE,
                 "leptos_dom::tracing_props",
                 props
             );

--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -196,7 +196,7 @@ impl ToTokens for Model {
         let props_serializer = if is_island_with_other_props {
             let fields = prop_serializer_fields(vis, props);
             quote! {
-                #[derive(::leptos::serde::Deserialize)]
+                #[derive(::leptos::__reexports::serde::Deserialize)]
                 #vis struct #props_serialized_name {
                     #fields
                 }
@@ -241,7 +241,7 @@ impl ToTokens for Model {
                  *
                  * However, until https://github.com/tokio-rs/tracing/pull/1819 is merged
                  * (?), you can't provide an alternate path for `tracing` (for example,
-                 * ::leptos::tracing), which means that if you're going to use the macro
+                 * ::leptos::__reexports::tracing), which means that if you're going to use the macro
                  * you *must* have `tracing` in your Cargo.toml.
                  *
                  * Including the feature-check here causes cargo warnings on
@@ -255,7 +255,7 @@ impl ToTokens for Model {
                 let instrument = cfg!(feature = "trace-components").then(|| quote! {
                     #[cfg_attr(
                         feature = "tracing",
-                        ::leptos::tracing::instrument(level = "info", name = #trace_name, skip_all)
+                        ::leptos::__reexports::tracing::instrument(level = "info", name = #trace_name, skip_all)
                     )]
                 });
 
@@ -265,7 +265,7 @@ impl ToTokens for Model {
                         #instrument
                     },
                     quote! {
-                        let __span = ::leptos::tracing::Span::current();
+                        let __span = ::leptos::__reexports::tracing::Span::current();
                     },
                     quote! {
                         #[cfg(debug_assertions)]
@@ -299,7 +299,7 @@ impl ToTokens for Model {
 
         let island_serialize_props = if is_island_with_other_props {
             quote! {
-                let _leptos_ser_props = ::leptos::serde_json::to_string(&props).expect("couldn't serialize island props");
+                let _leptos_ser_props = ::leptos::__reexports::serde_json::to_string(&props).expect("couldn't serialize island props");
             }
         } else {
             quote! {}
@@ -521,8 +521,8 @@ impl ToTokens for Model {
             };
             let deserialize_island_props = if is_island_with_other_props {
                 quote! {
-                    let props = el.dataset().get(::leptos::wasm_bindgen::intern("props"))
-                        .and_then(|data| ::leptos::serde_json::from_str::<#props_serialized_name>(&data).ok())
+                    let props = el.dataset().get(::leptos::__reexports::wasm_bindgen::intern("props"))
+                        .and_then(|data| ::leptos::__reexports::serde_json::from_str::<#props_serialized_name>(&data).ok())
                         .expect("could not deserialize props");
                 }
             } else {
@@ -531,9 +531,9 @@ impl ToTokens for Model {
 
             let hydrate_fn_name = hydrate_fn_name.as_ref().unwrap();
             quote! {
-                #[::leptos::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos::wasm_bindgen)]
+                #[::leptos::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::leptos::__reexports::wasm_bindgen)]
                 #[allow(non_snake_case)]
-                pub fn #hydrate_fn_name(el: ::leptos::web_sys::HtmlElement) {
+                pub fn #hydrate_fn_name(el: ::leptos::__reexports::web_sys::HtmlElement) {
                     #deserialize_island_props
                     let island = #name(#island_props);
                     let state = island.hydrate_from_position::<true>(&el, ::leptos::tachys::view::Position::Current);
@@ -546,7 +546,7 @@ impl ToTokens for Model {
         };
 
         let props_derive_serialize = if is_island_with_other_props {
-            quote! { , ::leptos::serde::Serialize }
+            quote! { , ::leptos::__reexports::serde::Serialize }
         } else {
             quote! {}
         };


### PR DESCRIPTION
The crate `leptos` re-exports several dependencies to use them in the `#[component]` macro:

- `wasm_bindgen`
- `web_sys` - There is a direct usage of it [in an example](https://github.com/leptos-rs/leptos/blob/671ada36ab95217dd19f661144e706d990df873c/examples/directives/src/lib.rs#L52-L64).
- `tracing`
- `serde`
- `serde_json`

This is problematic because it could hide the definition of direct dependencies of a project in Leptos, which can cause hard to debug issues with version mismatches of duplicated dependencies and duplication of dependencies itself. Additionally, it confuses to developer consumers of Leptos about if they must use, for some reason, the dependencies from this path.

Leptos has an example with this problem going unnoticed that serves to understand the problem.

1. Comment the line `use leptos::wasm_bindgen::JsCast;` in `examples/directives/src/lib.rs`.
2. Run `trunk serve` in the `examples/directives` directory.

Rustc will show an error like this:

```text
error[E0599]: no method named `unchecked_into` found for struct `Element` in the current scope
  --> src/lib.rs:54:17
   |
54 |     let el = el.unchecked_into::<web_sys::HtmlElement>();
   |                 ^^^^^^^^^^^^^^
   |
  ::: /.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-0.2.100/src/cast.rs:78:8
   |
78 |     fn unchecked_into<T>(self) -> T
   |        -------------- the method is available for `Element` here
   |
   = help: items from traits can only be used if the trait is in scope
help: trait `JsCast` which provides `unchecked_into` is implemented but not in scope; perhaps you want to import it
   |
1  + use leptos::wasm_bindgen::JsCast;
   |
help: there is a method `unchecked_into_f64` with a similar name
   |
54 |     let el = el.unchecked_into_f64::<web_sys::HtmlElement>();
   |                               ++++
```

Note that the error message suggests to import `JsCast` from `leptos::wasm_bindgen`, which is not a good suggestion for the reasons explained above.

The solution included in this PR is to hide re-exports of `leptos` in a `__reexports` internal public module. This is the solution suggested in <https://github.com/rust-lang/rust/issues/63687#issuecomment-526254208> for hygienic usage of libraries in proc-macro generated code.

> There is a pattern to use std or any other third party crate in a hygienic way. You define a `#[doc(hidden)] pub mod __reexports { pub use std; }` in lib.rs and then use `$crate::__reexports::std::...` to refer to std items in the macro.

You can see linked PRs in the issue of the linked comment examples of the same solution in other libraries. Are called different to `__reexports`, sometimes `__export` (liballoc), `__macro_support`... but it is consistent that rustc will not suggest to import from a module starting with `__`.