### PR TITLE
Fix broken Trunk website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pub fn SimpleCounterWithBuilder(initial_value: i32) -> impl IntoView {
     ))
 }
 
-// Easy to use with Trunk (trunkrs.dev) or with a simple wasm-bindgen setup
+// Easy to use with Trunk (trunk-rs.github.io/trunk) or with a simple wasm-bindgen setup
 pub fn main() {
     mount_to_body(|| view! {
         <SimpleCounter initial_value=3 />

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ To the extent that new features have been released or breaking changes have been
 
 ## Getting Started
 
-The simplest way to get started with any example is to use the “quick start” command found in the README for each example. Most of the examples use either [`trunk`](https://trunkrs.dev/) (a simple build system and dev server for client-side-rendered apps) or [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos) (a build system for server-rendered and client-hydrated apps).
+The simplest way to get started with any example is to use the “quick start” command found in the README for each example. Most of the examples use either [`trunk`](https://trunk-rs.github.io/trunk/) (a simple build system and dev server for client-side-rendered apps) or [`cargo-leptos`](https://github.com/leptos-rs/cargo-leptos) (a build system for server-rendered and client-hydrated apps).
 
 ## Using Cargo Make
 

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -132,7 +132,7 @@
 //! }
 //! ```
 //!
-//! Leptos is easy to use with [Trunk](https://trunkrs.dev/) (or with a simple wasm-bindgen setup):
+//! Leptos is easy to use with [Trunk](https://trunk-rs.github.io/trunk/) (or with a simple wasm-bindgen setup):
 //!
 //! ```rust
 //! use leptos::{mount::mount_to_body, prelude::*};


### PR DESCRIPTION
`trunkrs.dev` no longer points to the official Trunk site, so this updates the link to the new website instead.

https://github.com/trunk-rs/trunk/issues/1043