### PR TITLE
Add `css_file_path` helper to LeptosOptions (see #3513)

### DIFF
--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -6,7 +6,12 @@ use crate::errors::LeptosConfigError;
 use config::{Case, Config, File, FileFormat};
 use regex::Regex;
 use std::{
-    env::VarError, fs, net::SocketAddr, path::Path, str::FromStr, sync::Arc,
+    env::VarError,
+    fs,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
 };
 use typed_builder::TypedBuilder;
 
@@ -165,6 +170,21 @@ impl LeptosOptions {
                 .is_some(),
             server_fn_mod_path: env_wo_default("SERVER_FN_MOD_PATH")?.is_some(),
         })
+    }
+
+    /// Returns the path to the generated CSS file.
+    ///
+    /// # Example
+    /// ```
+    /// let path = leptos_options.css_file_path();
+    /// println!("{}", path);
+    /// ```
+    pub fn css_path(&self) -> PathBuf {
+        let mut path = PathBuf::new();
+        path.push(&*self.site_pkg_dir);
+        let file_name = format!("{}.css", self.output_name);
+        path.push(file_name);
+        path
     }
 }
 


### PR DESCRIPTION
## Context
Users need a convenient way to get the path to the generated CSS file without manually reconstructing it.

## Problem
LeptosOptions did not provide a built-in method for retrieving the CSS path, so users had to duplicate logic.

## Solution
Added a new method `css_file_path()` to `LeptosOptions` that returns the correct CSS file path as a string.

## Example
```rust
let leptos_options = LeptosOptions {
    site_pkg_dir: "pkg".into(),
    output_name: "app".into(),
    ..Default::default()
};

println!("CSS path: {}", leptos_options.css_file_path());
