### PR TITLE
feat: add default "auto" live reload protocol option

### DIFF
--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -27,6 +27,7 @@ pub fn AutoReload(
             None => options.reload_port,
         };
         let protocol = match options.reload_ws_protocol {
+            leptos_config::ReloadWSProtocol::Auto => "null",
             leptos_config::ReloadWSProtocol::WS => "'ws://'",
             leptos_config::ReloadWSProtocol::WSS => "'wss://'",
         };

--- a/leptos/src/hydration/reload_script.js
+++ b/leptos/src/hydration/reload_script.js
@@ -1,4 +1,9 @@
 let host = window.location.hostname;
+
+if (protocol === null) {
+	protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
+}
+
 let ws = new WebSocket(`${protocol}${host}:${reload_port}/live_reload`);
 ws.onmessage = (ev) => {
 	let msg = JSON.parse(ev.data);

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -153,7 +153,7 @@ impl LeptosOptions {
                 None => None,
             },
             reload_ws_protocol: ws_from_str(
-                env_w_default("LEPTOS_RELOAD_WS_PROTOCOL", "ws")?.as_str(),
+                env_w_default("LEPTOS_RELOAD_WS_PROTOCOL", "auto")?.as_str(),
             )?,
             not_found_path: env_w_default("LEPTOS_NOT_FOUND_PATH", "/404")?
                 .into(),
@@ -281,24 +281,26 @@ impl TryFrom<String> for Env {
 /// Defaults to `ws`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum ReloadWSProtocol {
+    Auto,
     WS,
     WSS,
 }
 
 impl Default for ReloadWSProtocol {
     fn default() -> Self {
-        Self::WS
+        Self::Auto
     }
 }
 
 fn ws_from_str(input: &str) -> Result<ReloadWSProtocol, LeptosConfigError> {
     let sanitized = input.to_lowercase();
     match sanitized.as_ref() {
+        "auto" => Ok(ReloadWSProtocol::Auto),
         "ws" | "WS" => Ok(ReloadWSProtocol::WS),
         "wss" | "WSS" => Ok(ReloadWSProtocol::WSS),
         _ => Err(LeptosConfigError::EnvVarError(format!(
-            "{input} is not a supported websocket protocol. Use only `ws` or \
-             `wss`.",
+            "{input} is not a supported websocket protocol. Use only `auto`, \
+             `ws` or `wss`.",
         ))),
     }
 }

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -281,9 +281,9 @@ impl TryFrom<String> for Env {
 /// Defaults to `ws`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub enum ReloadWSProtocol {
-    Auto,
     WS,
     WSS,
+    Auto,
 }
 
 impl Default for ReloadWSProtocol {


### PR DESCRIPTION
The current behavior is to always try to connect to the live reload endpoint via `ws://`, but I think that's not very smart since, if the website is being served via HTTPS, the browser will actively prevent `ws://` connections. Thus defaulting to `wss://` in those situations seems reasonable, as there is not really another option (unless the browser is configured to allow `ws://` from `https://` somehow...).

Thus I introduce a new option for LEPTOS_RELOAD_WS_PROTOCOL: `auto`. That will make it so that the actual protocol to be used from the client will be determined by the protocol used to access the originating website: if the website was accessed via `https://`, then the live reload protocol is `wss://`. Otherwise it is `ws://`.

This was the only option on #1548, but #1613 removed it in favor of static configuration. Now both should be possible.

I also made `auto` the default option since:

- If one is not using HTTPS at all, nothing changes;
- If one is using HTTPS, they should also be using WSS, since the browser would block the connection otherwise, so nothing changes.

So it shouldn't break anything; and, since it allows for both options (HTTP and HTTPS) at the same time, it should be more flexible.