### PR TITLE
docs: correctly document additional serialization features for `leptos_server`

### DIFF
--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -44,7 +44,8 @@ denylist = ["tracing"]
 max_combination_size = 2
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition", "--cfg", "docsrs"]
+all-features = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -386,6 +386,7 @@ T: Send + Sync + 'static,
 }
 
 #[cfg(feature = "serde-wasm-bindgen")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-wasm-bindgen")))]
 impl<T> ArcOnceResource<T, JsonSerdeWasmCodec>
 where
 T: Send + Sync + 'static,
@@ -418,6 +419,7 @@ fut: impl Future<Output = T> + Send + 'static
     }
 }
 #[cfg(feature = "miniserde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miniserde")))]
 impl<T> ArcOnceResource<T, MiniserdeCodec>
 where
     T: Send + Sync + 'static,
@@ -451,6 +453,7 @@ where
 }
 
 #[cfg(feature = "serde-lite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-lite")))]
 impl<T> ArcOnceResource<T, SerdeLite<JsonSerdeCodec>>
 where
 T: Send + Sync + 'static,
@@ -484,6 +487,7 @@ fut: impl Future<Output = T> + Send + 'static
 }
 
 #[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
 impl<T> ArcOnceResource<T, RkyvCodec>
 where
     T: Send + Sync + 'static,
@@ -748,6 +752,7 @@ T: Send + Sync + 'static,
 }
 
 #[cfg(feature = "serde-wasm-bindgen")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-wasm-bindgen")))]
 impl<T> OnceResource<T, JsonSerdeWasmCodec>
 where
 T: Send + Sync + 'static,
@@ -780,6 +785,7 @@ fut: impl Future<Output = T> + Send + 'static
     }
 }
 #[cfg(feature = "miniserde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miniserde")))]
 impl<T> OnceResource<T, MiniserdeCodec>
 where
     T: Send + Sync + 'static,
@@ -813,6 +819,7 @@ where
 }
 
 #[cfg(feature = "serde-lite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-lite")))]
 impl<T> OnceResource<T, SerdeLite<JsonSerdeCodec>>
 where
 T: Send + Sync + 'static,
@@ -846,6 +853,7 @@ fut: impl Future<Output = T> + Send + 'static
 }
 
 #[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
 impl<T> OnceResource<T, RkyvCodec>
 where
     T: Send + Sync + 'static,

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -709,6 +709,7 @@ where
 }
 
 #[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
 impl<T> ArcResource<T, RkyvCodec>
 where
     RkyvCodec: Encoder<T> + Decoder<T>,
@@ -1048,6 +1049,7 @@ where
 }
 
 #[cfg(feature = "serde-wasm-bindgen")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-wasm-bindgen")))]
 impl<T> Resource<T, JsonSerdeWasmCodec>
 where
     JsonSerdeWasmCodec: Encoder<T> + Decoder<T>,
@@ -1105,6 +1107,7 @@ where
 }
 
 #[cfg(feature = "miniserde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miniserde")))]
 impl<T> Resource<T, MiniserdeCodec>
 where
     MiniserdeCodec: Encoder<T> + Decoder<T>,
@@ -1164,6 +1167,7 @@ where
 }
 
 #[cfg(feature = "serde-lite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-lite")))]
 impl<T> Resource<T, SerdeLite<JsonSerdeCodec>>
 where
     SerdeLite<JsonSerdeCodec>: Encoder<T> + Decoder<T>,
@@ -1222,6 +1226,7 @@ where
 }
 
 #[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
 impl<T> Resource<T, RkyvCodec>
 where
     RkyvCodec: Encoder<T> + Decoder<T>,

--- a/leptos_server/src/shared.rs
+++ b/leptos_server/src/shared.rs
@@ -80,6 +80,7 @@ where
 }
 
 #[cfg(feature = "serde-lite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-lite")))]
 impl<T> SharedValue<T, SerdeLite<JsonSerdeCodec>>
 where
     SerdeLite<JsonSerdeCodec>: Encoder<T> + Decoder<T>,
@@ -102,6 +103,7 @@ where
 }
 
 #[cfg(feature = "serde-wasm-bindgen")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde-wasm-bindgen")))]
 impl<T> SharedValue<T, JsonSerdeWasmCodec>
 where
     JsonSerdeWasmCodec: Encoder<T> + Decoder<T>,
@@ -124,6 +126,7 @@ where
 }
 
 #[cfg(feature = "miniserde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miniserde")))]
 impl<T> SharedValue<T, MiniserdeCodec>
 where
     MiniserdeCodec: Encoder<T> + Decoder<T>,
@@ -146,6 +149,7 @@ where
 }
 
 #[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
 impl<T> SharedValue<T, RkyvCodec>
 where
     RkyvCodec: Encoder<T> + Decoder<T>,


### PR DESCRIPTION
This should allow feature-gated methods like `Resource::new_rkyv()` and so on to appear correctly on docs.rs.