### PR TITLE
fix: remove possibility of view-related `SendWrapper` errors on server (closes #4432, #4402)

### DIFF
--- a/tachys/src/html/directive.rs
+++ b/tachys/src/html/directive.rs
@@ -47,11 +47,13 @@ pub fn directive<T, P, D>(handler: D, param: P) -> Directive<T, D, P>
 where
     D: IntoDirective<T, P>,
 {
-    Directive(Some(SendWrapper::new(DirectiveInner {
-        handler,
-        param,
-        t: PhantomData,
-    })))
+    Directive((!cfg!(feature = "ssr")).then(|| {
+        SendWrapper::new(DirectiveInner {
+            handler,
+            param,
+            t: PhantomData,
+        })
+    }))
 }
 
 /// Custom logic that runs in the browser when the element is created or hydrated.
@@ -151,13 +153,7 @@ where
         Directive(inner)
     }
 
-    fn dry_resolve(&mut self) {
-        // dry_resolve() only runs during SSR, and we should use it to
-        // synchronously remove and drop the SendWrapper value
-        // we don't need this value during SSR and leaving it here could drop it
-        // from a different thread
-        self.0.take();
-    }
+    fn dry_resolve(&mut self) {}
 
     async fn resolve(self) -> Self::AsyncOutput {
         self

--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -113,7 +113,7 @@ where
         event,
         #[cfg(feature = "reactive_graph")]
         owner: reactive_graph::owner::Owner::current().unwrap_or_default(),
-        cb: Some(SendWrapper::new(cb)),
+        cb: (!cfg!(feature = "ssr")).then(|| SendWrapper::new(cb)),
     }
 }
 
@@ -352,13 +352,7 @@ where
         }
     }
 
-    fn dry_resolve(&mut self) {
-        // dry_resolve() only runs during SSR, and we should use it to
-        // synchronously remove and drop the SendWrapper value
-        // we don't need this value during SSR and leaving it here could drop it
-        // from a different thread
-        self.cb.take();
-    }
+    fn dry_resolve(&mut self) {}
 
     async fn resolve(self) -> Self::AsyncOutput {
         self

--- a/tachys/src/html/property.rs
+++ b/tachys/src/html/property.rs
@@ -22,7 +22,7 @@ where
 {
     Property {
         key,
-        value: Some(SendWrapper::new(value)),
+        value: (!cfg!(feature = "ssr")).then(|| SendWrapper::new(value)),
     }
 }
 
@@ -115,13 +115,7 @@ where
         }
     }
 
-    fn dry_resolve(&mut self) {
-        // dry_resolve() only runs during SSR, and we should use it to
-        // synchronously remove and drop the SendWrapper value
-        // we don't need this value during SSR and leaving it here could drop it
-        // from a different thread
-        self.value.take();
-    }
+    fn dry_resolve(&mut self) {}
 
     async fn resolve(self) -> Self::AsyncOutput {
         self


### PR DESCRIPTION
In an attempt to avoid conditional compilation/the proliferation of `ssr` features and so on, the original implementation of this cleverly overloaded a pre-existing `.dry_resolve()` method that was used to detect the presence of resource reads for Suspense in order to also drop single-threaded values browser-only from the view. This solution was too clever by half and didn't work very well, leading to some frustrating bugs. And it was also pointless, because in the time since, I've caved and let conditional compilation/feature flags leak into the `tachys` crate anyway. 

This PR rationalizes all these instances. It should prevent `SendWrapper` panics related to event listeners, DOM properties, and directives, leaving only the wrappers created by explicitly calling the `_local` signal types, which at least come from user code. 