### PR TITLE
add homepage to leptos cargo metadata

### DIFF
--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.12"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
+homepage = "https://leptos.dev/"
 description = "Leptos is a full-stack, isomorphic Rust web framework leveraging fine-grained reactivity to build declarative user interfaces."
 readme = "../README.md"
 rust-version.workspace = true


### PR DESCRIPTION
This updates the links at Are We Web Yet..

See also https://doc.rust-lang.org/cargo/commands/cargo-metadata.html

Closes https://github.com/rust-lang/arewewebyet/issues/451