### PR TITLE
Fixed: Env inconsistent deserialization

### DIFF
--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -226,9 +226,7 @@ pub const ENV_PROD_KEY_LONG: &str = "production";
 /// An enum that can be used to define the environment Leptos is running in.
 /// Setting this to the `PROD` variant will not include the WebSocket code for `cargo-leptos` watch mode.
 /// Defaults to `DEV`.
-#[derive(
-    Debug, Clone, serde::Serialize, PartialEq, Eq, Default,
-)]
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq, Default)]
 pub enum Env {
     PROD,
     #[default]
@@ -241,9 +239,9 @@ fn env_from_str(input: &str) -> Result<Env, LeptosConfigError> {
         ENV_DEV_KEY_SHORT | ENV_DEV_KEY_LONG => Ok(Env::DEV),
         ENV_PROD_KEY_SHORT | ENV_PROD_KEY_LONG => Ok(Env::PROD),
         _ => Err(LeptosConfigError::EnvVarError(format!(
-            "{input} is not a supported environment. \
-            Use either `{ENV_DEV_KEY_SHORT}`, `{ENV_DEV_KEY_LONG}`, \
-            `{ENV_PROD_KEY_SHORT}`, or `{ENV_PROD_KEY_LONG}`.",
+            "{input} is not a supported environment. Use either \
+             `{ENV_DEV_KEY_SHORT}`, `{ENV_DEV_KEY_LONG}`, \
+             `{ENV_PROD_KEY_SHORT}`, or `{ENV_PROD_KEY_LONG}`.",
         ))),
     }
 }
@@ -286,11 +284,15 @@ struct EnvVisitor;
 impl<'de> serde::de::Visitor<'de> for EnvVisitor {
     type Value = Env;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(
+        &self,
+        formatter: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
         write!(
             formatter,
-            "a case-insensitive string of either `{ENV_DEV_KEY_SHORT}`, `{ENV_DEV_KEY_LONG}`, \
-            `{ENV_PROD_KEY_SHORT}`, or `{ENV_PROD_KEY_LONG}`"
+            "a case-insensitive string of either `{ENV_DEV_KEY_SHORT}`, \
+             `{ENV_DEV_KEY_LONG}`, `{ENV_PROD_KEY_SHORT}`, or \
+             `{ENV_PROD_KEY_LONG}`"
         )
     }
 

--- a/leptos_config/tests/config.rs
+++ b/leptos_config/tests/config.rs
@@ -291,20 +291,20 @@ fn env_consistent_deserialization() {
 output-name = "app-test"
 env = "{env_value}"
             "#
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     let path: &Path = cargo_tmp.as_ref();
     let path_s = path.to_string_lossy().to_string();
 
-    let config_from_file = get_config_from_file(&path_s).unwrap().leptos_options;
+    let config_from_file =
+        get_config_from_file(&path_s).unwrap().leptos_options;
 
-    let config_from_env = temp_env::with_vars(
-        [
-            ("LEPTOS_ENV", Some(env_value))
-        ],
-        || get_config_from_env().unwrap().leptos_options
-    );
+    let config_from_env =
+        temp_env::with_vars([("LEPTOS_ENV", Some(env_value))], || {
+            get_config_from_env().unwrap().leptos_options
+        });
 
     assert_eq!(config_from_file.env, config_from_env.env);
 }


### PR DESCRIPTION
# Description

Fixes #4511

- Manually implemented `serde::Deserialize` to use `env_from_str()`
- Added test to prevent regression
- Extracted valid serialized values for `Env` into constants