### PR TITLE
chore: remove now-unused `join_contexts` API

### DIFF
--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -167,7 +167,6 @@ impl Owner {
                     .map(|parent| parent.read().or_poisoned().arena.clone())
                     .unwrap_or_default(),
                 paused: false,
-                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context,
@@ -202,7 +201,6 @@ impl Owner {
                 #[cfg(feature = "sandboxed-arenas")]
                 arena: Default::default(),
                 paused: false,
-                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context,
@@ -228,7 +226,6 @@ impl Owner {
                 #[cfg(feature = "sandboxed-arenas")]
                 arena,
                 paused,
-                joined_owners: Vec::new(),
             })),
             #[cfg(feature = "hydration")]
             shared_context: self.shared_context.clone(),
@@ -464,7 +461,6 @@ pub(crate) struct OwnerInner {
     #[cfg(feature = "sandboxed-arenas")]
     arena: Arc<RwLock<ArenaMap>>,
     paused: bool,
-    joined_owners: Vec<WeakOwner>,
 }
 
 impl Debug for OwnerInner {


### PR DESCRIPTION
This API was introduced in #4015, but was pretty much a hack to fix #3042 and similar issues, which are fixed in a more principled way by #4091, which no longer used these APIs. Removing them removes the overhead cost of their existence.