### PR TITLE
feat: add `debug_log!`, `debug_error!`, `console_debug_log` and `console_debug_error` 

### DIFF
--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -23,6 +23,19 @@ macro_rules! error {
     ($($t:tt)*) => ($crate::logging::console_error(&format_args!($($t)*).to_string()))
 }
 
+/// Uses `println!()`-style formatting to log something to the console (in the browser)
+/// or via `println!()` (if not in the browser), but only if it's a debug build.
+#[macro_export]
+macro_rules! debug_log {
+    ($($x:tt)*) => {
+        {
+            if cfg!(debug_assertions) {
+                $crate::log!($($x)*)
+            }
+        }
+    }
+}
+
 /// Uses `println!()`-style formatting to log warnings to the console (in the browser)
 /// or via `eprintln!()` (if not in the browser), but only if it's a debug build.
 #[macro_export]
@@ -31,6 +44,19 @@ macro_rules! debug_warn {
         {
             if cfg!(debug_assertions) {
                 $crate::warn!($($x)*)
+            }
+        }
+    }
+}
+
+/// Uses `println!()`-style formatting to log errors to the console (in the browser)
+/// or via `eprintln!()` (if not in the browser), but only if it's a debug build.
+#[macro_export]
+macro_rules! debug_error {
+    ($($x:tt)*) => {
+        {
+            if cfg!(debug_assertions) {
+                $crate::error!($($x)*)
             }
         }
     }
@@ -75,8 +101,27 @@ pub fn console_error(s: &str) {
     }
 }
 
-/// Log an error to the console (in the browser)
+/// Log a string to the console (in the browser)
 /// or via `println!()` (if not in the browser), but only in a debug build.
+#[inline(always)]
+pub fn console_debug_log(s: &str) {
+    #[cfg(debug_assertions)]
+    {
+        if log_to_stdout() {
+            println!("{s}");
+        } else {
+            web_sys::console::log_1(&JsValue::from_str(s));
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = s;
+    }
+}
+
+/// Log a warning to the console (in the browser)
+/// or via `eprintln!()` (if not in the browser), but only in a debug build.
 #[inline(always)]
 pub fn console_debug_warn(s: &str) {
     #[cfg(debug_assertions)]
@@ -85,6 +130,25 @@ pub fn console_debug_warn(s: &str) {
             eprintln!("{s}");
         } else {
             web_sys::console::warn_1(&JsValue::from_str(s));
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = s;
+    }
+}
+
+/// Log an error to the console (in the browser)
+/// or via `eprintln!()` (if not in the browser), but only in a debug build.
+#[inline(always)]
+pub fn console_debug_error(s: &str) {
+    #[cfg(debug_assertions)]
+    {
+        if log_to_stdout() {
+            eprintln!("{s}");
+        } else {
+            web_sys::console::error_1(&JsValue::from_str(s));
         }
     }
 

--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -105,18 +105,8 @@ pub fn console_error(s: &str) {
 /// or via `println!()` (if not in the browser), but only in a debug build.
 #[inline(always)]
 pub fn console_debug_log(s: &str) {
-    #[cfg(debug_assertions)]
-    {
-        if log_to_stdout() {
-            println!("{s}");
-        } else {
-            web_sys::console::log_1(&JsValue::from_str(s));
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = s;
+    if cfg!(debug_assertions) {
+        console_log(s)
     }
 }
 
@@ -124,18 +114,8 @@ pub fn console_debug_log(s: &str) {
 /// or via `eprintln!()` (if not in the browser), but only in a debug build.
 #[inline(always)]
 pub fn console_debug_warn(s: &str) {
-    #[cfg(debug_assertions)]
-    {
-        if log_to_stdout() {
-            eprintln!("{s}");
-        } else {
-            web_sys::console::warn_1(&JsValue::from_str(s));
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = s;
+    if cfg!(debug_assertions) {
+        console_warn(s)
     }
 }
 
@@ -143,17 +123,7 @@ pub fn console_debug_warn(s: &str) {
 /// or via `eprintln!()` (if not in the browser), but only in a debug build.
 #[inline(always)]
 pub fn console_debug_error(s: &str) {
-    #[cfg(debug_assertions)]
-    {
-        if log_to_stdout() {
-            eprintln!("{s}");
-        } else {
-            web_sys::console::error_1(&JsValue::from_str(s));
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = s;
+    if cfg!(debug_assertions) {
+        console_error(s)
     }
 }

--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -55,7 +55,7 @@ pub fn console_log(s: &str) {
 }
 
 /// Log a warning to the console (in the browser)
-/// or via `println!()` (if not in the browser).
+/// or via `eprintln!()` (if not in the browser).
 pub fn console_warn(s: &str) {
     if log_to_stdout() {
         eprintln!("{s}");
@@ -65,7 +65,7 @@ pub fn console_warn(s: &str) {
 }
 
 /// Log an error to the console (in the browser)
-/// or via `println!()` (if not in the browser).
+/// or via `eprintln!()` (if not in the browser).
 #[inline(always)]
 pub fn console_error(s: &str) {
     if log_to_stdout() {


### PR DESCRIPTION
This PR adds debug-only macros and methods for `log` and `error` levels, aligning with the existing warning level implementation. I guess the debug-only methods contain duplicated code, but I’ve kept them as-is to match the existing pattern. Additionally, I noticed that `console_error` is defined inline, while the other two methods are not. I left this unchanged to avoid potential impacts on compile times. Let me know if any changes are needed.