### PR TITLE
Set correct `Content-Type` for server fn errors (non-breaking) (closes #4209)

### DIFF
--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -568,7 +568,7 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// Converts a [`ServerFnErrorErr`] into the application-specific custom error type.
     fn from_server_fn_error(value: ServerFnErrorErr) -> Self;
 
-    /// Converts the custom error type to a [`String`].
+    /// Serializes the custom error type to bytes, according to the encoding given by `Self::Encoding`.
     fn ser(&self) -> Bytes {
         Self::Encoder::encode(self).unwrap_or_else(|e| {
             Self::Encoder::encode(&Self::from_server_fn_error(
@@ -581,7 +581,7 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
         })
     }
 
-    /// Deserializes the custom error type from a [`&str`].
+    /// Deserializes the custom error type, according to the encoding given by `Self::Encoding`.
     fn de(data: Bytes) -> Self {
         Self::Encoder::decode(data).unwrap_or_else(|e| {
             ServerFnErrorErr::Deserialization(e.to_string()).into_app_error()

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -319,6 +319,12 @@ pub trait ServerFn: Send + Sized {
                         )
                     });
 
+            if err.is_some() {
+                res.set_content_type(
+                    <<Self::Error as FromServerFnError>::Encoder>::CONTENT_TYPE,
+                );
+            }
+
             // if it accepts HTML, we'll redirect to the Referer
             #[cfg(feature = "form-redirects")]
             if accepts_html {

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -72,6 +72,8 @@ mod axum {
             let inner = self.call(req);
             Box::pin(async move {
                 inner.await.unwrap_or_else(|e| {
+                    // TODO: this needs to set the Content-Type correctly depending on the error type
+                    // note that this only applies to middleware errors
                     let err =
                         ser(ServerFnErrorErr::MiddlewareError(e.to_string()));
                     Response::<Body>::error_response(&path, err)
@@ -149,6 +151,8 @@ mod actix {
             let inner = self.call(req);
             Box::pin(async move {
                 inner.await.unwrap_or_else(|e| {
+                    // TODO: this needs to set the Content-Type correctly depending on the error type
+                    // note that this only applies to middleware errors
                     let err =
                         ser(ServerFnErrorErr::MiddlewareError(e.to_string()));
                     ActixResponse::error_response(&path, err).take()

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -4,8 +4,7 @@ use crate::error::{
 };
 use actix_web::{
     http::{
-        header,
-        header::{HeaderValue, LOCATION},
+        header::{self, HeaderValue, CONTENT_TYPE, LOCATION},
         StatusCode,
     },
     HttpResponse,
@@ -78,6 +77,12 @@ impl Res for ActixResponse {
                 .append_header((SERVER_FN_ERROR_HEADER, path))
                 .body(err),
         ))
+    }
+
+    fn set_content_type(&mut self, content_type: &str) {
+        self.0
+            .headers_mut()
+            .append(CONTENT_TYPE, HeaderValue::from_str(content_type).unwrap());
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/generic.rs
+++ b/server_fn/src/response/generic.rs
@@ -19,7 +19,10 @@ use crate::error::{
 };
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
-use http::{header, HeaderValue, Response, StatusCode};
+use http::{
+    header::{self, CONTENT_TYPE},
+    HeaderValue, Response, StatusCode,
+};
 use std::pin::Pin;
 use throw_error::Error;
 
@@ -98,6 +101,11 @@ impl Res for Response<Body> {
             .header(SERVER_FN_ERROR_HEADER, path)
             .body(err.into())
             .unwrap()
+    }
+
+    fn set_content_type(&mut self, content_type: &str) {
+        self.headers_mut()
+            .append(CONTENT_TYPE, HeaderValue::from_str(content_type).unwrap());
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -6,7 +6,10 @@ use crate::error::{
 use axum::body::Body;
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
-use http::{header, HeaderValue, Response, StatusCode};
+use http::{
+    header::{self, CONTENT_TYPE},
+    HeaderValue, Response, StatusCode,
+};
 
 impl<E> TryRes<E> for Response<Body>
 where
@@ -58,6 +61,11 @@ impl Res for Response<Body> {
             .header(SERVER_FN_ERROR_HEADER, path)
             .body(err.into())
             .unwrap()
+    }
+
+    fn set_content_type(&mut self, content_type: &str) {
+        self.headers_mut()
+            .append(CONTENT_TYPE, HeaderValue::from_str(content_type).unwrap());
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -37,8 +37,15 @@ where
 
 /// Represents the response as created by the server;
 pub trait Res {
-    /// Converts an error into a response, with a `500` status code and the error text as its body.
+    /// Converts an error into a response, with a `500` status code and the error as its body.
     fn error_response(path: &str, err: Bytes) -> Self;
+
+    /// Sets the `Content-Type` header on the response.
+    fn set_content_type(&mut self, content_type: &str) {
+        // TODO 0.9: remove this method and default implementation
+        // it is included here to make this change non-breaking
+        _ = content_type;
+    }
 
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
@@ -100,6 +107,11 @@ impl<E> TryRes<E> for BrowserMockRes {
 
 impl Res for BrowserMockRes {
     fn error_response(_path: &str, _err: Bytes) -> Self {
+        unreachable!()
+    }
+
+    fn set_content_type(&mut self, content_type: &str) {
+        _ = content_type;
         unreachable!()
     }
 


### PR DESCRIPTION
cf. #4215. This is an alternate approach that shouldn't be semver-breaking and therefore can be merged into 0.8.

The only case it doesn't cover is the case in which a *middleware* throws the error, which would require modifying `BoxedService` as in #4215.