### PR TITLE
Update readme playground link to that of leptos.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Discord](https://img.shields.io/discord/1031524867910148188?color=%237289DA&label=discord)](https://discord.gg/YdRAhS7eQB)
 [![Matrix](https://img.shields.io/badge/Matrix-leptos-grey?logo=matrix&labelColor=white&logoColor=black)](https://matrix.to/#/#leptos:matrix.org)
 
-[Website](https://leptos.dev) | [Book](https://leptos-rs.github.io/leptos/) | [Docs.rs](https://docs.rs/leptos/latest/leptos/) | [Playground](https://codesandbox.io/p/sandbox/leptos-rtfggt?file=%2Fsrc%2Fmain.rs%3A1%2C1) | [Discord](https://discord.gg/YdRAhS7eQB)
+[Website](https://leptos.dev) | [Book](https://leptos-rs.github.io/leptos/) | [Docs.rs](https://docs.rs/leptos/latest/leptos/) | [Playground](https://codesandbox.io/p/devbox/playground-j23dz7?file=%2Fsrc%2Fmain.rs) | [Discord](https://discord.gg/YdRAhS7eQB)
 
 You can find a list of useful libraries and example projects at [`awesome-leptos`](https://github.com/leptos-rs/awesome-leptos).
 


### PR DESCRIPTION
Leptos's README.md [playground link](https://codesandbox.io/p/sandbox/leptos-rtfggt?file=%2Fsrc%2Fmain.rs%3A1%2C1) appears to point to an older sample that no longer works. This is what I saw when I clicked on the readme playground link as of [commit ea74f1e](https://github.com/leptos-rs/leptos/commit/ea74f1e5531efc930fc70b9b1dbe45549db33a27) :
<img width="1180" height="780" alt="image" src="https://github.com/user-attachments/assets/b0137051-84a3-410a-a8b9-11d6b8b8429b" />

The sandbox terminal shows that it is failing to build leptos_macro v0.5.2:
```
   Compiling leptos_macro v0.5.2
error[E0599]: no method named `source_file` found for struct `slice::proc_macro::Span` in the current scope
   --> /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/leptos_macro-0.5.2/src/lib.rs:376:22
    |
376 |                 site.source_file().path(),
    |                      ^^^^^^^^^^^
    |
help: there is a method `source` with a similar name
    |
376 -                 site.source_file().path(),
376 +                 site.source().path(),
    |

For more information about this error, try `rustc --explain E0599`.
```

The [playground link](https://codesandbox.io/p/devbox/playground-j23dz7?file=%2Fsrc%2Fmain.rs) from [leptos.dev](leptos.dev) points to a different working example with the button counter and I see in the terminal that it is `Compiling leptos_server v0.7.0`.

This should help with a good first impression for potentially interested users :)