### PR TITLE
fix(hot-reload): hot-reload stops working when number of views changes in a file + small fixes

### DIFF
--- a/leptos_hot_reload/src/lib.rs
+++ b/leptos_hot_reload/src/lib.rs
@@ -121,6 +121,10 @@ impl ViewMacros {
                     }
                     diffs
                 } else {
+                    // TODO: instead of simply returning no patches, when number of views differs,
+                    // we can compare views content to determine which views were shifted
+                    // or come up with another idea that will allow to send patches when views were shifted/removed/added
+                    lock.insert(path.clone(), new_views);
                     return Ok(None);
                 }
             }

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -99,11 +99,10 @@ function patch(json) {
               child.node,
               action.AppendChildren,
             );
-            const newChildren = fromReplacementNode(
-              action.AppendChildren,
-              actualChildren,
+            const newChildren = action.AppendChildren.map((x) =>
+              fromReplacementNode(x, actualChildren),
             );
-            child.node.append(newChildren);
+            child.node.append(...newChildren);
           } else if (action.RemoveChild) {
             console.log(
               "[HOT RELOAD] > RemoveChild",

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -38,7 +38,14 @@ function patch(json) {
           const action = patch.action;
           if (action == "ClearChildren") {
             console.log("[HOT RELOAD] > ClearChildren", child.node);
-            child.node.textContent = "";
+            if (child.node) {
+              child.node.textContent = "";
+            } else {
+              for (const existingChild of child.children) {
+                let parent = existingChild.node.parentElement;
+                parent.removeChild(existingChild.node);
+              }
+            }
           } else if (action.ReplaceWith) {
             console.log(
               "[HOT RELOAD] > ReplaceWith",

--- a/leptos_hot_reload/src/patch.js
+++ b/leptos_hot_reload/src/patch.js
@@ -59,11 +59,17 @@ function patch(json) {
             if (child.node) {
               child.node.replaceWith(replacement);
             } else {
-              const range = new Range();
-              range.setStartAfter(child.start);
-              range.setEndAfter(child.end);
-              range.deleteContents();
-              child.start.replaceWith(replacement);
+              if (child.children) {
+                child.children[0].node.parentElement.insertBefore(
+                  replacement,
+                  child.children[0].node,
+                );
+                for (const existingChild of child.children) {
+                  existingChild.node.parentElement.removeChild(
+                    existingChild.node,
+                  );
+                }
+              }
             }
           } else if (action.ChangeTagName) {
             const oldNode = child.node;


### PR DESCRIPTION
This PR fixes four bugs:

- hot-reload stops updating view macro map when number of view macro in a file mismatch with previous state of a file
- fragment couldn't be replaced with a single tag
```rust
view! {
<p>"Text 1"</p>
<p>"Text 1"</p>
<p>"Text 1"</p>
}
```
```rust
view! {
<p>"Text 1"</p>
}
```
- unable to fully clear fragment view 
```rust
view! {
<p>"Text 1"</p>
<p>"Text 1"</p>
<p>"Text 1"</p>
}
```
```rust
view! {
}
```
- unable to append children to an empty tag
```rust
view! {
<div></div>
}
```
```rust
view! {
<div>
<p>"Text"</p>
</div>
}
```