### PR TITLE
fix(CI): check latest commit for version release instead of version tag

### DIFF
--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -169,7 +169,9 @@ jobs:
           cd '${{ inputs.directory }}'
           cargo make --no-workspace --profile=github-actions ci
           # check the direct-minimal-versions on release
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s')
+          # Supports: v1.2.3, v1.2.3-alpha, v1.2.3-beta1, v1.2.3-rc.1, etc.
+          if [[ "$COMMIT_MSG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.?[0-9]+)?)?$ ]]; then
             cargo make --no-workspace --profile=github-actions check-minimal-versions
           fi
       # Check if the counter_isomorphic can be built with leptos_debuginfo cfg flag in release mode


### PR DESCRIPTION
This will trigger check minimal versions. Related #4149, #4146.

@gbj, Please first publish the crates to crates.io and then push commit a version release like `v0.8.4` to make sure the CI and `check-minimal-versions` work/trigger properly.