### PR TITLE
fix: use wss for live reload if on https

### DIFF
--- a/leptos/src/hydration/reload_script.js
+++ b/leptos/src/hydration/reload_script.js
@@ -1,3 +1,7 @@
+if (window.location.protocol === 'https:') {
+	protocol = 'wss://';
+}
+
 let host = window.location.hostname;
 let ws = new WebSocket(`${protocol}${host}:${reload_port}/live_reload`);
 ws.onmessage = (ev) => {


### PR DESCRIPTION
Non-breaking version of #4224, as suggested by @gbj.

This builds on top of #4255.

I would like to make another PR reintroducing the `auto` option for an eventual 0.9 release, as I think it's a more elegant solution.