### PR TITLE
fix: hygiene on `view` macro.

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -431,7 +431,9 @@ fn element_children_to_tokens(
     } else if cfg!(feature = "__internal_erase_components") {
         Some(quote! {
             .child(
-                leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_maybe_erased()),*])
+                ::leptos::tachys::view::iterators::StaticVec::from(vec![#(
+                    ::leptos::prelude::IntoMaybeErased::into_maybe_erased(#children)
+                ),*])
             )
         })
     } else if children.len() > 16 {
@@ -481,7 +483,9 @@ fn fragment_to_tokens(
         children.into_iter().next()
     } else if cfg!(feature = "__internal_erase_components") {
         Some(quote! {
-            leptos::tachys::view::iterators::StaticVec::from(vec![#(#children.into_maybe_erased()),*])
+            ::leptos::tachys::view::iterators::StaticVec::from(vec![#(
+                ::leptos::prelude::IntoMaybeErased::into_maybe_erased(#children)
+            ),*])
         })
     } else if children.len() > 16 {
         // implementations of various traits used in routing and rendering are implemented for

--- a/leptos_macro/tests/component.rs
+++ b/leptos_macro/tests/component.rs
@@ -119,3 +119,45 @@ fn returns_static_lifetime() {
         WithLifetime(WithLifetimeProps::builder().data(&val).build())
     }
 }
+
+// an attempt to catch unhygienic macros regression
+mod macro_hygiene {
+    // To ensure no relative module path to leptos inside macros.
+    mod leptos {}
+
+    // doing this separately to below due to this being the smallest
+    // unit with the lowest import surface.
+    #[test]
+    fn view() {
+        use ::leptos::IntoView;
+        use ::leptos_macro::{component, view};
+
+        #[component]
+        fn Component() -> impl IntoView {
+            view! {
+                {()}
+                {()}
+            }
+        }
+    }
+
+    // may extend this test with other items as necessary.
+    #[test]
+    fn view_into_any() {
+        use ::leptos::{
+            prelude::{ElementChild, IntoAny},
+            IntoView,
+        };
+        use ::leptos_macro::{component, view};
+
+        #[component]
+        fn Component() -> impl IntoView {
+            view! {
+                <div>
+                    {().into_any()}
+                    {()}
+                </div>
+            }
+        }
+    }
+}


### PR DESCRIPTION
Otherwise, something like this can happen when `RUSTFLAG='--cfg erase_components'` is set:

```
error[E0599]: no method named `into_maybe_erased` found for unit type `()` in the current scope
   --> leptos_macro/tests/component.rs:131:13
    |
131 |               view! {
    |  _____________^
132 | |                 {()}
133 | |                 {()}
134 | |             }
    | |_____________^ method not found in `()`
    |
   ::: /github/leptos/tachys/src/view/any_view.rs:120:8
    |
120 |       fn into_maybe_erased(self) -> Self::Output;
    |          ----------------- the method is available for `()` here
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `IntoMaybeErased` which provides `into_maybe_erased` is implemented but not in scope; perhaps you want to import it
    |
124 +     use leptos::prelude::IntoMaybeErased;
    |
```

A major reason why I think this should be fixed (#3161, #3162, plus others notwithstanding) is that this particular import may or may not be required depending on how the `RUSTFLAG` is set up, and without that, when compiling something that tries to limit `*` module imports, effectively forces `unused_imports` warnings if `use leptos::prelude::IntoMaybeErased;` was added to get a module compiled in that case.  This is trivial to come across when doing `cargo leptos build` vs `cargo leptos build --release`; if we include the imports as per suggestion, we get this when doing release builds:

```
warning: unused import: `leptos::prelude::IntoMaybeErased`
 --> ./src/component.rs:5:5
  |
5 | use leptos::prelude::IntoMaybeErased;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```