### PR TITLE
Fix SSR Suspense livelock when multiple boundaries share Resources via .get()

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -406,7 +406,7 @@ where
                         tasks.track();
                     }
                 }
-                false
+                double_checking.unwrap_or(false)
             }
         });
 

--- a/leptos/tests/ssr_suspense_livelock.rs
+++ b/leptos/tests/ssr_suspense_livelock.rs
@@ -1,0 +1,62 @@
+//! Regression test for SSR livelock when multiple Suspense boundaries share
+//! Resources via `.get()`.
+//!
+//! Root cause: The Suspense Effect's state machine (in suspense_component.rs)
+//! returned `false` as a catch-all, resetting `double_checking` from `Some(true)`
+//! to `Some(false)` when the Effect saw non-empty tasks between individual monitor
+//! completions. This caused `dry_resolve()` to be called again when tasks drained,
+//! spawning new monitors in an infinite cycle.
+//!
+//! The fix: replace the catch-all `false` with `double_checking.unwrap_or(false)`,
+//! preserving the `Some(true)` state through intermediate Effect wakeups.
+
+#[cfg(feature = "ssr")]
+mod imports {
+    pub use any_spawner::Executor;
+    pub use futures::StreamExt;
+    pub use leptos::prelude::*;
+}
+
+/// Two Suspense boundaries sharing two Resources via `.get()` must resolve
+/// within a reasonable time. Previously this livelocked with worker_threads=2-3
+/// due to the Suspense Effect's dry_resolve re-registration cycle.
+#[cfg(feature = "ssr")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shared_resources_across_suspense_boundaries_no_livelock() {
+    use imports::*;
+
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let r_a = Resource::new(|| (), |_| async { "a".to_string() });
+    let r_b = Resource::new(|| (), |_| async { "b".to_string() });
+
+    let app = view! {
+        <Transition fallback=|| "loading 1">
+            {move || {
+                let a = r_a.get()?;
+                let b = r_b.get()?;
+                Some(view! { <div>{a} " " {b}</div> })
+            }}
+        </Transition>
+        <Suspense fallback=|| "loading 2">
+            {move || {
+                let a = r_a.get()?;
+                let b = r_b.get()?;
+                Some(view! { <div>{a} " " {b}</div> })
+            }}
+        </Suspense>
+    };
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        app.to_html_stream_in_order().collect::<String>(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "SSR timed out with worker_threads=2 — Suspense Effect livelock"
+    );
+}


### PR DESCRIPTION
## Summary

One-line fix for an SSR livelock where 2+ `Suspense`/`Transition` boundaries sharing 2+ Resources via `.get()` causes the Suspense Effect to endlessly re-run `dry_resolve()`, consuming 100% CPU (~297k closure invocations per boundary per 5s) and never completing SSR.

Manifests on AWS Lambda (128MB, 2 cores → `worker_threads=2`) as intermittent 500 errors.

## Root Cause

The Effect's isomorphic closure returns a `bool` that becomes `double_checking: Option<bool>`. After `dry_resolve()` returns `true` (setting `double_checking = Some(true)`), the Effect is woken by individual monitor completions. If tasks aren't empty yet, the catch-all `false` at the end resets `double_checking` to `Some(false)`. When tasks finally drain, the Effect sees `double_checking == Some(false)` and calls `dry_resolve()` again — infinite cycle.

```
dry_resolve → true → double_checking = Some(true)
  monitor1 completes → Effect wakes → tasks NOT empty → returns false (RESETS!)
  monitor2 completes → Effect wakes → tasks empty + double_checking == Some(false) → dry_resolve again!
```

## The Fix

`leptos/src/suspense_component.rs`, line 409:

```diff
-                false
+                double_checking.unwrap_or(false)
```

This preserves `Some(true)` through intermediate wakeups so the completion branch is reached:

```
dry_resolve → true → double_checking = Some(true)
  monitor1 completes → Effect wakes → tasks NOT empty → returns true (PRESERVED!)
  monitor2 completes → Effect wakes → tasks empty + double_checking == Some(true) → COMPLETION
```

Only the `Some(true)` → non-empty-tasks path changes behavior. All other paths return the same value as before.

## Reproduction

Minimal repro at https://github.com/alilee/feedback/tree/main/bugs/ssr-race (Cargo.toml + src/main.rs).

```bash
cargo run --features ssr  # uses worker_threads = 2
curl -s -m 5 http://localhost:3000/broken | grep -c RESOLVED_RESOURCES  # 0 (livelock)
curl -s -m 5 http://localhost:3000/works  | grep -c RESOLVED_RESOURCES  # 1 (Suspend::new workaround)
```

Thread count dependency:
| `worker_threads` | Result |
|---|---|
| 1 | Works |
| **2-3** | **Livelocks** |
| 4+ | Works |

## Testing

- New regression test: `leptos/tests/ssr_suspense_livelock.rs` — 2 Suspense boundaries, 2 shared Resources, `worker_threads=2`, 2s timeout
- All existing `leptos` crate tests pass (72 tests: 58 doc + 11 ssr + 2 pr_4061 + 1 new)
- Test fails without the fix, passes with it