### PR TITLE
[fix] Update `svg::InertElement` for `dom` cache.

### DIFF
--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -229,14 +229,14 @@ impl Render for InertElement {
     type State = InertElementState;
 
     fn build(self) -> Self::State {
-        let el = Rndr::create_element_from_html(&self.html);
+        let el = Rndr::create_element_from_html(self.html.clone());
         InertElementState(self.html, el)
     }
 
     fn rebuild(self, state: &mut Self::State) {
         let InertElementState(prev, el) = state;
         if &self.html != prev {
-            let mut new_el = Rndr::create_element_from_html(&self.html);
+            let mut new_el = Rndr::create_element_from_html(self.html.clone());
             el.insert_before_this(&mut new_el);
             el.unmount();
             *el = new_el;


### PR DESCRIPTION
#4099 introduced caching for inert elements, changing the API for [`dom::Dom::create_element_from_html`](https://github.com/leptos-rs/leptos/blob/30b0a579cad0765e9cc5c62739785cb155fe6154/tachys/src/renderer/dom.rs#L495). This updates `svg::InertElement` (added in #4085) to match the new API.