### PR TITLE
add IntoIterator implementantion for &ParamsMap

### DIFF
--- a/router/src/params.rs
+++ b/router/src/params.rs
@@ -66,7 +66,7 @@ impl ParamsMap {
     }
 
     /// Gets an iterator for all the most-recently-added values on the map
-    pub fn get_iter(&self) -> ParamsMapIterRef<'_> {
+    pub fn latest_values(&self) -> ParamsMapIterRef<'_> {
         let inner: Vec<_> = self
             .0
             .iter()


### PR DESCRIPTION
When manually implementing `Params` the trait only gives access to a reference of `ParamsMap`, for convenience this PR adds an `IntoIterator` implementation for `&ParamsMap` as well as a helper function `get_iter` that returns an iterator over the most-recently-added values for every param on the map.