### PR TITLE
fix(leptos/suspense): always track `tasks` signal to prevent SSR stream hang

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -353,10 +353,18 @@ where
         let eff = reactive_graph::effect::Effect::new_isomorphic({
             let children = Arc::clone(&children);
             move |double_checking: Option<bool>| {
-                // on the first run, always track the tasks
-                if double_checking.is_none() {
-                    tasks.track();
-                }
+                // Always re-track the `tasks` signal at the top of every run.
+                //
+                // This guarantees the effect keeps a live subscription on `tasks`
+                // regardless of which branch we exit through. In particular, if
+                // `tasks.try_read_untracked()` below returns `None` (because a
+                // concurrent `tasks.update()` is holding the write lock), we
+                // would otherwise fall through to `false` without tracking any
+                // signal — the effect would silently lose its subscription and
+                // never be re-scheduled by subsequent `tasks.update(...)` calls
+                // in `TaskHandle::drop`. That deadlocks `tasks_rx.await` in
+                // `to_html_async_with_buf` and stalls the SSR stream forever.
+                tasks.track();
 
                 if let Some(curr_tasks) = tasks.try_read_untracked() {
                     if curr_tasks.is_empty() {


### PR DESCRIPTION
## Bug

Under load, an SSR response can hang permanently after the initial
`<Suspense>` chunk is written. The client receives HTTP 200 plus the
first bytes of the body, then the stream stalls forever. The hung future
is `tasks_rx.await` inside `to_html_async_with_buf`. The matching
`tasks_tx.send(())` never fires because the Suspense effect has silently
lost its subscription on the `tasks` `ArcRwSignal<SlotMap>`.

**Root cause** (`leptos/src/suspense_component.rs`): the effect calls
`tasks.track()` only when `double_checking` is `None`, then calls
`tasks.try_read_untracked()`. If a concurrent `tasks.update(...)` (e.g.
from `TaskHandle::drop` when a child `Resource` finishes) holds the
write lock at that moment, `try_read_untracked()` returns `None` and the
effect exits **without having tracked any signal**. The effect is now
unsubscribed: subsequent `tasks.update(|t| t.remove(self.key))` calls no
longer mark it dirty, the effect is never re-scheduled, `tasks_rx` never
receives, and the SSR stream hangs forever. Classic lost-wakeup race.

Reproduces with ≥ 2 parallel `Resource::new_blocking` resolvers under
any `<Suspense>` boundary at roughly 3–5 % per request under load.

## Fix

Move `tasks.track()` unconditionally to the top of every effect run.
`tasks.track()` is idempotent for an already-subscribed effect, so the
previous `if double_checking.is_none()` guard was an unnecessary
micro-optimization that opened the race window. With unconditional
tracking the effect retains a live subscription regardless of which
branch it exits through.

Change is 1 line of behavior in `leptos/src/suspense_component.rs`; no
API surface change, no semver impact, safe to backport to `0.8.x`.

## Reproduction

```rust
#[component]
fn Page() -> impl IntoView {
    let a = Resource::new_blocking(|| (), |_| async { fetch_a().await });
    let b = Resource::new_blocking(|| (), |_| async { fetch_b().await });
    view! {
        <Suspense fallback=|| "loading">
            {move || Suspend::new(async move {
                let (_a, _b) = (a.await, b.await);
                view! { <div>"ok"</div> }
            })}
        </Suspense>
    }
}
