### PR TITLE
 Document getrandom/rand setup for wasm32 builds, closes #3979

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ Here are some resources for learning more about Leptos:
 - [API Documentation](https://docs.rs/leptos/latest/leptos/)
 - [Common Bugs](https://github.com/leptos-rs/leptos/tree/main/docs/COMMON_BUGS.md) (and how to fix them!)
 
+### Random numbers on wasm (`rand` / `getrandom`)
+
+When you compile a Leptos app to `wasm32-unknown-unknown`, `rand` and `getrandom` need a JavaScript-backed source of randomness. If that backend isn’t enabled, your build can fail or randomness just won’t work in the browser.
+
+Leptos itself takes care of this for its own code, but that does **not** automatically configure your app’s own `rand` / `getrandom` dependencies. If you use them directly, you need to turn on the JS backend yourself.
+
+A simple setup in your `Cargo.toml` might look like this:
+
+```toml
+[dependencies]
+# Make sure getrandom works on wasm by enabling its JS backend
+getrandom = { version = "0.2", features = ["js"] }
+rand      = { version = "0.8", features = ["small_rng"] }
+```
+
+Some of the examples in this repo (for example `js-framework-benchmark` and `hackernews_js_fetch`) already do this, so you can use them as a reference if you’re unsure.
+
 ## `cargo-leptos`
 
 [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos) is a build tool that's designed to make it easy to build apps that run on both the client and the server, with seamless integration. The best way to get started with a real Leptos project right now is to use `cargo-leptos` and our starter templates for [Actix](https://github.com/leptos-rs/start) or [Axum](https://github.com/leptos-rs/start-axum).


### PR DESCRIPTION
This updates #3979 with a short docs section explaining how to configure rand / getrandom when building Leptos apps for wasm32-unknown-unknown.

The docs clarify that Leptos already sets up its own randomness, but if an app depends on rand or getrandom directly, the JS backend still needs to be enabled. It also includes a small Cargo.toml example and points to existing repo examples that already have this set up.