### PR TITLE
WIP: Refactor ArcAsyncDerived

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,17 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,27 +1081,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -2918,7 +2886,6 @@ name = "reactive_graph"
 version = "0.2.9"
 dependencies = [
  "any_spawner",
- "async-lock",
  "futures",
  "guardian",
  "hydration_context",

--- a/reactive_graph/Cargo.toml
+++ b/reactive_graph/Cargo.toml
@@ -23,7 +23,6 @@ slotmap = { workspace = true, default-features = true }
 thiserror = { workspace = true, default-features = true }
 tracing = { optional = true, workspace = true, default-features = true }
 guardian = { workspace = true, default-features = true }
-async-lock = { workspace = true, default-features = true }
 send_wrapper = { features = [
   "futures",
 ], workspace = true, default-features = true }

--- a/reactive_graph/src/signal/guards.rs
+++ b/reactive_graph/src/signal/guards.rs
@@ -1,7 +1,6 @@
 //! Guards that integrate with the reactive system, wrapping references to the values of signals.
 
 use crate::{
-    computed::BlockingLock,
     traits::{Notify, UntrackableGuard},
 };
 use core::fmt::Debug;
@@ -138,7 +137,7 @@ impl<T: Display> Display for Plain<T> {
 
 /// A guard that provides access to an async signal's value.
 pub struct AsyncPlain<T: 'static> {
-    pub(crate) guard: async_lock::RwLockReadGuardArc<T>,
+    pub(crate) guard: guardian::ArcRwLockReadGuardian<T>,
 }
 
 impl<T: 'static> Debug for AsyncPlain<T> {
@@ -149,9 +148,9 @@ impl<T: 'static> Debug for AsyncPlain<T> {
 
 impl<T: 'static> AsyncPlain<T> {
     /// Takes a reference-counted async read guard on the given lock.
-    pub fn try_new(inner: &Arc<async_lock::RwLock<T>>) -> Option<Self> {
+    pub fn try_new(inner: &Arc<RwLock<T>>) -> Option<Self> {
         Some(Self {
-            guard: inner.blocking_read_arc(),
+            guard: guardian::ArcRwLockReadGuardian::take(inner.clone()).ok()?,
         })
     }
 }


### PR DESCRIPTION
This refactors state management in `ArcAsyncDerived` to reduce the amount of separate locks.
This also replaces the `AsyncRwLock` from the `async_lock` library with a normal rwlock.