### PR TITLE
fix: dynamically delegate add_any_attr in AnyView

### DIFF
--- a/leptos/tests/issue_4676.rs
+++ b/leptos/tests/issue_4676.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "ssr")]
+use leptos::attribute_interceptor::AttributeInterceptor;
+#[cfg(feature = "ssr")]
+use leptos::prelude::*;
+
+#[cfg(feature = "ssr")]
+#[component]
+pub fn Child() -> impl IntoView {
+    view! {
+        <AttributeInterceptor let:attrs>
+            <div id="wrapper">
+                <div id="inner" {..attrs} />
+            </div>
+        </AttributeInterceptor>
+    }
+}
+
+#[cfg(feature = "ssr")]
+#[component]
+pub fn Parent() -> impl IntoView {
+    let spread_onto_component = view! {
+        <{..} aria-label="a component with attribute spreading"/>
+    };
+
+    view! {
+        <Child {..spread_onto_component} />
+    }
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn test_attribute_interceptor_erased() {
+    // Test the output html
+    let html = Parent().into_view().to_html();
+
+    assert!(html.contains(
+        "<div id=\"inner\" aria-label=\"a component with attribute \
+         spreading\"></div>"
+    ));
+}

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -77,6 +77,12 @@ pub struct AnyView {
         &Cursor,
         &PositionState,
     ) -> Pin<Box<dyn Future<Output = AnyViewState>>>,
+    // Only needed under erase_components: without it, AddAnyAttr for AnyView
+    // falls back to AnyViewWithAttrs (wrapping), which avoids the recursive
+    // monomorphization chain that T -> T::Output<AnyAttribute> -> ... would
+    // otherwise create. Under erase_components, all NextAttribute::Output
+    // converge to Vec<AnyAttribute>, so the chain terminates in ≤2 steps.
+    #[cfg(erase_components)]
     add_any_attr: fn(Erased, AnyAttribute) -> AnyView,
 }
 
@@ -351,6 +357,7 @@ where
             value.into_inner::<T>().rebuild(state);
         }
 
+        #[cfg(erase_components)]
         fn add_any_attr<T: RenderHtml + 'static>(
             value: Erased,
             attr: AnyAttribute,
@@ -379,6 +386,7 @@ where
             hydrate_from_server: hydrate_from_server::<T::Owned>,
             #[cfg(feature = "hydrate")]
             hydrate_async: hydrate_async::<T::Owned>,
+            #[cfg(erase_components)]
             add_any_attr: add_any_attr::<T::Owned>,
             value: Erased::new(value),
         }
@@ -409,10 +417,13 @@ impl Render for AnyView {
     }
 }
 
+// Under erase_components, the vtable delegates add_any_attr to the inner type.
+// This is safe because erase_components makes all NextAttribute::Output converge
+// to Vec<AnyAttribute> (a fixed point), so the monomorphization chain terminates.
+#[cfg(erase_components)]
 impl AddAnyAttr for AnyView {
     type Output<SomeNewAttr: Attribute> = AnyView;
 
-    #[allow(unused_variables)]
     fn add_any_attr<NewAttr: Attribute>(
         self,
         attr: NewAttr,
@@ -424,6 +435,27 @@ impl AddAnyAttr for AnyView {
             self.value,
             attr.into_cloneable_owned().into_any_attr(),
         )
+    }
+}
+
+// Without erase_components, wrap in AnyViewWithAttrs (attrs applied externally).
+// Delegating through the vtable here would cause an unbounded T -> T::Output<AnyAttribute>
+// monomorphization chain, since attribute tuple types grow on each step.
+#[cfg(not(erase_components))]
+impl AddAnyAttr for AnyView {
+    type Output<SomeNewAttr: Attribute> = AnyViewWithAttrs;
+
+    fn add_any_attr<NewAttr: Attribute>(
+        self,
+        attr: NewAttr,
+    ) -> Self::Output<NewAttr>
+    where
+        Self::Output<NewAttr>: RenderHtml,
+    {
+        AnyViewWithAttrs {
+            view: self,
+            attrs: vec![attr.into_cloneable_owned().into_any_attr()],
+        }
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -77,6 +77,7 @@ pub struct AnyView {
         &Cursor,
         &PositionState,
     ) -> Pin<Box<dyn Future<Output = AnyViewState>>>,
+    add_any_attr: fn(Erased, AnyAttribute) -> AnyView,
 }
 
 impl AnyView {
@@ -350,6 +351,13 @@ where
             value.into_inner::<T>().rebuild(state);
         }
 
+        fn add_any_attr<T: RenderHtml + 'static>(
+            value: Erased,
+            attr: AnyAttribute,
+        ) -> AnyView {
+            value.into_inner::<T>().add_any_attr(attr).into_any()
+        }
+
         let value = self.into_owned();
         AnyView {
             type_id: TypeId::of::<T::Owned>(),
@@ -371,6 +379,7 @@ where
             hydrate_from_server: hydrate_from_server::<T::Owned>,
             #[cfg(feature = "hydrate")]
             hydrate_async: hydrate_async::<T::Owned>,
+            add_any_attr: add_any_attr::<T::Owned>,
             value: Erased::new(value),
         }
     }
@@ -401,7 +410,7 @@ impl Render for AnyView {
 }
 
 impl AddAnyAttr for AnyView {
-    type Output<SomeNewAttr: Attribute> = AnyViewWithAttrs;
+    type Output<SomeNewAttr: Attribute> = AnyView;
 
     #[allow(unused_variables)]
     fn add_any_attr<NewAttr: Attribute>(
@@ -411,10 +420,10 @@ impl AddAnyAttr for AnyView {
     where
         Self::Output<NewAttr>: RenderHtml,
     {
-        AnyViewWithAttrs {
-            view: self,
-            attrs: vec![attr.into_cloneable_owned().into_any_attr()],
-        }
+        (self.add_any_attr)(
+            self.value,
+            attr.into_cloneable_owned().into_any_attr(),
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #4676

### Description
When `erase_components` is enabled, components are wrapped in `AnyView`. Previously, spreading attributes onto an `AnyView` would just wrap it in an `AnyViewWithAttrs` instead of delegating to the inner component's `AddAnyAttr` implementation. This caused components like `AttributeInterceptor` to fail to intercept attributes, applying them to the top-level element instead.

This fix adds an `add_any_attr` function pointer to `AnyView`'s vtable, allowing it to correctly delegate attribute spreading to the underlying erased view.

### Changes
- Added `add_any_attr` fn pointer to `AnyView`.
- Implemented `add_any_attr` passing for `T: RenderHtml + 'static` in `IntoAny`.
- Changed `AddAnyAttr` implementation for `AnyView` to delegate the logic to the inner erased value.
- Added a test case `test_attribute_interceptor_erased` that is verified to pass with and without `erase_components` flag.