### PR TITLE
make is_server and is_browser public

### DIFF
--- a/leptos_dom/src/helpers.rs
+++ b/leptos_dom/src/helpers.rs
@@ -593,7 +593,8 @@ impl WindowListenerHandle {
     }
 }
 
-fn is_server() -> bool {
+/// Returns `true` if the current environment is a server.
+pub fn is_server() -> bool {
     #[cfg(feature = "hydration")]
     {
         Owner::current_shared_context()
@@ -604,4 +605,9 @@ fn is_server() -> bool {
     {
         false
     }
+}
+
+/// Returns `true` if the current environment is a browser.
+pub fn is_browser() -> bool {
+    !is_server()
 }


### PR DESCRIPTION
Referring to discussion #4200, this allows easier branching based on server/client that is not based on cargo features. This is usefull for cases where all the code can compile for both environments, but there is no point in doing the extra work on the server/client.