### PR TITLE
chore: pull in latest `wasm_split_helpers` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,7 +1961,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leptos"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "any_spawner",
  "base64",
@@ -4589,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_helpers"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a114b3073258dd5de3d812cdd048cca6842342755e828a14dbf15f843f2d1b84"
+checksum = "d0cb6d1008be3c4c5abc31a407bfb8c8449ae14efc8561c1db821f79b9614b0a"
 dependencies = [
  "async-once-cell",
  "wasm_split_macros",
@@ -4599,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56481f8ed1a9f9ae97ea7b08a5e2b12e8adf9a7818a6ba952b918e09c7be8bf0"
+checksum = "d0a659ffe5c7f4538aa6357c07e3d73221cc61eba03bd9a081e14bc91ed09b8c"
 dependencies = [
  "base16",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ sha2 = { default-features = false, version = "0.10" }
 subsecond = { default-features = false, version = "0.7" }
 dioxus-cli-config = { default-features = false, version = "0.7" }
 dioxus-devtools = { default-features = false, version = "0.7" }
-wasm_split_helpers = { default-features = false, version = "0.2" }
+wasm_split_helpers = { default-features = false, version = "0.2.1" }
 
 [profile.release]
 codegen-units = 1

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos"
-version = "0.8.17"
+version = "0.8.18"
 authors = ["Greg Johnston"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos"
@@ -164,15 +164,42 @@ denylist = [
   "multipart",
 ]
 skip_feature_sets = [
-  ["csr", "ssr"],
-  ["csr", "hydrate"],
-  ["ssr", "hydrate"],
-  ["serde", "serde-lite"],
-  ["serde", "miniserde"],
-  ["serde", "rkyv"],
-  ["miniserde", "rkyv"],
-  ["serde-lite", "rkyv"],
-  ["default-tls", "rustls"],
+  [
+    "csr",
+    "ssr",
+  ],
+  [
+    "csr",
+    "hydrate",
+  ],
+  [
+    "ssr",
+    "hydrate",
+  ],
+  [
+    "serde",
+    "serde-lite",
+  ],
+  [
+    "serde",
+    "miniserde",
+  ],
+  [
+    "serde",
+    "rkyv",
+  ],
+  [
+    "miniserde",
+    "rkyv",
+  ],
+  [
+    "serde-lite",
+    "rkyv",
+  ],
+  [
+    "default-tls",
+    "rustls",
+  ],
 ]
 max_combination_size = 2
 


### PR DESCRIPTION
Fixes breakage from https://github.com/rust-lang/rust/pull/149868

See https://github.com/leptos-rs/cargo-leptos/issues/642 