### PR TITLE
feat: add method `take` for BrowserFormData

### DIFF
--- a/server_fn/src/request/browser.rs
+++ b/server_fn/src/request/browser.rs
@@ -75,6 +75,13 @@ impl DerefMut for BrowserRequest {
 #[derive(Debug)]
 pub struct BrowserFormData(pub(crate) SendWrapper<FormData>);
 
+impl BrowserFormData {
+    /// Returns the raw `web_sys::FormData` struct.
+    pub fn take(self) -> FormData {
+        self.0.take()
+    }
+}
+
 impl From<FormData> for BrowserFormData {
     fn from(value: FormData) -> Self {
         Self(SendWrapper::new(value))


### PR DESCRIPTION
The `MultipartData` struct (used as an argument for server functions of `input = MultipartFormData`) allows access to a `BrowserFormData` on the client. However, there is not much useful that can be done with it at this time.

As @gbj suggested, this adds a `take` method that transforms the `BrowserFormData` into a regular `FormData` from `web_sys`. From there it is possible to retrieve data about the form fields and whatnot.

### Suggestion

In my project, it would be very helpful if MultipartFormData server functions behaved more like the default ones: where the parameters define the expected request body and the contents can be assembled into a struct automatically by using `ServerFn::from_event` and `ServerFn::from_form_data` (I supposed there would need to be some mechanism to limit allowed file sizes and the like, however).

I say this because I have validation functions that I apply on the server function payloads on the client, before actually sending them to the server (and then running them again there), and I had to create an entirely different component to work with multipart form data because of the differences (they accept a `MultipartData` instead of a generic struct, can't be constructed with `ServerFn::from_...`, do not work well with `ServerAction`, require async processing because of [`File#arrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer)...). I'm also having to process the `MultipartData` in different ways on the client and the server, since all the `MultipartData` gives me is access to the underlying objects of each environment with no abstractions.

I imagine the signature for a server function with such conveniences would look something like

```rs
#[server(input = MultipartFormData)]
pub async fn my_server_fn(
  description: String,
  
  #[param(max_size = "10MB")] // Something like this?.. I don't even know how these are implemented
  profile_image: File, // Should probably be a new type, I think, that contains the binary data in memory
                       // and MIME type information at least
) -> Result<(), MyServerFnError> { /* ... */ }
```

Anyhow, I suppose having the single `MultipartData` argument would be useful to handle the incoming data in a streaming manner, but for simple cases it is a chore (I think).

If this suggestion is understood to make sense, I can open an issue for it. I'm being very naive: there are probably many problems I'm not anticipating; I wouldn't even know how to implement it myself with the knowledge I have right now.