### PR TITLE
Use inert_element for top level <svg> elements.

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -707,7 +707,7 @@ fn node_to_tokens(
                     && el_name != "textarea";
 
                 let el_name = el_node.name().to_string();
-                if is_svg_element(&el_name) && el_name!= "svg" {
+                if is_svg_element(&el_name) && el_name != "svg" {
                     Some(inert_svg_element_to_tokens(
                         node,
                         escape,

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -401,6 +401,9 @@ fn inert_element_to_tokens(
     }
 }
 
+/// # Note
+/// Should not be used on top level `<svg>` elements.
+/// Use [`inert_element_to_tokens`] instead.
 fn inert_svg_element_to_tokens(
     node: &Node<impl CustomNode>,
     escape_text: bool,
@@ -704,7 +707,7 @@ fn node_to_tokens(
                     && el_name != "textarea";
 
                 let el_name = el_node.name().to_string();
-                if is_svg_element(&el_name) {
+                if is_svg_element(&el_name) && el_name!= "svg" {
                     Some(inert_svg_element_to_tokens(
                         node,
                         escape,


### PR DESCRIPTION
Fixes a bug that wraps top level `<svg>` elements in a `<g>` tag, invalidating the DOM subtree and causing them not to render.