### PR TITLE
Enhancing members’ versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ members = [
 exclude = ["benchmarks", "examples", "projects"]
 
 [workspace.package]
-version = "0.8.5"
 edition = "2021"
 rust-version = "1.88"
 

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Actix integrations for the Leptos web framework."
-version = { workspace = true }
+version = "0.8.5"
 rust-version.workspace = true
 edition.workspace = true
 
@@ -22,10 +22,10 @@ leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 server_fn = { workspace = true, features = ["actix-no-default"] }
 tachys = { workspace = true }
-serde_json = { workspace = true , default-features = true }
+serde_json = { workspace = true, default-features = true }
 parking_lot = { workspace = true, default-features = true }
-tracing = { optional = true , workspace = true, default-features = true }
-tokio = { features = ["rt", "fs"] , workspace = true, default-features = true }
+tracing = { optional = true, workspace = true, default-features = true }
+tokio = { features = ["rt", "fs"], workspace = true, default-features = true }
 send_wrapper = { workspace = true, default-features = true }
 dashmap = { workspace = true, default-features = true }
 

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Axum integrations for the Leptos web framework."
-version = { workspace = true }
+version = "0.8.5"
 rust-version.workspace = true
 edition.workspace = true
 

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Utilities to help build server integrations for the Leptos web framework."
-version = { workspace = true }
+version = "0.8.5"
 rust-version.workspace = true
 edition.workspace = true
 

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "Configuration for the Leptos web framework."
 readme = "../README.md"
-version = { workspace = true }
+version = "0.8.5"
 rust-version.workspace = true
 edition.workspace = true
 
@@ -13,16 +13,24 @@ edition.workspace = true
 config = { default-features = false, features = [
   "toml",
   "convert-case",
-] , workspace = true }
+], workspace = true }
 regex = { workspace = true, default-features = true }
-serde = { features = ["derive", "rc"] , workspace = true, default-features = true }
-thiserror = { workspace = true , default-features = true }
-typed-builder = { workspace = true , default-features = true }
+serde = { features = [
+  "derive",
+  "rc",
+], workspace = true, default-features = true }
+thiserror = { workspace = true, default-features = true }
+typed-builder = { workspace = true, default-features = true }
 
 [dev-dependencies]
-tokio = { features = ["rt", "macros"] , workspace = true, default-features = true }
+tokio = { features = [
+  "rt",
+  "macros",
+], workspace = true, default-features = true }
 tempfile = { workspace = true, default-features = true }
-temp-env = { features = ["async_closure"] , workspace = true, default-features = true }
+temp-env = { features = [
+  "async_closure",
+], workspace = true, default-features = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_dom"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
@@ -14,10 +14,10 @@ reactive_graph = { workspace = true }
 or_poisoned = { workspace = true }
 js-sys = { workspace = true, default-features = true }
 send_wrapper = { workspace = true, default-features = true }
-tracing = { optional = true , workspace = true, default-features = true }
-wasm-bindgen = { workspace = true , default-features = true }
-serde_json = { optional = true , workspace = true, default-features = true }
-serde = { optional = true , workspace = true, default-features = true }
+tracing = { optional = true, workspace = true, default-features = true }
+wasm-bindgen = { workspace = true, default-features = true }
+serde_json = { optional = true, workspace = true, default-features = true }
+serde = { optional = true, workspace = true, default-features = true }
 
 [dev-dependencies]
 leptos = { path = "../leptos" }

--- a/leptos_hot_reload/Cargo.toml
+++ b/leptos_hot_reload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_hot_reload"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
@@ -11,17 +11,20 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true, default-features = true }
-serde = { features = ["derive"] , workspace = true, default-features = true }
+serde = { features = ["derive"], workspace = true, default-features = true }
 syn = { features = [
   "full",
   "parsing",
   "extra-traits",
   "visit",
   "printing",
-] , workspace = true, default-features = true }
+], workspace = true, default-features = true }
 quote = { workspace = true, default-features = true }
 rstml = { workspace = true, default-features = true }
-proc-macro2 = { features = ["span-locations", "nightly"] , workspace = true, default-features = true }
+proc-macro2 = { features = [
+  "span-locations",
+  "nightly",
+], workspace = true, default-features = true }
 parking_lot = { workspace = true, default-features = true }
 walkdir = { workspace = true, default-features = true }
 camino = { workspace = true, default-features = true }

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_macro"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
@@ -13,26 +13,28 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-attribute-derive = { features = ["syn-full"] , workspace = true, default-features = true }
+attribute-derive = { features = [
+  "syn-full",
+], workspace = true, default-features = true }
 cfg-if = { workspace = true, default-features = true }
 html-escape = { workspace = true, default-features = true }
-itertools = { workspace = true , default-features = true }
+itertools = { workspace = true, default-features = true }
 prettyplease = { workspace = true, default-features = true }
-proc-macro-error2 = { default-features = false , workspace = true }
+proc-macro-error2 = { default-features = false, workspace = true }
 proc-macro2 = { workspace = true, default-features = true }
 quote = { workspace = true, default-features = true }
-syn = { features = ["full"] , workspace = true, default-features = true }
+syn = { features = ["full"], workspace = true, default-features = true }
 rstml = { workspace = true, default-features = true }
 leptos_hot_reload = { workspace = true }
 server_fn_macro = { workspace = true }
-convert_case = { workspace = true , default-features = true }
-uuid = { features = ["v4"] , workspace = true, default-features = true }
-tracing = { optional = true , workspace = true, default-features = true }
+convert_case = { workspace = true, default-features = true }
+uuid = { features = ["v4"], workspace = true, default-features = true }
+tracing = { optional = true, workspace = true, default-features = true }
 
 [dev-dependencies]
 log = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
-trybuild = { workspace = true , default-features = true }
+trybuild = { workspace = true, default-features = true }
 leptos = { path = "../leptos" }
 leptos_router = { path = "../router", features = ["ssr"] }
 server_fn = { path = "../server_fn", features = ["cbor"] }

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_server"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
@@ -11,11 +11,11 @@ edition.workspace = true
 
 [dependencies]
 base64 = { workspace = true, default-features = true }
-codee = { features = ["json_serde"] , workspace = true, default-features = true }
+codee = { features = ["json_serde"], workspace = true, default-features = true }
 hydration_context = { workspace = true }
 reactive_graph = { workspace = true, features = ["hydration"] }
 server_fn = { workspace = true }
-tracing = { optional = true , workspace = true, default-features = true }
+tracing = { optional = true, workspace = true, default-features = true }
 futures = { workspace = true, default-features = true }
 
 any_spawner = { workspace = true }
@@ -25,9 +25,9 @@ send_wrapper = { workspace = true, default-features = true }
 
 # serialization formats
 serde = { workspace = true, default-features = true }
-js-sys = { optional = true , workspace = true, default-features = true }
-wasm-bindgen = { workspace = true, optional = true , default-features = true }
-serde_json = { workspace = true , default-features = true }
+js-sys = { optional = true, workspace = true, default-features = true }
+wasm-bindgen = { workspace = true, optional = true, default-features = true }
+serde_json = { workspace = true, default-features = true }
 
 [features]
 ssr = []

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_meta"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_router_macro"
-version = { workspace = true }
+version = "0.8.5"
 authors = ["Greg Johnston", "Ben Wishovich"]
 license = "MIT"
 readme = "../README.md"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+LAST_TAG=$(git describe --tags --abbrev=0 --match "v*")
+
+# Get package name and manifest_path for all members
+PACKAGES=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | "\(.name):::\(.manifest_path)"')
+
+for PKG in $PACKAGES; do
+    NAME="${PKG%%:::*}"
+    MANIFEST_PATH="${PKG##*:::}"
+    DIR=$(dirname "$MANIFEST_PATH")
+
+    # Check if any file in the package directory changed since the last tag
+    if git diff --quiet "$LAST_TAG"..HEAD -- "$DIR"; then
+        continue
+    fi
+
+    echo "Changes detected in $NAME ($DIR)"
+    PS3="Select version bump for $NAME: "
+    select BUMP in patch minor major; do
+        if [[ "$BUMP" == "patch" || "$BUMP" == "minor" || "$BUMP" == "major" ]]; then
+            break
+        else
+            echo "Invalid option"
+        fi
+    done
+
+    if cargo set-version --help >/dev/null 2>&1; then
+        cargo set-version --bump "$BUMP" --package "$NAME"
+    else
+        echo "Please install cargo-edit first."
+        exit 1
+    fi
+
+    echo "$NAME bumped to $BUMP"
+done

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "RPC for any web framework."
 readme = "../README.md"
-version = { workspace = true }
+version = "0.8.5"
 rust-version.workspace = true
 edition.workspace = true
 

--- a/server_fn/server_fn_macro_default/Cargo.toml
+++ b/server_fn/server_fn_macro_default/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "The default implementation of the server_fn macro without a context"
-version = { workspace = true }
+version = "0.8.5"
 edition.workspace = true
 
 [lib]

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -5,16 +5,22 @@ license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
 description = "RPC for any web framework."
 readme = "../README.md"
-version = { workspace = true }
+version = "0.8.5"
 edition.workspace = true
 
 [dependencies]
 quote = { workspace = true, default-features = true }
-syn = { features = ["full", "parsing", "extra-traits"] , workspace = true, default-features = true }
+syn = { features = [
+  "full",
+  "parsing",
+  "extra-traits",
+], workspace = true, default-features = true }
 proc-macro2 = { workspace = true, default-features = true }
-xxhash-rust = { features = ["const_xxh64"] , workspace = true, default-features = true }
+xxhash-rust = { features = [
+  "const_xxh64",
+], workspace = true, default-features = true }
 const_format = { workspace = true, default-features = true }
-convert_case = { workspace = true , default-features = true }
+convert_case = { workspace = true, default-features = true }
 
 
 [build-dependencies]


### PR DESCRIPTION
This PR introduces two changes:

- Decouple versioning of members from the workspace. If there are no changes to a member, there shouldn't be a version bump and a release.
- To tackle the difficulty of tracking changes in the members, I wrote and added a `bump.sh` script that tracks the changes from the last release tag and provides a simple interface to update member versions. The changes will be applied to both the workspace and the crate's `Cargo.toml`.

Here is the usage:

```bash
# First please install cargo-edit: cargo install cargo-edit
# Then run the script in workspace directory

$ ./scripts/bump.sh

Changes detected in reactive_graph (/Users/sabify/dev/leptos/reactive_graph)
1) patch
2) minor
3) major
Select version bump for reactive_graph: 1
   Upgrading reactive_graph from 0.2.3 to 0.2.4
    Updating workspace's dependency from 0.2.3 to 0.2.4
reactive_graph bumped to patch

# and so on for every changed member that has been detected...
```