### PR TITLE
Allow MultipartData ActionForms

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -45,7 +45,7 @@ typed-builder = { workspace = true, default-features = true }
 typed-builder-macro = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
-server_fn = { workspace = true, features = ["form-redirects", "browser"] }
+server_fn = { workspace = true, features = ["form-redirects", "browser", "multipart"] }
 web-sys = { features = [
   "ShadowRoot",
   "ShadowRootInit",

--- a/leptos/src/form.rs
+++ b/leptos/src/form.rs
@@ -138,6 +138,7 @@ where
     let action_form = form()
         .action(ServFn::url())
         .method("post")
+        .enctype(<InputProtocol as server_fn::ContentType>::CONTENT_TYPE)
         .on(submit, on_submit)
         .child(children());
     if let Some(node_ref) = node_ref {
@@ -206,6 +207,7 @@ where
         .action(ServFn::url())
         .method("post")
         .attr("method", "post")
+        .enctype(<InputProtocol as server_fn::ContentType>::CONTENT_TYPE)
         .on(submit, on_submit)
         .child(children());
     if let Some(node_ref) = node_ref {
@@ -325,7 +327,7 @@ fn form_data_from_event(
 }
 
 mod enc_type {
-    pub trait EncType {}
+    pub trait EncType: server_fn::ContentType {}
 
     impl EncType for server_fn::codec::PostUrl {}
     impl EncType for server_fn::codec::MultipartFormData {}

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -345,6 +345,7 @@ pub mod task {
 pub use serde;
 #[doc(hidden)]
 pub use serde_json;
+pub use serde_qs;
 #[cfg(feature = "tracing")]
 #[doc(hidden)]
 pub use tracing;

--- a/server_fn/src/codec/multipart.rs
+++ b/server_fn/src/codec/multipart.rs
@@ -31,6 +31,20 @@ pub enum MultipartData {
     Server(multer::Multipart<'static>),
 }
 
+impl Clone for MultipartData {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Client(data) => {
+                let form_data = (*data.0).clone();
+                Self::from(form_data)
+            }
+            Self::Server(_) => {
+                panic!("Cannot clone server side multipart data")
+            }
+        }
+    }
+}
+
 impl MultipartData {
     /// Extracts the inner data to handle as a stream.
     ///


### PR DESCRIPTION
In [the chapter about `ActionForm`s](https://book.leptos.dev/progressive_enhancement/action_form.html), it says:
> Note: `<ActionForm/>` only works with the default URL-encoded `POST` encoding for server functions, to ensure graceful degradation/correct behaviour as an HTML form.

This, however, prevents file uploads from working without JavaScript being enabled. As multi part forms are also supported natively, I feel like it should be possible to allow using them as well.

This is a very naive - but functional - approach that implements support for this. There are currently a few issues though:

1. The `Clone for MultipartData` impl on the server side panics. I'm not sure how to best clone the server value. It's not required for this use case, but should obviously be fixed. I think I need some guidance here.
2. The `server_fn_macro` impl now refers to `leptos`, which is probably not desirable, as it is a standalone crate. I don't know the code base well enough to move this implementation somewhere else. How could I best solve this?
3. The `server_fn/multipart` feature is now enabled unconditionally. The easy solution would be to add another feature to `leptos`. But I feel like resolving issue `2` will also lead to a nicer solution here.



Also, while testing, I found what I believe is a bug. Before specifying the `enctype` on the `ActionForm`, the server-side code would panic with `couldn't parse boundary` when submitting the form. It seems like the `FromReq<MultipartFormData, Request, E>` impl doesn't handle encoding errors at all.


Here is some example code for testing:
```rust
use leptos::prelude::*;

#[component]
pub fn Upload() -> impl IntoView {
    let upload_file = ServerAction::<Upload>::new();

    view! {
        <ActionForm action=upload_file>
            <label>
                "File"
                <input
                    type="file"
                    name="file"
                    accept=".csv, text/*"
                />
            </label>
            <input type="submit" value="Upload" />
        </ActionForm>
    }
}

#[server(input = server_fn::codec::MultipartFormData)]
async fn upload(data: server_fn::codec::MultipartData) -> Result<(), ServerFnError> {
  let _ = data;
  Ok(())
}
```