### PR TITLE
Paste is dead, long live Pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 name = "either_of"
 version = "0.1.6"
 dependencies = [
- "paste",
+ "pastey",
  "pin-project-lite",
 ]
 
@@ -1779,7 +1779,7 @@ dependencies = [
  "leptos_server",
  "oco_ref",
  "or_poisoned",
- "paste",
+ "pastey",
  "rand",
  "reactive_graph",
  "rustc-hash 2.1.1",
@@ -2381,6 +2381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a8cb46bdc156b1c90460339ae6bfd45ba0394e5effbaa640badb4987fdc261"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,7 +2754,7 @@ dependencies = [
  "itertools",
  "leptos",
  "or_poisoned",
- "paste",
+ "pastey",
  "reactive_graph",
  "reactive_stores_macro",
  "rustc-hash 2.1.1",
@@ -3534,7 +3540,7 @@ dependencies = [
  "oco_ref",
  "or_poisoned",
  "parking_lot",
- "paste",
+ "pastey",
  "reactive_graph",
  "reactive_stores",
  "rustc-hash 2.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ axum = { default-features = false, version = "0.8.4" }
 serde_qs = { default-features = false, version = "0.15.0" }
 syn = { default-features = false, version = "2.0.101" }
 xxhash-rust = { default-features = false, version = "0.8.15" }
-paste = { default-features = false, version = "1.0.15" }
+pastey = { default-features = false, version = "0.1.0" }
 quote = { default-features = false, version = "1.0.40" }
 web-sys = { default-features = false, version = "0.3.77" }
 js-sys = { default-features = false, version = "0.3.77" }

--- a/either_of/Cargo.toml
+++ b/either_of/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 
 [dependencies]
 pin-project-lite = { workspace = true, default-features = true }
-paste = { workspace = true, default-features = true }
+pastey = { workspace = true, default-features = true }
 
 [features]
 default = ["no_std"]

--- a/either_of/src/lib.rs
+++ b/either_of/src/lib.rs
@@ -11,7 +11,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use paste::paste;
+use pastey::paste;
 use pin_project_lite::pin_project;
 #[cfg(not(feature = "no_std"))]
 use std::error::Error; // TODO: replace with core::error::Error once MSRV is >= 1.81.0

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -27,7 +27,7 @@ leptos_config = { workspace = true }
 leptos-spin-macro = { optional = true , workspace = true, default-features = true }
 oco_ref = { workspace = true }
 or_poisoned = { workspace = true }
-paste = { workspace = true, default-features = true }
+pastey = { workspace = true, default-features = true }
 rand = { optional = true , workspace = true, default-features = true }
 # NOTE: While not used directly, `getrandom`'s `wasm_js` feature is needed when `rand` is used on WASM to
 #       avoid a compilation error

--- a/leptos/src/callback.rs
+++ b/leptos/src/callback.rs
@@ -124,7 +124,7 @@ macro_rules! impl_unsync_callable_from_fn {
             $($arg: 'static,)*
         {
             fn from(f: F) -> Self {
-                paste::paste!(
+                pastey::paste!(
                     Self::new(move |($([<$arg:lower>],)*)| f($([<$arg:lower>]),*).into())
                 )
             }
@@ -217,7 +217,7 @@ macro_rules! impl_callable_from_fn {
             $($arg: Send + Sync + 'static,)*
         {
             fn from(f: F) -> Self {
-                paste::paste!(
+                pastey::paste!(
                     Self::new(move |($([<$arg:lower>],)*)| f($([<$arg:lower>]),*).into())
                 )
             }

--- a/reactive_stores/Cargo.toml
+++ b/reactive_stores/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 guardian = { workspace = true, default-features = true }
 itertools = { workspace = true , default-features = true }
 or_poisoned = { workspace = true }
-paste = { workspace = true, default-features = true }
+pastey = { workspace = true, default-features = true }
 reactive_graph = { workspace = true }
 rustc-hash = { workspace = true, default-features = true }
 reactive_stores_macro = { workspace = true }

--- a/reactive_stores/src/patch.rs
+++ b/reactive_stores/src/patch.rs
@@ -211,7 +211,7 @@ macro_rules! patch_tuple {
                 let mut new_path = path.to_owned();
                 new_path.push(0);
 
-                paste::paste! {
+                pastey::paste! {
                     #[allow(non_snake_case)]
                     let ($($ty,)*) = self;
                     let ($([<new_ $ty:lower>],)*) = new;

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -21,7 +21,7 @@ reactive_stores = { workspace = true, optional = true }
 slotmap = { optional = true, workspace = true, default-features = true }
 oco_ref = { workspace = true, optional = true }
 async-trait = { workspace = true, default-features = true }
-paste = { workspace = true, default-features = true }
+pastey = { workspace = true, default-features = true }
 erased = { workspace = true, default-features = true }
 wasm-bindgen = { workspace = true, default-features = true }
 html-escape = { workspace = true, default-features = true }

--- a/tachys/src/html/attribute/global.rs
+++ b/tachys/src/html/attribute/global.rs
@@ -352,7 +352,7 @@ where
 
 macro_rules! on_definitions {
 	($(#[$meta:meta] $key:ident $html:literal),* $(,)?) => {
-        paste::paste! {
+        pastey::paste! {
             $(
                 #[doc = concat!("Adds the HTML `", $html, "` attribute to the element.\n\n**Note**: This is the HTML attribute, which takes a JavaScript string, not an `on:` listener that takes application logic written in Rust.")]
                 #[track_caller]

--- a/tachys/src/html/attribute/key.rs
+++ b/tachys/src/html/attribute/key.rs
@@ -9,7 +9,7 @@ pub trait AttributeKey: Clone + Send + 'static {
 
 macro_rules! attributes {
 	($(#[$meta:meta] $key:ident $html:literal),* $(,)?) => {
-        paste::paste! {
+        pastey::paste! {
             $(
                 #[$meta]
                 #[track_caller]

--- a/tachys/src/html/attribute/mod.rs
+++ b/tachys/src/html/attribute/mod.rs
@@ -312,7 +312,7 @@ macro_rules! impl_attr_for_tuples {
             }
 
             fn rebuild(self, state: &mut Self::State) {
-                paste::paste! {
+                pastey::paste! {
                     let ([<$first:lower>], $([<$ty:lower>],)*) = self;
                     let ([<view_ $first:lower>], $([<view_ $ty:lower>],)*) = state;
                     [<$first:lower>].rebuild([<view_ $first:lower>]);
@@ -421,7 +421,7 @@ macro_rules! impl_attr_for_tuples_truncate_additional {
             }
 
             fn rebuild(self, state: &mut Self::State) {
-                paste::paste! {
+                pastey::paste! {
                     let ([<$first:lower>], $([<$ty:lower>],)*) = self;
                     let ([<view_ $first:lower>], $([<view_ $ty:lower>],)*) = state;
                     [<$first:lower>].rebuild([<view_ $first:lower>]);

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -16,7 +16,7 @@ macro_rules! html_element_inner {
         [$($attr:ty),*]
         $escape:literal
     ) => {
-        paste::paste! {
+        pastey::paste! {
             #[$meta]
             #[track_caller]
             pub fn $tag() -> HtmlElement<$struct_name, (), ()>
@@ -102,7 +102,7 @@ macro_rules! html_elements {
       ),*
       $(,)?
     ) => {
-        paste::paste! {
+        pastey::paste! {
             $(html_element_inner! {
                 #[$meta]
                 $tag
@@ -122,7 +122,7 @@ macro_rules! html_self_closing_elements {
       ),*
       $(,)?
     ) => {
-        paste::paste! {
+        pastey::paste! {
             $(
                 #[$meta]
                 #[track_caller]

--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -511,7 +511,7 @@ macro_rules! generate_event_types {
     $( #[$does_not_bubble:ident] )?
     $( $event:ident )+ : $web_event:ident
   ),* $(,)?} => {
-    ::paste::paste! {
+    ::pastey::paste! {
       $(
         #[doc = "The `" [< $($event)+ >] "` event, which receives [" $web_event "](web_sys::" $web_event ") as its argument."]
         #[derive(Copy, Clone, Debug)]

--- a/tachys/src/mathml/mod.rs
+++ b/tachys/src/mathml/mod.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 
 macro_rules! mathml_global {
 	($tag:ty, $attr:ty) => {
-		paste::paste! {
+		pastey::paste! {
             /// A MathML attribute.
 			pub fn $attr<V>(self, value: V) -> HtmlElement <
 				[<$tag:camel>],
@@ -42,7 +42,7 @@ macro_rules! mathml_global {
 
 macro_rules! mathml_elements {
 	($($tag:ident  [$($attr:ty),*]),* $(,)?) => {
-        paste::paste! {
+        pastey::paste! {
             $(
                 // `tag()` function
                 /// A MathML element.

--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -15,7 +15,7 @@ use std::{borrow::Cow, fmt::Debug};
 
 macro_rules! svg_elements {
 	($($tag:ident  [$($attr:ty),*]),* $(,)?) => {
-        paste::paste! {
+        pastey::paste! {
             $(
                 /// An SVG element.
                 // `tag()` function

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -720,7 +720,7 @@ where
 
 macro_rules! tuples {
     ($num:literal => $($ty:ident),*) => {
-        paste::paste! {
+        pastey::paste! {
             #[doc = concat!("Retained view state for ", stringify!([<EitherOf $num>]), ".")]
             pub struct [<EitherOf $num State>]<$($ty,)*>
             where

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -20,7 +20,7 @@ use std::{
 macro_rules! render_primitive {
   ($($child_type:ty),* $(,)?) => {
     $(
-		paste::paste! {
+		pastey::paste! {
 			pub struct [<$child_type:camel State>](crate::renderer::types::Text, $child_type);
 
 			impl Mountable for [<$child_type:camel State>] {

--- a/tachys/src/view/tuples.rs
+++ b/tachys/src/view/tuples.rs
@@ -250,7 +250,7 @@ macro_rules! impl_view_for_tuples {
 			}
 
 			fn rebuild(self, state: &mut Self::State) {
-				paste::paste! {
+				pastey::paste! {
 					let ([<$first:lower>], $([<$ty:lower>],)*) = self;
 					let ([<view_ $first:lower>], $([<view_ $ty:lower>],)*) = state;
 					[<$first:lower>].rebuild([<view_ $first:lower>]);


### PR DESCRIPTION
The crate paste is no longer maintained, and has a replacement. On that basis only my IDE is reporting "paste" as a security hazard.

"pastey is the fork of paste and is aimed to be a drop-in replacement with additional features for paste crate" <https://crates.io/crates/pastey>