### PR TITLE
Fix immediate effect memo recomputation

### DIFF
--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -441,7 +441,8 @@ impl<T: 'static> ArcAsyncDerived<T> {
         }
 
         // notify reactive subscribers that we're not loading any more
-        for sub in (&inner.read().or_poisoned().subscribers).into_iter() {
+        let subs = inner.read().or_poisoned().subscribers.clone();
+        for sub in subs {
             sub.mark_dirty();
         }
 

--- a/reactive_graph/src/computed/async_derived/inner.rs
+++ b/reactive_graph/src/computed/async_derived/inner.rs
@@ -50,8 +50,8 @@ impl ReactiveNode for RwLock<ArcAsyncDerivedInner> {
     }
 
     fn mark_subscribers_check(&self) {
-        let lock = self.read().or_poisoned();
-        for sub in (&lock.subscribers).into_iter() {
+        let subs = self.read().or_poisoned().subscribers.clone();
+        for sub in subs {
             sub.mark_check();
         }
     }

--- a/reactive_graph/src/computed/inner.rs
+++ b/reactive_graph/src/computed/inner.rs
@@ -67,22 +67,29 @@ where
     S: Storage<T>,
 {
     fn mark_dirty(&self) {
-        self.reactivity.write().or_poisoned().state = ReactiveNodeState::Dirty;
-        self.mark_subscribers_check();
+        let subs = {
+            let mut lock = self.reactivity.write().or_poisoned();
+            lock.state = ReactiveNodeState::Dirty;
+            lock.subscribers.clone()
+        };
+
+        for sub in subs {
+            sub.mark_check();
+        }
     }
 
     fn mark_check(&self) {
         /// codegen optimisation:
         fn inner(reactivity: &RwLock<MemoInnerReactivity>) {
-            {
+            let subs = {
                 let mut lock = reactivity.write().or_poisoned();
                 if lock.state != ReactiveNodeState::Dirty {
                     lock.state = ReactiveNodeState::Check;
                 }
-            }
-            for sub in
-                (&reactivity.read().or_poisoned().subscribers).into_iter()
-            {
+                lock.subscribers.clone()
+            };
+
+            for sub in subs {
                 sub.mark_check();
             }
         }
@@ -90,8 +97,8 @@ where
     }
 
     fn mark_subscribers_check(&self) {
-        let lock = self.reactivity.read().or_poisoned();
-        for sub in (&lock.subscribers).into_iter() {
+        let subs = self.reactivity.read().or_poisoned().subscribers.clone();
+        for sub in subs {
             sub.mark_check();
         }
     }

--- a/reactive_graph/src/effect/immediate.rs
+++ b/reactive_graph/src/effect/immediate.rs
@@ -388,7 +388,8 @@ mod inner {
 
         fn mark_check(&self) {
             self.write().or_poisoned().state = ReactiveNodeState::Check;
-            let any_subscriber = self.read().or_poisoned().any_subscriber.clone();
+            let any_subscriber =
+                self.read().or_poisoned().any_subscriber.clone();
             any_subscriber.with_observer(|| self.update_if_necessary());
         }
 

--- a/reactive_graph/src/effect/immediate.rs
+++ b/reactive_graph/src/effect/immediate.rs
@@ -388,7 +388,8 @@ mod inner {
 
         fn mark_check(&self) {
             self.write().or_poisoned().state = ReactiveNodeState::Check;
-            self.update_if_necessary();
+            let any_subscriber = self.read().or_poisoned().any_subscriber.clone();
+            any_subscriber.with_observer(|| self.update_if_necessary());
         }
 
         fn mark_dirty(&self) {

--- a/reactive_graph/tests/memo.rs
+++ b/reactive_graph/tests/memo.rs
@@ -15,7 +15,7 @@ pub mod imports {
     pub use any_spawner::Executor;
     pub use reactive_graph::{
         computed::{ArcMemo, Memo},
-        effect::{Effect, RenderEffect},
+        effect::{Effect, ImmediateEffect, RenderEffect},
         prelude::*,
         signal::RwSignal,
         wrappers::read::Signal,
@@ -372,6 +372,35 @@ async fn effect_doesnt_rerun_if_memo_didnt_change() {
             assert_eq!(*combined_count.read().unwrap(), 2);
         })
         .await
+}
+
+#[cfg(feature = "effects")]
+#[test]
+fn sync_effect_can_recompute_dirty_memo_while_being_notified() {
+    let owner = Owner::new();
+    owner.set();
+
+    use imports::*;
+
+    let source = RwSignal::new(0);
+    let even = Memo::new(move |_| source.get() % 2 == 0);
+    let combined_count = Arc::new(RwLock::new(0));
+
+    let _effect = ImmediateEffect::new({
+        let combined_count = Arc::clone(&combined_count);
+        move || {
+            _ = even.get();
+            *combined_count.write().unwrap() += 1;
+        }
+    });
+
+    assert_eq!(*combined_count.read().unwrap(), 1);
+
+    source.set(1);
+    assert_eq!(*combined_count.read().unwrap(), 2);
+
+    assert_eq!(even.get_untracked(), false);
+    assert_eq!(*combined_count.read().unwrap(), 2);
 }
 
 #[cfg(feature = "effects")]


### PR DESCRIPTION
Fix a deadlock when an `ImmediateEffect` reads a dirty `Memo` while that memo is notifying subscribers. See new test `sync_effect_can_recompute_dirty_memo_while_being_notified`.

This changes memo and async-derived subscriber notification to snapshot subscribers before notifying them, so re-entrant reads do not try to upgrade the same lock. It also updates `ImmediateEffect::mark_check()` to run dependency checks with the effect installed as the current observer, which avoids an unnecessary extra rerun after the memo recomputes.