### PR TITLE
fix!: Set content type header for server function errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d9ef19ae5263a138da9a86871eca537478ab0332a7770bac7e3f08b801f89f"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577ae008f2ca11ca7641bd44601002ee5ab49ef0af64846ce1ab6057218a5cc1"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +851,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1654,6 +1714,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3288,6 +3354,7 @@ dependencies = [
  "actix-ws",
  "axum",
  "base64",
+ "bon",
  "bytes",
  "ciborium",
  "const-str",
@@ -3487,6 +3554,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ async-lock = { default-features = false, version = "3.4.0" }
 base16 = { default-features = false, version = "0.2.1" }
 digest = { default-features = false, version = "0.10.7" }
 sha2 = { default-features = false, version = "0.10.8" }
+bon = { default-features = false, version = "3.6.5" }
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ async-lock = { default-features = false, version = "3.4.0" }
 base16 = { default-features = false, version = "0.2.1" }
 digest = { default-features = false, version = "0.10.7" }
 sha2 = { default-features = false, version = "0.10.8" }
-bon = { default-features = false, version = "3.6.5" }
+bon = { default-features = false, version = "3.0.0" }
 
 [profile.release]
 codegen-units = 1

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -25,6 +25,7 @@ send_wrapper = { features = [
   "futures",
 ], optional = true, workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
+bon = { workspace = true }
 
 # registration system
 inventory = { optional = true, workspace = true, default-features = true }

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -282,7 +282,8 @@ pub mod reqwest {
                     Err(e) => Err(OutputStreamError::from_server_fn_error(
                         ServerFnErrorErr::Request(e.to_string()),
                     )
-                    .ser()),
+                    .ser()
+                    .body),
                 }),
                 write.with(|msg: Bytes| async move {
                     Ok::<

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -141,7 +141,8 @@ pub mod browser {
                         Err(OutputStreamError::from_server_fn_error(
                             ServerFnErrorErr::Request(err.to_string()),
                         )
-                        .ser())
+                        .ser()
+                        .body)
                     }
                 });
                 let stream = SendWrapper::new(stream);

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -120,7 +120,7 @@ where
     async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(
             Streaming::CONTENT_TYPE,
-            self.into_inner().map_err(|e| e.ser()),
+            self.into_inner().map_err(|e| e.ser().body),
         )
     }
 }
@@ -255,7 +255,7 @@ where
         Response::try_from_stream(
             Streaming::CONTENT_TYPE,
             self.into_inner()
-                .map(|stream| stream.map(Into::into).map_err(|e| e.ser())),
+                .map(|stream| stream.map(Into::into).map_err(|e| e.ser().body)),
         )
     }
 }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -474,7 +474,7 @@ impl<E: FromServerFnError> ServerFnUrlError<E> {
         let mut url = Url::parse(base)?;
         url.query_pairs_mut()
             .append_pair("__path", &self.path)
-            .append_pair("__err", &URL_SAFE.encode(self.error.ser()));
+            .append_pair("__err", &URL_SAFE.encode(self.error.ser().body));
         Ok(url)
     }
 
@@ -536,7 +536,7 @@ impl<E: FromServerFnError> Display for ServerFnErrorWrapper<E> {
         write!(
             f,
             "{}",
-            <E::Encoder as FormatType>::into_encoded_string(self.0.ser())
+            <E::Encoder as FormatType>::into_encoded_string(self.0.ser().body)
         )
     }
 }
@@ -560,6 +560,17 @@ impl<E: FromServerFnError> FromStr for ServerFnErrorWrapper<E> {
     }
 }
 
+/// Response parts returned by [`FromServerFnError::ser`] to be returned to the client.
+#[derive(bon::Builder)]
+#[non_exhaustive]
+pub struct ServerFnErrorResponseParts {
+    /// The raw [`Bytes`] of the serialized error.
+    pub body: Bytes,
+    /// The value of the `CONTENT_TYPE` associated constant for the `FromServerFnError`
+    /// implementation. Used to set the `content-type` header in http responses.
+    pub content_type: &'static str,
+}
+
 /// A trait for types that can be returned from a server function.
 pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// The encoding strategy used to serialize and deserialize this error type. Must implement the [`Encodes`](server_fn::Encodes) trait for references to the error type.
@@ -569,8 +580,8 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     fn from_server_fn_error(value: ServerFnErrorErr) -> Self;
 
     /// Converts the custom error type to a [`String`].
-    fn ser(&self) -> Bytes {
-        Self::Encoder::encode(self).unwrap_or_else(|e| {
+    fn ser(&self) -> ServerFnErrorResponseParts {
+        let body = Self::Encoder::encode(self).unwrap_or_else(|e| {
             Self::Encoder::encode(&Self::from_server_fn_error(
                 ServerFnErrorErr::Serialization(e.to_string()),
             ))
@@ -578,7 +589,11 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
                 "error serializing should success at least with the \
                  Serialization error",
             )
-        })
+        });
+        ServerFnErrorResponseParts::builder()
+            .body(body)
+            .content_type(Self::Encoder::CONTENT_TYPE)
+            .build()
     }
 
     /// Deserializes the custom error type from a [`&str`].

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -579,7 +579,7 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// Converts a [`ServerFnErrorErr`] into the application-specific custom error type.
     fn from_server_fn_error(value: ServerFnErrorErr) -> Self;
 
-    /// Converts the custom error type to a [`String`].
+    /// Converts the custom error type to [`ServerFnErrorResponseParts`].
     fn ser(&self) -> ServerFnErrorResponseParts {
         let body = Self::Encoder::encode(self).unwrap_or_else(|e| {
             Self::Encoder::encode(&Self::from_server_fn_error(

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -307,16 +307,18 @@ pub trait ServerFn: Send + Sized {
                     .await
                     .map(|res| (res, None))
                     .unwrap_or_else(|e| {
-                        (
+                        let mut response =
                             <<Self as ServerFn>::Server as crate::Server<
                                 Self::Error,
                                 Self::InputStreamError,
                                 Self::OutputStreamError,
                             >>::Response::error_response(
                                 Self::PATH, e.ser()
-                            ),
-                            Some(e),
-                        )
+                            );
+                        let content_type =
+                    <Self::Error as FromServerFnError>::Encoder::CONTENT_TYPE;
+                        response.content_type(content_type);
+                        (response, Some(e))
                     });
 
             // if it accepts HTML, we'll redirect to the Referer

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -307,18 +307,16 @@ pub trait ServerFn: Send + Sized {
                     .await
                     .map(|res| (res, None))
                     .unwrap_or_else(|e| {
-                        let mut response =
+                        (
                             <<Self as ServerFn>::Server as crate::Server<
                                 Self::Error,
                                 Self::InputStreamError,
                                 Self::OutputStreamError,
                             >>::Response::error_response(
                                 Self::PATH, e.ser()
-                            );
-                        let content_type =
-                    <Self::Error as FromServerFnError>::Encoder::CONTENT_TYPE;
-                        response.content_type(content_type);
-                        (response, Some(e))
+                            ),
+                            Some(e),
+                        )
                     });
 
             // if it accepts HTML, we'll redirect to the Referer
@@ -669,8 +667,9 @@ where
                         ServerFnErrorErr::Serialization(e.to_string()),
                     )
                     .ser()
+                    .body
                 }),
-                Err(err) => Err(err.ser()),
+                Err(err) => Err(err.ser().body),
             };
             serialize_result(result)
         });
@@ -713,9 +712,10 @@ where
                                     ),
                                 )
                                 .ser()
+                                .body
                             })
                         }
-                        Err(err) => Err(err.ser()),
+                        Err(err) => Err(err.ser().body),
                     };
                     let result = serialize_result(result);
                     if sink.send(result).await.is_err() {
@@ -783,7 +783,8 @@ fn deserialize_result<E: FromServerFnError>(
         return Err(E::from_server_fn_error(
             ServerFnErrorErr::Deserialization("Data is empty".into()),
         )
-        .ser());
+        .ser()
+        .body);
     }
 
     let tag = bytes[0];
@@ -795,7 +796,8 @@ fn deserialize_result<E: FromServerFnError>(
         _ => Err(E::from_server_fn_error(ServerFnErrorErr::Deserialization(
             "Invalid data tag".into(),
         ))
-        .ser()), // Invalid tag
+        .ser()
+        .body), // Invalid tag
     }
 }
 
@@ -885,7 +887,7 @@ pub struct ServerFnTraitObj<Req, Res> {
     method: Method,
     handler: fn(Req) -> Pin<Box<dyn Future<Output = Res> + Send>>,
     middleware: fn() -> MiddlewareSet<Req, Res>,
-    ser: fn(ServerFnErrorErr) -> Bytes,
+    ser: middleware::ServerFnErrorSerializer,
 }
 
 impl<Req, Res> ServerFnTraitObj<Req, Res> {
@@ -961,7 +963,7 @@ where
     fn run(
         &mut self,
         req: Req,
-        _ser: fn(ServerFnErrorErr) -> Bytes,
+        _err_ser: middleware::ServerFnErrorSerializer,
     ) -> Pin<Box<dyn Future<Output = Res> + Send>> {
         let handler = self.handler;
         Box::pin(async move { handler(req).await })

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -129,9 +129,9 @@ mod axum {
 
 #[cfg(feature = "actix-no-default")]
 mod actix {
-    use crate::middleware::ServerFnErrorSerializer;
     use crate::{
         error::ServerFnErrorErr,
+        middleware::ServerFnErrorSerializer,
         request::actix::ActixRequest,
         response::{actix::ActixResponse, Res},
     };

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -38,7 +38,7 @@ impl<Req, Res> BoxedService<Req, Res> {
     }
 }
 
-/// todo
+/// Type alias for the function that serializes a server fn error to [`ServerFnErrorResponseParts`].
 pub type ServerFnErrorSerializer =
     fn(ServerFnErrorErr) -> ServerFnErrorResponseParts;
 

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -11,7 +11,7 @@ pub trait Layer<Req, Res>: Send + Sync + 'static {
 /// A type-erased service, which takes an HTTP request and returns a response.
 #[non_exhaustive]
 pub struct BoxedService<Req, Res> {
-    /// A function that converts a [`ServerFnErrorErr`] into a string.
+    /// A function that converts a [`ServerFnErrorErr`] into [`ServerFnErrorResponseParts`].
     pub err_ser: ServerFnErrorSerializer,
     /// The inner service.
     pub service: Box<dyn Service<Req, Res> + Send>,
@@ -38,7 +38,8 @@ impl<Req, Res> BoxedService<Req, Res> {
     }
 }
 
-/// Type alias for the function that serializes a server fn error to [`ServerFnErrorResponseParts`].
+/// Type alias for a function that serializes a [`ServerFnErrorErr`] into
+/// [`ServerFnErrorResponseParts`].
 pub type ServerFnErrorSerializer =
     fn(ServerFnErrorErr) -> ServerFnErrorResponseParts;
 

--- a/server_fn/src/request/actix.rs
+++ b/server_fn/src/request/actix.rs
@@ -107,6 +107,7 @@ where
                     e.to_string(),
                 ))
                 .ser()
+                .body
             })
         });
         Ok(SendWrapper::new(stream))
@@ -143,7 +144,7 @@ where
                             break;
                         };
                                 if let Err(err) = session.binary(incoming).await {
-                                    _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser()));
+                                    _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body));
                                 }
                     },
                     outgoing = msg_stream.next().fuse() => {
@@ -171,7 +172,7 @@ where
                             Ok(_other) => {
                             }
                             Err(e) => {
-                                _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser()));
+                                _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body));
                             }
                         }
                     }

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -70,6 +70,7 @@ where
                     e.to_string(),
                 ))
                 .ser()
+                .body
             })
         }))
     }
@@ -124,7 +125,7 @@ where
         .on_failed_upgrade({
             let mut outgoing_tx = outgoing_tx.clone();
             move |err: axum::Error| {
-                _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(err.to_string())).ser()));
+                _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(err.to_string())).ser().body));
             }
         })
         .on_upgrade(|mut session| async move {
@@ -135,7 +136,7 @@ where
                             break;
                         };
                         if let Err(err) = session.send(Message::Binary(incoming)).await {
-                            _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser()));
+                            _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body));
                         }
                     },
                         outgoing = session.recv().fuse() => {
@@ -159,7 +160,7 @@ where
                             }
                             Ok(_other) => {}
                             Err(e) => {
-                                _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser()));
+                                _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body));
                             }
                         }
                     }

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -12,6 +12,7 @@ use actix_web::{
 };
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
+use http::header::CONTENT_TYPE;
 use send_wrapper::SendWrapper;
 
 /// A wrapped Actix response.
@@ -78,6 +79,12 @@ impl Res for ActixResponse {
                 .append_header((SERVER_FN_ERROR_HEADER, path))
                 .body(err),
         ))
+    }
+
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.0.headers_mut().insert(CONTENT_TYPE, content_type);
+        }
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -5,14 +5,13 @@ use crate::error::{
 use actix_web::{
     http::{
         header,
-        header::{HeaderValue, LOCATION},
+        header::{HeaderValue, CONTENT_TYPE, LOCATION},
         StatusCode,
     },
     HttpResponse,
 };
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use http::header::CONTENT_TYPE;
 use send_wrapper::SendWrapper;
 
 /// A wrapped Actix response.

--- a/server_fn/src/response/actix.rs
+++ b/server_fn/src/response/actix.rs
@@ -1,6 +1,7 @@
 use super::{Res, TryRes};
 use crate::error::{
-    FromServerFnError, ServerFnErrorWrapper, SERVER_FN_ERROR_HEADER,
+    FromServerFnError, ServerFnErrorResponseParts, ServerFnErrorWrapper,
+    SERVER_FN_ERROR_HEADER,
 };
 use actix_web::{
     http::{
@@ -72,18 +73,13 @@ where
 }
 
 impl Res for ActixResponse {
-    fn error_response(path: &str, err: Bytes) -> Self {
+    fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self {
         ActixResponse(SendWrapper::new(
             HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR)
                 .append_header((SERVER_FN_ERROR_HEADER, path))
-                .body(err),
+                .append_header((CONTENT_TYPE, err.content_type))
+                .body(err.body),
         ))
-    }
-
-    fn content_type(&mut self, content_type: &str) {
-        if let Ok(content_type) = HeaderValue::from_str(content_type) {
-            self.0.headers_mut().insert(CONTENT_TYPE, content_type);
-        }
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/browser.rs
+++ b/server_fn/src/response/browser.rs
@@ -69,7 +69,8 @@ impl<E: FromServerFnError> ClientRes<E> for BrowserResponse {
                     Err(E::from_server_fn_error(ServerFnErrorErr::Request(
                         format!("{e:?}"),
                     ))
-                    .ser())
+                    .ser()
+                    .body)
                 }
                 Ok(data) => {
                     let data = data.unchecked_into::<Uint8Array>();

--- a/server_fn/src/response/generic.rs
+++ b/server_fn/src/response/generic.rs
@@ -100,6 +100,13 @@ impl Res for Response<Body> {
             .unwrap()
     }
 
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
+        }
+    }
+
     fn redirect(&mut self, path: &str) {
         if let Ok(path) = HeaderValue::from_str(path) {
             self.headers_mut().insert(header::LOCATION, path);

--- a/server_fn/src/response/generic.rs
+++ b/server_fn/src/response/generic.rs
@@ -14,8 +14,8 @@
 
 use super::{Res, TryRes};
 use crate::error::{
-    FromServerFnError, IntoAppError, ServerFnErrorErr, ServerFnErrorWrapper,
-    SERVER_FN_ERROR_HEADER,
+    FromServerFnError, IntoAppError, ServerFnErrorErr,
+    ServerFnErrorResponseParts, ServerFnErrorWrapper, SERVER_FN_ERROR_HEADER,
 };
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
@@ -92,19 +92,13 @@ where
 }
 
 impl Res for Response<Body> {
-    fn error_response(path: &str, err: Bytes) -> Self {
+    fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self {
         Response::builder()
             .status(http::StatusCode::INTERNAL_SERVER_ERROR)
             .header(SERVER_FN_ERROR_HEADER, path)
-            .body(err.into())
+            .header(header::CONTENT_TYPE, err.content_type)
+            .body(err.body.into())
             .unwrap()
-    }
-
-    fn content_type(&mut self, content_type: &str) {
-        if let Ok(content_type) = HeaderValue::from_str(content_type) {
-            self.headers_mut()
-                .insert(header::CONTENT_TYPE, content_type);
-        }
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -60,6 +60,13 @@ impl Res for Response<Body> {
             .unwrap()
     }
 
+    fn content_type(&mut self, content_type: &str) {
+        if let Ok(content_type) = HeaderValue::from_str(content_type) {
+            self.headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
+        }
+    }
+
     fn redirect(&mut self, path: &str) {
         if let Ok(path) = HeaderValue::from_str(path) {
             self.headers_mut().insert(header::LOCATION, path);

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -1,7 +1,7 @@
 use super::{Res, TryRes};
 use crate::error::{
-    FromServerFnError, IntoAppError, ServerFnErrorErr, ServerFnErrorWrapper,
-    SERVER_FN_ERROR_HEADER,
+    FromServerFnError, IntoAppError, ServerFnErrorErr,
+    ServerFnErrorResponseParts, ServerFnErrorWrapper, SERVER_FN_ERROR_HEADER,
 };
 use axum::body::Body;
 use bytes::Bytes;
@@ -16,7 +16,7 @@ where
         let builder = http::Response::builder();
         builder
             .status(200)
-            .header(http::header::CONTENT_TYPE, content_type)
+            .header(header::CONTENT_TYPE, content_type)
             .body(Body::from(data))
             .map_err(|e| {
                 ServerFnErrorErr::Response(e.to_string()).into_app_error()
@@ -27,7 +27,7 @@ where
         let builder = http::Response::builder();
         builder
             .status(200)
-            .header(http::header::CONTENT_TYPE, content_type)
+            .header(header::CONTENT_TYPE, content_type)
             .body(Body::from(data))
             .map_err(|e| {
                 ServerFnErrorErr::Response(e.to_string()).into_app_error()
@@ -43,7 +43,7 @@ where
         let builder = http::Response::builder();
         builder
             .status(200)
-            .header(http::header::CONTENT_TYPE, content_type)
+            .header(header::CONTENT_TYPE, content_type)
             .body(body)
             .map_err(|e| {
                 ServerFnErrorErr::Response(e.to_string()).into_app_error()
@@ -52,19 +52,13 @@ where
 }
 
 impl Res for Response<Body> {
-    fn error_response(path: &str, err: Bytes) -> Self {
+    fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self {
         Response::builder()
             .status(http::StatusCode::INTERNAL_SERVER_ERROR)
             .header(SERVER_FN_ERROR_HEADER, path)
-            .body(err.into())
+            .header(header::CONTENT_TYPE, err.content_type)
+            .body(err.body.into())
             .unwrap()
-    }
-
-    fn content_type(&mut self, content_type: &str) {
-        if let Ok(content_type) = HeaderValue::from_str(content_type) {
-            self.headers_mut()
-                .insert(header::CONTENT_TYPE, content_type);
-        }
     }
 
     fn redirect(&mut self, path: &str) {

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -39,7 +39,8 @@ where
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
     fn error_response(path: &str, err: Bytes) -> Self;
-
+    /// Set the content type header for the response.
+    fn content_type(&mut self, #[allow(unused_variables)] content_type: &str) {}
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
 }
@@ -100,6 +101,10 @@ impl<E> TryRes<E> for BrowserMockRes {
 
 impl Res for BrowserMockRes {
     fn error_response(_path: &str, _err: Bytes) -> Self {
+        unreachable!()
+    }
+
+    fn content_type(&mut self, _content_type: &str) {
         unreachable!()
     }
 

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -39,7 +39,7 @@ where
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
     fn error_response(path: &str, err: Bytes) -> Self;
-    /// Set the content type header for the response.
+    /// Set the content-type header for the response.
     fn content_type(&mut self, #[allow(unused_variables)] content_type: &str) {}
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);

--- a/server_fn/src/response/mod.rs
+++ b/server_fn/src/response/mod.rs
@@ -13,6 +13,7 @@ pub mod http;
 #[cfg(feature = "reqwest")]
 pub mod reqwest;
 
+use crate::error::ServerFnErrorResponseParts;
 use bytes::Bytes;
 use futures::Stream;
 use std::future::Future;
@@ -38,9 +39,7 @@ where
 /// Represents the response as created by the server;
 pub trait Res {
     /// Converts an error into a response, with a `500` status code and the error text as its body.
-    fn error_response(path: &str, err: Bytes) -> Self;
-    /// Set the content-type header for the response.
-    fn content_type(&mut self, #[allow(unused_variables)] content_type: &str) {}
+    fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self;
     /// Redirect the response by setting a 302 code and Location header.
     fn redirect(&mut self, path: &str);
 }
@@ -100,11 +99,7 @@ impl<E> TryRes<E> for BrowserMockRes {
 }
 
 impl Res for BrowserMockRes {
-    fn error_response(_path: &str, _err: Bytes) -> Self {
-        unreachable!()
-    }
-
-    fn content_type(&mut self, _content_type: &str) {
+    fn error_response(_path: &str, _err: ServerFnErrorResponseParts) -> Self {
         unreachable!()
     }
 

--- a/server_fn/src/response/reqwest.rs
+++ b/server_fn/src/response/reqwest.rs
@@ -24,6 +24,7 @@ impl<E: FromServerFnError> ClientRes<E> for Response {
         Ok(self.bytes_stream().map_err(|e| {
             E::from_server_fn_error(ServerFnErrorErr::Response(e.to_string()))
                 .ser()
+                .body
         }))
     }
 


### PR DESCRIPTION
Problem
-------
When a server function returns an error, the content-type header is not set.

Solution
--------
In order to set the content-type header in the response, the `FromServerFnError::Encoder::CONTENT_TYPE` associated constant needs to make its way to where the response object is constructed. This PR achieves this with the following changes:

- **[breaking]** Update the `FromServerFnError#ser` trait method to return the content type as well as the serialized error response bytes. This is returned in a new `ServerFnErrorResponseParts` struct that contains both values and is marked `#[non_exhaustive]` to allow adding new fields in the future without breaking semver.
- **[breaking]** Update the type of the `BoxedService#ser` field to be a function that returns `ServerFnErrorResponseParts` to match the updated `FromServerFnError#ser` trait method. The field is also renamed to `err_ser`.
- **[breaking**] Mark `BoxedService` as `#[non_exhaustive]` to allow adding new fields in the future without breaking semver.
- **[breaking]** Update the `Res#error_response` trait method to take `ServerFnErrorResponseParts` instead of `Bytes`.
- Update the implementations of `Res#error_response` to set the content-type header using the value from `ServerFnErrorResponseParts`.
- Add a dependency on `bon` to auto-generate a builder API for the `ServerFnErrorResponseParts` struct.

Note: I wasn't entirely sure how to handle `ServerFnErrorResponseParts` being used in stream/websocket responses, so I simply extracted the `body` field in order to match the existing behavior.

Closes https://github.com/leptos-rs/leptos/issues/4209