### PR TITLE
Use binary search when `subscribe`ing

### DIFF
--- a/reactive_graph/src/graph/sets.rs
+++ b/reactive_graph/src/graph/sets.rs
@@ -68,8 +68,8 @@ impl SubscriberSet {
     }
 
     pub fn subscribe(&mut self, subscriber: AnySubscriber) {
-        if !self.0.contains(&subscriber) {
-            self.0.push(subscriber);
+        if let Err(idx) = self.0.binary_search_by_key(&subscriber.0, |s| s.0) {
+            self.0.insert(idx, subscriber)
         }
     }
 


### PR DESCRIPTION
Use binary search when `subscribe`ing to a `SubscriberSet`. In tests, reduced `subscribe` time by 7 to 10 times.