### PR TITLE
`server_fn` feature propagation

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -152,6 +152,11 @@ denylist = [
   "trace-component-props",
   "spin",
   "islands",
+  "serde-lite",
+  "cbor",
+  "msgpack",
+  "postcard",
+  "multipart",
 ]
 skip_feature_sets = [
   ["csr", "ssr"],


### PR DESCRIPTION
I have the ability to do the following:

```toml
# Cargo.toml
[dependencies]
leptos = { version = "0.8", features = ["rkyv"] }
```

and then

```rust
use leptos::server;
use leptos::server_fn::codec::Rkyv;
use leptos::server_fn::ServerFnError;

#[server(
    input = Rkyv,
    output = Rkyv,
)]
pub async fn example(input: String) -> Result<String, ServerFnError> {
    // ...
}
```

this is ergonomic, good 👍 . But, when attempting to do `serde-lite`, I have to manually import the separate `server_fn` crate:

```toml
# Cargo.toml
[dependencies]
leptos = { version = "0.8" } # `serde-lite` feat does not exist in `leptos`
server_fn = { version = "0.8", features = ["serde-lite"] } # separate crate def
```

and then

```rust
use leptos::server;
use server_fn::codec::SerdeLite;
use server_fn::ServerFnError;

#[server(
    input = SerdeLite,
    output = SerdeLite,
)]
pub async fn example(input: String) -> Result<String, ServerFnError> {
    // ...
}
```

Which is not that ergonomic. 

I added other `server_fn` features to also propagate like `cbor` and whatnot, if people want to use `leptos::server_fn` rather than a separate `server_fn` instance. 

Any need for this? It's mainly a QOL update