### PR TITLE
Fix issue with missing documentation parts on `docs.rs`

### DIFF
--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -30,6 +30,7 @@ send_wrapper = { workspace = true, default-features = true }
 dashmap = { workspace = true, default-features = true }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [features]

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -49,6 +49,7 @@ islands-router = ["tachys/islands"]
 tracing = ["dep:tracing"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -18,4 +18,5 @@ leptos_config = { workspace = true }
 reactive_graph = { workspace = true, features = ["sandboxed-arenas"] }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -177,7 +177,8 @@ skip_feature_sets = [
 max_combination_size = 2
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--generate-link-to-definition"]
+all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg", "erase_components"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/leptos_config/Cargo.toml
+++ b/leptos_config/Cargo.toml
@@ -33,6 +33,7 @@ temp-env = { features = [
 ], workspace = true, default-features = true }
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [lints.rust]

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -34,6 +34,7 @@ trace-component-props = ["dep:serde", "dep:serde_json"]
 hydration = ["reactive_graph/hydration"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]

--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -98,6 +98,7 @@ skip_feature_sets = [
 max_combination_size = 2
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [lints.rust]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -44,8 +44,8 @@ denylist = ["tracing"]
 max_combination_size = 2
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--generate-link-to-definition", "--cfg", "docsrs"]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition", "--cfg", "docsrs"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }

--- a/meta/Cargo.toml
+++ b/meta/Cargo.toml
@@ -29,6 +29,7 @@ tracing = ["dep:tracing"]
 nonce = ["leptos/nonce"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -65,6 +65,7 @@ ssr = ["dep:percent-encoding"]
 nightly = []
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]

--- a/server_fn_macro/Cargo.toml
+++ b/server_fn_macro/Cargo.toml
@@ -36,6 +36,7 @@ generic = []
 reqwest = []
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.cargo-all-features]


### PR DESCRIPTION
For example on the <https://docs.rs/leptos/0.8.15/leptos/mount/index.html> page there are no mentions of any `hydrate_*` functions because such functions require the `#cfg(feature = "hydrate")` definition to appear in docs.

Some lines in `Cargo.toml` files were reordered for uniformity and ability to quick review all docs.rs flags with a command like:
```
rg -A2 -g Cargo.toml package.metadata.docs.rs
```