### PR TITLE
Warn when trying to update a signal with an active read guard

### DIFF
--- a/reactive_graph/src/traits.rs
+++ b/reactive_graph/src/traits.rs
@@ -545,11 +545,13 @@ where
 
     #[track_caller]
     fn set(&self, value: Self::Value) {
-        if self.try_update(|n| *n = value).is_none() && !self.is_disposed() {
+        let failed = self.try_update(|n| *n = value).is_none();
+
+        #[cfg(any(debug_assertions, leptos_debuginfo))]
+        if failed && !self.is_disposed() {
             let called_at = Location::caller();
             let ty = std::any::type_name::<Self::Value>();
 
-            #[cfg(any(debug_assertions, leptos_debuginfo))]
             crate::log_warning(format_args!(
                 "At {called_at}, you tried to update a {ty}, but the update \
                  failed. This can happen if a read guard over the value is \


### PR DESCRIPTION
Using `reactive_stores`, I had the following code
```rs
let value = t.value().read();

other_t.value().set(value.clone());
```
where `t` is a value of a custom struct type with store field `value`. This would silently fail to update the value of `value`.

This PR adds code to log a warning on a call to `set()` when the the update fails and the signal is not disposed.