### PR TITLE
fix: make server_fn `Websocket` protocol respect custom server URL

### DIFF
--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -55,7 +55,7 @@ pub trait Client<Error, InputStreamError = Error, OutputStreamError = Error> {
 #[cfg(feature = "browser")]
 /// Implements [`Client`] for a `fetch` request in the browser.
 pub mod browser {
-    use super::Client;
+    use super::{get_server_url, Client};
     use crate::{
         error::{FromServerFnError, IntoAppError, ServerFnErrorErr},
         request::browser::{BrowserRequest, RequestInner},
@@ -120,9 +120,19 @@ pub mod browser {
                 Error,
             >,
         > + Send {
+            let mut websocket_server_url = get_server_url().to_string();
+            if let Some(postfix) = websocket_server_url.strip_prefix("http://")
+            {
+                websocket_server_url = format!("ws://{postfix}");
+            } else if let Some(postfix) =
+                websocket_server_url.strip_prefix("https://")
+            {
+                websocket_server_url = format!("wss://{postfix}");
+            }
+            let url = format!("{websocket_server_url}{url}");
             SendWrapper::new(async move {
                 let websocket =
-                    gloo_net::websocket::futures::WebSocket::open(url)
+                    gloo_net::websocket::futures::WebSocket::open(&url)
                         .map_err(|err| {
                             web_sys::console::error_1(&err.to_string().into());
                             Error::from_server_fn_error(


### PR DESCRIPTION
When using server functions with a custom server URL I noticed that server functions using the `Websocket` protocol ignore the custom URL. This change formats the custom URL resulting in the expected behavior.

It's a bit of a weird one to test, basically I have a ssr/hydrate app that's set up so I can also build just the client in csr mode with Trunk to put into Tauri or whatever. I use 
```rs
#[component]
pub fn App() -> impl IntoView {
    #[cfg(feature = "csr"]
    server_fn::client::set_server_url("...");
    ...
```
to point the server functions at the server from the ssr build which works great unless it's a websocket.

The fix works in my app, I can cook up a minimal example repo if you want. I tried to run CI tests locally but something failed for a seemingly unrelated reason, so I'll let github try for now I guess and see what happens.

Also, I pretty much just copied and pasted code from lower in the file where this was already implemented for the `reqwest` feature, would you rather keep this little bit of duplication, or pull it out into a function?