### PR TITLE
fix(tachys): abort prior Suspend rebuild future to prevent RefCell race

### DIFF
--- a/tachys/src/reactive_graph/suspense.rs
+++ b/tachys/src/reactive_graph/suspense.rs
@@ -140,6 +140,12 @@ where
     T: Render,
 {
     inner: Rc<RefCell<OptionState<T>>>,
+    // The `AbortHandle` of the in-flight rebuild future, if any. Tracked so
+    // that a subsequent `rebuild` call can cancel the prior future before
+    // spawning a new one. Without this, two futures can race for
+    // `inner.borrow_mut()` and the loser panics with
+    // "RefCell already borrowed".
+    abort: Option<AbortHandle>,
 }
 
 impl<T> Mountable for SuspendState<T>
@@ -181,7 +187,10 @@ where
         // await, if they have already been cleaned up
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         let mut fut = Box::pin(Abortable::new(inner, abort_registration));
-        on_cleanup(move || abort_handle.abort());
+        on_cleanup({
+            let abort_handle = abort_handle.clone();
+            move || abort_handle.abort()
+        });
 
         // poll the future once immediately
         // if it's already available, start in the ready state
@@ -197,7 +206,7 @@ where
         // if the initial state was pending, spawn a future to wait for it
         // spawning immediately means that our now_or_never poll result isn't lost
         // if it wasn't pending at first, we don't need to poll the Future again
-        if initially_pending {
+        let abort = if initially_pending {
             reactive_graph::spawn_local_scoped({
                 let state = Rc::clone(&inner);
                 async move {
@@ -209,26 +218,43 @@ where
                     drop(id);
 
                     if let Ok(value) = value {
-                        Some(value).rebuild(&mut *state.borrow_mut());
+                        // try_borrow_mut: if a newer rebuild has already
+                        // taken the borrow, drop our stale value rather
+                        // than panicking. The newer rebuild produces the
+                        // up-to-date view.
+                        if let Ok(mut s) = state.try_borrow_mut() {
+                            Some(value).rebuild(&mut s);
+                        }
                     }
 
                     subscriber.forward();
                 }
             });
+            Some(abort_handle)
         } else {
             subscriber.forward();
-        }
+            None
+        };
 
-        SuspendState { inner }
+        SuspendState { inner, abort }
     }
 
     fn rebuild(self, state: &mut Self::State) {
         let Self { subscriber, inner } = self;
 
+        // Cancel any in-flight rebuild future. Without this, the prior
+        // future continues running and eventually calls
+        // `state.borrow_mut()`, racing the new future for the same borrow
+        // and panicking with "RefCell already borrowed".
+        if let Some(prev) = state.abort.take() {
+            prev.abort();
+        }
+
         // create a Future that will be aborted on on_cleanup
         // this prevents trying to access signals or other resources inside the Suspend, after the
         // await, if they have already been cleaned up
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        state.abort = Some(abort_handle.clone());
         let fut = Abortable::new(inner, abort_registration);
         on_cleanup(move || abort_handle.abort());
 
@@ -252,7 +278,12 @@ where
                 // has no parent
                 Executor::tick().await;
                 if let Ok(value) = value {
-                    Some(value).rebuild(&mut *state.borrow_mut());
+                    // try_borrow_mut defends against any remaining ordering
+                    // edge around `Executor::tick`. If a newer rebuild has
+                    // already grabbed the borrow, drop the stale value.
+                    if let Ok(mut s) = state.try_borrow_mut() {
+                        Some(value).rebuild(&mut s);
+                    }
                 }
 
                 subscriber.forward();
@@ -406,7 +437,10 @@ where
         // await, if they have already been cleaned up
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         let mut fut = Box::pin(Abortable::new(inner, abort_registration));
-        on_cleanup(move || abort_handle.abort());
+        on_cleanup({
+            let abort_handle = abort_handle.clone();
+            move || abort_handle.abort()
+        });
 
         // poll the future once immediately
         // if it's already available, start in the ready state
@@ -424,7 +458,7 @@ where
         // if the initial state was pending, spawn a future to wait for it
         // spawning immediately means that our now_or_never poll result isn't lost
         // if it wasn't pending at first, we don't need to poll the Future again
-        if initially_pending {
+        let abort = if initially_pending {
             reactive_graph::spawn_local_scoped({
                 let state = Rc::clone(&inner);
                 async move {
@@ -436,17 +470,22 @@ where
                     drop(id);
 
                     if let Ok(value) = value {
-                        Some(value).rebuild(&mut *state.borrow_mut());
+                        // try_borrow_mut: see comment in `build`.
+                        if let Ok(mut s) = state.try_borrow_mut() {
+                            Some(value).rebuild(&mut s);
+                        }
                     }
 
                     subscriber.forward();
                 }
             });
+            Some(abort_handle)
         } else {
             subscriber.forward();
-        }
+            None
+        };
 
-        SuspendState { inner }
+        SuspendState { inner, abort }
     }
 
     async fn resolve(self) -> Self::AsyncOutput {


### PR DESCRIPTION
Fixes #4693.

## Problem

When `Suspend::rebuild` is called multiple times before the previously awaited future has resolved, each call spawns a fresh future. Both futures eventually call `state.borrow_mut()` (`tachys/src/reactive_graph/suspense.rs:255`) after `Executor::tick().await`, and the second one panics with:

> panicked at tachys/src/reactive_graph/suspense.rs:255: RefCell already borrowed

The existing `on_cleanup(abort_handle)` only triggers when the parent owner is disposed, not when a new rebuild begins, so the prior in-flight future is never cancelled.

The same race is reachable from the spawned future in `build` / `hydrate` (initial pending state) racing the first `rebuild`.

## Production impact

134 occurrences across ≥ 4 distinct routes in 7 days on a leptos 0.8.19 / tachys 0.2.15 deployment. Details in the linked issue.

## Fix

1. Track the in-flight rebuild's `AbortHandle` on `SuspendState`. `rebuild` aborts it before spawning a new one — this is the root-cause fix.
2. Use `try_borrow_mut` defensively when the spawned future finally borrows. If a newer rebuild has already taken the borrow (any remaining ordering edge around `Executor::tick`), drop the stale value rather than panicking — the newer rebuild produces the up-to-date view.

Applied symmetrically in `build`, `rebuild`, and `hydrate`.

## Notes

- No public API change; `SuspendState` is internal.
- I'd like to add a unit test but the panic requires an async executor and tight Suspend re-entry. Happy to add one if a maintainer can point me at a similar concurrency test pattern in the repo.
- `cargo check`, `cargo clippy`, and `cargo fmt` clean.