### PR TITLE
Codegen optimizations

### DIFF
--- a/leptos/src/for_loop.rs
+++ b/leptos/src/for_loop.rs
@@ -139,7 +139,7 @@ where
     let children = move |_, child| {
         let owner = parent.with(Owner::new);
         let view = owner.with(|| children(child));
-        (|_| {}, OwnedView::new_with_owner(view, owner))
+        (drop, OwnedView::new_with_owner(view, owner))
     };
     move || keyed(each(), key.clone(), children.clone())
 }

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -670,7 +670,7 @@ fn apply_diff<T, VFS, V>(
     marker: &crate::renderer::types::Placeholder,
     diff: Diff,
     children: &mut Vec<Option<(VFS, V::State)>>,
-    view_fn: impl Fn(usize, T) -> (VFS, V),
+    view_fn: &dyn Fn(usize, T) -> (VFS, V),
     mut items: Vec<Option<T>>,
 ) where
     VFS: Fn(usize),


### PR DESCRIPTION
The amount of data generated by the Rust compiler is starting to get out of control for my project. I spent a couple of hours exploring ways to mitigate the issue. Specifically, I analyzed the results of [`cargo-llvm-lines`](https://crates.io/crates/cargo-llvm-lines) on the front-end build (using a recent `nightly` on `debug` profile, without enabling `erase_components` and no symbols).

I was able to identify some quick wins in the `tachys` and `leptos_router` crates, which reduced the generated lines of LLVM IR from 1.33 million down to 1.10 million in my example:

#### Before
```
  Lines                  Copies               Function name
  -----                  ------               -------------
  1331831                59911                (TOTAL)
    49813 (3.7%,  3.7%)     70 (0.1%,  0.1%)  tachys::view::keyed::apply_diff
    44743 (3.4%,  7.1%)    727 (1.2%,  1.3%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::rebuild
    43914 (3.3%, 10.4%)    564 (0.9%,  2.3%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::insert_before_this
    33799 (2.5%, 12.9%)    852 (1.4%,  3.7%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::build
    33477 (2.5%, 15.4%)    124 (0.2%,  3.9%)  <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::size_hint
    32673 (2.5%, 17.9%)    564 (0.9%,  4.8%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::elements
    25710 (1.9%, 19.8%)    559 (0.9%,  5.8%)  alloc::sync::Arc<T>::new
    19369 (1.5%, 21.3%)     50 (0.1%,  5.9%)  <leptos_router::matching::nested::NestedRoute<Segments,Children,Data,View> as leptos_router::matching::MatchNestedRoutes>::match_nested::{{closure}}
    19139 (1.4%, 22.7%)    406 (0.7%,  6.5%)  reactive_graph::effect::render_effect::RenderEffect<T>::with_value_mut
    17181 (1.3%, 24.0%)    254 (0.4%,  7.0%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value_erased::{{closure}}
    13987 (1.1%, 25.1%)    659 (1.1%,  8.1%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::into_owned
    13874 (1.0%, 26.1%)    344 (0.6%,  8.6%)  reactive_graph::effect::render_effect::RenderEffect<T>::new
    13724 (1.0%, 27.1%)    127 (0.2%,  8.8%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value_erased
    13722 (1.0%, 28.2%)    170 (0.3%,  9.1%)  <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::fold
    13677 (1.0%, 29.2%)    205 (0.3%,  9.5%)  tachys::reactive_graph::<impl tachys::view::Render for F>::build::{{closure}}
    13032 (1.0%, 30.2%)    215 (0.4%,  9.8%)  <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
    12626 (0.9%, 31.1%)    200 (0.3%, 10.2%)  <alloc::sync::Weak<T,A> as core::ops::drop::Drop>::drop
    12519 (0.9%, 32.1%)    280 (0.5%, 10.6%)  <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::next
    10572 (0.8%, 32.9%)    439 (0.7%, 11.4%)  <reactive_graph::graph::subscriber::AnySubscriber as reactive_graph::graph::subscriber::WithObserver>::with_observer
    10391 (0.8%, 33.6%)     70 (0.1%, 11.5%)  <tachys::view::keyed::Keyed<T,I,K,KF,VF,VFS,V> as tachys::view::Render>::build
     9847 (0.7%, 34.4%)    198 (0.3%, 11.8%)  alloc::vec::Vec<T,A>::extend_trusted
     9274 (0.7%, 35.1%)     70 (0.1%, 11.9%)  <tachys::view::keyed::Keyed<T,I,K,KF,VF,VFS,V> as tachys::view::Render>::rebuild
     8818 (0.7%, 35.7%)    633 (1.1%, 13.0%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::mount
     8790 (0.7%, 36.4%)    256 (0.4%, 13.4%)  <alloc::boxed::Box<T,A> as core::ops::drop::Drop>::drop
     8591 (0.6%, 37.0%)   1384 (2.3%, 15.7%)  core::ops::function::FnOnce::call_once
     8285 (0.6%, 37.7%)    304 (0.5%, 16.2%)  <core::iter::adapters::fuse::Fuse<I> as core::iter::adapters::fuse::FuseImpl<I>>::next
     7913 (0.6%, 38.3%)    568 (0.9%, 17.2%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::unmount
     7843 (0.6%, 38.8%)    563 (0.9%, 18.1%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::try_mount
[...]
```

#### After
```
  Lines                  Copies               Function name
  -----                  ------               -------------
  1104478                55021                (TOTAL)
    46111 (4.2%,  4.2%)    727 (1.3%,  1.3%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::rebuild
    34895 (3.2%,  7.3%)     49 (0.1%,  1.4%)  tachys::view::keyed::apply_diff
    33799 (3.1%, 10.4%)    852 (1.5%,  3.0%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::Render>::build
    24238 (2.2%, 12.6%)    527 (1.0%,  3.9%)  alloc::sync::Arc<T>::new
    22685 (2.1%, 14.6%)     75 (0.1%,  4.1%)  <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::size_hint
    14783 (1.3%, 16.0%)    314 (0.6%,  4.6%)  reactive_graph::effect::render_effect::RenderEffect<T>::with_value_mut
    13987 (1.3%, 17.2%)    659 (1.2%,  5.8%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::view::RenderHtml>::into_owned
    13874 (1.3%, 18.5%)    344 (0.6%,  6.4%)  reactive_graph::effect::render_effect::RenderEffect<T>::new
    13677 (1.2%, 19.7%)    205 (0.4%,  6.8%)  tachys::reactive_graph::<impl tachys::view::Render for F>::build::{{closure}}
    12861 (1.2%, 20.9%)    190 (0.3%,  7.2%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value_erased::{{closure}}
    12168 (1.1%, 22.0%)    149 (0.3%,  7.4%)  <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::fold
    10738 (1.0%, 23.0%)    168 (0.3%,  7.7%)  <alloc::sync::Weak<T,A> as core::ops::drop::Drop>::drop
    10394 (0.9%, 23.9%)    174 (0.3%,  8.1%)  <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
    10391 (0.9%, 24.9%)     70 (0.1%,  8.2%)  <tachys::view::keyed::Keyed<T,I,K,KF,VF,VFS,V> as tachys::view::Render>::build
    10268 (0.9%, 25.8%)     95 (0.2%,  8.4%)  reactive_graph::effect::render_effect::RenderEffect<T>::new_with_value_erased
     9274 (0.8%, 26.6%)     70 (0.1%,  8.5%)  <tachys::view::keyed::Keyed<T,I,K,KF,VF,VFS,V> as tachys::view::Render>::rebuild
     9226 (0.8%, 27.5%)   1454 (2.6%, 11.1%)  core::ops::function::FnOnce::call_once
     8268 (0.7%, 28.2%)    343 (0.6%, 11.8%)  <reactive_graph::graph::subscriber::AnySubscriber as reactive_graph::graph::subscriber::WithObserver>::with_observer
     7768 (0.7%, 28.9%)    156 (0.3%, 12.0%)  alloc::vec::Vec<T,A>::extend_trusted
     7542 (0.7%, 29.6%)    224 (0.4%, 12.4%)  <alloc::boxed::Box<T,A> as core::ops::drop::Drop>::drop
     7381 (0.7%, 30.3%)    526 (1.0%, 13.4%)  <tachys::html::element::HtmlElement<E,At,Ch> as tachys::html::element::ElementChild<NewChild>>::child
     7198 (0.7%, 30.9%)     59 (0.1%, 13.5%)  <T as reactive_graph::traits::Track>::track
     6966 (0.6%, 31.6%)    149 (0.3%, 13.8%)  <core::iter::adapters::flatten::FlattenCompat<I,U> as core::iter::traits::iterator::Iterator>::next
     6555 (0.6%, 32.1%)   1190 (2.2%, 15.9%)  core::ops::function::FnOnce::call_once{{vtable.shim}}
     6212 (0.6%, 32.7%)    358 (0.7%, 16.6%)  tachys::view::tuples::<impl tachys::view::Render for (A,B)>::build
     6131 (0.6%, 33.3%)    179 (0.3%, 16.9%)  alloc::boxed::Box<T>::pin
     6042 (0.5%, 33.8%)    159 (0.3%, 17.2%)  tachys::reactive_graph::<impl tachys::view::Render for F>::rebuild
[...]
     5407 (0.5%, 35.3%)     17 (0.0%, 17.4%)  <leptos_router::matching::nested::NestedRoute<Segments,Children,Data,View> as leptos_router::matching::MatchNestedRoutes>::match_nested::inner
     4982 (0.5%, 39.1%)     50 (0.1%, 19.5%)  <leptos_router::matching::nested::NestedRoute<Segments,Children,Data,View> as leptos_router::matching::MatchNestedRoutes>::match_nested::{{closure}}
     1608 (0.1%, 66.3%)    549 (1.0%, 42.3%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::unmount
     1596 (0.1%, 66.4%)    545 (1.0%, 43.3%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::elements
     1596 (0.1%, 66.6%)    545 (1.0%, 44.3%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::insert_before_this
     1593 (0.1%, 66.7%)    544 (1.0%, 45.2%)  <tachys::html::element::ElementState<At,Ch> as tachys::view::Mountable>::try_mount
[...]
```