### PR TITLE
docs: fix broken links in suspense

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -32,12 +32,12 @@ use tachys::{
 };
 use throw_error::ErrorHookFuture;
 
-/// If any [`Resource`](leptos_reactive::Resource) is read in the `children` of this
+/// If any [`Resource`](crate::prelude::Resource) is read in the `children` of this
 /// component, it will show the `fallback` while they are loading. Once all are resolved,
 /// it will render the `children`.
 ///
 /// Each time one of the resources is loading again, it will fall back. To keep the current
-/// children instead, use [Transition](crate::Transition).
+/// children instead, use [Transition](crate::prelude::Transition).
 ///
 /// Note that the `children` will be rendered initially (in order to capture the fact that
 /// those resources are read under the suspense), so you cannot assume that resources read

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -16,11 +16,11 @@ use reactive_graph::{
 use slotmap::{DefaultKey, SlotMap};
 use tachys::reactive_graph::OwnedView;
 
-/// If any [`Resource`](leptos_reactive::Resource) is read in the `children` of this
+/// If any [`Resource`](crate::prelude::Resource) is read in the `children` of this
 /// component, it will show the `fallback` while they are loading. Once all are resolved,
 /// it will render the `children`.
 ///
-/// Unlike [`Suspense`](crate::Suspense), this will not fall
+/// Unlike [`Suspense`](crate::prelude::Suspense), this will not fall
 /// back to the `fallback` state if there are further changes after the initial load.
 ///
 /// Note that the `children` will be rendered initially (in order to capture the fact that


### PR DESCRIPTION
Hi,
in the documentation of  [module suspense](https://docs.rs/leptos/0.8.8/leptos/suspense/index.html) the links to `Resource` are broken.

The links are broken even on the [Suspense](https://docs.rs/leptos/0.8.8/leptos/suspense/fn.Suspense.html) and [Transition](https://docs.rs/leptos/latest/leptos/suspense/fn.Transition.html) pages when they reference each other.