### PR TITLE
Use remove_event_listener_with_callback_and_bool when capturing listener

### DIFF
--- a/tachys/src/renderer/dom.rs
+++ b/tachys/src/renderer/dom.rs
@@ -281,9 +281,10 @@ impl Dom {
             let cb = send_wrapper::SendWrapper::new(cb);
             move |el: &Element| {
                 or_debug!(
-                    el.remove_event_listener_with_callback(
+                    el.remove_event_listener_with_callback_and_bool(
                         intern(&name),
-                        cb.as_ref().unchecked_ref()
+                        cb.as_ref().unchecked_ref(),
+                        true
                     ),
                     el,
                     "removeEventListener"


### PR DESCRIPTION
This PR fixes the removal of an event listener when it was created with set_capture(true) described in https://github.com/leptos-rs/leptos/issues/4081

For reference see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener