### PR TITLE
Remove IntoIterator bound from KeyedSubfield

### DIFF
--- a/reactive_stores/src/arc_field.rs
+++ b/reactive_stores/src/arc_field.rs
@@ -1,7 +1,8 @@
 use crate::{
     path::{StorePath, StorePathSegment},
     ArcStore, AtIndex, AtKeyed, DerefedField, KeyMap, KeyedAccess,
-    KeyedSubfield, Store, StoreField, StoreFieldTrigger, Subfield,
+    KeyedIterable, KeyedSubfield, Store, StoreField, StoreFieldTrigger,
+    Subfield,
 };
 use reactive_graph::{
     owner::Storage,
@@ -367,7 +368,8 @@ where
     AtKeyed<Inner, Prev, K, T>: Clone,
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev> + Send + Sync + 'static,
     Prev: 'static,
     T: KeyedAccess<K> + 'static,

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -2,7 +2,8 @@ use crate::{
     arc_field::{StoreFieldReader, StoreFieldWriter},
     path::{StorePath, StorePathSegment},
     ArcField, ArcStore, AtIndex, AtKeyed, DerefedField, KeyMap, KeyedAccess,
-    KeyedSubfield, Store, StoreField, StoreFieldTrigger, Subfield,
+    KeyedIterable, KeyedSubfield, Store, StoreField, StoreFieldTrigger,
+    Subfield,
 };
 use reactive_graph::{
     owner::{ArenaItem, Storage, SyncStorage},
@@ -197,7 +198,8 @@ where
     AtKeyed<Inner, Prev, K, T>: Clone,
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev> + Send + Sync + 'static,
     Prev: 'static,
     T: KeyedAccess<K> + 'static,

--- a/reactive_stores/src/keyed.rs
+++ b/reactive_stores/src/keyed.rs
@@ -14,13 +14,66 @@ use reactive_graph::{
     },
 };
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, HashMap, VecDeque},
     fmt::Debug,
     hash::Hash,
     iter,
     ops::{Deref, DerefMut, Index, IndexMut},
     panic::Location,
 };
+
+/// A trait that provides the iterator item type for keyed collections.
+/// This uses a GAT to express the lifetime-parameterized item type,
+/// avoiding problematic struct-level bounds on `IntoIterator` that can
+/// conflict with other crates' blanket implementations.
+pub trait KeyedIterable {
+    /// The iterator item type when borrowing the collection with lifetime `'a`.
+    type IterItem<'a>
+    where
+        Self: 'a;
+}
+
+impl<T> KeyedIterable for Vec<T> {
+    type IterItem<'a>
+        = &'a T
+    where
+        Self: 'a;
+}
+
+impl<T> KeyedIterable for [T] {
+    type IterItem<'a>
+        = &'a T
+    where
+        Self: 'a;
+}
+
+impl<T, const N: usize> KeyedIterable for [T; N] {
+    type IterItem<'a>
+        = &'a T
+    where
+        Self: 'a;
+}
+
+impl<K, V> KeyedIterable for HashMap<K, V> {
+    type IterItem<'a>
+        = (&'a K, &'a V)
+    where
+        Self: 'a;
+}
+
+impl<K, V> KeyedIterable for BTreeMap<K, V> {
+    type IterItem<'a>
+        = (&'a K, &'a V)
+    where
+        Self: 'a;
+}
+
+impl<T> KeyedIterable for VecDeque<T> {
+    type IterItem<'a>
+        = &'a T
+    where
+        Self: 'a;
+}
 
 /// Accesses an item from a keyed collection.
 ///
@@ -86,7 +139,7 @@ impl<K: Hash + Eq, V> KeyedAccess<K> for std::collections::HashMap<K, V> {
 #[derive(Debug)]
 pub struct KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
 {
     #[cfg(any(debug_assertions, leptos_debuginfo))]
     defined_at: &'static Location<'static>,
@@ -94,12 +147,12 @@ where
     inner: Inner,
     read: fn(&Prev) -> &T,
     write: fn(&mut Prev) -> &mut T,
-    pub(crate) key_fn: fn(<&T as IntoIterator>::Item) -> K,
+    pub(crate) key_fn: for<'a> fn(<T as KeyedIterable>::IterItem<'a>) -> K,
 }
 
 impl<Inner, Prev, K, T> Clone for KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: Clone,
 {
     fn clone(&self) -> Self {
@@ -117,21 +170,21 @@ where
 
 impl<Inner, Prev, K, T> Copy for KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: Copy,
 {
 }
 
 impl<Inner, Prev, K, T> KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
 {
     /// Creates a keyed subfield of the inner data type with the given key function.
     #[track_caller]
     pub fn new(
         inner: Inner,
         path_segment: StorePathSegment,
-        key_fn: fn(<&T as IntoIterator>::Item) -> K,
+        key_fn: for<'a> fn(<T as KeyedIterable>::IterItem<'a>) -> K,
         read: fn(&Prev) -> &T,
         write: fn(&mut Prev) -> &mut T,
     ) -> Self {
@@ -150,7 +203,8 @@ where
 impl<Inner, Prev, K, T> StoreField for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -220,7 +274,8 @@ where
 impl<Inner, Prev, K, T> KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -255,7 +310,7 @@ where
 impl<Inner, Prev, K, T> KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: StoreField<Value = Prev>,
 {
     /// Keyed access to a keyed subfield of a store.
@@ -268,7 +323,8 @@ where
 pub struct KeyedSubfieldWriteGuard<Inner, Prev, K, T, Guard>
 where
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -283,7 +339,8 @@ impl<Inner, Prev, K, T, Guard> Deref
 where
     Guard: Deref,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -303,7 +360,8 @@ impl<Inner, Prev, K, T, Guard> DerefMut
 where
     Guard: DerefMut,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -321,7 +379,8 @@ impl<Inner, Prev, K, T, Guard> UntrackableGuard
 where
     Guard: UntrackableGuard,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -338,7 +397,8 @@ impl<Inner, Prev, K, T, Guard> Drop
     for KeyedSubfieldWriteGuard<Inner, Prev, K, T, Guard>
 where
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -363,7 +423,7 @@ where
 
 impl<Inner, Prev, K, T> DefinedAt for KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: StoreField<Value = Prev>,
 {
     fn defined_at(&self) -> Option<&'static Location<'static>> {
@@ -380,7 +440,7 @@ where
 
 impl<Inner, Prev, K, T> IsDisposed for KeyedSubfield<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: IsDisposed,
 {
     fn is_disposed(&self) -> bool {
@@ -391,7 +451,8 @@ where
 impl<Inner, Prev, K, T> Notify for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -406,7 +467,8 @@ where
 impl<Inner, Prev, K, T> Track for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev> + Track + 'static,
     Prev: 'static,
     T: 'static,
@@ -420,7 +482,8 @@ where
 impl<Inner, Prev, K, T> ReadUntracked for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -435,7 +498,8 @@ where
 impl<Inner, Prev, K, T> Write for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     T: 'static,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
@@ -469,7 +533,7 @@ where
 #[derive(Debug)]
 pub struct AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
 {
     #[cfg(any(debug_assertions, leptos_debuginfo))]
     defined_at: &'static Location<'static>,
@@ -479,7 +543,7 @@ where
 
 impl<Inner, Prev, K, T> AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     K: Clone,
 {
     /// Key used for keyed collection access.
@@ -490,7 +554,7 @@ where
 
 impl<Inner, Prev, K, T> Clone for AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
     K: Debug + Clone,
 {
@@ -506,7 +570,7 @@ where
 
 impl<Inner, Prev, K, T> Copy for AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     KeyedSubfield<Inner, Prev, K, T>: Copy,
     K: Debug + Copy,
 {
@@ -514,7 +578,7 @@ where
 
 impl<Inner, Prev, K, T> AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
 {
     /// Provides access to the item in the inner collection at this key.
     #[track_caller]
@@ -532,7 +596,8 @@ impl<Inner, Prev, K, T> AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -556,7 +621,8 @@ impl<Inner, Prev, K, T> StoreField for AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -680,7 +746,7 @@ where
 
 impl<Inner, Prev, K, T> DefinedAt for AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
 {
     fn defined_at(&self) -> Option<&'static Location<'static>> {
         #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -696,7 +762,7 @@ where
 
 impl<Inner, Prev, K, T> IsDisposed for AtKeyed<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
     Inner: IsDisposed,
 {
     fn is_disposed(&self) -> bool {
@@ -708,7 +774,8 @@ impl<Inner, Prev, K, T> Notify for AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -725,7 +792,8 @@ impl<Inner, Prev, K, T> Track for AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -740,7 +808,8 @@ impl<Inner, Prev, K, T> ReadUntracked for AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -757,7 +826,8 @@ impl<Inner, Prev, K, T> Write for AtKeyed<Inner, Prev, K, T>
 where
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
     KeyedSubfield<Inner, Prev, K, T>: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     T: KeyedAccess<K>,
@@ -782,7 +852,8 @@ where
 impl<Inner, Prev, K, T> KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: StoreField<Value = Prev>,
     Prev: 'static,
     K: Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -811,7 +882,8 @@ where
 impl<Inner, Prev, K, T> IntoIterator for KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Inner: Clone + StoreField<Value = Prev> + 'static,
     Prev: 'static,
     K: Clone + Debug + Send + Sync + PartialEq + Eq + Hash + 'static,
@@ -846,8 +918,7 @@ where
 /// An iterator over a [`KeyedSubfield`].
 pub struct StoreFieldKeyedIter<Inner, Prev, K, T>
 where
-    for<'a> &'a T: IntoIterator,
-    T: KeyedAccess<K>,
+    T: KeyedIterable + KeyedAccess<K>,
 {
     inner: KeyedSubfield<Inner, Prev, K, T>,
     keys: VecDeque<K>,
@@ -855,9 +926,9 @@ where
 
 impl<Inner, Prev, K, T> Iterator for StoreFieldKeyedIter<Inner, Prev, K, T>
 where
+    T: KeyedIterable,
     Inner: StoreField<Value = Prev> + Clone + 'static,
     T: KeyedAccess<K> + 'static,
-    for<'a> &'a T: IntoIterator,
 {
     type Item = AtKeyed<Inner, Prev, K, T>;
 
@@ -871,10 +942,10 @@ where
 impl<Inner, Prev, K, T> DoubleEndedIterator
     for StoreFieldKeyedIter<Inner, Prev, K, T>
 where
+    T: KeyedIterable,
     Inner: StoreField<Value = Prev> + Clone + 'static,
     T: KeyedAccess<K> + 'static,
     T::Value: Sized + 'static,
-    for<'a> &'a T: IntoIterator,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.keys

--- a/reactive_stores/src/patch.rs
+++ b/reactive_stores/src/patch.rs
@@ -1,4 +1,7 @@
-use crate::{path::StorePath, KeyMap, KeyedAccess, KeyedSubfield, StoreField};
+use crate::{
+    path::StorePath, KeyMap, KeyedAccess, KeyedIterable, KeyedSubfield,
+    StoreField,
+};
 use indexmap::IndexMap;
 use itertools::{EitherOrBoth, Itertools};
 use reactive_graph::traits::{Notify, UntrackableGuard};
@@ -51,7 +54,8 @@ where
 impl<Inner, Prev, K, T> KeyedSubfield<Inner, Prev, K, T>
 where
     Self: Clone,
-    for<'a> &'a T: IntoIterator,
+    T: KeyedIterable,
+    for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
     Self: StoreField<Value = T>,
     <Self as StoreField>::Value: PatchFieldKeyed<K>,
     Inner: StoreField<Value = Prev>,

--- a/reactive_stores/src/slotmap.rs
+++ b/reactive_stores/src/slotmap.rs
@@ -1,5 +1,37 @@
 //! SlotMap support for keyed fields based on their map types.
-use crate::KeyedAccess;
+use crate::{KeyedAccess, KeyedIterable};
+
+impl<K: slotmap::Key, V> KeyedIterable for slotmap::SlotMap<K, V> {
+    type IterItem<'a>
+        = (K, &'a V)
+    where
+        Self: 'a;
+}
+impl<K: slotmap::Key, V> KeyedIterable for slotmap::DenseSlotMap<K, V> {
+    type IterItem<'a>
+        = (K, &'a V)
+    where
+        Self: 'a;
+}
+#[allow(deprecated)]
+impl<K: slotmap::Key, V> KeyedIterable for slotmap::HopSlotMap<K, V> {
+    type IterItem<'a>
+        = (K, &'a V)
+    where
+        Self: 'a;
+}
+impl<K: slotmap::Key, V> KeyedIterable for slotmap::SecondaryMap<K, V> {
+    type IterItem<'a>
+        = (K, &'a V)
+    where
+        Self: 'a;
+}
+impl<K: slotmap::Key, V> KeyedIterable for slotmap::SparseSecondaryMap<K, V> {
+    type IterItem<'a>
+        = (K, &'a V)
+    where
+        Self: 'a;
+}
 
 impl<K: slotmap::Key, V> KeyedAccess<K> for slotmap::SlotMap<K, V> {
     type Value = V;

--- a/tachys/src/reactive_graph/bind.rs
+++ b/tachys/src/reactive_graph/bind.rs
@@ -395,8 +395,8 @@ where
 #[cfg(feature = "reactive_stores")]
 impl<Inner, Prev, K, T> IntoSplitSignal for KeyedSubfield<Inner, Prev, K, T>
 where
+    T: reactive_stores::KeyedIterable,
     Self: Get<Value = T> + Set<Value = T> + Clone,
-    for<'a> &'a T: IntoIterator,
 {
     type Value = T;
     type Read = Self;
@@ -410,8 +410,8 @@ where
 #[cfg(feature = "reactive_stores")]
 impl<Inner, Prev, K, T> IntoSplitSignal for AtKeyed<Inner, Prev, K, T>
 where
+    T: reactive_stores::KeyedIterable,
     Self: Get<Value = T> + Set<Value = T> + Clone,
-    for<'a> &'a T: IntoIterator,
 {
     type Value = T;
     type Read = Self;

--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -815,7 +815,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     class_reactive!(
@@ -826,7 +826,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     class_reactive!(
@@ -873,27 +873,8 @@ mod reactive_stores {
         Inner: Send + Sync + Clone + 'static,
     );
 
-    tuple_class_reactive!(
-        AtKeyed,
-        <Inner, Prev, K>,
-        <Inner, Prev, K, bool>,
-        AtKeyed<Inner, Prev, K, bool>: Get<Value = bool>,
-        Prev: Send + Sync + 'static,
-        Inner: Send + Sync + Clone + 'static,
-        K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a bool: IntoIterator,
-    );
-
-    tuple_class_reactive!(
-        KeyedSubfield,
-        <Inner, Prev, K>,
-        <Inner, Prev, K, bool>,
-        KeyedSubfield<Inner, Prev, K, bool>: Get<Value = bool>,
-        Prev: Send + Sync + 'static,
-        Inner: Send + Sync + Clone + 'static,
-        K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a bool: IntoIterator,
-    );
+    // Note: tuple_class_reactive! for AtKeyed and KeyedSubfield with bool values
+    // are not applicable since bool doesn't implement KeyedIterable.
 
     tuple_class_reactive!(
         DerefedField,

--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -235,7 +235,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     inner_html_reactive!(
@@ -246,7 +246,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     inner_html_reactive!(

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -936,7 +936,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     reactive_impl!(
@@ -948,7 +948,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     reactive_impl!(

--- a/tachys/src/reactive_graph/property.rs
+++ b/tachys/src/reactive_graph/property.rs
@@ -212,7 +212,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     property_reactive!(
@@ -223,7 +223,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     property_reactive!(

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -428,7 +428,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     style_reactive!(
@@ -439,7 +439,7 @@ mod reactive_stores {
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
         K: Send + Sync + std::fmt::Debug + Clone + 'static,
-        for<'a> &'a V: IntoIterator,
+        V: reactive_stores::KeyedIterable,
     );
 
     style_reactive!(


### PR DESCRIPTION
The `KeyedSubfield` struct previously had a struct-level bound:

```
pub struct KeyedSubfield<Inner, Prev, K, T>
where
for<'a> &'a T: IntoIterator,
{ ... }
```

This causes infinite trait resolution when used alongside, for example, `bevy_ecs`. The root cause is that `bevy_ecs` has a blanket implementation:

```
impl<'w, 's, T: Resource> IntoIterator for &Res<'w, 's, T> { ... }
```

During compilation we end up recursing infinitely checking `Res<..>`, `Res<Res<..>>`, `Res<Res<Res<..>>>` and so on.

This commit replaces that bound w/ a new trait `KeyedIterable` and moves the `IntoIterator` bound to the impl blocks where it's actually needed.

The downside of this is that `reactive_stores` must now explicitly impl this trait for supported collections, so support for 3rd-party collections (e.g. `DashMap`) will need to be added here as requested (because of the orphan rule).

------------

This is of course a big breaking change for this crate. I think it's warranted as bevy is pretty popular, there is plenty of bevy + leptos interest (see [1](https://github.com/Synphonyte/leptos-bevy-canvas), [2](https://www.reddit.com/r/rust/comments/16dbxvg/can_bevy_and_leptos_interoperate/)), and this problem is not unique to `bevy_ecs` but would happen when combining `reactive_stores` w/ any crate that has a blanket `IntoIterator` impl on a wrapper type (like `Res`).

Were this to be merged, impls of `KeyedIterable` for 3rd party collections will have to live here, gated behind feature flags. This is a fairly common practice but if that's too big of a change and/or you'd rather not, feel free to close as `wontfix` and I'll keep using my fork.