### PR TITLE
Fix for InertElement hydration error

### DIFF
--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -302,6 +302,22 @@ impl RenderHtml for InertElement {
         } else if curr_position != Position::Current {
             cursor.sibling();
         }
+
+        // if it's a comment node that starts with hot-reload, it's a marker that should be
+        // ignored
+        #[cfg(debug_assertions)]
+        {
+            let node = cursor.current();
+            if node.node_type() == 8
+                && node
+                    .text_content()
+                    .unwrap_or_default()
+                    .starts_with("hot-reload")
+            {
+                cursor.sibling();
+            }
+        }
+
         let el = crate::renderer::types::Element::cast_from(cursor.current())
             .unwrap();
         position.set(Position::NextChild);


### PR DESCRIPTION
Seems like the hot-reload comments were tripping up hydration finding the correct element when using InertElement.
This tries to skip those comments similar to [other places](https://github.com/leptos-rs/leptos/blob/4f3a26ce88eb1b429d382a871c47e086be96d559/tachys/src/renderer/dom.rs#L163-L180) in the codebase.

Should fix https://github.com/carloskiki/leptos-icons/issues/64