### PR TITLE
add `scrollend` event to view macro

### DIFF
--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -1678,7 +1678,7 @@ fn attribute_value(
 }
 
 // Keep list alphabetized for binary search
-const TYPED_EVENTS: [&str; 126] = [
+const TYPED_EVENTS: [&str; 127] = [
     "DOMContentLoaded",
     "abort",
     "afterprint",
@@ -1774,6 +1774,7 @@ const TYPED_EVENTS: [&str; 126] = [
     "reset",
     "resize",
     "scroll",
+    "scrollend",
     "securitypolicyviolation",
     "seeked",
     "seeking",


### PR DESCRIPTION
I was trying to use `on:scrollend` on an element in a view macro and got an error, upon investigation it seems like it just never got hooked up. Is there a reason for this? It seems like just an oversight. Anyway this appears to be all that is needed to hook it up? It works as expected now in my project.