### PR TITLE
examples/cf-worker: Broken test investigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "collection_literals"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
 
 [[package]]
 name = "concurrent-queue"
@@ -1704,6 +1704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2826,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64",
  "bytes",
@@ -3702,17 +3713,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/examples/cf-worker/.cargo.config.toml
+++ b/examples/cf-worker/.cargo.config.toml
@@ -1,0 +1,8 @@
+# For crates within the workspace this cfg flag
+# is added automatically (see the build.rs file)
+#
+# examples/cf-worker is not a workspace item
+# and so this needs to be specified here.
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+

--- a/examples/cf-worker/Cargo.toml
+++ b/examples/cf-worker/Cargo.toml
@@ -29,12 +29,16 @@ server_fn = { path = "../../server_fn", default-features = false, features = [
 	"multipart",
 	"postcard",
 ] }
-getrandom = { version = "0.3.3", default-features = false, features = [
-	"wasm_js",
-] }
+getrandom = { version = "0.3.3", default-features = false}
 
 worker = { version = "0.6.0", features = ["http", "axum"] }
 worker-macros = { version = "0.6.0", features = ["http"] }
 axum = { version = "0.8", default-features = false }
 tower-service = "0.3.2"
 console_error_panic_hook = { version = "0.1.1" }
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+getrandom = { version = "0.3.3", default-features = false, features=["wasm_js"] }
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+getrandom = { version = "0.3.3", default-features = false}

--- a/examples/cf-worker/Cargo.toml
+++ b/examples/cf-worker/Cargo.toml
@@ -33,8 +33,8 @@ getrandom = { version = "0.3.3", default-features = false, features = [
 	"wasm_js",
 ] }
 
-worker = { version = "0.5.0", features = ["http", "axum"] }
-worker-macros = { version = "0.5.0", features = ["http"] }
+worker = { version = "0.6.0", features = ["http", "axum"] }
+worker-macros = { version = "0.6.0", features = ["http"] }
 axum = { version = "0.8", default-features = false }
 tower-service = "0.3.2"
 console_error_panic_hook = { version = "0.1.1" }

--- a/examples/cf-worker/Cargo.toml
+++ b/examples/cf-worker/Cargo.toml
@@ -29,7 +29,6 @@ server_fn = { path = "../../server_fn", default-features = false, features = [
 	"multipart",
 	"postcard",
 ] }
-getrandom = { version = "0.3.3", default-features = false}
 
 worker = { version = "0.6.0", features = ["http", "axum"] }
 worker-macros = { version = "0.6.0", features = ["http"] }
@@ -38,7 +37,7 @@ tower-service = "0.3.2"
 console_error_panic_hook = { version = "0.1.1" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-getrandom = { version = "0.3.3", default-features = false, features=["wasm_js"] }
+getrandom = { version = "0.3.3", features=["wasm_js"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 getrandom = { version = "0.3.3", default-features = false}

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -29,9 +29,6 @@ oco_ref = { workspace = true }
 or_poisoned = { workspace = true }
 paste = { workspace = true, default-features = true }
 rand = { optional = true , workspace = true, default-features = true }
-# NOTE: While not used directly, `getrandom`'s `wasm_js` feature is needed when `rand` is used on WASM to
-#       avoid a compilation error
-getrandom = { optional = true , workspace = true, default-features = true }
 reactive_graph = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true, default-features = true }
 tachys = { workspace = true, features = [
@@ -154,3 +151,11 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(leptos_debuginfo)',
   'cfg(rustc_nightly)',
 ] }
+
+# NOTE: While not used directly, `getrandom`'s `wasm_js` feature is needed when `rand` is used on WASM to
+#       avoid a compilation error
+[target.'cfg(target_arch="wasm32")'.dependencies]
+getrandom = { optional = true , workspace = true, features=["wasm_js"] }
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+getrandom = { optional = true , workspace = true, default-features = true }


### PR DESCRIPTION
Top of the tree is currently failing tests.
Failing on the following build

```bash
cd examples/cf-worker$
cargo build  --lib --release --target wasm32-unknown-unknown
```

* builds Ok without the --target specified
* builds Ok with --target specified BUT after cargo clean

so something is sticky, and messy crate dependency issue

My IDE reports "worker" and "worker-macros" are outdated That is the first thing that needs to be resolved.