### PR TITLE
Allow accessing a parent owner from a child

### DIFF
--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -209,6 +209,25 @@ impl Owner {
         this
     }
 
+    /// Returns the parent of this `Owner`, if any.
+    ///
+    /// None when:
+    /// - This is a root owner
+    /// - The parent has been dropped
+    pub fn parent(&self) -> Option<Owner> {
+        self.inner
+            .read()
+            .or_poisoned()
+            .parent
+            .as_ref()
+            .and_then(|p| p.upgrade())
+            .map(|inner| Owner {
+                inner,
+                #[cfg(feature = "hydration")]
+                shared_context: self.shared_context.clone(),
+            })
+    }
+
     /// Creates a new `Owner` that is the child of the current `Owner`, if any.
     pub fn child(&self) -> Self {
         let parent = Some(Arc::downgrade(&self.inner));


### PR DESCRIPTION
This has come about from me trying to fix a really confusing bug in leptos-fetch. 

Scenario:
- I want from userland to clone and hold onto an `Owner`, to prevent it getting dropped. So that I can call `use_context()` as I please.
- A parent of this owner is dropped, and the context was actually stored on that owner.
- Panic

This PR allows me in userland (LF) to produce the chain of owners,`Vec<Owner>` by calling `.parent()` over and over again, to preserve the entire chain, not just the current owner.
