### PR TITLE
fix: add `'static` return annotation for `<A/>` (closes #4525)

### DIFF
--- a/router/src/link.rs
+++ b/router/src/link.rs
@@ -116,7 +116,7 @@ pub fn A<H>(
     scroll: bool,
     /// The nodes or elements to be shown inside the link.
     children: Children,
-) -> impl IntoView
+) -> impl IntoView + 'static
 where
     H: ToHref + Send + Sync + 'static,
 {


### PR DESCRIPTION
This changes a component function signature but I'm pretty sure it's not a breaking change, because it just strengthens the guarantee on a return type, saying that `<A/>` returns a value that is not only `-> impl IntoView` but `-> impl IntoView + 'static`.