### PR TITLE
docs: add warning for reading hash on the server

### DIFF
--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -67,7 +67,7 @@ impl Url {
     }
 
     pub fn hash(&self) -> &str {
-        #[cfg(feature = "ssr")]
+        #[cfg(all(feature = "ssr", any(debug_assertions, leptos_debuginfo)))]
         {
             #[cfg(feature = "tracing")]
             tracing::warn!(
@@ -82,7 +82,7 @@ impl Url {
     }
 
     pub fn hash_mut(&mut self) -> &mut String {
-        #[cfg(feature = "ssr")]
+        #[cfg(all(feature = "ssr", any(debug_assertions, leptos_debuginfo)))]
         {
             #[cfg(feature = "tracing")]
             tracing::warn!(


### PR DESCRIPTION
Closes #4059 

There is currently no check on if the app is running in dev or prod mode, since I couldn't figure out how to access the current LeptosOptions to check against the env. If there's a way to get the current options or if you want to check against the build type instead I'm happy to implement those.

From my (admittedly limited) testing this does not appear to produce false positives.