### PR TITLE
Add template cache for dom.

### DIFF
--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -125,14 +125,14 @@ impl Render for InertElement {
     type State = InertElementState;
 
     fn build(self) -> Self::State {
-        let el = Rndr::create_element_from_html(&self.html);
+        let el = Rndr::create_element_from_html(self.html.clone());
         InertElementState(self.html, el)
     }
 
     fn rebuild(self, state: &mut Self::State) {
         let InertElementState(prev, el) = state;
         if &self.html != prev {
-            let mut new_el = Rndr::create_element_from_html(&self.html);
+            let mut new_el = Rndr::create_element_from_html(self.html.clone());
             el.insert_before_this(&mut new_el);
             el.unmount();
             *el = new_el;

--- a/tachys/src/renderer/dom.rs
+++ b/tachys/src/renderer/dom.rs
@@ -21,6 +21,7 @@ pub struct Dom;
 
 thread_local! {
     pub(crate) static GLOBAL_EVENTS: RefCell<FxHashSet<Cow<'static, str>>> = Default::default();
+    pub static TEMPLATE_CACHE: RefCell<Vec<(Cow<'static, str>, web_sys::Element)>> = Default::default();
 }
 
 pub type Node = web_sys::Node;
@@ -487,11 +488,22 @@ impl Dom {
             .unchecked_into()
     }
 
-    pub fn create_element_from_html(html: &str) -> Element {
-        // TODO can be optimized to cache HTML strings or cache <template>?
-        let tpl = document().create_element("template").unwrap();
-        tpl.set_inner_html(html);
-        let tpl = Self::clone_template(tpl.unchecked_ref());
+    pub fn create_element_from_html(html: Cow<'static, str>) -> Element {
+        let tpl = TEMPLATE_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            if let Some(tpl) = cache.iter().find_map(|(key, tpl)| {
+                (html == *key)
+                    .then_some(Self::clone_template(tpl.unchecked_ref()))
+            }) {
+                tpl
+            } else {
+                let tpl = document().create_element("template").unwrap();
+                tpl.set_inner_html(&html);
+                let tpl2 = Self::clone_template(tpl.unchecked_ref());
+                cache.push((html, tpl));
+                tpl2
+            }
+        });
         tpl.first_element_child().unwrap_or(tpl)
     }
 }


### PR DESCRIPTION
Adds caching for inert elements. This removes the need to call `set_inner_html` every time when creating `<template>`s for inert elements.

The cache **reduced time to next paint by 67%**.
I [profiled with and without the cache](https://drive.google.com/file/d/1fKaxBQHD6HpULGKOD1kUzRsCs58AQB-w/view?usp=sharing) using the same example app as described in the [original `leptos-icons` issue](https://github.com/carloskiki/leptos-icons/issues/60#issuecomment-2979146003). The app uses inert SVG elements from #4085 rendering 10k SVG elements in a table.
|   | cache | no cache |
| --- | --- | --- |
| time / s | 2.7 | 6.3 |

This resolves #4094.