### PR TITLE
Fix out-of-order SSR streaming with nested async chunks (+ html_len and unescape fixes)

### DIFF
--- a/router/src/link.rs
+++ b/router/src/link.rs
@@ -467,33 +467,25 @@ mod tests {
     #[test]
     fn normalize_path_test() {
         // Make sure it doesn't touch already normalized urls.
-        assert!(normalize_path("") == "".to_string());
-        assert!(normalize_path("/") == "/".to_string());
-        assert!(normalize_path("/some") == "/some".to_string());
-        assert!(normalize_path("/some/") == "/some/".to_string());
+        assert!(normalize_path("").is_empty());
+        assert_eq!(normalize_path("/"), "/");
+        assert_eq!(normalize_path("/some"), "/some");
+        assert_eq!(normalize_path("/some/"), "/some/");
 
         // Correctly removes ".." segments.
-        assert!(normalize_path("/some/../another") == "/another".to_string());
-        assert!(
-            normalize_path("/one/two/../three/../../four")
-                == "/four".to_string()
-        );
+        assert_eq!(normalize_path("/some/../another"), "/another");
+        assert_eq!(normalize_path("/one/two/../three/../../four"), "/four");
 
         // Correctly sets trailing slash if last segement is "..".
-        assert!(normalize_path("/one/two/..") == "/one/".to_string());
-        assert!(normalize_path("/one/two/../") == "/one/".to_string());
+        assert_eq!(normalize_path("/one/two/.."), "/one/");
+        assert_eq!(normalize_path("/one/two/../"), "/one/");
 
         // Level outside of the url.
-        assert!(normalize_path("/..") == "/".to_string());
-        assert!(normalize_path("/../") == "/".to_string());
+        assert_eq!(normalize_path("/.."), "/");
+        assert_eq!(normalize_path("/../"), "/");
 
         // Going into negative levels and coming back into the positives.
-        assert!(
-            normalize_path("/one/../../two/three") == "/two/three".to_string()
-        );
-        assert!(
-            normalize_path("/one/../../two/three/")
-                == "/two/three/".to_string()
-        );
+        assert_eq!(normalize_path("/one/../../two/three"), "/two/three");
+        assert_eq!(normalize_path("/one/../../two/three/"), "/two/three/");
     }
 }

--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -172,14 +172,17 @@ impl Url {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "ssr", target_arch = "wasm32"))]
     use super::Url;
 
     #[test]
+    #[cfg(any(feature = "ssr", target_arch = "wasm32"))]
     fn unescape_decodes_valid_sequences() {
         assert_eq!(Url::unescape("hello%20world"), "hello world");
     }
 
     #[test]
+    #[cfg(any(feature = "ssr", target_arch = "wasm32"))]
     fn unescape_preserves_invalid_sequences() {
         assert_eq!(Url::unescape("%FF"), "%FF");
     }

--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -139,9 +139,10 @@ impl Url {
     pub fn unescape(s: &str) -> String {
         #[cfg(feature = "ssr")]
         {
-            percent_encoding::percent_decode_str(s)
-                .decode_utf8_lossy()
-                .to_string()
+            match percent_encoding::percent_decode_str(s).decode_utf8() {
+                Ok(v) => v.into_owned(),
+                Err(_) => s.into(),
+            }
         }
 
         #[cfg(not(feature = "ssr"))]
@@ -166,6 +167,21 @@ impl Url {
         {
             Self::unescape(s)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Url;
+
+    #[test]
+    fn unescape_decodes_valid_sequences() {
+        assert_eq!(Url::unescape("hello%20world"), "hello world");
+    }
+
+    #[test]
+    fn unescape_preserves_invalid_sequences() {
+        assert_eq!(Url::unescape("%FF"), "%FF");
     }
 }
 

--- a/tachys/src/html/attribute/custom.rs
+++ b/tachys/src/html/attribute/custom.rs
@@ -56,7 +56,7 @@ where
     type CloneableOwned = CustomAttr<K, V::CloneableOwned>;
 
     fn html_len(&self) -> usize {
-        self.key.as_ref().len() + 3 + self.value.html_len()
+        self.key.as_ref().len() + 4 + self.value.html_len()
     }
 
     fn to_html(

--- a/tachys/src/html/attribute/custom.rs
+++ b/tachys/src/html/attribute/custom.rs
@@ -56,7 +56,7 @@ where
     type CloneableOwned = CustomAttr<K, V::CloneableOwned>;
 
     fn html_len(&self) -> usize {
-        self.key.as_ref().len() + 4 + self.value.html_len()
+        self.key.as_ref().len() + 3 + self.value.html_len()
     }
 
     fn to_html(

--- a/tachys/src/html/attribute/mod.rs
+++ b/tachys/src/html/attribute/mod.rs
@@ -229,7 +229,7 @@ where
     type CloneableOwned = Attr<K, V::CloneableOwned>;
 
     fn html_len(&self) -> usize {
-        K::KEY.len() + 3 + self.1.html_len()
+        K::KEY.len() + 4 + self.1.html_len()
     }
 
     fn to_html(

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -514,7 +514,7 @@ impl AttributeValue for char {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        0
+        1
     }
 
     fn to_html(self, key: &str, buf: &mut String) {
@@ -749,7 +749,7 @@ macro_rules! render_primitive {
             type CloneableOwned = Self;
 
             fn html_len(&self) -> usize {
-                0
+                10
             }
 
             fn to_html(self, key: &str, buf: &mut String) {

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -514,17 +514,13 @@ impl AttributeValue for char {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        0
+        self.len_utf8()
     }
 
     fn to_html(self, key: &str, buf: &mut String) {
-        buf.push(' ');
-        buf.push_str(key);
-        buf.push_str("=\"");
         let mut buffer = [0u8; 4];
         let str = self.encode_utf8(&mut buffer);
-        buf.push_str(&escape_attr(str));
-        buf.push('"');
+        <&str as AttributeValue>::to_html(str, key, buf);
     }
 
     fn to_template(_key: &str, _buf: &mut String) {}

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -514,13 +514,17 @@ impl AttributeValue for char {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len_utf8()
+        0
     }
 
     fn to_html(self, key: &str, buf: &mut String) {
+        buf.push(' ');
+        buf.push_str(key);
+        buf.push_str("=\"");
         let mut buffer = [0u8; 4];
         let str = self.encode_utf8(&mut buffer);
-        <&str as AttributeValue>::to_html(str, key, buf);
+        buf.push_str(&escape_attr(str));
+        buf.push('"');
     }
 
     fn to_template(_key: &str, _buf: &mut String) {}

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -518,7 +518,13 @@ impl AttributeValue for char {
     }
 
     fn to_html(self, key: &str, buf: &mut String) {
-        <String as AttributeValue>::to_html(self.to_string(), key, buf);
+        buf.push(' ');
+        buf.push_str(key);
+        buf.push_str("=\"");
+        let mut buffer = [0u8; 4];
+        let str = self.encode_utf8(&mut buffer);
+        buf.push_str(&escape_attr(str));
+        buf.push('"');
     }
 
     fn to_template(_key: &str, _buf: &mut String) {}
@@ -531,20 +537,30 @@ impl AttributeValue for char {
         // if we're actually hydrating from SSRed HTML, we don't need to set the attribute
         // if we're hydrating from a CSR-cloned <template>, we do need to set non-StaticAttr attributes
         if !FROM_SERVER {
-            Rndr::set_attribute(el, key, &self.to_string());
+            let mut buffer = [0u8; 4];
+            let str = self.encode_utf8(&mut buffer);
+            Rndr::set_attribute(el, key, str);
         }
         (el.clone(), self)
     }
 
-    fn build(self, el: &crate::renderer::types::Element, key: &str) -> Self::State {
-        Rndr::set_attribute(el, key, &self.to_string());
+    fn build(
+        self,
+        el: &crate::renderer::types::Element,
+        key: &str,
+    ) -> Self::State {
+        let mut buffer = [0u8; 4];
+        let str = self.encode_utf8(&mut buffer);
+        Rndr::set_attribute(el, key, str);
         (el.to_owned(), self)
     }
 
     fn rebuild(self, key: &str, state: &mut Self::State) {
         let (el, prev_value) = state;
         if self != *prev_value {
-            Rndr::set_attribute(el, key, &self.to_string());
+            let mut buffer = [0u8; 4];
+            let str = self.encode_utf8(&mut buffer);
+            Rndr::set_attribute(el, key, str);
         }
         *prev_value = self;
     }

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -506,7 +506,63 @@ impl AttributeValue for Arc<str> {
         self
     }
 }
-// TODO impl AttributeValue for Rc<str> and Arc<str> too
+
+impl AttributeValue for char {
+    type AsyncOutput = Self;
+    type State = (crate::renderer::types::Element, Self);
+    type Cloneable = Self;
+    type CloneableOwned = Self;
+
+    fn html_len(&self) -> usize {
+        0
+    }
+
+    fn to_html(self, key: &str, buf: &mut String) {
+        <String as AttributeValue>::to_html(self.to_string(), key, buf);
+    }
+
+    fn to_template(_key: &str, _buf: &mut String) {}
+
+    fn hydrate<const FROM_SERVER: bool>(
+        self,
+        key: &str,
+        el: &crate::renderer::types::Element,
+    ) -> Self::State {
+        // if we're actually hydrating from SSRed HTML, we don't need to set the attribute
+        // if we're hydrating from a CSR-cloned <template>, we do need to set non-StaticAttr attributes
+        if !FROM_SERVER {
+            Rndr::set_attribute(el, key, &self.to_string());
+        }
+        (el.clone(), self)
+    }
+
+    fn build(self, el: &crate::renderer::types::Element, key: &str) -> Self::State {
+        Rndr::set_attribute(el, key, &self.to_string());
+        (el.to_owned(), self)
+    }
+
+    fn rebuild(self, key: &str, state: &mut Self::State) {
+        let (el, prev_value) = state;
+        if self != *prev_value {
+            Rndr::set_attribute(el, key, &self.to_string());
+        }
+        *prev_value = self;
+    }
+
+    fn into_cloneable(self) -> Self::Cloneable {
+        self
+    }
+
+    fn into_cloneable_owned(self) -> Self::CloneableOwned {
+        self
+    }
+
+    fn dry_resolve(&mut self) {}
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        self
+    }
+}
 
 impl AttributeValue for bool {
     type AsyncOutput = Self;
@@ -681,7 +737,12 @@ macro_rules! render_primitive {
             }
 
             fn to_html(self, key: &str, buf: &mut String) {
-                <String as AttributeValue>::to_html(self.to_string(), key, buf);
+                use std::fmt::Write;
+                buf.push(' ');
+                buf.push_str(key);
+                buf.push_str("=\"");
+                write!(buf, "{}", self).expect("failed to write primitive attribute");
+                buf.push('"');
             }
 
             fn to_template(_key: &str, _buf: &mut String) {}
@@ -746,7 +807,6 @@ render_primitive![
     i128,
     f32,
     f64,
-    char,
     IpAddr,
     SocketAddr,
     SocketAddrV4,

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -514,7 +514,9 @@ impl AttributeValue for char {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        1
+        let mut buffer = [0u8; 4];
+        let str = self.encode_utf8(&mut buffer);
+        escape_attr(str).len()
     }
 
     fn to_html(self, key: &str, buf: &mut String) {
@@ -749,7 +751,7 @@ macro_rules! render_primitive {
             type CloneableOwned = Self;
 
             fn html_len(&self) -> usize {
-                10
+                core::mem::size_of::<$child_type>() * 4
             }
 
             fn to_html(self, key: &str, buf: &mut String) {
@@ -842,3 +844,27 @@ render_primitive![
     NonZeroIsize,
     NonZeroUsize,
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::AttributeValue;
+
+    #[test]
+    fn char_html_len_counts_utf8_width() {
+        assert_eq!('é'.html_len(), 2);
+    }
+
+    #[test]
+    fn char_html_len_accounts_for_escaping() {
+        assert_eq!('"'.html_len(), 6);
+    }
+
+    #[test]
+    fn primitive_html_len_matches_display_width() {
+        let int_value = -42i32;
+        assert!(int_value.html_len() >= int_value.to_string().len());
+
+        let float_value = 3.5f32;
+        assert!(float_value.html_len() >= float_value.to_string().len());
+    }
+}

--- a/tachys/src/html/class.rs
+++ b/tachys/src/html/class.rs
@@ -47,7 +47,7 @@ where
     type CloneableOwned = Class<C::CloneableOwned>;
 
     fn html_len(&self) -> usize {
-        self.class.html_len() + 1
+        self.class.html_len() + 9
     }
 
     fn to_html(

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -289,7 +289,7 @@ impl<'a> IntoStyle for &'a str {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -344,7 +344,7 @@ impl IntoStyle for Arc<str> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -399,7 +399,7 @@ impl IntoStyle for String {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -577,7 +577,7 @@ macro_rules! impl_style_value {
             type CloneableOwned = Self;
 
             fn html_len(&self) -> usize {
-                self.len()
+                self.len() + 1
             }
 
             fn to_html(self, name: &str, style: &mut String) {
@@ -638,7 +638,7 @@ macro_rules! impl_style_value {
             type CloneableOwned = Self;
 
             fn html_len(&self) -> usize {
-                self.as_ref().map_or(0, |v| v.len())
+                self.as_ref().map_or(0, |v| v.len() + 1)
             }
 
             fn to_html(self, name: &str, style: &mut String) {
@@ -721,7 +721,7 @@ impl<const V: &'static str> IntoStyleValue for Static<V> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        V.len()
+        V.len() + 1
     }
 
     fn to_html(self, name: &str, style: &mut String) {
@@ -772,7 +772,7 @@ impl<const V: &'static str> IntoStyleValue for Option<Static<V>> {
 
     fn html_len(&self) -> usize {
         if self.is_some() {
-            V.len()
+            V.len() + 1
         } else {
             0
         }
@@ -838,7 +838,7 @@ impl<const V: &'static str> IntoStyle for crate::view::static_types::Static<V> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        V.len()
+        V.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -878,6 +878,28 @@ impl<const V: &'static str> IntoStyle for crate::view::static_types::Static<V> {
     }
 
     fn reset(_state: &mut Self::State) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{style, IntoStyle, IntoStyleValue};
+    use crate::html::attribute::Attribute;
+
+    #[test]
+    fn style_html_len_accounts_for_trailing_semicolon() {
+        assert_eq!(style("display: block").html_len(), 24);
+    }
+
+    #[test]
+    fn style_html_len_accounts_for_named_values() {
+        assert_eq!(style(("color", "blue")).html_len(), 20);
+    }
+
+    #[test]
+    fn style_value_html_len_accounts_for_trailing_semicolon() {
+        assert_eq!("blue".html_len(), 5);
+        assert_eq!(("color", "blue").html_len(), 11);
+    }
 }
 
 /*

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -897,8 +897,8 @@ mod tests {
 
     #[test]
     fn style_value_html_len_accounts_for_trailing_semicolon() {
-        assert_eq!("blue".html_len(), 5);
-        assert_eq!(("color", "blue").html_len(), 11);
+        assert_eq!(IntoStyleValue::html_len(&"blue"), 5);
+        assert_eq!(IntoStyle::html_len(&("color", "blue")), 11);
     }
 }
 

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -50,10 +50,9 @@ where
     type Cloneable = Style<S::Cloneable>;
     type CloneableOwned = Style<S::CloneableOwned>;
 
-    // TODO
     #[inline(always)]
     fn html_len(&self) -> usize {
-        0
+        self.style.html_len() + 9
     }
 
     fn to_html(
@@ -126,14 +125,16 @@ impl<S> ToTemplate for Style<S>
 where
     S: IntoStyle,
 {
+    const STYLE: &'static str = S::TEMPLATE;
+
     fn to_template(
         _buf: &mut String,
-        _style: &mut String,
         _class: &mut String,
+        style: &mut String,
         _inner_html: &mut String,
         _position: &mut Position,
     ) {
-        // TODO: should there be some templating for static styles?
+        S::to_template(style);
     }
 }
 
@@ -142,6 +143,9 @@ where
 ///
 /// This could be a plain string, or a property name-value pair.
 pub trait IntoStyle: Send {
+    /// The HTML that should be included in a `<template>`.
+    const TEMPLATE: &'static str = "";
+
     /// The type after all async data have resolved.
     type AsyncOutput: IntoStyle;
     /// The view state retained between building and rebuilding.
@@ -151,8 +155,15 @@ pub trait IntoStyle: Send {
     /// An equivalent value that can be cloned and is `'static`.
     type CloneableOwned: IntoStyle + Clone + 'static;
 
+    /// The estimated length of the HTML.
+    fn html_len(&self) -> usize;
+
     /// Renders the style to HTML.
     fn to_html(self, style: &mut String);
+
+    /// Renders the style to HTML for a `<template>`.
+    #[allow(unused)] // it's used with `nightly` feature
+    fn to_template(style: &mut String) {}
 
     /// Adds interactivity as necessary, given DOM nodes that were created from HTML that has
     /// either been rendered on the server, or cloned for a `<template>`.
@@ -190,6 +201,10 @@ impl<T: IntoStyle> IntoStyle for Option<T> {
     type State = (crate::renderer::types::Element, Option<T::State>);
     type Cloneable = Option<T::Cloneable>;
     type CloneableOwned = Option<T::CloneableOwned>;
+
+    fn html_len(&self) -> usize {
+        self.as_ref().map_or(0, IntoStyle::html_len)
+    }
 
     fn to_html(self, style: &mut String) {
         if let Some(t) = self {
@@ -271,6 +286,10 @@ impl<'a> IntoStyle for &'a str {
     type Cloneable = Self;
     type CloneableOwned = Arc<str>;
 
+    fn html_len(&self) -> usize {
+        self.len()
+    }
+
     fn to_html(self, style: &mut String) {
         style.push_str(self);
         style.push(';');
@@ -322,6 +341,10 @@ impl IntoStyle for Arc<str> {
     type Cloneable = Self;
     type CloneableOwned = Self;
 
+    fn html_len(&self) -> usize {
+        self.len()
+    }
+
     fn to_html(self, style: &mut String) {
         style.push_str(&self);
         style.push(';');
@@ -372,6 +395,10 @@ impl IntoStyle for String {
     type State = (crate::renderer::types::Element, String);
     type Cloneable = Arc<str>;
     type CloneableOwned = Arc<str>;
+
+    fn html_len(&self) -> usize {
+        self.len()
+    }
 
     fn to_html(self, style: &mut String) {
         style.push_str(&self);
@@ -432,6 +459,9 @@ pub trait IntoStyleValue: Send {
     /// An equivalent value that can be cloned and is `'static`.
     type CloneableOwned: Clone + IntoStyleValue + 'static;
 
+    /// The estimated length of the HTML.
+    fn html_len(&self) -> usize;
+
     /// Renders the style to HTML.
     fn to_html(self, name: &str, style: &mut String);
 
@@ -474,6 +504,10 @@ where
     type State = (crate::renderer::types::CssStyleDeclaration, K, V::State);
     type Cloneable = (K, V::Cloneable);
     type CloneableOwned = (K, V::CloneableOwned);
+
+    fn html_len(&self) -> usize {
+        self.0.as_ref().len() + 1 + self.1.html_len()
+    }
 
     fn to_html(self, style: &mut String) {
         let (name, value) = self;
@@ -538,6 +572,10 @@ macro_rules! impl_style_value {
             type Cloneable = Self;
             type CloneableOwned = Self;
 
+            fn html_len(&self) -> usize {
+                self.len()
+            }
+
             fn to_html(self, name: &str, style: &mut String) {
                 style.push_str(name);
                 style.push(':');
@@ -594,6 +632,10 @@ macro_rules! impl_style_value {
             type State = Self;
             type Cloneable = Self;
             type CloneableOwned = Self;
+
+            fn html_len(&self) -> usize {
+                self.as_ref().map_or(0, |v| v.len())
+            }
 
             fn to_html(self, name: &str, style: &mut String) {
                 if let Some(value) = self {
@@ -674,6 +716,10 @@ impl<const V: &'static str> IntoStyleValue for Static<V> {
     type Cloneable = Self;
     type CloneableOwned = Self;
 
+    fn html_len(&self) -> usize {
+        V.len()
+    }
+
     fn to_html(self, name: &str, style: &mut String) {
         style.push_str(name);
         style.push(':');
@@ -719,6 +765,14 @@ impl<const V: &'static str> IntoStyleValue for Option<Static<V>> {
     type State = Self;
     type Cloneable = Self;
     type CloneableOwned = Self;
+
+    fn html_len(&self) -> usize {
+        if self.is_some() {
+            V.len()
+        } else {
+            0
+        }
+    }
 
     fn to_html(self, name: &str, style: &mut String) {
         if self.is_some() {
@@ -772,12 +826,23 @@ impl<const V: &'static str> IntoStyleValue for Option<Static<V>> {
 
 #[cfg(all(feature = "nightly", rustc_nightly))]
 impl<const V: &'static str> IntoStyle for crate::view::static_types::Static<V> {
+    const TEMPLATE: &'static str = V;
+
     type AsyncOutput = Self;
     type State = ();
     type Cloneable = Self;
     type CloneableOwned = Self;
 
+    fn html_len(&self) -> usize {
+        V.len()
+    }
+
     fn to_html(self, style: &mut String) {
+        style.push_str(V);
+        style.push(';');
+    }
+
+    fn to_template(style: &mut String) {
         style.push_str(V);
         style.push(';');
     }

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -156,7 +156,9 @@ pub trait IntoStyle: Send {
     type CloneableOwned: IntoStyle + Clone + 'static;
 
     /// The estimated length of the HTML.
-    fn html_len(&self) -> usize;
+    fn html_len(&self) -> usize {
+        0
+    }
 
     /// Renders the style to HTML.
     fn to_html(self, style: &mut String);
@@ -287,7 +289,7 @@ impl<'a> IntoStyle for &'a str {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len() + 1
+        self.len()
     }
 
     fn to_html(self, style: &mut String) {
@@ -342,7 +344,7 @@ impl IntoStyle for Arc<str> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len() + 1
+        self.len()
     }
 
     fn to_html(self, style: &mut String) {
@@ -397,7 +399,7 @@ impl IntoStyle for String {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len() + 1
+        self.len()
     }
 
     fn to_html(self, style: &mut String) {
@@ -460,7 +462,9 @@ pub trait IntoStyleValue: Send {
     type CloneableOwned: Clone + IntoStyleValue + 'static;
 
     /// The estimated length of the HTML.
-    fn html_len(&self) -> usize;
+    fn html_len(&self) -> usize {
+        0
+    }
 
     /// Renders the style to HTML.
     fn to_html(self, name: &str, style: &mut String);
@@ -506,7 +510,7 @@ where
     type CloneableOwned = (K, V::CloneableOwned);
 
     fn html_len(&self) -> usize {
-        self.0.as_ref().len() + 2 + self.1.html_len()
+        self.0.as_ref().len() + 1 + self.1.html_len()
     }
 
     fn to_html(self, style: &mut String) {
@@ -834,7 +838,7 @@ impl<const V: &'static str> IntoStyle for crate::view::static_types::Static<V> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        V.len() + 1
+        V.len()
     }
 
     fn to_html(self, style: &mut String) {

--- a/tachys/src/html/style.rs
+++ b/tachys/src/html/style.rs
@@ -287,7 +287,7 @@ impl<'a> IntoStyle for &'a str {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -342,7 +342,7 @@ impl IntoStyle for Arc<str> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -397,7 +397,7 @@ impl IntoStyle for String {
     type CloneableOwned = Arc<str>;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {
@@ -506,7 +506,7 @@ where
     type CloneableOwned = (K, V::CloneableOwned);
 
     fn html_len(&self) -> usize {
-        self.0.as_ref().len() + 1 + self.1.html_len()
+        self.0.as_ref().len() + 2 + self.1.html_len()
     }
 
     fn to_html(self, style: &mut String) {
@@ -834,7 +834,7 @@ impl<const V: &'static str> IntoStyle for crate::view::static_types::Static<V> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        V.len()
+        V.len() + 1
     }
 
     fn to_html(self, style: &mut String) {

--- a/tachys/src/oco.rs
+++ b/tachys/src/oco.rs
@@ -298,6 +298,10 @@ impl IntoStyle for Oco<'static, str> {
     type Cloneable = Self;
     type CloneableOwned = Self;
 
+    fn html_len(&self) -> usize {
+        self.len()
+    }
+
     fn to_html(self, style: &mut String) {
         style.push_str(&self);
         style.push(';');

--- a/tachys/src/oco.rs
+++ b/tachys/src/oco.rs
@@ -299,7 +299,7 @@ impl IntoStyle for Oco<'static, str> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len() + 1
+        self.len()
     }
 
     fn to_html(self, style: &mut String) {

--- a/tachys/src/oco.rs
+++ b/tachys/src/oco.rs
@@ -299,7 +299,7 @@ impl IntoStyle for Oco<'static, str> {
     type CloneableOwned = Self;
 
     fn html_len(&self) -> usize {
-        self.len()
+        self.len() + 1
     }
 
     fn to_html(self, style: &mut String) {

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -104,6 +104,10 @@ where
         self.into_shared()
     }
 
+    fn html_len(&self) -> usize {
+        0
+    }
+
     fn dry_resolve(&mut self) {
         self.invoke();
     }
@@ -123,6 +127,10 @@ where
     type State = RenderEffect<C::State>;
     type Cloneable = SharedReactiveFunction<C>;
     type CloneableOwned = SharedReactiveFunction<C>;
+
+    fn html_len(&self) -> usize {
+        0
+    }
 
     fn to_html(mut self, style: &mut String) {
         let value = self.invoke();
@@ -252,6 +260,10 @@ macro_rules! style_reactive {
                 self
             }
 
+            fn html_len(&self) -> usize {
+                0
+            }
+
             fn dry_resolve(&mut self) {}
 
             async fn resolve(self) -> Self::AsyncOutput {
@@ -324,6 +336,10 @@ macro_rules! style_reactive {
 
             fn into_cloneable_owned(self) -> Self::CloneableOwned {
                 self
+            }
+
+            fn html_len(&self) -> usize {
+                0
             }
 
             fn dry_resolve(&mut self) {}

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -404,9 +404,9 @@ impl Stream for StreamBuilder {
                                             .find(&closing)
                                             .unwrap();
 
-                                        let after = this.sync_buf.split_off(
-                                            end + closing.len(),
-                                        );
+                                        let after = this
+                                            .sync_buf
+                                            .split_off(end + closing.len());
                                         this.sync_buf.truncate(start);
 
                                         let mut chunks = chunks;

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -758,3 +758,37 @@ mod tests {
     }
 }
 */
+
+#[cfg(test)]
+mod tests {
+    use super::{OooChunk, StreamBuilder, StreamChunk};
+    use futures::StreamExt;
+    use std::collections::VecDeque;
+
+    #[tokio::test]
+    async fn repolls_when_ooo_processing_leaves_followup_chunks() {
+        let mut stream = StreamBuilder {
+            sync_buf: "<!--s-1-o--><!--s-1-c-->".to_string(),
+            chunks: VecDeque::new(),
+            pending: None,
+            pending_ooo: VecDeque::new(),
+            id: None,
+        };
+
+        stream.pending_ooo.push_back(Box::pin(async {
+            OooChunk {
+                id: "1-".to_string(),
+                chunks: VecDeque::from([StreamChunk::Async {
+                    chunks: Box::pin(async {
+                        VecDeque::from([StreamChunk::Sync("done".to_string())])
+                    }),
+                }]),
+                replace: false,
+                nonce: None,
+            }
+        }));
+
+        assert_eq!(stream.next().await.as_deref(), Some("done"));
+        assert!(stream.next().await.is_none());
+    }
+}

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -850,7 +850,6 @@ mod tests {
         }
 
         let combined = results.join("");
-        println!("Combined output: {}", combined);
 
         // If it works correctly, we should NOT see the <template>/<script> fallback for "2-"
         // because it should have been found and replaced in sync_buf.

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -403,53 +403,71 @@ impl Stream for StreamBuilder {
                                             .sync_buf
                                             .find(&closing)
                                             .unwrap();
-                                        let chunks_iter =
-                                            chunks.into_iter().rev();
 
-                                        // TODO can probably make this more efficient
-                                        let (before, replaced) =
-                                            this.sync_buf.split_at(start);
-                                        let (_, after) = replaced.split_at(
-                                            end - start + closing.len(),
+                                        let after = this.sync_buf.split_off(
+                                            end + closing.len(),
                                         );
-                                        let mut buf = String::new();
-                                        buf.push_str(before);
+                                        this.sync_buf.truncate(start);
 
-                                        let mut held_chunks = VecDeque::new();
-                                        for chunk in chunks_iter {
-                                            if let StreamChunk::Sync(ready) =
-                                                chunk
-                                            {
-                                                buf.push_str(&ready);
-                                            } else {
-                                                held_chunks.push_front(chunk);
-                                            }
+                                        let mut chunks = chunks;
+                                        while let Some(StreamChunk::Sync(s)) =
+                                            chunks.front()
+                                        {
+                                            this.sync_buf.push_str(s);
+                                            chunks.pop_front();
                                         }
-                                        buf.push_str(after);
-                                        this.sync_buf = buf;
-                                        for chunk in held_chunks {
-                                            this.chunks.push_front(chunk);
+
+                                        if !chunks.is_empty() {
+                                            if !after.is_empty() {
+                                                chunks.push_back(
+                                                    StreamChunk::Sync(after),
+                                                );
+                                            }
+                                            for chunk in
+                                                chunks.into_iter().rev()
+                                            {
+                                                this.chunks.push_front(chunk);
+                                            }
+                                        } else {
+                                            this.sync_buf.push_str(&after);
                                         }
                                     } else {
                                         OooChunk::push_start(
                                             &id,
                                             &mut this.sync_buf,
                                         );
-                                        for chunk in chunks.into_iter().rev() {
-                                            if let StreamChunk::Sync(ready) =
-                                                chunk
+                                        let mut chunks = chunks;
+                                        while let Some(StreamChunk::Sync(s)) =
+                                            chunks.front()
+                                        {
+                                            this.sync_buf.push_str(s);
+                                            chunks.pop_front();
+                                        }
+
+                                        if !chunks.is_empty() {
+                                            let mut end_buf = String::new();
+                                            OooChunk::push_end_with_nonce(
+                                                replace,
+                                                &id,
+                                                &mut end_buf,
+                                                nonce.as_deref(),
+                                            );
+                                            chunks.push_back(
+                                                StreamChunk::Sync(end_buf),
+                                            );
+                                            for chunk in
+                                                chunks.into_iter().rev()
                                             {
-                                                this.sync_buf.push_str(&ready);
-                                            } else {
                                                 this.chunks.push_front(chunk);
                                             }
+                                        } else {
+                                            OooChunk::push_end_with_nonce(
+                                                replace,
+                                                &id,
+                                                &mut this.sync_buf,
+                                                nonce.as_deref(),
+                                            );
                                         }
-                                        OooChunk::push_end_with_nonce(
-                                            replace,
-                                            &id,
-                                            &mut this.sync_buf,
-                                            nonce.as_deref(),
-                                        );
                                     }
                                 }
                                 Poll::Pending => {

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -386,7 +386,8 @@ impl Stream for StreamBuilder {
                         }
                     } else {
                         // check if *any* pending out-of-order chunk is ready
-                        for mut chunk in mem::take(&mut this.pending_ooo) {
+                        let mut ooo = mem::take(&mut this.pending_ooo);
+                        while let Some(mut chunk) = ooo.pop_front() {
                             match chunk.as_mut().poll(cx) {
                                 Poll::Ready(OooChunk {
                                     id,
@@ -428,6 +429,19 @@ impl Stream for StreamBuilder {
                                             {
                                                 this.chunks.push_front(chunk);
                                             }
+                                            // we just split the sync_buf and moved the remainder
+                                            // into this.chunks. as such, any subsequent OOO chunks
+                                            // will not be able to find their placeholders.
+                                            // we stop here and let the next poll_next call
+                                            // handle them
+                                            this.pending_ooo.extend(ooo);
+                                            let sync =
+                                                mem::take(&mut this.sync_buf);
+                                            return if sync.is_empty() {
+                                                self.poll_next(cx)
+                                            } else {
+                                                Poll::Ready(Some(sync))
+                                            };
                                         } else {
                                             this.sync_buf.push_str(&after);
                                         }
@@ -475,6 +489,7 @@ impl Stream for StreamBuilder {
                                 }
                             }
                         }
+                        this.pending_ooo.extend(ooo);
 
                         if this.sync_buf.is_empty() {
                             if this.chunks.is_empty() {
@@ -790,5 +805,61 @@ mod tests {
 
         assert_eq!(stream.next().await.as_deref(), Some("done"));
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn multiple_ooo_with_async_subchunks() {
+        let mut stream = StreamBuilder {
+            sync_buf: "<!--s-1-o--><!--s-1-c--><!--s-2-o--><!--s-2-c-->"
+                .to_string(),
+            chunks: VecDeque::new(),
+            pending: None,
+            pending_ooo: VecDeque::new(),
+            id: None,
+        };
+
+        // OOO chunk 1: resolves to an async chunk
+        stream.pending_ooo.push_back(Box::pin(async {
+            OooChunk {
+                id: "1-".to_string(),
+                chunks: VecDeque::from([StreamChunk::Async {
+                    chunks: Box::pin(async {
+                        VecDeque::from([StreamChunk::Sync("done1".to_string())])
+                    }),
+                }]),
+                replace: false,
+                nonce: None,
+            }
+        }));
+
+        // OOO chunk 2: resolves to sync content
+        stream.pending_ooo.push_back(Box::pin(async {
+            OooChunk {
+                id: "2-".to_string(),
+                chunks: VecDeque::from([StreamChunk::Sync(
+                    "done2".to_string(),
+                )]),
+                replace: false,
+                nonce: None,
+            }
+        }));
+
+        let mut results = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            results.push(chunk);
+        }
+
+        let combined = results.join("");
+        println!("Combined output: {}", combined);
+
+        // If it works correctly, we should NOT see the <template>/<script> fallback for "2-"
+        // because it should have been found and replaced in sync_buf.
+        // The fallback contains "document.createTreeWalker"
+        assert!(
+            !combined.contains("document.createTreeWalker"),
+            "Should not contain fallback script when placeholder is present"
+        );
+        assert!(combined.contains("done1"));
+        assert!(combined.contains("done2"));
     }
 }

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -477,7 +477,11 @@ impl Stream for StreamBuilder {
                         }
 
                         if this.sync_buf.is_empty() {
-                            Poll::Pending
+                            if this.chunks.is_empty() {
+                                Poll::Pending
+                            } else {
+                                self.poll_next(cx)
+                            }
                         } else {
                             Poll::Ready(Some(mem::take(&mut this.sync_buf)))
                         }


### PR DESCRIPTION
This PR contains several improvements across the Leptos stack:

SSR streaming OOO fix: Fixes a bug where processing an out-of-order chunk with async sub-chunks would corrupt sync_buf, causing subsequent OOO chunks to miss their placeholders and fall back to expensive client-side DOM manipulation scripts.

html_len accuracy: Fixes off-by-one errors in html_len() for attributes, classes, and styles. Adds missing html_len() implementations throughout the IntoStyle/IntoStyleValue traits and implementors. Fixes primitive attribute html_len from always returning 0.

Dedicated char AttributeValue impl: Replaces the macro-generated impl with a hand-written one that avoids to_string() allocation.

Router unescape fix: Url::unescape now preserves invalid percent-encoded sequences (e.g. %FF) instead of using lossy UTF-8 decoding with replacement characters.

Test improvements: Adds unit tests for the streaming, style, attribute, and router changes. Cleans up existing router tests to use assert_eq!.