### PR TITLE
Support `ToggleEvent` for `on:toggle`.

### DIFF
--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -72,6 +72,7 @@ web-sys = { features = [
   "SecurityPolicyViolationEvent",
   "StorageEvent",
   "SubmitEvent",
+  "ToggleEvent",
   "TouchEvent",
   "TransitionEvent",
   "UiEvent",

--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -614,7 +614,7 @@ generate_event_types! {
   animation start: AnimationEvent,
   aux click: MouseEvent,
   before input: InputEvent,
-  before toggle: Event, // web_sys does not include `ToggleEvent`
+  before toggle: ToggleEvent,
   #[does_not_bubble]
   blur: FocusEvent,
   #[does_not_bubble]
@@ -725,7 +725,7 @@ generate_event_types! {
   #[does_not_bubble]
   time update: Event,
   #[does_not_bubble]
-  toggle: Event,
+  toggle: ToggleEvent,
   touch cancel: TouchEvent,
   touch end: TouchEvent,
   touch move: TouchEvent,


### PR DESCRIPTION
* Closes #4361.

Allows you to do this:

```rust
#[component]
pub fn MyDetails() -> impl IntoView {
    let (expanded, expanded_set) = leptos::prelude::signal(true);
    view! {
        <details
            open={move || expanded.get()}
            on:toggle=move |event| *expanded_set.write() = event.new_state() == "open"
        >
            <summary><OneLineSummary expanded /></summary>
            <p>contents</p>
        </details>
    }
}

#[component]
#[component]
pub fn OneLineSummary(expanded: ReadSignal<bool>) -> impl IntoView {
    view! {
        <span>{move || if expanded.get() { "Long text" } else { "short" }}</span>
    }
}
```