### PR TITLE
Revert recent broken changes

### DIFF
--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -27,7 +27,6 @@ pub fn AutoReload(
             None => options.reload_port,
         };
         let protocol = match options.reload_ws_protocol {
-            leptos_config::ReloadWSProtocol::Auto => "null",
             leptos_config::ReloadWSProtocol::WS => "'ws://'",
             leptos_config::ReloadWSProtocol::WSS => "'wss://'",
         };

--- a/leptos/src/hydration/reload_script.js
+++ b/leptos/src/hydration/reload_script.js
@@ -1,9 +1,4 @@
 let host = window.location.hostname;
-
-if (protocol === null) {
-	protocol = window.location.protocol === 'https:' ? 'wss://' : 'ws://';
-}
-
 let ws = new WebSocket(`${protocol}${host}:${reload_port}/live_reload`);
 ws.onmessage = (ev) => {
 	let msg = JSON.parse(ev.data);

--- a/leptos/src/show.rs
+++ b/leptos/src/show.rs
@@ -1,116 +1,30 @@
 use crate::{
     children::{TypedChildrenFn, ViewFn},
-    prelude::{FunctionMarker, SignalMarker},
     IntoView,
 };
 use leptos_macro::component;
 use reactive_graph::{computed::ArcMemo, traits::Get};
-use std::{marker::PhantomData, sync::Arc};
 use tachys::either::Either;
 
-/// Shows its children whenever the condition `when` prop is `true`.
-/// Otherwise it renders the `fallback` prop, which defaults to the empty view.
-///
-/// The prop `when` can be a closure that returns a bool, a signal of type bool, or a boolean value.
-///
-/// ## Usage
-///
-/// ```
-/// # use leptos::prelude::*;
-/// #
-/// # #[component]
-/// # pub fn Demo() -> impl IntoView {
-/// let (condition, set_condition) = signal(true);
-///
-/// view! {
-///     <Show when=condition>
-///         <p>"Hello, world!"</p>
-///     </Show>
-/// }
-/// # }
-/// ```
-///
-/// Or with a closure as the `when` condition:
-///
-/// ```
-/// # use leptos::prelude::*;
-/// #
-/// # #[component]
-/// # pub fn Demo() -> impl IntoView {
-/// let (condition, set_condition) = signal(true);
-///
-/// view! {
-///     <Show when=move || condition.get()>
-///         <p>"Hello, world!"</p>
-///     </Show>
-/// }
-/// # }
-/// ```
 #[component]
-pub fn Show<M, C>(
+pub fn Show<W, C>(
     /// The children will be shown whenever the condition in the `when` closure returns `true`.
     children: TypedChildrenFn<C>,
-    /// When true the children are shown, otherwise the fallback.
-    /// It accepts a closure that returns a boolean value as well as a boolean signal or plain boolean value.
-    when: impl IntoCondition<M>,
+    /// A closure that returns a bool that determines whether this thing runs
+    when: W,
     /// A closure that returns what gets rendered if the when statement is false. By default this is the empty view.
     #[prop(optional, into)]
     fallback: ViewFn,
-
-    /// Marker for generic parameters. Ignore this.
-    #[prop(optional)]
-    _marker: PhantomData<M>,
 ) -> impl IntoView
 where
+    W: Fn() -> bool + Send + Sync + 'static,
     C: IntoView + 'static,
 {
-    let when = when.into_condition();
-    let memoized_when = ArcMemo::new(move |_| when.run());
+    let memoized_when = ArcMemo::new(move |_| when());
     let children = children.into_inner();
 
     move || match memoized_when.get() {
         true => Either::Left(children()),
         false => Either::Right(fallback.run()),
-    }
-}
-
-/// A closure that returns a bool. Can be converted from a closure, a signal, or a boolean value.
-pub struct Condition(Arc<dyn Fn() -> bool + Send + Sync + 'static>);
-
-impl Condition {
-    /// Evaluates the condition and returns its result.
-    pub fn run(&self) -> bool {
-        (self.0)()
-    }
-}
-
-/// Trait to convert various types into a `Condition`.
-/// Implemented for closures, signals, and boolean values.
-pub trait IntoCondition<M> {
-    /// Does the conversion
-    fn into_condition(self) -> Condition;
-}
-
-impl<S> IntoCondition<SignalMarker> for S
-where
-    S: Get<Value = bool> + Send + Sync + 'static,
-{
-    fn into_condition(self) -> Condition {
-        Condition(Arc::new(move || self.get()))
-    }
-}
-
-impl<F> IntoCondition<FunctionMarker> for F
-where
-    F: Fn() -> bool + Send + Sync + 'static,
-{
-    fn into_condition(self) -> Condition {
-        Condition(Arc::new(self))
-    }
-}
-
-impl IntoCondition<Condition> for Condition {
-    fn into_condition(self) -> Condition {
-        self
     }
 }

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -153,7 +153,7 @@ impl LeptosOptions {
                 None => None,
             },
             reload_ws_protocol: ws_from_str(
-                env_w_default("LEPTOS_RELOAD_WS_PROTOCOL", "auto")?.as_str(),
+                env_w_default("LEPTOS_RELOAD_WS_PROTOCOL", "ws")?.as_str(),
             )?,
             not_found_path: env_w_default("LEPTOS_NOT_FOUND_PATH", "/404")?
                 .into(),
@@ -283,24 +283,22 @@ impl TryFrom<String> for Env {
 pub enum ReloadWSProtocol {
     WS,
     WSS,
-    Auto,
 }
 
 impl Default for ReloadWSProtocol {
     fn default() -> Self {
-        Self::Auto
+        Self::WS
     }
 }
 
 fn ws_from_str(input: &str) -> Result<ReloadWSProtocol, LeptosConfigError> {
     let sanitized = input.to_lowercase();
     match sanitized.as_ref() {
-        "auto" => Ok(ReloadWSProtocol::Auto),
         "ws" | "WS" => Ok(ReloadWSProtocol::WS),
         "wss" | "WSS" => Ok(ReloadWSProtocol::WSS),
         _ => Err(LeptosConfigError::EnvVarError(format!(
-            "{input} is not a supported websocket protocol. Use only `auto`, \
-             `ws` or `wss`.",
+            "{input} is not a supported websocket protocol. Use only `ws` or \
+             `wss`.",
         ))),
     }
 }


### PR DESCRIPTION
Reverts #4236, which doesn't compile with `nightly`, and reverts #4224, which caused breaking changes to be published in a patch release, so that I can republish `leptos_config` and `leptos` and resolve #4254.