### PR TITLE
fix!: Set content type if error occurs in Leptos middleware

### DIFF
--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -307,16 +307,18 @@ pub trait ServerFn: Send + Sized {
                     .await
                     .map(|res| (res, None))
                     .unwrap_or_else(|e| {
-                        (
+                        let mut response =
                             <<Self as ServerFn>::Server as crate::Server<
                                 Self::Error,
                                 Self::InputStreamError,
                                 Self::OutputStreamError,
                             >>::Response::error_response(
                                 Self::PATH, e.ser()
-                            ),
-                            Some(e),
-                        )
+                            );
+                        let content_type =
+                    <Self::Error as FromServerFnError>::Encoder::CONTENT_TYPE;
+                        response.content_type(content_type);
+                        (response, Some(e))
                     });
 
             // if it accepts HTML, we'll redirect to the Referer

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -163,9 +163,9 @@ mod axum {
 
 #[cfg(feature = "actix-no-default")]
 mod actix {
-    use crate::middleware::ServiceRunConfig;
     use crate::{
         error::ServerFnErrorErr,
+        middleware::ServiceRunConfig,
         request::actix::ActixRequest,
         response::{actix::ActixResponse, Res},
     };

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -12,6 +12,7 @@ use actix_web::{
 };
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
+use http::header::CONTENT_TYPE;
 use send_wrapper::SendWrapper;
 
 /// A wrapped Actix response.
@@ -78,6 +79,12 @@ impl Res for ActixResponse {
                 .append_header((SERVER_FN_ERROR_HEADER, path))
                 .body(err),
         ))
+    }
+
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.0.headers_mut().insert(CONTENT_TYPE, content_type);
+        }
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -5,14 +5,13 @@ use crate::error::{
 use actix_web::{
     http::{
         header,
-        header::{HeaderValue, LOCATION},
+        header::{HeaderValue, CONTENT_TYPE, LOCATION},
         StatusCode,
     },
     HttpResponse,
 };
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use http::header::CONTENT_TYPE;
 use send_wrapper::SendWrapper;
 
 /// A wrapped Actix response.

--- a/server_fn/src/response/generic.rs
+++ b/server_fn/src/response/generic.rs
@@ -100,6 +100,13 @@ impl Res for Response<Body> {
             .unwrap()
     }
 
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
+        }
+    }
+
     fn redirect(&mut self, path: &str) {
         if let Ok(path) = HeaderValue::from_str(path) {
             self.headers_mut().insert(header::LOCATION, path);

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -60,6 +60,13 @@ impl Res for Response<Body> {
             .unwrap()
     }
 
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
+        }
+    }
+
     fn redirect(&mut self, path: &str) {
         if let Ok(path) = HeaderValue::from_str(path) {
             self.headers_mut().insert(header::LOCATION, path);

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -39,7 +39,8 @@ where
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
     fn error_response(path: &str, err: Bytes) -> Self;
-
+    /// Set the content type header for the response.
+    fn content_type(&mut self, #[allow(unused_variables)] content_type: &str) {}
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
 }
@@ -100,6 +101,10 @@ impl<E> TryRes<E> for BrowserMockRes {
 
 impl Res for BrowserMockRes {
     fn error_response(_path: &str, _err: Bytes) -> Self {
+        unreachable!()
+    }
+
+    fn content_type(&mut self, _content_type: &str) {
         unreachable!()
     }
 

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -39,7 +39,7 @@ where
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
     fn error_response(path: &str, err: Bytes) -> Self;
-    /// Set the content type header for the response.
+    /// Set the content-type header for the response.
     fn content_type(&mut self, #[allow(unused_variables)] content_type: &str) {}
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);


### PR DESCRIPTION
Problem
-------
If an error occurs
[in Leptos's middleware chain](https://github.com/leptos-rs/leptos/blob/main/server_fn/src/middleware/mod.rs#L77), the content-type header of the returned error response is not set.

Solution
--------
Save the error's content-type from the boxed service in `BoxedService`, and pass the content type into `Service::run`.

Note that this requires the following breaking changes:
- Add a new field to `BoxedService`.
- Update the `Service::run` trait method to accept the error's content type as a parameter.

However, since this requires breaking changes anyway, this PR achieves
the following in a more extensible way (but still API-breaking):
- Replace the `ser` field in `BoxedService` with a `ServiceRunConfig` that contains the `ser` error serializer and the error's content type string.
- Mark `BoxedService` as `#[non_exhaustive]` so new fields can be added in the future without breaking the API.
- Replace the `ser` parameter of `Service::run` with the `ServiceRunConfig` This allows `Service::run` to remain the same even if new fields are added to the `ServiceRunConfig` in the future.
 
Note: this is written on top of [another PR](https://github.com/leptos-rs/leptos/pull/4215) that's currently open, so there are some changes in this PR that are originally from that PR.

Closes https://github.com/leptos-rs/leptos/issues/4209