### PR TITLE
Locking dependencies in cargo-leptos install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Here are some resources for learning more about Leptos:
 [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos) is a build tool that's designed to make it easy to build apps that run on both the client and the server, with seamless integration. The best way to get started with a real Leptos project right now is to use `cargo-leptos` and our starter templates for [Actix](https://github.com/leptos-rs/start) or [Axum](https://github.com/leptos-rs/start-axum).
 
 ```bash
-cargo install cargo-leptos
+cargo install cargo-leptos --locked
 cargo leptos new --git https://github.com/leptos-rs/start-axum
 cd [your project name]
 cargo leptos watch


### PR DESCRIPTION
This limits dependency errors on install