### PR TITLE
fix: issues with nested keyed store field initialization (see #4697)

### DIFF
--- a/reactive_stores/src/keyed.rs
+++ b/reactive_stores/src/keyed.rs
@@ -1360,6 +1360,58 @@ mod tests {
         let _fields = store.items().into_iter();
     }
 
+    #[test]
+    fn nested_keyed_subfields_dont_deadlock_on_first_iter() {
+        _ = any_spawner::Executor::init_tokio();
+        
+
+        // Regression test for a panic/deadlock that occurred when a `For`
+        // over a keyed subfield was nested inside another `For` over a
+        // keyed subfield. Iterating the inner subfield's `KeyedSubfield`
+        // would call `update_keys`, which, while holding a write lock on
+        // the global `KeyMap`, would initialize its entry by calling
+        // `latest_keys()`. That traversed back through the parent
+        // `AtKeyed::reader` -> `resolve_index` -> `with_field_keys`,
+        // attempting to re-acquire the same write lock and aborting.
+        use crate::Field;
+
+        #[derive(Debug, Store, Clone)]
+        struct Part {
+            id: usize,
+            #[store(key: usize = |c| c.id)]
+            chapters: Vec<Chapter>,
+        }
+
+        #[derive(Debug, Store, Clone)]
+        struct Chapter {
+            id: usize,
+        }
+
+        #[derive(Debug, Store)]
+        struct Structure {
+            #[store(key: usize = |p| p.id)]
+            parts: Vec<Part>,
+        }
+
+        let store = Store::new(Structure {
+            parts: vec![Part {
+                id: 1,
+                chapters: vec![Chapter { id: 10 }],
+            }],
+        });
+
+        // Mimic the behavior of nested `<For>` components: iterate the
+        // outer keyed subfield, take a `Field<Part>` for each item, and
+        // iterate its inner keyed subfield. Doing so on a freshly
+        // constructed store ensures both the outer and the inner entries
+        // need to be initialized, which is the case that triggered the
+        // re-entrant write lock.
+        for at_part in store.parts() {
+            let part: Field<Part> = at_part.into();
+            let _: Vec<_> = part.chapters().into_iter().collect();
+        }
+    }
+
     #[tokio::test]
     async fn patching_keyed_field_only_notifies_changed_keys() {
         _ = any_spawner::Executor::init_tokio();

--- a/reactive_stores/src/keyed.rs
+++ b/reactive_stores/src/keyed.rs
@@ -1363,7 +1363,6 @@ mod tests {
     #[test]
     fn nested_keyed_subfields_dont_deadlock_on_first_iter() {
         _ = any_spawner::Executor::init_tokio();
-        
 
         // Regression test for a panic/deadlock that occurred when a `For`
         // over a keyed subfield was nested inside another `For` over a

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -493,10 +493,20 @@ impl KeyMap {
     where
         K: Debug + Hash + PartialEq + Eq + Send + Sync + 'static,
     {
+        // We must call `initialize()` *outside* the write lock below,
+        // because nested keyed subfields can recursively re-enter this map:
+        // initializing a child path may call `latest_keys()` on a parent
+        // keyed field, whose `AtKeyed::reader` calls `resolve_index`, which
+        // itself calls `with_field_keys` and would attempt to acquire the
+        // same write lock — aborting in single-threaded environments and
+        // deadlocking in multi-threaded ones.
+        let needs_init = !self.0.read().or_poisoned().contains_key(&path);
+        let mut initial = needs_init.then(initialize);
+
         let mut guard = self.0.write().or_poisoned();
-        let entry = guard
-            .entry(path.clone())
-            .or_insert_with(|| Box::new(FieldKeys::new(initialize())));
+        let entry = guard.entry(path.clone()).or_insert_with(|| {
+            Box::new(FieldKeys::new(initial.take().unwrap_or_default()))
+        });
 
         let entry = entry.downcast_mut::<FieldKeys<K>>()?;
         let (result, new_keys) = fun(entry);


### PR DESCRIPTION
PR #4620 made `initialize()` lazy by moving it from before the write lock into the `or_insert_with closure` (which runs while the write lock is held). For nested `<For>` over keyed subfields, this causes a panic on WASM because it tries to take the write lock on the nested field while it's already taken.