### PR TITLE
Clean up nested routing ownership and add regression tests

### DIFF
--- a/examples/regression/e2e/features/issue_4088.feature
+++ b/examples/regression/e2e/features/issue_4088.feature
@@ -12,3 +12,9 @@ Feature: Check that issue 4088 does not reappear
 		When I select the link Class 1
 		Then I see the result is the string Assignments for team of user with id 42
 
+	Scenario: The user info is shared via context
+		Given I see the app
+		And I can access regression test 4088
+		When I select the link Class 1
+		When I refresh the browser
+		Then I see the result is the string Assignments for team of user with id 42

--- a/examples/regression/e2e/features/issue_4088.feature
+++ b/examples/regression/e2e/features/issue_4088.feature
@@ -1,0 +1,14 @@
+@check_issue_4088
+Feature: Check that issue 4088 does not reappear
+
+	Scenario: I can see the navbar
+		Given I see the app
+		And I can access regression test 4088
+		Then I see the navbar
+
+	Scenario: The user info is shared via context
+		Given I see the app
+		And I can access regression test 4088
+		When I select the link Class 1
+		Then I see the result is the string Assignments for team of user with id 42
+

--- a/examples/regression/e2e/features/pr_4015.feature
+++ b/examples/regression/e2e/features/pr_4015.feature
@@ -1,0 +1,8 @@
+@check_pr_4015
+Feature: Check that PR 4015 does not regress
+
+	Scenario: The correct text appears
+		Given I see the app
+		And I can access regression test 4015
+		Then I see the result is the string Some(42)
+

--- a/examples/regression/e2e/features/pr_4091.feature
+++ b/examples/regression/e2e/features/pr_4091.feature
@@ -37,3 +37,11 @@ Feature: Regression from pull request 4091
             | Home |
             | 4091 |
         Then I see the navbar
+
+    Scenario: The signal is not disposed too early
+        Given I see the app
+        And I can access regression test 4091
+        When I select the following links
+            | test1 |
+            | home  |
+        Then I see the navbar

--- a/examples/regression/e2e/features/pr_4091.feature
+++ b/examples/regression/e2e/features/pr_4091.feature
@@ -24,3 +24,16 @@ Feature: Regression from pull request 4091
             | test1     |
             | 4091 Home |
         Then I see the result is empty
+
+    Scenario: I can see the navbar
+        Given I see the app
+        And I can access regression test 4091
+        Then I see the navbar
+
+    Scenario: If I navigate to home and back, I can still see the navbar
+        Given I see the app
+        And I can access regression test 4091
+        When I select the following links
+            | Home |
+            | 4091 |
+        Then I see the navbar

--- a/examples/regression/e2e/features/pr_4091.feature
+++ b/examples/regression/e2e/features/pr_4091.feature
@@ -43,5 +43,6 @@ Feature: Regression from pull request 4091
         And I can access regression test 4091
         When I select the following links
             | test1 |
-            | home  |
+            | Home  |
+            | 4091  |
         Then I see the navbar

--- a/examples/regression/e2e/tests/fixtures/check.rs
+++ b/examples/regression/e2e/tests/fixtures/check.rs
@@ -11,3 +11,10 @@ pub async fn result_text_is(
     assert_eq!(&actual, expected_text);
     Ok(())
 }
+
+pub async fn element_exists(client: &Client, id: &str) -> Result<()> {
+    find::element_by_id(client, id)
+        .await
+        .expect(&format!("could not find element with id `{id}`"));
+    Ok(())
+}

--- a/examples/regression/e2e/tests/fixtures/find.rs
+++ b/examples/regression/e2e/tests/fixtures/find.rs
@@ -2,9 +2,7 @@ use anyhow::{Ok, Result};
 use fantoccini::{elements::Element, Client, Locator};
 
 pub async fn text_at_id(client: &Client, id: &str) -> Result<String> {
-    let element = client
-        .wait()
-        .for_element(Locator::Id(id))
+    let element = element_by_id(client, id)
         .await
         .expect(format!("no such element with id `{}`", id).as_str());
     let text = element.text().await?;
@@ -18,4 +16,9 @@ pub async fn link_with_text(client: &Client, text: &str) -> Result<Element> {
         .await
         .expect(format!("Link not found by `{}`", text).as_str());
     Ok(link)
+}
+
+pub async fn element_by_id(client: &Client, id: &str) -> Result<Element> {
+    let element = client.wait().for_element(Locator::Id(id)).await?;
+    Ok(element)
 }

--- a/examples/regression/e2e/tests/fixtures/find.rs
+++ b/examples/regression/e2e/tests/fixtures/find.rs
@@ -19,6 +19,5 @@ pub async fn link_with_text(client: &Client, text: &str) -> Result<Element> {
 }
 
 pub async fn element_by_id(client: &Client, id: &str) -> Result<Element> {
-    let element = client.wait().for_element(Locator::Id(id)).await?;
-    Ok(element)
+    Ok(client.wait().for_element(Locator::Id(id)).await?)
 }

--- a/examples/regression/e2e/tests/fixtures/world/check_steps.rs
+++ b/examples/regression/e2e/tests/fixtures/world/check_steps.rs
@@ -3,9 +3,7 @@ use anyhow::{Ok, Result};
 use cucumber::then;
 
 #[then(regex = r"^I see the result is empty$")]
-async fn i_see_the_result_is_empty(
-    world: &mut AppWorld,
-) -> Result<()> {
+async fn i_see_the_result_is_empty(world: &mut AppWorld) -> Result<()> {
     let client = &world.client;
     check::result_text_is(client, "").await?;
     Ok(())
@@ -18,5 +16,12 @@ async fn i_see_the_result_is_the_string(
 ) -> Result<()> {
     let client = &world.client;
     check::result_text_is(client, &text).await?;
+    Ok(())
+}
+
+#[then(regex = r"^I see the navbar$")]
+async fn i_see_the_navbar(world: &mut AppWorld) -> Result<()> {
+    let client = &world.client;
+    check::element_exists(client, "nav").await?;
     Ok(())
 }

--- a/examples/regression/src/app.rs
+++ b/examples/regression/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{pr_4015::Routes4015, pr_4091::Routes4091};
+use crate::{issue_4088::Routes4088, pr_4015::Routes4015, pr_4091::Routes4091};
 use leptos::prelude::*;
 use leptos_meta::{MetaTags, *};
 use leptos_router::{
@@ -36,6 +36,7 @@ pub fn App() -> impl IntoView {
                     <Route path=path!("") view=HomePage/>
                     <Routes4091/>
                     <Routes4015/>
+                    <Routes4088/>
                 </Routes>
             </main>
         </Router>
@@ -57,6 +58,7 @@ fn HomePage() -> impl IntoView {
             <ul>
                 <li><a href="/4091/">"4091"</a></li>
                 <li><a href="/4015/">"4015"</a></li>
+                <li><a href="/4088/">"4088"</a></li>
             </ul>
         </nav>
     }

--- a/examples/regression/src/app.rs
+++ b/examples/regression/src/app.rs
@@ -1,4 +1,4 @@
-use crate::pr_4091::Routes4091;
+use crate::{pr_4015::Routes4015, pr_4091::Routes4091};
 use leptos::prelude::*;
 use leptos_meta::{MetaTags, *};
 use leptos_router::{
@@ -35,6 +35,7 @@ pub fn App() -> impl IntoView {
                 <Routes fallback>
                     <Route path=path!("") view=HomePage/>
                     <Routes4091/>
+                    <Routes4015/>
                 </Routes>
             </main>
         </Router>
@@ -55,6 +56,7 @@ fn HomePage() -> impl IntoView {
         <nav>
             <ul>
                 <li><a href="/4091/">"4091"</a></li>
+                <li><a href="/4015/">"4015"</a></li>
             </ul>
         </nav>
     }

--- a/examples/regression/src/issue_4088.rs
+++ b/examples/regression/src/issue_4088.rs
@@ -1,0 +1,119 @@
+use leptos::{either::Either, prelude::*};
+#[allow(unused_imports)]
+use leptos_router::{
+    components::{Outlet, ParentRoute, Redirect, Route},
+    path, MatchNestedRoutes, NavigateOptions,
+};
+use serde::{Deserialize, Serialize};
+
+#[component]
+pub fn Routes4088() -> impl MatchNestedRoutes + Clone {
+    view! {
+        <ParentRoute path=path!("4088") view=|| view!{ <LoggedIn/> }>
+			<ParentRoute path=path!("") view=||view!{<AssignmentsSelector/>}>
+				<Route path=path!("/:team_id") view=||view!{<AssignmentsForTeam/>} />
+				<Route path=path!("") view=||view!{ <p>No class selected</p> }/>
+			</ParentRoute>
+        </ParentRoute>
+    }
+    .into_inner()
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserInfo {
+    pub id: usize,
+}
+
+#[server]
+pub async fn get_user_info() -> Result<Option<UserInfo>, ServerFnError> {
+    Ok(Some(UserInfo { id: 42 }))
+}
+
+#[component]
+pub fn LoggedIn() -> impl IntoView {
+    let user_info_resource =
+        Resource::new(|| (), move |_| async { get_user_info().await });
+
+    view! {
+
+      <Transition fallback=move || view!{
+            "loading"
+            }
+        >
+        {move || {
+            user_info_resource.get()
+                .map(|a|
+                    match a {
+                        Ok(Some(a)) => Either::Left(view! {
+                            <LoggedInContent user_info={a} />
+                        }),
+                        _ => Either::Right(view!{
+                            <Redirect path="/not_logged_in"/>
+                        })
+                    })
+        }}
+        </Transition>
+    }
+}
+
+#[component]
+/// Component which provides UserInfo and renders it's child
+/// Can also contain some code to check for specific situations (e.g. privacy policies accepted or not? redirect if needed...)
+pub fn LoggedInContent(user_info: UserInfo) -> impl IntoView {
+    provide_context(user_info.clone());
+
+    if user_info.id == 42 {
+        Either::Left(Outlet())
+    } else {
+        Either::Right(
+            view! { <Redirect path="/somewhere" options={NavigateOptions::default()}/> },
+        )
+    }
+}
+
+#[component]
+/// This component also uses Outlet (so nested Outlet)
+fn AssignmentsSelector() -> impl IntoView {
+    let user_info = use_context::<UserInfo>().expect("user info not provided");
+
+    view! {
+        <p>"Assignments for user with ID: "{user_info.id}</p>
+        <ul id="nav">
+            <li><a href="/4088/1">"Class 1"</a></li>
+            <li><a href="/4088/2">"Class 2"</a></li>
+            <li><a href="/4088/3">"Class 3"</a></li>
+        </ul>
+
+        <Outlet />
+    }
+}
+
+#[component]
+fn AssignmentsForTeam() -> impl IntoView {
+    // THIS FAILS -> Because of the nested outlet in LoggedInContent > AssignmentsSelector?
+    // It did not fail when LoggedIn did not use a resource and transition (but a hardcoded UserInfo in the component)
+    let user_info = use_context::<UserInfo>().expect("user info not provided");
+
+    let items = vec!["Assignment 1", "Assignment 2", "Assignment 3"];
+    view! {
+        <p id="result">"Assignments for team of user with id " {user_info.id}</p>
+        <ul>
+            {
+            items.into_iter().map(|item| {
+                view! {
+                    <Assignment name=item.to_string() />
+                }
+            }).collect_view()
+            }
+        </ul>
+    }
+}
+
+#[component]
+fn Assignment(name: String) -> impl IntoView {
+    let user_info = use_context::<UserInfo>().expect("user info not provided");
+
+    view! {
+        <li>{name}" "{user_info.id}</li>
+    }
+}

--- a/examples/regression/src/lib.rs
+++ b/examples/regression/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+mod issue_4088;
 mod pr_4015;
 mod pr_4091;
 

--- a/examples/regression/src/lib.rs
+++ b/examples/regression/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+mod pr_4015;
 mod pr_4091;
 
 #[cfg(feature = "hydrate")]

--- a/examples/regression/src/pr_4015.rs
+++ b/examples/regression/src/pr_4015.rs
@@ -1,0 +1,29 @@
+use leptos::{context::Provider, prelude::*};
+use leptos_router::{
+    components::{ParentRoute, Route},
+    nested_router::Outlet,
+    path,
+};
+
+#[component]
+pub fn Routes4015() -> impl leptos_router::MatchNestedRoutes + Clone {
+    view! {
+        <ParentRoute path=path!("4015") view=|| view! {
+            <Provider value=42i32>
+                <Outlet/>
+            </Provider>
+        }>
+            <Route path=path!("") view=Child/>
+        </ParentRoute>
+    }
+    .into_inner()
+}
+
+#[component]
+fn Child() -> impl IntoView {
+    let value = use_context::<i32>();
+
+    view! {
+        <p id="result">{format!("{value:?}")}</p>
+    }
+}

--- a/examples/regression/src/pr_4091.rs
+++ b/examples/regression/src/pr_4091.rs
@@ -28,8 +28,9 @@ fn Container() -> impl IntoView {
     provide_context(rw_signal);
 
     view! {
-        <nav>
+        <nav id="nav">
             <ul>
+                <li><A href="/">"Home"</A></li>
                 <li><A href="./">"4091 Home"</A></li>
                 <li><A href="test1">"test1"</A></li>
             </ul>

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -90,6 +90,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
     type Owned = View<T::Owned>;
 
     const MIN_LENGTH: usize = <T as RenderHtml>::MIN_LENGTH;
+    const EXISTS: bool = <T as RenderHtml>::EXISTS;
 
     async fn resolve(self) -> Self::AsyncOutput {
         self.inner.resolve().await

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -413,6 +413,7 @@ where
     type Owned = RegisteredMetaTag<E, At::CloneableOwned, Ch::Owned>;
 
     const MIN_LENGTH: usize = 0;
+    const EXISTS: bool = false;
 
     fn dry_resolve(&mut self) {
         self.el.dry_resolve()

--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -322,6 +322,7 @@ impl RenderHtml for TitleView {
     type Owned = Self;
 
     const MIN_LENGTH: usize = 0;
+    const EXISTS: bool = false;
 
     fn dry_resolve(&mut self) {}
 

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -700,6 +700,12 @@ where
             .take(*items)
             .map(|route| (route.params.clone(), route.matched.clone()))
             .unzip();
+
+        if outlets.get(*items).is_some() && *items > 0 {
+            *outlets[*items - 1].child.0.lock().or_poisoned() =
+                Some(outlets[*items].clone());
+        }
+
         let current = outlets.get_mut(*items);
         match current {
             // if there's nothing currently in the routes at this point, build from here

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -853,6 +853,8 @@ where
                     if let Some(child) = child {
                         child
                             .build_nested_route(url, base, preloaders, outlets);
+                    } else {
+                        *outlets[*items].child.0.lock().or_poisoned() = None;
                     }
 
                     return level;
@@ -876,6 +878,7 @@ where
                         level + 1,
                     )
                 } else {
+                    *current.child.0.lock().or_poisoned() = None;
                     level
                 }
             }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -818,6 +818,15 @@ where
                                             }),
                                         );
 
+                                        // a single owner is created per Outlet
+                                        // this code only runs if the old Route has been left for the new Route
+                                        // cleaning up the reactivity is therefore safe here
+                                        //
+                                        // note: with lazy loading enabled, this might run *before* the new page is
+                                        // actually shown; a TODO would be to give an "after loaded, before running"
+                                        // callback to .choose() to avoid canceling until it's actually ready
+                                        owner_where_used.cleanup();
+
                                         let view = view.await;
 
                                         if let Some(tx) = full_tx {

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -930,10 +930,11 @@ fn top_level_outlet(outlets: &[RouteContext], outer_owner: &Owner) -> AnyView {
     let trigger = outlet.trigger.clone();
     outer_owner.clone().with(|| {
         provide_context(child.clone());
+        let outer_owner = outer_owner.clone();
         (move || {
             trigger.track();
             let mut view_fn = view_fn.lock().or_poisoned();
-            view_fn(Owner::new())
+            view_fn(outer_owner.child())
         })
         .into_any()
     })
@@ -948,11 +949,12 @@ where
     let ChildRoute(child) = use_context()
         .expect("<Outlet/> used without RouteContext being provided.");
     let child = child.lock().or_poisoned().clone();
+    let outer_owner = Owner::new();
     child.map(|child| {
         move || {
             child.trigger.track();
             let mut view_fn = child.view_fn.lock().or_poisoned();
-            view_fn(Owner::new())
+            view_fn(outer_owner.child())
         }
     })
 }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -928,7 +928,6 @@ fn top_level_outlet(outlets: &[RouteContext], outer_owner: &Owner) -> AnyView {
     let child = outlet.child.clone();
     let view_fn = outlet.view_fn.clone();
     let trigger = outlet.trigger.clone();
-    let owner = outer_owner.child();
     outer_owner.clone().with(|| {
         provide_context(child.clone());
         (move || {

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -945,7 +945,7 @@ where
     let ChildRoute(child) = use_context()
         .expect("<Outlet/> used without RouteContext being provided.");
     let child = child.lock().or_poisoned().clone();
-    let outer_owner = Owner::new();
+    let outer_owner = Owner::current().unwrap();
     child.map(|child| {
         move || {
             child.trigger.track();

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -109,7 +109,6 @@ where
                     base,
                     &mut loaders,
                     &mut outlets,
-                    &outer_owner,
                 );
                 drop(url);
 
@@ -180,7 +179,6 @@ where
                     &mut preloaders,
                     &mut full_loaders,
                     &mut state.outlets,
-                    &self.outer_owner,
                     self.set_is_routing.is_some(),
                     0,
                 );
@@ -340,7 +338,6 @@ where
                         base,
                         &mut loaders,
                         &mut outlets,
-                        &outer_owner,
                     );
 
                     // outlets will not send their views if the loaders are never polled
@@ -394,7 +391,6 @@ where
                     base,
                     &mut loaders,
                     &mut outlets,
-                    &outer_owner,
                 );
 
                 // outlets will not send their views if the loaders are never polled
@@ -448,7 +444,6 @@ where
                         base,
                         &mut loaders,
                         &mut outlets,
-                        &outer_owner,
                     );
                     drop(url);
 
@@ -483,7 +478,6 @@ pub(crate) struct RouteContext {
     trigger: ArcTrigger,
     url: ArcRwSignal<Url>,
     params: ArcRwSignal<ParamsMap>,
-    owner: Owner,
     pub matched: ArcRwSignal<String>,
     base: Option<Oco<'static, str>>,
     view_fn: Arc<Mutex<OutletViewFn>>,
@@ -500,7 +494,6 @@ impl Debug for RouteContext {
             .field("trigger", &self.trigger)
             .field("url", &self.url)
             .field("params", &self.params)
-            .field("owner", &self.owner.debug_id())
             .field("matched", &self.matched)
             .field("base", &self.base)
             .finish_non_exhaustive()
@@ -514,7 +507,6 @@ impl Clone for RouteContext {
             id: self.id,
             trigger: self.trigger.clone(),
             params: self.params.clone(),
-            owner: self.owner.clone(),
             matched: self.matched.clone(),
             base: self.base.clone(),
             view_fn: Arc::clone(&self.view_fn),
@@ -530,7 +522,6 @@ trait AddNestedRoute {
         base: Option<Oco<'static, str>>,
         loaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
         outlets: &mut Vec<RouteContext>,
-        parent: &Owner,
     );
 
     #[allow(clippy::too_many_arguments)]
@@ -542,7 +533,6 @@ trait AddNestedRoute {
         loaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
         full_loaders: &mut Vec<oneshot::Receiver<()>>,
         outlets: &mut Vec<RouteContext>,
-        parent: &Owner,
         set_is_routing: bool,
         level: u8,
     ) -> u8;
@@ -558,14 +548,8 @@ where
         base: Option<Oco<'static, str>>,
         loaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
         outlets: &mut Vec<RouteContext>,
-        parent: &Owner,
     ) {
         let orig_url = url;
-
-        // each Outlet gets its own owner, so it can inherit context from its parent route,
-        // a new owner will be constructed if a different route replaces this one in the outlet,
-        // so that any signals it creates or context it provides will be cleaned up
-        let owner = parent.child();
 
         // the params signal can be updated to allow the same outlet to update to changes in the
         // params, even if there's not a route match change
@@ -624,7 +608,6 @@ where
             url,
             trigger: trigger.clone(),
             params,
-            owner: owner.clone(),
             matched,
             view_fn: Arc::new(Mutex::new(Box::new(|_owner| {
                 Suspend::new(Box::pin(async { ().into_any() }))
@@ -696,7 +679,7 @@ where
         // this is important because to build the view, we need access to the outlet
         // and the outlet will be returned from building this child
         if let Some(child) = child {
-            child.build_nested_route(orig_url, base, loaders, outlets, &owner);
+            child.build_nested_route(orig_url, base, loaders, outlets);
         }
     }
 
@@ -709,7 +692,6 @@ where
         preloaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
         full_loaders: &mut Vec<oneshot::Receiver<()>>,
         outlets: &mut Vec<RouteContext>,
-        parent: &Owner,
         set_is_routing: bool,
         level: u8,
     ) -> u8 {
@@ -722,7 +704,7 @@ where
         match current {
             // if there's nothing currently in the routes at this point, build from here
             None => {
-                self.build_nested_route(url, base, preloaders, outlets, parent);
+                self.build_nested_route(url, base, preloaders, outlets);
                 level
             }
             Some(current) => {
@@ -789,9 +771,6 @@ where
 
                     // assign a new owner, so that contexts and signals owned by the previous route
                     // in this outlet can be dropped
-                    let mut old_owner =
-                        Some(mem::replace(&mut current.owner, parent.child()));
-                    let owner = current.owner.clone();
                     let (full_tx, full_rx) = oneshot::channel();
                     let full_tx = Mutex::new(Some(full_tx));
                     full_loaders.push(full_rx);
@@ -801,7 +780,6 @@ where
                     // and notify the trigger so that the reactive view inside the Outlet tracking
                     // the trigger runs again
                     preloaders.push(Box::pin(ScopedFuture::new({
-                        let owner = owner.clone();
                         let trigger = current.trigger.clone();
                         let url = current.url.clone();
                         let matched = Matched(matched_including_parents);
@@ -812,11 +790,9 @@ where
                             let child = child.clone();
                             *view_fn.lock().or_poisoned() =
                                 Box::new(move |owner_where_used| {
-                                    let owner = owner.clone();
                                     let view = view.clone();
                                     let full_tx =
                                         full_tx.lock().or_poisoned().take();
-                                    let old_owner = old_owner.take();
                                     let child = child.clone();
                                     let params =
                                         params_including_parents.clone();
@@ -841,15 +817,13 @@ where
                                                 })
                                             }),
                                         );
+
                                         let view = view.await;
-                                        if let Some(old_owner) = old_owner {
-                                            old_owner.cleanup();
-                                        }
 
                                         if let Some(tx) = full_tx {
                                             _ = tx.send(());
                                         }
-                                        owner.with(|| {
+                                        owner_where_used.with(|| {
                                             OwnedView::new(view).into_any()
                                         })
                                     }))
@@ -868,9 +842,8 @@ where
 
                     // if this children has matches, then rebuild the lower section of the tree
                     if let Some(child) = child {
-                        child.build_nested_route(
-                            url, base, preloaders, outlets, &owner,
-                        );
+                        child
+                            .build_nested_route(url, base, preloaders, outlets);
                     }
 
                     return level;
@@ -882,7 +855,6 @@ where
                 current.params.set(new_params);
                 current.url.set(url.to_owned());
                 if let Some(child) = child {
-                    let owner = current.owner.clone();
                     *items += 1;
                     child.rebuild_nested_route(
                         url,
@@ -891,7 +863,6 @@ where
                         preloaders,
                         full_loaders,
                         outlets,
-                        &owner,
                         set_is_routing,
                         level + 1,
                     )

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -533,7 +533,7 @@ trait AddNestedRoute {
         base: Option<Oco<'static, str>>,
         items: &mut usize,
         loaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
-        full_loaders: &mut Vec<oneshot::Receiver<()>>,
+        full_loaders: &mut Vec<oneshot::Receiver<Option<Owner>>>,
         outlets: &mut Vec<RouteContext>,
         set_is_routing: bool,
         level: u8,
@@ -696,7 +696,7 @@ where
         base: Option<Oco<'static, str>>,
         items: &mut usize,
         preloaders: &mut Vec<Pin<Box<dyn Future<Output = ArcTrigger>>>>,
-        full_loaders: &mut Vec<oneshot::Receiver<()>>,
+        full_loaders: &mut Vec<oneshot::Receiver<Option<Owner>>>,
         outlets: &mut Vec<RouteContext>,
         set_is_routing: bool,
         level: u8,
@@ -837,12 +837,8 @@ where
 
                                         let view = view.await;
 
-                                        if let Some(prev_owner) = prev_owner {
-                                            prev_owner.cleanup();
-                                        }
-
                                         if let Some(tx) = full_tx {
-                                            _ = tx.send(());
+                                            _ = tx.send(prev_owner);
                                         }
                                         owner_where_used.with(|| {
                                             OwnedView::new(view).into_any()

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -12,6 +12,7 @@ use crate::{
         Attribute,
     },
     hydration::Cursor,
+    renderer::Rndr,
     ssr::StreamBuilder,
 };
 use futures::future::{join, join_all};
@@ -90,6 +91,7 @@ pub struct AnyViewState {
     ),
     insert_before_this: fn(&ErasedLocal, child: &mut dyn Mountable) -> bool,
     elements: fn(&ErasedLocal) -> Vec<crate::renderer::types::Element>,
+    placeholder: Option<crate::renderer::types::Placeholder>,
 }
 
 impl Debug for AnyViewState {
@@ -214,6 +216,9 @@ where
                 mark_branches,
                 extra_attrs,
             );
+            if !T::EXISTS {
+                buf.push_str("<!>");
+            }
         }
 
         #[cfg(feature = "ssr")]
@@ -232,6 +237,9 @@ where
                 mark_branches,
                 extra_attrs,
             );
+            if !T::EXISTS {
+                buf.push_sync("<!>");
+            }
         }
 
         #[cfg(feature = "ssr")]
@@ -250,10 +258,14 @@ where
                 mark_branches,
                 extra_attrs,
             );
+            if !T::EXISTS {
+                buf.push_sync("<!>");
+            }
         }
 
         fn build<T: RenderHtml + 'static>(value: Erased) -> AnyViewState {
             let state = ErasedLocal::new(value.into_inner::<T>().build());
+            let placeholder = (!T::EXISTS).then(Rndr::create_placeholder);
             AnyViewState {
                 type_id: TypeId::of::<T>(),
                 state,
@@ -261,6 +273,7 @@ where
                 unmount: unmount_any::<T>,
                 insert_before_this: insert_before_this::<T>,
                 elements: elements::<T>,
+                placeholder,
             }
         }
 
@@ -273,6 +286,8 @@ where
             let state = ErasedLocal::new(
                 value.into_inner::<T>().hydrate::<true>(cursor, position),
             );
+            let placeholder =
+                (!T::EXISTS).then(|| cursor.next_placeholder(position));
             AnyViewState {
                 type_id: TypeId::of::<T>(),
                 state,
@@ -280,6 +295,7 @@ where
                 unmount: unmount_any::<T>,
                 insert_before_this: insert_before_this::<T>,
                 elements: elements::<T>,
+                placeholder,
             }
         }
 
@@ -327,7 +343,12 @@ impl Render for AnyView {
             (self.rebuild)(self.value, state)
         } else {
             let mut new = self.build();
-            state.insert_before_this(&mut new);
+            if let Some(placeholder) = &mut state.placeholder {
+                placeholder.insert_before_this(&mut new);
+                placeholder.unmount();
+            } else {
+                state.insert_before_this(&mut new);
+            }
             state.unmount();
             *state = new;
         }
@@ -554,7 +575,10 @@ impl RenderHtml for AnyView {
 
 impl Mountable for AnyViewState {
     fn unmount(&mut self) {
-        (self.unmount)(&mut self.state)
+        (self.unmount)(&mut self.state);
+        if let Some(placeholder) = &mut self.placeholder {
+            placeholder.unmount();
+        }
     }
 
     fn mount(
@@ -562,11 +586,23 @@ impl Mountable for AnyViewState {
         parent: &crate::renderer::types::Element,
         marker: Option<&crate::renderer::types::Node>,
     ) {
-        (self.mount)(&mut self.state, parent, marker)
+        (self.mount)(&mut self.state, parent, marker);
+        if let Some(placeholder) = &mut self.placeholder {
+            placeholder.mount(parent, marker);
+        }
     }
 
     fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
-        (self.insert_before_this)(&self.state, child)
+        let before_view = (self.insert_before_this)(&self.state, child);
+        if before_view {
+            return true;
+        }
+
+        if let Some(placeholder) = &self.placeholder {
+            placeholder.insert_before_this(child)
+        } else {
+            false
+        }
     }
 
     fn elements(&self) -> Vec<crate::renderer::types::Element> {

--- a/tachys/src/view/tuples.rs
+++ b/tachys/src/view/tuples.rs
@@ -134,6 +134,7 @@ where
     type Owned = (A::Owned,);
 
     const MIN_LENGTH: usize = A::MIN_LENGTH;
+    const EXISTS: bool = A::EXISTS;
 
     fn html_len(&self) -> usize {
         self.0.html_len()
@@ -239,7 +240,6 @@ macro_rules! impl_view_for_tuples {
 		{
 			type State = ($first::State, $($ty::State,)*);
 
-
 			fn build(self) -> Self::State {
                 #[allow(non_snake_case)]
                 let ($first, $($ty,)*) = self;
@@ -267,7 +267,7 @@ macro_rules! impl_view_for_tuples {
 		{
             type AsyncOutput = ($first::AsyncOutput, $($ty::AsyncOutput,)*);
             type Owned = ($first::Owned, $($ty::Owned,)*);
-
+            const EXISTS: bool = $first::EXISTS || $($ty::EXISTS || )* false;
             const MIN_LENGTH: usize = $first::MIN_LENGTH $(+ $ty::MIN_LENGTH)*;
 
             #[inline(always)]


### PR DESCRIPTION
This should fix the ownership/cleanup issue identified in #4114, fixing the failing test in `examples/regression`.

Todo
- [x] Add regression test for #4015/#3042
- [x] Add regression test for #4088
