### PR TITLE
chore: Respond to updated clippy rules

### DIFF
--- a/examples/stores/src/lib.rs
+++ b/examples/stores/src/lib.rs
@@ -159,7 +159,7 @@ fn TodoRow(
 
     view! {
         <li style:text-decoration=move || {
-            status.done().then_some("line-through").unwrap_or_default()
+          if status.done() { "line-through" } else { Default::default() }
         }>
 
             <p


### PR DESCRIPTION
 status.done().then_some("line-through").unwrap_or_default()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `if status.done() { "line-through" } else { Default::default() }`

Just for the record this is appearing in the buld artefacts of this currently active PR

#4118
