### PR TITLE
fix: three hot-reloading bugs ( closes #3191 )

### DIFF
--- a/leptos_hot_reload/src/node.rs
+++ b/leptos_hot_reload/src/node.rs
@@ -66,6 +66,9 @@ impl LNode {
                     LNode::parse_node(child, views)?;
                 }
             }
+            Node::RawText(text) => {
+                views.push(LNode::Text(text.to_string_best()));
+            }
             Node::Text(text) => {
                 views.push(LNode::Text(text.value_string()));
             }

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -1,10 +1,15 @@
-console.log("[HOT RELOADING] Connected to server.\n\nNote: `cargo-leptos watch --hot-reload` only works with the `nightly` feature enabled on Leptos.");
+console.log(
+  "[HOT RELOADING] Connected to server.\n\nNote: `cargo-leptos watch --hot-reload` only works with the `nightly` feature enabled on Leptos.",
+);
 function patch(json) {
   try {
     const views = JSON.parse(json);
     for (const [id, patches] of views) {
       console.log("[HOT RELOAD]", id, patches);
-      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT),
+      const walker = document.createTreeWalker(
+          document.body,
+          NodeFilter.SHOW_COMMENT,
+        ),
         open = `hot-reload|${id}|open`,
         close = `hot-reload|${id}|close`;
       let start, end;
@@ -22,14 +27,20 @@ function patch(json) {
 
       for (const [start, end] of instances) {
         // build tree of current actual children
-        const actualChildren = childrenFromRange(start.parentElement, start, end);
+        const actualChildren = childrenFromRange(
+          start.parentElement,
+          start,
+          end,
+        );
         const actions = [];
 
         // build up the set of actions
         for (const patch of patches) {
           const child = childAtPath(
-            actualChildren.length > 1 ? { children: actualChildren } : actualChildren[0],
-            patch.path
+            actualChildren.length > 1
+              ? { children: actualChildren }
+              : actualChildren[0],
+            patch.path,
           );
           const action = patch.action;
           if (action == "ClearChildren") {
@@ -39,8 +50,15 @@ function patch(json) {
             });
           } else if (action.ReplaceWith) {
             actions.push(() => {
-              console.log("[HOT RELOAD] > ReplaceWith", child, action.ReplaceWith);
-              const replacement = fromReplacementNode(action.ReplaceWith, actualChildren);
+              console.log(
+                "[HOT RELOAD] > ReplaceWith",
+                child,
+                action.ReplaceWith,
+              );
+              const replacement = fromReplacementNode(
+                action.ReplaceWith,
+                actualChildren,
+              );
               if (child.node) {
                 child.node.replaceWith(replacement);
               } else {
@@ -54,7 +72,11 @@ function patch(json) {
           } else if (action.ChangeTagName) {
             const oldNode = child.node;
             actions.push(() => {
-              console.log("[HOT RELOAD] > ChangeTagName", child.node, action.ChangeTagName);
+              console.log(
+                "[HOT RELOAD] > ChangeTagName",
+                child.node,
+                action.ChangeTagName,
+              );
               const newElement = document.createElement(action.ChangeTagName);
               for (const attr of oldNode.attributes) {
                 newElement.setAttribute(attr.name, attr.value);
@@ -67,13 +89,21 @@ function patch(json) {
             });
           } else if (action.RemoveAttribute) {
             actions.push(() => {
-              console.log("[HOT RELOAD] > RemoveAttribute", child.node, action.RemoveAttribute);
+              console.log(
+                "[HOT RELOAD] > RemoveAttribute",
+                child.node,
+                action.RemoveAttribute,
+              );
               child.node.removeAttribute(action.RemoveAttribute);
             });
           } else if (action.SetAttribute) {
             const [name, value] = action.SetAttribute;
             actions.push(() => {
-              console.log("[HOT RELOAD] > SetAttribute", child.node, action.SetAttribute);
+              console.log(
+                "[HOT RELOAD] > SetAttribute",
+                child.node,
+                action.SetAttribute,
+              );
               child.node.setAttribute(name, value);
             });
           } else if (action.SetText) {
@@ -84,13 +114,25 @@ function patch(json) {
             });
           } else if (action.AppendChildren) {
             actions.push(() => {
-              console.log("[HOT RELOAD] > AppendChildren", child.node, action.AppendChildren);
-              const newChildren = fromReplacementNode(action.AppendChildren, actualChildren);
+              console.log(
+                "[HOT RELOAD] > AppendChildren",
+                child.node,
+                action.AppendChildren,
+              );
+              const newChildren = fromReplacementNode(
+                action.AppendChildren,
+                actualChildren,
+              );
               child.node.append(newChildren);
             });
           } else if (action.RemoveChild) {
             actions.push(() => {
-              console.log("[HOT RELOAD] > RemoveChild", child.node, child.children, action.RemoveChild);
+              console.log(
+                "[HOT RELOAD] > RemoveChild",
+                child.node,
+                child.children,
+                action.RemoveChild,
+              );
               const toRemove = child.children[action.RemoveChild.at];
               let toRemoveNode = toRemove.node;
               if (!toRemoveNode) {
@@ -103,33 +145,56 @@ function patch(json) {
               }
             });
           } else if (action.InsertChild) {
-            const newChild = fromReplacementNode(action.InsertChild.child, actualChildren);
+            const newChild = fromReplacementNode(
+              action.InsertChild.child,
+              actualChildren,
+            );
             let children = [];
             if (child.children) {
               children = child.children;
             } else if (child.start && child.end) {
-              children = childrenFromRange(child.node || child.start.parentElement, start, end);
+              children = childrenFromRange(
+                child.node || child.start.parentElement,
+                start,
+                end,
+              );
             } else {
               console.warn("InsertChildAfter could not build children.");
             }
             const before = children[action.InsertChild.before];
             actions.push(() => {
-              console.log("[HOT RELOAD] > InsertChild", child, child.node, action.InsertChild, " before ", before);
+              console.log(
+                "[HOT RELOAD] > InsertChild",
+                child,
+                child.node,
+                action.InsertChild,
+                " before ",
+                before,
+              );
               if (!before && child.node) {
                 child.node.appendChild(newChild);
               } else {
                 let node = child.node || child.end.parentElement;
-                const reference = before ? before.node || before.start : child.end;
+                const reference = before
+                  ? before.node || before.start
+                  : child.end;
                 node.insertBefore(newChild, reference);
               }
             });
           } else if (action.InsertChildAfter) {
-            const newChild = fromReplacementNode(action.InsertChildAfter.child, actualChildren);
+            const newChild = fromReplacementNode(
+              action.InsertChildAfter.child,
+              actualChildren,
+            );
             let children = [];
             if (child.children) {
               children = child.children;
             } else if (child.start && child.end) {
-              children = childrenFromRange(child.node || child.start.parentElement, start, end);
+              children = childrenFromRange(
+                child.node || child.start.parentElement,
+                start,
+                end,
+              );
             } else {
               console.warn("InsertChildAfter could not build children.");
             }
@@ -141,17 +206,24 @@ function patch(json) {
                 child.node,
                 action.InsertChildAfter,
                 " after ",
-                after
+                after,
               );
-              if (child.node && (!after || !(after.node || after.start).nextSibling)) {
+              if (
+                child.node &&
+                (!after || !(after.node || after.start).nextSibling)
+              ) {
                 child.node.appendChild(newChild);
               } else {
                 const node = child.node || child.end;
-                const parent = node.nodeType === Node.COMMENT_NODE ? node.parentNode : node;
+                const parent =
+                  node.nodeType === Node.COMMENT_NODE ? node.parentNode : node;
                 if (!after) {
                   parent.appendChild(newChild);
                 } else {
-                  parent.insertBefore(newChild, (after.node || after.start).nextSibling);
+                  parent.insertBefore(
+                    newChild,
+                    (after.node || after.start).nextSibling,
+                  );
                 }
               }
             });
@@ -191,8 +263,10 @@ function patch(json) {
       return element;
     } else {
       const child = childAtPath(
-        actualChildren.length > 1 ? { children: actualChildren } : actualChildren[0],
-        node.Path
+        actualChildren.length > 1
+          ? { children: actualChildren }
+          : actualChildren[0],
+        node.Path,
       );
       if (child) {
         let childNode = child.node;
@@ -215,7 +289,10 @@ function patch(json) {
         }
         return childNode;
       } else {
-        console.warn("[HOT RELOADING] Could not find replacement node at ", node.Path);
+        console.warn(
+          "[HOT RELOADING] Could not find replacement node at ",
+          node.Path,
+        );
         return undefined;
       }
     }
@@ -227,13 +304,16 @@ function patch(json) {
       NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT | NodeFilter.SHOW_COMMENT,
       {
         acceptNode(node) {
-          if (node.parentNode == element && (!range || range.isPointInRange(node, 0))) {
+          if (
+            node.parentNode == element &&
+            (!range || range.isPointInRange(node, 0))
+          ) {
             return NodeFilter.FILTER_ACCEPT;
           } else {
             return NodeFilter.FILTER_REJECT;
           }
         },
-      }
+      },
     );
     const actualChildren = [],
       elementCount = {};
@@ -260,9 +340,13 @@ function patch(json) {
         });
       } else if (walker.currentNode.nodeType == Node.COMMENT_NODE) {
         if (walker.currentNode.textContent.trim().startsWith("hot-reload")) {
-          if (walker.currentNode.textContent.trim().endsWith("-children|open")) {
+          if (
+            walker.currentNode.textContent.trim().endsWith("-children|open")
+          ) {
             const startingName = walker.currentNode.textContent.trim();
-            const componentName = startingName.replace("-children|open").replace("hot-reload|");
+            const componentName = startingName
+              .replace("-children|open")
+              .replace("hot-reload|");
             const endingName = `hot-reload|${componentName}-children|close`;
             let start = walker.currentNode;
             let depth = 1;
@@ -270,7 +354,9 @@ function patch(json) {
             while (walker.nextNode()) {
               if (walker.currentNode.textContent.trim() == endingName) {
                 depth--;
-              } else if (walker.currentNode.textContent.trim() == startingName) {
+              } else if (
+                walker.currentNode.textContent.trim() == startingName
+              ) {
                 depth++;
               }
 
@@ -283,7 +369,11 @@ function patch(json) {
               type: "fragment",
               start: start.nextSibling,
               end: end.previousSibling,
-              children: childrenFromRange(start.parentElement, start.nextSibling, end.previousSibling),
+              children: childrenFromRange(
+                start.parentElement,
+                start.nextSibling,
+                end.previousSibling,
+              ),
             });
           }
         } else if (walker.currentNode.textContent.trim() == "<() />") {
@@ -358,7 +448,10 @@ function patch(json) {
           });
         }
       } else {
-        console.warn("[HOT RELOADING] Building children, encountered", walker.currentNode);
+        console.warn(
+          "[HOT RELOADING] Building children, encountered",
+          walker.currentNode,
+        );
       }
     }
     return actualChildren;
@@ -374,7 +467,11 @@ function patch(json) {
     } else if (path == [0]) {
       return element;
     } else if (element.start && element.end) {
-      const actualChildren = childrenFromRange(element.node || element.start.parentElement, element.start, element.end);
+      const actualChildren = childrenFromRange(
+        element.node || element.start.parentElement,
+        element.start,
+        element.end,
+      );
       return childAtPath({ children: actualChildren }, path);
     } else {
       console.warn("[HOT RELOADING] Child at ", path, "not found in ", element);

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -339,15 +339,13 @@ function patch(json) {
           node: walker.currentNode,
         });
       } else if (walker.currentNode.nodeType == Node.COMMENT_NODE) {
-        if (walker.currentNode.textContent.trim().startsWith("hot-reload")) {
-          if (
-            walker.currentNode.textContent.trim().endsWith("-children|open")
-          ) {
+        if (walker.currentNode.textContent.trim().startsWith("hot-reload|")) {
+          if (walker.currentNode.textContent.trim().endsWith("|open")) {
             const startingName = walker.currentNode.textContent.trim();
             const componentName = startingName
-              .replace("-children|open")
-              .replace("hot-reload|");
-            const endingName = `hot-reload|${componentName}-children|close`;
+              .replace("|open", "")
+              .replace("hot-reload|", "");
+            const endingName = `hot-reload|${componentName}|close`;
             let start = walker.currentNode;
             let depth = 1;
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -217,7 +217,7 @@ where
                 extra_attrs,
             );
             if !T::EXISTS {
-                buf.push_str("<!>");
+                buf.push_str("<!--<() />-->");
             }
         }
 
@@ -238,7 +238,7 @@ where
                 extra_attrs,
             );
             if !T::EXISTS {
-                buf.push_sync("<!>");
+                buf.push_sync("<!--<() />-->");
             }
         }
 
@@ -259,7 +259,7 @@ where
                 extra_attrs,
             );
             if !T::EXISTS {
-                buf.push_sync("<!>");
+                buf.push_sync("<!--<() />-->");
             }
         }
 


### PR DESCRIPTION
This PR fixes three bugs in hot-reload functionality ( two of which were mentioned in #3191 ).

1) unquoted text wasn't parsed into LNode which led to wrong indexing of children in patch.js
2) components without DOM ( e.g. metatags ) also broke indexing
3) changes to views with fragment components led to updating elements inside these fragments

# Considerations
- Now unquoted text parses into the same LNode::Text variant as Node::Text does. I searched for differences in handling RawText and Text variants, but didn't find any.
- DOM-less components now inserts <!--<() />--> comment into html, instead of <!---->. I also didn't find code that relies on that behaviour.

# MRE
Here is the code that I tested changes on:
```rust
use leptos::prelude::*;
use leptos_meta::{provide_meta_context, MetaTags, Title};
use leptos_router::{
    components::{Route, Router, Routes},
    StaticSegment,
};

pub fn shell(options: LeptosOptions) -> impl IntoView {
    view! {
        <!DOCTYPE html>
        <html lang="en">
            <head>
                <meta charset="utf-8"/>
                <meta name="viewport" content="width=device-width, initial-scale=1"/>
                <AutoReload options=options.clone()/>
                <HydrationScripts options/>
                <MetaTags/>
            </head>
            <body>
                <App/>
            </body>
        </html>
    }
}

#[component]
pub fn App() -> impl IntoView {
    provide_meta_context();

    view! {
        <Title text="Welcome to Leptos"/>
        <Router>
            <main>
                <Routes fallback=|| "Page not found.".into_view()>
                    <Route path=StaticSegment("") view=HomePage/>
                </Routes>
            </main>
        </Router>
    }
}

#[component]
fn HomePage() -> impl IntoView {
    view! {
        <div>
            <HotReloadAfterUnquotedText />
            <br />
            <br />
            <HotReloadAfterUnitComponent />
            <br />
            <br />
            <HotReloadAfterFragment />
        </div>
    }
}

#[component]
fn HotReloadAfterUnquotedText() -> impl IntoView {
    view! {
        <div>
            Some unquoted text
            <div>"Try to change me"</div>
        </div>
    }
}

#[component]
fn HotReloadAfterUnitComponent() -> impl IntoView {
    view! {
        <div>
            <Title text="Welcome to Leptos"/>
            <div>"Some text"</div>
            <MyUnitComponent />
            <div>"Try to change me"</div>
        </div>
    }
}

#[component]
fn HotReloadAfterFragment() -> impl IntoView {
    view! {
        <div>
            <MyFragmentComponent />
            <div>"Try to change me"</div>
        </div>
    }
}

#[component]
fn MyFragmentComponent() -> impl IntoView {
    view! {
        <p>"First fragment line"</p>
        <p>"Second fragment line"</p>
        <p>"Third fragment line"</p>
    }
}

#[component]
fn MyUnitComponent() -> impl IntoView {}
```
