### PR TITLE
fix: support file hashing when using lazy loading

### DIFF
--- a/wasm_split_macros/src/lib.rs
+++ b/wasm_split_macros/src/lib.rs
@@ -136,7 +136,7 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
             static #split_loader_ident: ::leptos::wasm_split_helpers::LazySplitLoader = ::leptos::wasm_split_helpers::LazySplitLoader::new(#load_module_ident);
         }
 
-        #[link(wasm_import_module = "/pkg/__wasm_split.js")]
+        #[link(wasm_import_module = "/pkg/__wasm_split.______________________.js")]
         extern "C" {
             #[no_mangle]
             fn #load_module_ident (callback: unsafe extern "C" fn(*const ::std::ffi::c_void, bool), data: *const ::std::ffi::c_void) -> ();


### PR DESCRIPTION
This supports the combination of lazy-loading and file hashing by inserting a placeholder hash in the name of `__wasm_split.js`. (This is necessary because changing the length of this string invalidates the WASM binary, so it's much easier to just replace the placeholder!) 

Needs to be used alongside https://github.com/leptos-rs/cargo-leptos/pull/553