### PR TITLE
fix: correctly poll all out-of-order streaming chunks (closes #4326)

### DIFF
--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -461,9 +461,7 @@ impl Stream for StreamBuilder {
                         if this.sync_buf.is_empty() {
                             Poll::Pending
                         } else {
-                            Poll::Ready(Some(mem::take(
-                                &mut this.sync_buf,
-                            )))
+                            Poll::Ready(Some(mem::take(&mut this.sync_buf)))
                         }
                     }
                 }

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -459,11 +459,11 @@ impl Stream for StreamBuilder {
                         }
 
                         if this.sync_buf.is_empty() {
-                            return Poll::Pending;
+                            Poll::Pending
                         } else {
-                            return Poll::Ready(Some(mem::take(
+                            Poll::Ready(Some(mem::take(
                                 &mut this.sync_buf,
-                            )));
+                            )))
                         }
                     }
                 }


### PR DESCRIPTION
Note to self: the current implementation was supposed to poll all pending out-of-order chunks round-robin, but instead only polled whichever one of them happened to be *first* in the queue: so if you had two chunks, 1 second and 2 second, you would
1) poll 1-second, find it pending, put it back on the back of the queue
2) wake up after 1 second was ready
3) poll 2-second, find it pending, add it to to back of the queue -- but not then also poll 1-second
4) wake up after 2 second was ready
5) poll 1-second, then poll 2-second, both ready, both flush

This fixes step 3 so that it will poll all pending out-of-order chunks every time, flushing any that are ready to the sync buffer and putting the rest back into the queue.