### PR TITLE
Don't force next axum state to be `()`.

### DIFF
--- a/integrations/axum/src/config.rs
+++ b/integrations/axum/src/config.rs
@@ -30,7 +30,7 @@ pub(crate) mod traits {
         LeptosOptions: FromRef<S>,
     {
         /// Apply the configuration onto the [`Router`].
-        fn apply(self, router: Router<S>) -> Router<()>;
+        fn apply<S2>(self, router: Router<S>) -> Router<S2>;
     }
 }
 
@@ -211,7 +211,7 @@ where
         feature = "tracing",
         tracing::instrument(level = "trace", fields(error), skip_all)
     )]
-    fn apply(self, router: Router<S>) -> Router<()> {
+    fn apply<S2>(self, router: Router<S>) -> Router<S2> {
         let app = self.app_fn.expect("an `App` should have been configured");
         let shell = self.shell.expect("a `shell` should have been configured");
         let state = self.state.expect("a `state` should have been configured");

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1986,7 +1986,7 @@ where
     /// Note that both configuration with this method with a `RouterConfiguration` builder and the verbose
     /// manner of setting up the router will allow an alternative fallback be specified without removing the
     /// site pkg routes, as in the case with the combined fallback handler.
-    fn leptos_route_configure<C>(self, conf: C) -> axum::Router<()>
+    fn leptos_route_configure<C, S2>(self, conf: C) -> axum::Router<S2>
     where
         C: config::traits::RouterConfiguration<S>;
 }
@@ -2283,7 +2283,7 @@ where
         feature = "tracing",
         tracing::instrument(level = "trace", fields(error), skip_all)
     )]
-    fn leptos_route_configure<C>(self, conf: C) -> axum::Router<()>
+    fn leptos_route_configure<C, S2>(self, conf: C) -> axum::Router<S2>
     where
         C: config::traits::RouterConfiguration<S>,
     {

--- a/integrations/axum/tests/axum_integration.rs
+++ b/integrations/axum/tests/axum_integration.rs
@@ -530,6 +530,7 @@ async fn leptos_options_css_moved() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn conf_alternate_router_state() -> anyhow::Result<()> {
+    use axum::{extract::State, routing::get, Router};
     use leptos::prelude::*;
     use leptos_axum::LeptosRoutes;
 
@@ -558,12 +559,20 @@ async fn conf_alternate_router_state() -> anyhow::Result<()> {
         dummy,
     };
 
-    let _ = axum::Router::new().leptos_route_configure(
+    let router /*: Router<Dummy>*/ = Router::new().leptos_route_configure(
         leptos_axum::RouterConfiguration::new()
             .app(App)
             .state(my_state.clone())
             .shell(shell),
     );
+    let router = router
+        .route(
+            "/somewhere/else",
+            get(|State(_dummy): State<Dummy>| async {}),
+        )
+        .with_state(Dummy);
+    let _ = router.into_make_service();
+
     Ok(())
 }
 


### PR DESCRIPTION
It could be any other type, so let's support that case.

I did want to see if I could avoid calling `Router::with_state` if the `S2` in the `Router<S2>` to be returned is the same as the current `S`, but that proved to be annoying to do so I am going to let that rest for the mean time - it is meant to be a convenience over calling the more verbose setup, so detailed/specific configurations should still use the more verbose API for that.

Forcing `()` as the return type was an oversight I made when I was initially building this, and this change rectifies that.