### PR TITLE
Preserve owner in Actions and event listeners

### DIFF
--- a/reactive_graph/src/actions/action.rs
+++ b/reactive_graph/src/actions/action.rs
@@ -207,10 +207,10 @@ where
             version: Default::default(),
             dispatched: Default::default(),
             action_fn: Arc::new(move |input| {
-                Box::pin(ScopedFuture::new_untracked_with_owner(
-                    owner.with(|| action_fn(input)),
-                    owner.clone(),
-                ))
+                Box::pin(
+                    owner
+                        .with(|| ScopedFuture::new_untracked(action_fn(input))),
+                )
             }),
             #[cfg(any(debug_assertions, leptos_debuginfo))]
             defined_at: Location::caller(),
@@ -386,10 +386,8 @@ where
             dispatched: Default::default(),
             action_fn: Arc::new(move |input| {
                 Box::pin(SendWrapper::new(
-                    ScopedFuture::new_untracked_with_owner(
-                        owner.with(|| action_fn(input)),
-                        owner.clone(),
-                    ),
+                    owner
+                        .with(|| ScopedFuture::new_untracked(action_fn(input))),
                 ))
             }),
             #[cfg(any(debug_assertions, leptos_debuginfo))]

--- a/reactive_graph/src/actions/action.rs
+++ b/reactive_graph/src/actions/action.rs
@@ -1,7 +1,7 @@
 use crate::{
-    computed::{ArcMemo, Memo},
+    computed::{ArcMemo, Memo, ScopedFuture},
     diagnostics::is_suppressing_resource_load,
-    owner::{ArcStoredValue, ArenaItem},
+    owner::{ArcStoredValue, ArenaItem, Owner},
     send_wrapper_ext::SendOption,
     signal::{ArcMappedSignal, ArcRwSignal, MappedSignal, RwSignal},
     traits::{DefinedAt, Dispose, Get, GetUntracked, GetValue, Update, Write},
@@ -199,13 +199,19 @@ where
         I: Send + Sync,
         O: Send + Sync,
     {
+        let owner = Owner::current().unwrap_or_default();
         ArcAction {
             in_flight: ArcRwSignal::new(0),
             input: ArcRwSignal::new(SendOption::new(None)),
             value: ArcRwSignal::new(SendOption::new(value)),
             version: Default::default(),
             dispatched: Default::default(),
-            action_fn: Arc::new(move |input| Box::pin(action_fn(input))),
+            action_fn: Arc::new(move |input| {
+                Box::pin(ScopedFuture::new_untracked_with_owner(
+                    owner.with(|| action_fn(input)),
+                    owner.clone(),
+                ))
+            }),
             #[cfg(any(debug_assertions, leptos_debuginfo))]
             defined_at: Location::caller(),
         }
@@ -370,6 +376,7 @@ where
         F: Fn(&I) -> Fu + 'static,
         Fu: Future<Output = O> + 'static,
     {
+        let owner = Owner::current().unwrap_or_default();
         let action_fn = SendWrapper::new(action_fn);
         ArcAction {
             in_flight: ArcRwSignal::new(0),
@@ -378,7 +385,12 @@ where
             version: Default::default(),
             dispatched: Default::default(),
             action_fn: Arc::new(move |input| {
-                Box::pin(SendWrapper::new(action_fn(input)))
+                Box::pin(SendWrapper::new(
+                    ScopedFuture::new_untracked_with_owner(
+                        owner.with(|| action_fn(input)),
+                        owner.clone(),
+                    ),
+                ))
             }),
             #[cfg(any(debug_assertions, leptos_debuginfo))]
             defined_at: Location::caller(),

--- a/reactive_graph/src/computed/async_derived/mod.rs
+++ b/reactive_graph/src/computed/async_derived/mod.rs
@@ -54,6 +54,15 @@ impl<Fut> ScopedFuture<Fut> {
             fut,
         }
     }
+
+    /// Same as [`ScopedFuture::new_untracked`], but uses the passed owner.
+    pub fn new_untracked_with_owner(fut: Fut, owner: Owner) -> Self {
+        Self {
+            owner,
+            observer: None,
+            fut,
+        }
+    }
 }
 
 impl<Fut: Future> Future for ScopedFuture<Fut> {

--- a/reactive_graph/src/computed/async_derived/mod.rs
+++ b/reactive_graph/src/computed/async_derived/mod.rs
@@ -54,15 +54,6 @@ impl<Fut> ScopedFuture<Fut> {
             fut,
         }
     }
-
-    /// Same as [`ScopedFuture::new_untracked`], but uses the passed owner.
-    pub fn new_untracked_with_owner(fut: Fut, owner: Owner) -> Self {
-        Self {
-            owner,
-            observer: None,
-            fut,
-        }
-    }
 }
 
 impl<Fut: Future> Future for ScopedFuture<Fut> {


### PR DESCRIPTION
Migrating code from 0.6, it's a common painpoint that context doesn't work in `Action`s or event listeners.

I took a look into this today and it was actually pretty easy to support unless there are some downsides I'm missing!

With this PR, the following works:

```rust
    #[derive(Debug, Clone)]
    struct Ctx;
    provide_context(Ctx);

    let a = Action::new(move |_arg: &()| {
        expect_context::<Ctx>();
        async move {
            expect_context::<Ctx>();
        }
    });
    let a_local = Action::new_local(move |_arg: &()| {
        expect_context::<Ctx>();
        async move {
            expect_context::<Ctx>();
        }
    });
    Effect::new(move || {
        spawn_local(async move {
            a.dispatch(());
            a_local.dispatch(());
        });
    });

    view! {
        <button
            on:click={move |_| {
                expect_context::<Ctx>();
            }}
        >
            "Click me"
        </button>
    };
```