### PR TITLE
fix: do not unescape query and hash in URLs when clicking links (closes #4453, closes #4232)

### DIFF
--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -368,8 +368,8 @@ where
             ev.prevent_default();
             let to = path_name
                 + if url.search.is_empty() { "" } else { "?" }
-                + &Url::unescape(&url.search)
-                + &Url::unescape(&url.hash);
+                + &url.search
+                + &url.hash;
             let state = Reflect::get(&a, &JsValue::from_str("state"))
                 .ok()
                 .and_then(|value| {


### PR DESCRIPTION
Currently, the search query and hash of a URL are unescaped when clicking them. This means that if escaped characters are used in these pieces of links, they will be replaced. If they are URL characters like `&` this can change behavior (#4453). If they are characters like newlines, they may disappear from the URL entirely (#4232). 

I guess this is technically a breaking change but I'm not sure that unescaping these portions is ever actually the correct choice. I guess I'd be curious to hear from anyone for whom this would cause issues.

Note that values *are* unescaped in `use_query_map()` etc. in any case, so that `?arg=foo%26a%3Dbar` was and is still interpreted as a param of the value `foo&a=bar`.