### PR TITLE
Tweaks to Suspense behavior

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -352,6 +352,11 @@ where
         // check the set of tasks to see if it is empty, now or later
         let eff = reactive_graph::effect::Effect::new_isomorphic({
             let children = Arc::clone(&children);
+            // tracks whether a task has ever been registered in this Suspense.
+            // if none ever has, no resolving resource could gate a nested
+            // read, so the double-check pass would do no work and we can skip
+            // it (avoiding an extra invocation of the children body).
+            let mut any_task_ever_seen = false;
             move |double_checking: Option<bool>| {
                 // on the first run, always track the tasks
                 if double_checking.is_none() {
@@ -360,9 +365,13 @@ where
 
                 if let Some(curr_tasks) = tasks.try_read_untracked() {
                     if curr_tasks.is_empty() {
-                        if double_checking == Some(true) {
-                            // we have finished loading, and checking the children again told us there are
-                            // no more pending tasks. so we can render both the children and the error boundary
+                        if double_checking == Some(true) || !any_task_ever_seen
+                        {
+                            // either we've finished the confirming dry-walk,
+                            // or no task has ever been registered — in both
+                            // cases there is nothing more to discover, so we
+                            // can render both the children and the error
+                            // boundary
 
                             if let Some(tx) = tasks_tx.take() {
                                 // If the receiver has dropped, it means the ScopedFuture has already
@@ -403,6 +412,7 @@ where
                             return true;
                         }
                     } else {
+                        any_task_ever_seen = true;
                         tasks.track();
                     }
                 }

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -100,6 +100,13 @@ pub fn Suspense<Chil>(
     /// Children will be rendered once initially to catch any resource reads, then hidden until all
     /// data have loaded.
     children: TypedChildren<Chil>,
+    /// If `true`, disables the SSR "double-check" pass that re-walks the
+    /// children after initial resources resolve in order to discover
+    /// conditional/nested resource reads. Enable this when the children body
+    /// has no conditional resource reads but does have side effects that
+    /// should not fire more than once per render.
+    #[prop(optional)]
+    strict: bool,
 ) -> impl IntoView
 where
     Chil: IntoView + Send + 'static,
@@ -143,6 +150,7 @@ where
             children,
             error_boundary_parent,
             has_tasks,
+            strict,
         })
     })
 }
@@ -166,6 +174,10 @@ pub(crate) struct SuspenseBoundary<const TRANSITION: bool, Fal, Chil> {
     pub children: Chil,
     pub error_boundary_parent: Option<ErrorBoundarySuspendedChildren>,
     pub has_tasks: Arc<dyn Fn() -> bool + Send + Sync>,
+    /// If `true`, the children are only walked once to register resources.
+    /// Conditional resource reads that depend on other resources will not be
+    /// discovered, but side effects in the children body run fewer times.
+    pub strict: bool,
 }
 
 impl<const TRANSITION: bool, Fal, Chil> Render
@@ -260,6 +272,7 @@ where
             children,
             error_boundary_parent,
             has_tasks,
+            strict,
         } = self;
         SuspenseBoundary {
             id,
@@ -268,6 +281,7 @@ where
             children: children.add_any_attr(attr),
             error_boundary_parent,
             has_tasks,
+            strict,
         }
     }
 }
@@ -350,6 +364,7 @@ where
         let children = Arc::new(Mutex::new(Some(self.children)));
 
         // check the set of tasks to see if it is empty, now or later
+        let strict = self.strict;
         let eff = reactive_graph::effect::Effect::new_isomorphic({
             let children = Arc::clone(&children);
             // tracks whether a task has ever been registered in this Suspense.
@@ -365,7 +380,9 @@ where
 
                 if let Some(curr_tasks) = tasks.try_read_untracked() {
                     if curr_tasks.is_empty() {
-                        if double_checking == Some(true) || !any_task_ever_seen
+                        if strict
+                            || double_checking == Some(true)
+                            || !any_task_ever_seen
                         {
                             // either we've finished the confirming dry-walk,
                             // or no task has ever been registered — in both

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -83,6 +83,13 @@ pub fn Transition<Chil>(
     #[prop(optional, into)]
     set_pending: Option<SignalSetter<bool>>,
     children: TypedChildren<Chil>,
+    /// If `true`, disables the SSR "double-check" pass that re-walks the
+    /// children after initial resources resolve in order to discover
+    /// conditional/nested resource reads. Enable this when the children body
+    /// has no conditional resource reads but does have side effects that
+    /// should not fire more than once per render.
+    #[prop(optional)]
+    strict: bool,
 ) -> impl IntoView
 where
     Chil: IntoView + Send + 'static,
@@ -134,6 +141,7 @@ where
             children,
             error_boundary_parent,
             has_tasks,
+            strict,
         })
     })
 }

--- a/leptos/tests/suspense_body_runs.rs
+++ b/leptos/tests/suspense_body_runs.rs
@@ -135,3 +135,71 @@ async fn body_runs_with_conditional_nested_resource() {
     println!("nested-resource case: body ran {runs} times");
     assert_eq!(runs, 3, "expected 3 runs in the nested-resource case");
 }
+
+/// `strict=true` disables the double-check pass, so a Suspense with one
+/// top-level resource runs the body twice (initial `dry_resolve` + final
+/// `resolve`) rather than three times.
+#[tokio::test]
+async fn body_runs_with_strict_suspense() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let res = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            42
+        },
+    );
+
+    let app = view! {
+        <Suspense strict=true>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            res.get().map(|v| v.to_string())
+        }}</Suspense>
+    };
+
+    let html = render(app).await;
+    assert!(html.contains("42"), "rendered html was: {html:?}");
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("strict single-resource case: body ran {runs} times");
+    assert_eq!(runs, 2, "expected 2 runs in strict mode");
+}
+
+/// Same behavior for `<Transition strict=true/>`.
+#[tokio::test]
+async fn body_runs_with_strict_transition() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let res = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            42
+        },
+    );
+
+    let app = view! {
+        <Transition strict=true>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            res.get().map(|v| v.to_string())
+        }}</Transition>
+    };
+
+    let html = render(app).await;
+    assert!(html.contains("42"), "rendered html was: {html:?}");
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("strict transition case: body ran {runs} times");
+    assert_eq!(runs, 2, "expected 2 runs in strict transition mode");
+}

--- a/leptos/tests/suspense_body_runs.rs
+++ b/leptos/tests/suspense_body_runs.rs
@@ -1,0 +1,137 @@
+//! These test and record the current trade-off between:
+//! - #4430 / commit 4f3a26c: re-running children so that conditional resource
+//!   reads that depend on *other* resources are discovered before the
+//!   Suspense resolves.
+//! - #4688: side effects in the Suspense body running multiple times per SSR
+//!   render.
+
+#![cfg(feature = "ssr")]
+
+use any_spawner::Executor;
+use futures::StreamExt;
+use leptos::prelude::*;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+async fn render(app: impl IntoView + Send + 'static) -> String {
+    app.to_html_stream_in_order().collect::<String>().await
+}
+
+/// No resources read in the Suspense body at all. The "double-check" added
+/// by 4f3a26c cannot possibly discover anything new, yet the body still runs
+/// more than once.
+#[tokio::test]
+async fn body_runs_with_no_resources() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let app = view! {
+        <Suspense>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            "hi"
+        }}</Suspense>
+    };
+
+    let html = render(app).await;
+    assert!(html.contains("hi"), "rendered html was: {html:?}");
+
+    // With no async resources, the double-check pass is skipped, so the
+    // body only runs once for the initial `dry_resolve` and once for the
+    // final `resolve`.
+    let runs = count.load(Ordering::SeqCst);
+    println!("no-resource case: body ran {runs} times");
+    assert_eq!(runs, 2, "expected 2 runs in the no-resource case");
+}
+
+/// One top-level resource, read unconditionally. The framework only needs a
+/// single tracking pass to discover it — the double-check cannot reveal
+/// anything new.
+#[tokio::test]
+async fn body_runs_with_one_resource() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let res = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            42
+        },
+    );
+
+    let app = view! {
+        <Suspense>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            res.get().map(|v| v.to_string())
+        }}</Suspense>
+    };
+
+    let html = render(app).await;
+    assert!(html.contains("42"), "rendered html was: {html:?}");
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("single-resource case: body ran {runs} times");
+    assert_eq!(runs, 3, "expected 3 runs in the single-resource case");
+}
+
+/// The case the double-check exists for: a resource whose completion reveals
+/// a nested resource read. Here the double-check is necessary for
+/// correctness — the second resource must be discovered before the Suspense
+/// resolves, otherwise we'd render stale/None content.
+#[tokio::test]
+async fn body_runs_with_conditional_nested_resource() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let outer = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            true
+        },
+    );
+    let inner = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            "inner-data".to_string()
+        },
+    );
+
+    let app = view! {
+        <Suspense>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            // `inner` is only read on runs where `outer` has resolved. The
+            // double-check is what makes us notice that read and wait for
+            // `inner` before resolving the Suspense.
+            outer.get().and_then(|flag| {
+                if flag { inner.get() } else { None }
+            })
+        }}</Suspense>
+    };
+
+    let html = render(app).await;
+    assert!(
+        html.contains("inner-data"),
+        "conditional nested resource must resolve before Suspense settles; \
+         got: {html:?}"
+    );
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("nested-resource case: body ran {runs} times");
+    assert_eq!(runs, 3, "expected 3 runs in the nested-resource case");
+}

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -382,29 +382,18 @@ pub fn maybe_optimised_component_children(
                     return None;
                 } else if let Some(stmt) = block.stmts.first() {
                     match stmt {
-                        Stmt::Macro(mac) => {
-                            // eprintln!("Macro: {:?}", mac.mac.path);
-                            if is_supported(&mac.mac) {
-                                quote! { #block }
-                            } else {
-                                return None;
-                            }
+                        Stmt::Macro(mac) if is_supported(&mac.mac) => {
+                            quote! { #block }
                         }
-                        Stmt::Item(Item::Macro(mac)) => {
-                            // eprintln!("Item Macro: {:?}", mac.mac.path);
-                            if is_supported(&mac.mac) {
-                                quote! { #block }
-                            } else {
-                                return None;
-                            }
+                        Stmt::Item(Item::Macro(mac))
+                            if is_supported(&mac.mac) =>
+                        {
+                            quote! { #block }
                         }
-                        Stmt::Expr(Expr::Macro(mac), _) => {
-                            // eprintln!("Expr Macro: {:?}", mac.mac.path);
-                            if is_supported(&mac.mac) {
-                                quote! { #block }
-                            } else {
-                                return None;
-                            }
+                        Stmt::Expr(Expr::Macro(mac), _)
+                            if is_supported(&mac.mac) =>
+                        {
+                            quote! { #block }
                         }
                         _ => return None,
                     }


### PR DESCRIPTION
There's a certain disconnect in our Suspense component implementation which can be summarized in the following:

  https://github.com/leptos-rs/leptos/discussions/4430
  https://github.com/leptos-rs/leptos/commit/4f3a26ce88eb1b429d382a871c47e086be96d559
  https://github.com/leptos-rs/leptos/issues/4688

Correctly tracking *all* Resources that are read inside Suspense (4430) requires us to re-run the children of the Suspense component until it's settled. but re-running the children of the Suspense can over-re-run code with side effects. Basically Suspense assumes its children are pure and "idempotent" (can be run multiple times with the same result and no observable effects) but this is not always the case.

This PR 1) short-circuits if there are no Resource reads, rather than running 3 times, and 2) adds an optional `strict` prop to Suspense/Transition to avoid checking for additional resources again after all resources have resolved. This would break #4430 but avoid the extra runs of #4688.

In general, my suggestion would be to hoist all Resource creation into route-level data loading so that it can begin as soon as possible — rather than *creating* Resources inside Suspense, you should *read* them inside Suspense.