### PR TITLE
feat: improving the bump script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -12,8 +12,16 @@ for PKG in $PACKAGES; do
     MANIFEST_PATH="${PKG##*:::}"
     DIR=$(dirname "$MANIFEST_PATH")
 
-    # Check if any file in the package directory changed since the last tag
-    if git diff --quiet "$LAST_TAG"..HEAD -- "$DIR"; then
+    # Look for release commit for this member up to the last tag
+    RELEASE_COMMIT=$(git log --oneline --grep="^$NAME-v" --format="%H" "$LAST_TAG"..HEAD | head -n1)
+
+    if [[ -z "$RELEASE_COMMIT" ]]; then
+        # No release commit found, use the latest release tag commit
+        RELEASE_COMMIT=$(git rev-list -n 1 "$LAST_TAG")
+    fi
+
+    # Check if any file in the package directory changed since the member's release commit or latest tag release
+    if git diff --quiet "$RELEASE_COMMIT"..HEAD -- "$DIR"; then
         continue
     fi
 


### PR DESCRIPTION
Related: #4172 

The script now detects if any changes were made to a member from a commit release up to the latest tag.

@gbj, if you are going to release and publish a member crate without releasing a tag, please push a commit in the following format to keep track of the changes: `<member-name>-v<member-version>`. For example, `oco_ref-v0.2.1`.

Please keep in mind to use the member package name defined in the `Cargo.toml`, not the directory name.

Here is the logic:

- If there is a **release commit** newer than the latest tag for the member crate, check if there are any changes made to it from the **release commit** and request a bump.
- Otherwise, use the **latest tag** and check if there are any changes made to the member crate and request a bump.
