### PR TITLE
Add name attribute to details element

### DIFF
--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -269,7 +269,7 @@ html_elements! {
     /// The `<del>` HTML element represents a range of text that has been deleted from a document. This can be used when rendering "track changes" or source code diff information, for example. The ins element can be used for the opposite purpose: to indicate text that has been added to the document.
     del HtmlModElement [cite, datetime] true,
     /// The `<details>` HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state. A summary or label must be provided using the summary element.
-    details HtmlDetailsElement [open] true,
+    details HtmlDetailsElement [name, open] true,
     /// The `<dfn>` HTML element is used to indicate the term being defined within the context of a definition phrase or sentence. The p element, the dt/dd pairing, or the section element which is the nearest ancestor of the `<dfn>` is considered to be the definition of the term.
     dfn HtmlElement [] true,
     /// The `<dialog>` HTML element represents a dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.


### PR DESCRIPTION
When trying to use the `name` attribute of the `<details>` element I noticed it was missing. This is a relatively new attribute that is younger than Leptos so it was probably just never added. Basically if you have a group of `<details>`s that share a name then the browser handles only displaying one at a time. I would like to use this in my component library.

[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details#browser_compatibility) it is fully supported by all browsers, since September 2024.

I think it makes sense to add it.