### PR TITLE
fix(autoreload): add reload_external_host to fix live-reload WebSocket in DevContainers

### DIFF
--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -26,14 +26,18 @@ pub fn AutoReload(
             Some(val) => val,
             None => options.reload_port,
         };
+        let reload_host = match options.reload_external_host {
+            Some(ref host) => format!("'{host}'"),
+            None => "null".to_string(),
+        };
         let protocol = match options.reload_ws_protocol {
             leptos_config::ReloadWSProtocol::WS => "'ws://'",
             leptos_config::ReloadWSProtocol::WSS => "'wss://'",
         };
 
         let script = format!(
-            "(function (reload_port, protocol) {{ {} {} }})({reload_port:?}, \
-             {protocol})",
+            "(function (reload_port, protocol, reload_host) {{ {} {} \
+             }})({reload_port:?}, {protocol}, {reload_host})",
             leptos_hot_reload::HOT_RELOAD_JS,
             include_str!("reload_script.js")
         );

--- a/leptos/src/hydration/reload_script.js
+++ b/leptos/src/hydration/reload_script.js
@@ -2,7 +2,7 @@ if (window.location.protocol === "https:") {
 	protocol = "wss://";
 }
 
-let host = window.location.hostname;
+let host = reload_host || window.location.hostname;
 
 function connect() {
 	let ws = new WebSocket(`${protocol}${host}:${reload_port}/live_reload`);

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -80,6 +80,13 @@ pub struct LeptosOptions {
     #[builder(default)]
     #[serde(default)]
     pub reload_external_port: Option<u32>,
+    /// The hostname the Websocket watcher connects to on the client, e.g.,
+    /// when running inside a container and accessing from the host machine.
+    ///
+    /// Defaults to `window.location.hostname`.
+    #[builder(default)]
+    #[serde(default)]
+    pub reload_external_host: Option<String>,
     /// The protocol the Websocket watcher uses on the client: `ws` in most cases, `wss` when behind
     /// a reverse https proxy.
     ///
@@ -227,6 +234,9 @@ impl LeptosOptions {
                 Some(val) => Some(val.parse()?),
                 None => None,
             },
+            reload_external_host: env_wo_default(
+                "LEPTOS_RELOAD_EXTERNAL_HOST",
+            )?,
             reload_ws_protocol: ws_from_str(
                 env_w_default("LEPTOS_RELOAD_WS_PROTOCOL", "ws")?.as_str(),
             )?,


### PR DESCRIPTION
Closes #4638

## Problem

When running a `cargo-leptos` dev server inside a DevContainer (or any container) and accessing it from a host machine browser, the `<AutoReload>` component's live-reload WebSocket fails repeatedly:

```
WebSocket connection to 'ws://localhost:3001/live_reload' failed: Connection closed before receiving a handshake response
Live-reload disconnected. Reconnecting...
```

The root cause is in `reload_script.js`:
```js
let host = window.location.hostname;
```

`window.location.hostname` reflects the browser's perspective, `localhost` on the host machine, not the container's forwarded address, so the WebSocket can never connect.

## Solution

Adds `reload_external_host: Option<String>` to `LeptosOptions`, following the same pattern as the existing `reload_external_port`. When set, it overrides `window.location.hostname` as the WebSocket target. When unset (the default), behaviour is unchanged.

**Changes:**
- `leptos_config/src/lib.rs`: new `reload_external_host: Option<String>` field + `LEPTOS_RELOAD_EXTERNAL_HOST` env var support
- `leptos/src/hydration/reload_script.js`: `let host = reload_host || window.location.hostname`
- `leptos/src/hydration/mod.rs`: passes `reload_host` as a third IIFE argument

## Usage

For a DevContainer setup, set in `.env` or `Cargo.toml`:
```
LEPTOS_RELOAD_EXTERNAL_HOST=<forwarded-hostname>
```

Or configure directly:
```rust
LeptosOptions::builder()
    .output_name("my_app")
    .reload_external_host(Some("my-container-host".to_string()))
    .build()
```