### PR TITLE
Version updates + stable hot-reloading

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,7 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with: {toolchain: "nightly-2025-04-16", components: "rustfmt, clippy", target: "wasm32-unknown-unknown", rustflags: ""}
+        with:
+          {
+            toolchain: "nightly-2025-07-16",
+            components: "rustfmt, clippy",
+            target: "wasm32-unknown-unknown",
+            rustflags: "",
+          }
       - name: Install Glib
         run: |
           sudo apt-get update

--- a/.github/workflows/run-cargo-make-task.yml
+++ b/.github/workflows/run-cargo-make-task.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, nightly-2025-04-16]
+        toolchain: [stable, nightly-2025-07-16]
         erased_mode: [true, false]
     steps:
       - name: Free Disk Space

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ exclude = ["benchmarks", "examples", "projects"]
 [workspace.package]
 version = "0.8.3"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.88"
 
 [workspace.dependencies]
 # members

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,8 +2,6 @@
 name = "benchmarks"
 version = "0.1.0"
 edition = "2021"
-# std::sync::LazyLock is stabilized in Rust version 1.80.0
-rust-version = "1.80.0"
 
 [dependencies]
 l0410 = { package = "leptos", version = "0.4.10", features = [

--- a/examples/counter_isomorphic/Cargo.toml
+++ b/examples/counter_isomorphic/Cargo.toml
@@ -2,8 +2,6 @@
 name = "counter_isomorphic"
 version = "0.1.0"
 edition = "2021"
-# std::sync::LazyLock is stabilized in Rust version 1.80.0
-rust-version = "1.80.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/examples/ssr_modes/Cargo.toml
+++ b/examples/ssr_modes/Cargo.toml
@@ -2,8 +2,6 @@
 name = "ssr_modes"
 version = "0.1.0"
 edition = "2021"
-# std::sync::LazyLock is stabilized in Rust version 1.80.0
-rust-version = "1.80.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/examples/ssr_modes_axum/Cargo.toml
+++ b/examples/ssr_modes_axum/Cargo.toml
@@ -2,8 +2,6 @@
 name = "ssr_modes_axum"
 version = "0.1.0"
 edition = "2021"
-# std::sync::LazyLock is stabilized in Rust version 1.80.0
-rust-version = "1.80.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -108,9 +108,15 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         mark_branches: bool,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
-        let vm = self.view_marker.to_owned();
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
+        let vm = if cfg!(debug_assertions)
+            && option_env!("LEPTOS_WATCH").is_some()
+        {
+            self.view_marker.to_owned()
+        } else {
+            None
+        };
+
+        #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
             buf.push_str(&format!("<!--hot-reload|{vm}|open-->"));
         }
@@ -123,7 +129,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
             extra_attrs,
         );
 
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
+        #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
             buf.push_str(&format!("<!--hot-reload|{vm}|close-->"));
         }
@@ -139,9 +145,15 @@ impl<T: RenderHtml> RenderHtml for View<T> {
     ) where
         Self: Sized,
     {
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
-        let vm = self.view_marker.to_owned();
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
+        let vm = if cfg!(debug_assertions)
+            && option_env!("LEPTOS_WATCH").is_some()
+        {
+            self.view_marker.to_owned()
+        } else {
+            None
+        };
+
+        #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
             buf.push_sync(&format!("<!--hot-reload|{vm}|open-->"));
         }
@@ -154,7 +166,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
             extra_attrs,
         );
 
-        #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))]
+        #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
             buf.push_sync(&format!("<!--hot-reload|{vm}|close-->"));
         }

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -108,9 +108,8 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         mark_branches: bool,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        let vm = if cfg!(debug_assertions)
-            && option_env!("LEPTOS_WATCH").is_some()
-        {
+        #[cfg(debug_assertions)]
+        let vm = if option_env!("LEPTOS_WATCH").is_some() {
             self.view_marker.to_owned()
         } else {
             None
@@ -145,9 +144,8 @@ impl<T: RenderHtml> RenderHtml for View<T> {
     ) where
         Self: Sized,
     {
-        let vm = if cfg!(debug_assertions)
-            && option_env!("LEPTOS_WATCH").is_some()
-        {
+        #[cfg(debug_assertions)]
+        let vm = if option_env!("LEPTOS_WATCH").is_some() {
             self.view_marker.to_owned()
         } else {
             None

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -1,4 +1,3 @@
-console.log("[HOT RELOADING] Connected to server.\n\nNote: `cargo-leptos watch --hot-reload` only works with the `nightly` feature enabled on Leptos.");
 function patch(json) {
   try {
     const views = JSON.parse(json);

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -358,16 +358,14 @@ fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
 }
 
 fn normalized_call_site(site: proc_macro::Span) -> Option<String> {
-    cfg_if::cfg_if! {
-        if #[cfg(all(debug_assertions, feature = "nightly", rustc_nightly))] {
-            Some(leptos_hot_reload::span_to_stable_id(
-                site.file(),
-                site.start().line()
-            ))
-        } else {
-            _ = site;
-            None
-        }
+    if cfg!(debug_assertions) {
+        Some(leptos_hot_reload::span_to_stable_id(
+            site.file(),
+            site.start().line(),
+        ))
+    } else {
+        _ = site;
+        None
     }
 }
 

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -1105,11 +1105,6 @@ mod tests {
         assert_eq!(combined_count.load(Ordering::Relaxed), 3);
     }
 
-    #[derive(Debug, Store)]
-    pub struct StructWithOption {
-        opt_field: Option<Todo>,
-    }
-
     // regression test for https://github.com/leptos-rs/leptos/issues/3523
     #[tokio::test]
     async fn notifying_all_descendants() {

--- a/server_fn/tests/invalid/empty_return.stderr
+++ b/server_fn/tests/invalid/empty_return.stderr
@@ -7,20 +7,7 @@ error[E0277]: () is not a `Result` or aliased `Result`. Server functions must re
   = help: the trait `ServerFnMustReturnResult` is not implemented for `()`
   = note: If you are trying to return an alias of `Result`, you must also implement `FromServerFnError` for the error type.
   = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
-
-error[E0271]: expected `impl Future<Output = ()>` to be a future that resolves to `Result<_, _>`, but it resolves to `()`
- --> tests/invalid/empty_return.rs:3:1
-  |
-3 | #[server]
-  | ^^^^^^^^^ expected `Result<_, _>`, found `()`
-  |
-  = note:   expected enum `Result<_, _>`
-          found unit type `()`
-note: required by a bound in `ServerFn::{anon_assoc#0}`
- --> src/lib.rs
-  |
-  |     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
-  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServerFn::{anon_assoc#0}`
+  = note: this error originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: () is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
  --> tests/invalid/empty_return.rs:3:1
@@ -31,7 +18,20 @@ error[E0277]: () is not a `Result` or aliased `Result`. Server functions must re
   = help: the trait `ServerFnMustReturnResult` is not implemented for `()`
   = note: If you are trying to return an alias of `Result`, you must also implement `FromServerFnError` for the error type.
   = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
-  = note: this error originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: expected `impl Future<Output = ()>` to be a future that resolves to `Result<_, _>`, but it resolves to `()`
+ --> tests/invalid/empty_return.rs:3:1
+  |
+3 | #[server]
+  | ^^^^^^^^^ expected `Result<_, _>`, found `()`
+  |
+  = note:   expected enum `Result<_, _>`
+          found unit type `()`
+note: required by a bound in `ServerFn::run_body::{anon_assoc#0}`
+ --> src/lib.rs
+  |
+  |     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServerFn::run_body::{anon_assoc#0}`
 
 error[E0277]: () is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
  --> tests/invalid/empty_return.rs:3:1

--- a/server_fn/tests/invalid/not_result.stderr
+++ b/server_fn/tests/invalid/not_result.stderr
@@ -7,20 +7,7 @@ error[E0277]: CustomError is not a `Result` or aliased `Result`. Server function
    = help: the trait `ServerFnMustReturnResult` is not implemented for `CustomError`
    = note: If you are trying to return an alias of `Result`, you must also implement `FromServerFnError` for the error type.
    = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
-
-error[E0271]: expected `impl Future<Output = CustomError>` to be a future that resolves to `Result<_, _>`, but it resolves to `CustomError`
-  --> tests/invalid/not_result.rs:25:1
-   |
-25 | #[server]
-   | ^^^^^^^^^ expected `Result<_, _>`, found `CustomError`
-   |
-   = note: expected enum `Result<_, _>`
-              found enum `CustomError`
-note: required by a bound in `ServerFn::{anon_assoc#0}`
-  --> src/lib.rs
-   |
-   |     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServerFn::{anon_assoc#0}`
+   = note: this error originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: CustomError is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
   --> tests/invalid/not_result.rs:25:1
@@ -31,7 +18,20 @@ error[E0277]: CustomError is not a `Result` or aliased `Result`. Server function
    = help: the trait `ServerFnMustReturnResult` is not implemented for `CustomError`
    = note: If you are trying to return an alias of `Result`, you must also implement `FromServerFnError` for the error type.
    = help: the trait `ServerFnMustReturnResult` is implemented for `Result<T, E>`
-   = note: this error originates in the attribute macro `server` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: expected `impl Future<Output = CustomError>` to be a future that resolves to `Result<_, _>`, but it resolves to `CustomError`
+  --> tests/invalid/not_result.rs:25:1
+   |
+25 | #[server]
+   | ^^^^^^^^^ expected `Result<_, _>`, found `CustomError`
+   |
+   = note: expected enum `Result<_, _>`
+              found enum `CustomError`
+note: required by a bound in `ServerFn::run_body::{anon_assoc#0}`
+  --> src/lib.rs
+   |
+   |     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ServerFn::run_body::{anon_assoc#0}`
 
 error[E0277]: CustomError is not a `Result` or aliased `Result`. Server functions must return a `Result` or aliased `Result`.
   --> tests/invalid/not_result.rs:25:1


### PR DESCRIPTION
This PR makes a few related changes:
- Updates MSRV to 1.88 from 1.80, which allows us to use (stable) proc macro spans
- Updates the `nightly` compiler version used in CI to something more recent (2025-07-16 instead of 2025-04-16)
- Adds support for `cargo leptos watch --hot-reload` in stable Rust (enabled by the 1.88 update)

The same version bump will allow fixing #4157 on stable consistently with nightly as well, when lazy-loading/code-splitting is added.

There's some disagreement about whether an MSRV increase is a semver-breaking change. From my perspective, requiring a bump from 0.8 to 0.9 for a change like this would be a lot of unnecessary churn. Historically, we did not include an MSRV at all; I think adding it explicitly is a nice convenience, but I'm not willing to treat it as a breaking change. If anyone absolutely must be on a pre-1.88 compiler, though, I guess I'm open to counter-arguments.