### PR TITLE
Add support for native rendering out of tree (DO NOT MERGE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +623,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "cairo-rs"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c28280c6b12055b5e39e4554271ae4e6630b27c0da9148c4cf6485fc6d245c"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -722,6 +754,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "cocoa_dom"
+version = "0.1.0"
+dependencies = [
+ "any_spawner",
+ "dispatch2",
+ "futures",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "send_wrapper",
+ "taffy",
 ]
 
 [[package]]
@@ -1104,6 +1151,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1274,16 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1363,6 +1432,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk-pixbuf"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debb0d39e3cdd84626edfd54d6e4a6ba2da9a0ef2e796e691c4e9f8646fda00c"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd95ad50b9a3d2551e25dd4f6892aff0b772fe5372d84514e9d0583af60a0ce7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk4"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756564212bbe4a4ce05d88ffbd2582581ac6003832d0d32822d0825cca84bfbf"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk4-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e5b3ccf591826a4adcc83f5f57b4e59d1925cb4bf620b0d645f79498b034"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "generational-box"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1549,23 @@ dependencies = [
  "wasip2",
  "wasip3",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gio"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ff48bf600c68b476e61dc6b7c762f2f4eb91deef66583ba8bb815c30b5811a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
 ]
 
 [[package]]
@@ -1537,6 +1680,129 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "graphene-rs"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2730030ac9db663fd8bfe1e7093742c1cafb92db9c315c9417c29032341fe2f9"
+dependencies = [
+ "glib",
+ "graphene-sys",
+ "libc",
+]
+
+[[package]]
+name = "graphene-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915e32091ea9ad241e4b044af62b7351c2d68aeb24f489a0d7f37a0fc484fd93"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
+name = "grid"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
+
+[[package]]
+name = "gsk4"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e755de9d8c5896c5beaa028b89e1969d067f1b9bf1511384ede971f5983aa153"
+dependencies = [
+ "cairo-rs",
+ "gdk4",
+ "glib",
+ "graphene-rs",
+ "gsk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce91472391146f482065f1041876d8f869057b195b95399414caa163d72f4f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk4-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk4"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb21d53cfc6f7bfaf43549731c43b67ca47d87348d81c8cfc4dcdd44828e1a4"
+dependencies = [
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "graphene-rs",
+ "gsk4",
+ "gtk4-macros",
+ "gtk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ccfb5a14a3d941244815d5f8101fa12d4577b59cc47245778d8d907b0003e42"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842577fe5a1ee15d166cd3afe804ce0cab6173bc789ca32e21308834f20088dd"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "gsk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk_dom"
+version = "0.1.0"
+dependencies = [
+ "any_spawner",
+ "gio",
+ "glib",
+ "gtk4",
+ "send_wrapper",
 ]
 
 [[package]]
@@ -1937,6 +2203,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ios_dom"
+version = "0.1.0"
+dependencies = [
+ "any_spawner",
+ "dispatch2",
+ "futures",
+ "objc2",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-ui-kit",
+ "send_wrapper",
+ "taffy",
 ]
 
 [[package]]
@@ -2427,6 +2708,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2863,216 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.1"
 dependencies = [
@@ -2602,6 +3102,30 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 [[package]]
 name = "or_poisoned"
 version = "0.1.0"
+
+[[package]]
+name = "pango"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1d85e2078077a065bb7fc072783d5bcd4e51b379f22d67107d0a16937eb69"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f06627d36ed5ff303d2df65211fc2e52ba5b17bf18dd80ff3d9628d6e06cfd"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "parking"
@@ -3906,13 +4430,16 @@ version = "0.2.15"
 dependencies = [
  "any_spawner",
  "async-trait",
+ "cocoa_dom",
  "const_str_slice_concat",
  "drain_filter_polyfill",
  "either_of",
  "erased",
  "futures",
+ "gtk_dom",
  "html-escape",
  "indexmap",
+ "ios_dom",
  "itertools",
  "js-sys",
  "next_tuple",
@@ -3935,6 +4462,18 @@ dependencies = [
  "tracing",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "taffy"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aea22054047c16c3f34d3ac473a2170be1424b1115b2a3adcf28cfb067c88859"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ either_of = { path = "./either_of/", version = "0.1.9" }
 hydration_context = { path = "./hydration_context", version = "0.3.0" }
 leptos = { path = "./leptos", version = "0.8.19" }
 leptos_config = { path = "./leptos_config", version = "0.8.10" }
-leptos_dom = { path = "./leptos_dom", version = "0.8.8" }
+leptos_dom = { path = "./leptos_dom", version = "0.8.8", default-features = false }
 leptos_hot_reload = { path = "./leptos_hot_reload", version = "0.8.6" }
 leptos_integration_utils = { path = "./integrations/utils", version = "0.8.8" }
 leptos_macro = { path = "./leptos_macro", version = "0.8.16" }
 leptos_router = { path = "./router", version = "0.8.12" }
 leptos_router_macro = { path = "./router_macro", version = "0.8.6" }
-leptos_server = { path = "./leptos_server", version = "0.8.7" }
+leptos_server = { path = "./leptos_server", version = "0.8.7", default-features = false }
 leptos_meta = { path = "./meta", version = "0.8.6" }
 next_tuple = { path = "./next_tuple", version = "0.1.0" }
 oco_ref = { path = "./oco", version = "0.2.1" }
@@ -68,7 +68,7 @@ reactive_stores_macro = { path = "./reactive_stores_macro", version = "0.4.2" }
 server_fn = { path = "./server_fn", version = "0.8.12" }
 server_fn_macro = { path = "./server_fn_macro", version = "0.8.10" }
 server_fn_macro_default = { path = "./server_fn/server_fn_macro_default", version = "0.8.5" }
-tachys = { path = "./tachys", version = "0.2.15" }
+tachys = { path = "./tachys", version = "0.2.15", default-features = false }
 
 # members deps
 async-once-cell = { default-features = false, version = "0.5" }

--- a/leptos/Cargo.toml
+++ b/leptos/Cargo.toml
@@ -20,10 +20,10 @@ base64 = { optional = true, workspace = true, default-features = true }
 cfg-if = { workspace = true, default-features = true }
 hydration_context = { workspace = true }
 either_of = { workspace = true }
-leptos_dom = { workspace = true }
+leptos_dom = { workspace = true, default-features = false }
 leptos_hot_reload = { workspace = true }
 leptos_macro = { workspace = true }
-leptos_server = { workspace = true, features = ["tachys"] }
+leptos_server = { workspace = true, default-features = false, features = ["tachys"] }
 leptos_config = { workspace = true }
 leptos-spin-macro = { optional = true, workspace = true, default-features = true }
 oco_ref = { workspace = true }
@@ -35,7 +35,7 @@ rand = { optional = true, workspace = true, default-features = true }
 getrandom = { optional = true, workspace = true, default-features = true }
 reactive_graph = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true, default-features = true }
-tachys = { workspace = true, features = [
+tachys = { workspace = true, default-features = false, features = [
   "reactive_graph",
   "reactive_stores",
   "oco",
@@ -46,7 +46,7 @@ typed-builder = { workspace = true, default-features = true }
 typed-builder-macro = { workspace = true, default-features = true }
 serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
-server_fn = { workspace = true, features = ["form-redirects", "browser"] }
+server_fn = { workspace = true }
 web-sys = { features = [
   "ShadowRoot",
   "ShadowRootInit",
@@ -64,14 +64,30 @@ dioxus-cli-config = { workspace = true, default-features = true, optional = true
 dioxus-devtools = { workspace = true, default-features = true, optional = true }
 
 [features]
+default = []
+# `web` and `native-ui` are mutually exclusive — exactly one must be
+# enabled. The mutex is enforced by a compile_error! at the top of
+# `src/lib.rs`. csr/hydrate/ssr each implicitly activate `web`.
+# Neither is in `default` because Cargo unifies features across the
+# dep graph — defaults can leak through transitive deps and silently
+# violate the mutex. See ../tachys/Cargo.toml for the full rationale.
+web = ["tachys/web", "leptos_dom/web"]
 hydration = [
   "reactive_graph/hydration",
   "leptos_server/hydration",
   "hydration_context/browser",
   "leptos_dom/hydration",
 ]
-csr = ["leptos_macro/csr", "reactive_graph/effects", "getrandom?/wasm_js"]
+csr = [
+  "web",
+  "leptos_macro/csr",
+  "reactive_graph/effects",
+  "getrandom?/wasm_js",
+  "server_fn/browser",
+  "server_fn/form-redirects",
+]
 hydrate = [
+  "web",
   "leptos_macro/hydrate",
   "hydration",
   "tachys/hydrate",
@@ -81,6 +97,7 @@ hydrate = [
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]
 ssr = [
+  "web",
   "leptos_macro/ssr",
   "leptos_server/ssr",
   "server_fn/ssr",
@@ -113,6 +130,21 @@ trace-component-props = [
 ]
 delegation = ["tachys/delegation"]
 islands-router = ["tachys/mark_branches"]
+# Native UI builds: do `leptos = { default-features = false }`. By
+# default leptos exposes everything a native renderer needs (Render,
+# Mountable, IntoView, signals, components, the prelude — minus the
+# web-only `view!` macro and the DOM/SSR helpers). The renderer is
+# plugged in by depending on a glue crate (`leptos_cocoa`,
+# `leptos_ios`, `leptos_gtk`) which brings its own `view!` and the
+# corresponding element/event/bind builders.
+#
+# `reactive_graph/effects` is needed for reactive UI updates on any
+# target. Web builds activate it via `csr` / `hydrate`. Native
+# builds — depend on `reactive_graph = { features = ["effects"] }`
+# directly (the glue crates already do).
+# Passthrough for `tachys`'s `block_layout` feature — enables the
+# `<block>` tag/builder. Off by default to keep binary size down.
+block_layout = ["tachys/block_layout"]
 subsecond = [
   "reactive_graph/subsecond",
   "dep:subsecond",
@@ -143,6 +175,12 @@ rustc_version = { workspace = true, default-features = true }
 # downstream usage should never manually enable this feature.
 [target.'cfg(erase_components)'.dependencies]
 leptos_macro = { workspace = true, features = ["__internal_erase_components"] }
+
+# Native renderer crates (`cocoa_dom`, `ios_dom`, `gtk_dom`) used to
+# be optional deps here, activated by the now-removed `native-ui`
+# feature. They've moved out: native builds depend on the
+# corresponding glue crate (`leptos_cocoa`/`leptos_ios`/`leptos_gtk`),
+# which pulls them in directly.
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/leptos/build.rs
+++ b/leptos/build.rs
@@ -3,6 +3,8 @@ use rustc_version::{version_meta, Channel};
 fn main() {
     let target = std::env::var("TARGET").unwrap_or_default();
 
+    println!("cargo:rustc-check-cfg=cfg(rustc_nightly)");
+
     // Set cfg flags depending on release channel
     if matches!(version_meta().unwrap().channel, Channel::Nightly) {
         println!("cargo:rustc-cfg=rustc_nightly");

--- a/leptos/src/animated_show.rs
+++ b/leptos/src/animated_show.rs
@@ -1,7 +1,6 @@
 use crate::{children::ChildrenFn, component, control_flow::Show, IntoView};
 use core::time::Duration;
 use leptos_dom::helpers::TimeoutHandle;
-use leptos_macro::view;
 use reactive_graph::{
     effect::RenderEffect,
     owner::{on_cleanup, StoredValue},

--- a/leptos/src/await_.rs
+++ b/leptos/src/await_.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::Suspend, suspense_component::Suspense, IntoView};
-use leptos_macro::{component, view};
+use leptos_macro::component;
 use leptos_server::ArcOnceResource;
 use reactive_graph::prelude::ReadUntracked;
 use serde::{de::DeserializeOwned, Serialize};

--- a/leptos/src/form.rs
+++ b/leptos/src/form.rs
@@ -148,7 +148,7 @@ where
     }
 }
 
-/// Automatically turns a server [MultiAction](MultiAction) into an HTML
+/// Automatically turns a server [MultiAction](leptos_server::MultiAction) into an HTML
 /// [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
 /// progressively enhanced to use client-side routing.
 #[component]

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{prelude::*, WasmSplitManifest};
 use leptos_config::LeptosOptions;
-use leptos_macro::{component, view};
+use leptos_macro::component;
 use std::{path::PathBuf, sync::OnceLock};
 
 /// Inserts auto-reloading code used in `cargo-leptos`.

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -52,6 +52,19 @@ impl<T> View<T> {
 }
 
 /// A trait that is implemented for types that can be rendered.
+///
+/// **Note (refactor-in-progress):** the upstream-target end state is
+/// to drop the `RenderHtml` bound on native targets (no SSR or
+/// hydration there). That work is parked because `IntoView`,
+/// `RenderHtml`, `AsyncOutput`, and `AddAnyAttr` are tightly coupled
+/// across `children.rs`, `attribute_interceptor.rs`,
+/// `suspense_component.rs`, and `nonce.rs` — splitting the trait
+/// also requires cfg-gating those generic bounds, which is a Phase 5
+/// concern (when the per-OS builders move out and the relevant trait
+/// surface stops being native-reachable). For now native builds keep
+/// satisfying the `RenderHtml` bound via the no-op impls in
+/// `tachys::{cocoa,gtk,ios}::render_html_stub` and
+/// `impl_typed_attrs_for!`.
 pub trait IntoView
 where
     Self: Sized + Render + RenderHtml + Send,

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -155,6 +155,64 @@
 
 extern crate self as leptos;
 
+/// The renderer-toolkit namespace the `view!{}` macro routes through
+/// on web. The `view!` `macro_rules!` defined just below pre-supplies
+/// this path to `leptos_macro::raw_view!`, which aliases it as
+/// `__leptos_view` inside the generated block. Users don't import
+/// from this module — `view! { ... }` "just works" once `leptos` is
+/// in scope.
+///
+/// Native renderers (`leptos_cocoa`, `leptos_ios`, `leptos_gtk`)
+/// expose their own `__view_namespace` of the same shape and ship
+/// their own `view!` wrapper. See `ARCHITECTURE.md` in the
+/// leptos-native repo for the contract.
+#[cfg(feature = "web")]
+#[doc(hidden)]
+#[allow(non_camel_case_types, missing_docs)]
+pub mod __view_namespace {
+    pub mod elements {
+        pub use ::tachys::html::doctype;
+        pub use ::tachys::html::element::*;
+        pub use ::tachys::html::InertElement;
+    }
+    pub mod svg {
+        pub use ::tachys::svg::*;
+    }
+    pub mod mathml {
+        pub use ::tachys::mathml::*;
+    }
+    pub mod events {
+        pub use ::tachys::html::event::*;
+    }
+    pub mod attrs {
+        pub use ::tachys::html::attribute::custom::custom_attribute;
+        pub use ::tachys::html::attribute::*;
+        pub use ::tachys::html::class::class;
+        pub use ::tachys::html::directive::directive;
+        pub use ::tachys::html::node_ref::node_ref;
+        pub use ::tachys::html::property::prop;
+        pub use ::tachys::html::style::style;
+    }
+    pub mod bind {
+        pub use ::tachys::html::attribute::*;
+        pub use ::tachys::reactive_graph::bind::Group;
+    }
+}
+
+/// The web `view!{}` macro.
+/// Wraps `leptos_macro::raw_view!` with the web renderer namespace
+/// pre-supplied, so existing code keeps working unchanged.
+///
+/// On native targets, use the equivalent `view!` exported by your
+/// renderer crate (`leptos_cocoa::view!`, etc.).
+#[cfg(feature = "web")]
+#[macro_export]
+macro_rules! view {
+    ($($t:tt)*) => {
+        $crate::raw_view!($crate::__view_namespace, $($t)*)
+    };
+}
+
 /// Exports all the core types of the library.
 pub mod prelude {
     // Traits
@@ -168,14 +226,36 @@ pub mod prelude {
     mod export_types {
         #[cfg(feature = "nonce")]
         pub use crate::nonce::*;
+
+        // Modules available on every target.
         pub use crate::{
             callback::*, children::*, component::*, control_flow::*, error::*,
-            form::*, hydration::*, into_view::*, mount::*, suspense::*,
-            text_prop::*,
+            into_view::*, suspense::*, text_prop::*,
         };
+
+        // Web-only modules. These either import web-sys types directly
+        // or pull in tachys submodules that are cfg'd-out on macOS.
+        // The macOS port provides Cocoa-flavoured equivalents elsewhere.
+        #[cfg(feature = "web")]
+        pub use crate::{form::*, hydration::*, mount::*};
+
+        // The native mount entry points + NodeRef / Storage / set_interval /
+        // Color analogues moved out to per-renderer glue crates in
+        // Phase 5. Native users do
+        // `use leptos_cocoa::*;` (macOS), `use leptos_ios::*;` (iOS),
+        // or `use leptos_gtk::*;` (Linux) for the corresponding API.
+
         pub use leptos_config::*;
+        #[cfg(feature = "web")]
         pub use leptos_dom::helpers::*;
         pub use leptos_macro::*;
+        // The web `view!` `macro_rules!` lives at the leptos crate
+        // root (macro namespace, via #[macro_export]). Re-export it
+        // through the prelude so `use leptos::prelude::*` brings it
+        // into scope alongside `raw_view!`. Web-only — native users
+        // get their `view!` from `leptos_<backend>::prelude::*`.
+        #[cfg(feature = "web")]
+        pub use crate::view;
         pub use leptos_server::*;
         pub use oco_ref::*;
         pub use reactive_graph::{
@@ -191,15 +271,28 @@ pub mod prelude {
             self,
             error::{FromServerFnError, ServerFnError, ServerFnErrorErr},
         };
-        pub use tachys::{
-            reactive_graph::{bind::BindAttribute, node_ref::*, Suspend},
-            view::{fragment::Fragment, template::ViewTemplate},
+        // tachys::reactive_graph::{bind, node_ref} are cfg'd-out on
+        // native targets; only re-export them on the web target.
+        #[cfg(feature = "web")]
+        pub use tachys::reactive_graph::{
+            bind::BindAttribute, node_ref::*,
+        };
+        pub use tachys::reactive_graph::Suspend;
+        // The web `view!` `macro_rules!` is defined at the crate root
+        // (with `#[macro_export]`) so users get it via the
+        // `pub use leptos_macro::*` glob below — it lives in the same
+        // macro namespace.
+        pub use tachys::view::{
+            fragment::Fragment, template::ViewTemplate,
         };
     }
     pub use export_types::*;
 }
 
 /// Components used for working with HTML forms, like `<ActionForm>`.
+/// Web-only — AppKit form controls are wired through the Cocoa
+/// element module instead.
+#[cfg(feature = "web")]
 pub mod form;
 
 /// A standard way to wrap functions and closures to pass them to components.
@@ -224,20 +317,34 @@ pub mod error {
 
 /// Control-flow components like `<Show>`, `<For>`, and `<Await>`.
 pub mod control_flow {
-    pub use crate::{
-        animated_show::*, await_::*, for_loop::*, show::*, show_let::*,
-    };
+    #[cfg(feature = "web")]
+    pub use crate::animated_show::*;
+    #[cfg(feature = "web")]
+    pub use crate::await_::*;
+    pub use crate::{for_loop::*, show::*, show_let::*};
 }
+// `animated_show` uses leptos_dom::helpers::set_timeout_with_handle
+// which is web-only.
+#[cfg(feature = "web")]
 mod animated_show;
+// `<Await>` ships a `view!{<Suspense>...</Suspense>}` invocation,
+// which depends on `leptos::view!` being defined. The wrapper macro
+// is web-only (native users get their own from
+// `leptos_<backend>::view!`), so this module is web-only too.
+#[cfg(feature = "web")]
 mod await_;
 mod for_loop;
 mod show;
 mod show_let;
 
 /// A component that allows rendering a component somewhere else.
+/// Web-only — uses `leptos_dom::helpers::document()`.
+#[cfg(feature = "web")]
 pub mod portal;
 
-/// Components to enable server-side rendering and client-side hydration.
+/// Components to enable server-side rendering and client-side
+/// hydration. Web-only.
+#[cfg(feature = "web")]
 pub mod hydration;
 
 /// Utilities for exporting nonces to be used for a Content Security Policy.
@@ -270,7 +377,12 @@ mod provider;
 #[doc(inline)]
 pub use tachys;
 /// Tools to mount an application to the DOM, or to hydrate it from server-rendered HTML.
+#[cfg(feature = "web")]
 pub mod mount;
+// iOS and macOS mount entry points moved to the `leptos_ios` /
+// `leptos_cocoa` crates in Phase 5; users do `use leptos_ios::*;`
+// or `use leptos_cocoa::*;` for `run` / `mount_to_window`.
+// GTK mount entry point moved to the `leptos_gtk` crate in Phase 5.
 #[doc(inline)]
 pub use leptos_config as config;
 #[doc(inline)]
@@ -292,16 +404,27 @@ pub use leptos_server as server;
 /// HTML attribute types.
 #[doc(inline)]
 pub use tachys::html::attribute as attr;
-/// HTML element types.
+/// HTML element types. Web-only — on macOS the parallel Cocoa
+/// element builders live in `tachys::cocoa`; on Linux in
+/// `tachys::gtk`.
+#[cfg(feature = "web")]
 #[doc(inline)]
 pub use tachys::html::element as html;
+// Native element builders + their `view!` wrapper macros live in the
+// per-renderer glue crates: `leptos_cocoa` (macOS), `leptos_ios`
+// (iOS), `leptos_gtk` (Linux). Users `use leptos_<backend>::prelude::*;`
+// to get the right `view!`, element builders, mount entry points,
+// etc.
 /// HTML event types.
+#[cfg(feature = "web")]
 #[doc(no_inline)]
 pub use tachys::html::event as ev;
 /// MathML element types.
+#[cfg(feature = "web")]
 #[doc(inline)]
 pub use tachys::mathml as math;
 /// SVG element types.
+#[cfg(feature = "web")]
 #[doc(inline)]
 pub use tachys::svg;
 

--- a/leptos_dom/Cargo.toml
+++ b/leptos_dom/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dependencies]
-tachys = { workspace = true }
+tachys = { workspace = true, default-features = false }
 reactive_graph = { workspace = true }
 or_poisoned = { workspace = true }
 js-sys = { workspace = true, default-features = true }
@@ -29,6 +29,10 @@ default-features = true
 
 [features]
 default = []
+# Web build: gates the DOM helpers and `web_sys::console::*` paths.
+# Native builds disable this and depend on the appropriate glue
+# crate (`leptos_cocoa`, etc.) which provides the native renderer.
+web = ["tachys/web"]
 tracing = ["dep:tracing"]
 trace-component-props = ["dep:serde", "dep:serde_json"]
 hydration = ["reactive_graph/hydration"]

--- a/leptos_dom/src/lib.rs
+++ b/leptos_dom/src/lib.rs
@@ -3,8 +3,13 @@
 
 //! DOM helpers for Leptos.
 
+/// DOM helpers — web-only. The macOS port does not provide an
+/// equivalent module here; AppKit-flavoured app helpers live in
+/// `cocoa_dom::app` instead.
+#[cfg(feature = "web")]
 pub mod helpers;
 #[doc(hidden)]
+#[cfg(feature = "web")]
 pub mod macro_helpers;
 
 /// Utilities for simple isomorphic logging to the console or terminal.

--- a/leptos_dom/src/logging.rs
+++ b/leptos_dom/src/logging.rs
@@ -1,5 +1,6 @@
 //! Utilities for simple isomorphic logging to the console or terminal.
 
+#[cfg(feature = "web")]
 use wasm_bindgen::JsValue;
 
 /// Uses `println!()`-style formatting to log something to the console (in the browser)
@@ -76,6 +77,7 @@ pub fn console_log(s: &str) {
     if log_to_stdout() {
         println!("{s}");
     } else {
+        #[cfg(feature = "web")]
         web_sys::console::log_1(&JsValue::from_str(s));
     }
 }
@@ -86,6 +88,7 @@ pub fn console_warn(s: &str) {
     if log_to_stdout() {
         eprintln!("{s}");
     } else {
+        #[cfg(feature = "web")]
         web_sys::console::warn_1(&JsValue::from_str(s));
     }
 }
@@ -97,6 +100,7 @@ pub fn console_error(s: &str) {
     if log_to_stdout() {
         eprintln!("{s}");
     } else {
+        #[cfg(feature = "web")]
         web_sys::console::error_1(&JsValue::from_str(s));
     }
 }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -266,10 +266,28 @@ mod slot;
 ///     }
 /// }
 /// ```
+/// The pluggable form of [`view!`]. Same syntax, but takes a leading
+/// **namespace path** argument that selects the renderer toolkit:
+///
+/// ```text
+/// raw_view!(<namespace>, <view-body>)
+/// raw_view!(<namespace>, class = "scope-class", <view-body>)
+/// ```
+///
+/// `<namespace>` is a module path containing four submodules
+/// (`elements`, `events`, `attrs`, `bind`) — see the docs on
+/// `leptos::__view_namespace` and the per-renderer
+/// `leptos_<backend>::__view_namespace` for the contract.
+///
+/// Day-to-day, you don't call this directly. Each renderer crate
+/// (`leptos` for web, `leptos_cocoa` / `leptos_ios` / `leptos_gtk`
+/// for native) ships its own `view!` `macro_rules!` that wraps
+/// `raw_view!` with its own namespace pre-supplied. That way
+/// `view!{}` keeps its existing ergonomics across renderers.
 #[proc_macro_error2::proc_macro_error]
 #[proc_macro]
 #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
-pub fn view(tokens: TokenStream) -> TokenStream {
+pub fn raw_view(tokens: TokenStream) -> TokenStream {
     view_macro_impl(tokens, false)
 }
 
@@ -282,14 +300,60 @@ pub fn view(tokens: TokenStream) -> TokenStream {
 #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace", skip_all))]
 pub fn template(tokens: TokenStream) -> TokenStream {
     if cfg!(feature = "__internal_erase_components") {
-        view(tokens)
+        // The erase-components shortcut just goes through raw_view's
+        // path. Synthesize a namespace prefix pointing at the web
+        // renderer (this codepath is web-only).
+        let mut prefixed = TokenStream::from(quote! { ::leptos::__view_namespace , });
+        prefixed.extend(tokens);
+        raw_view(prefixed)
     } else {
-        view_macro_impl(tokens, true)
+        // template! is web-only — the macro emits SSR/hydrate-shaped
+        // template tags. Use the web namespace directly.
+        let namespace_tokens = quote! { ::leptos::__view_namespace };
+        let tokens: proc_macro2::TokenStream = tokens.into();
+        view_inner(tokens, namespace_tokens, true)
     }
 }
 
 fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
     let tokens: proc_macro2::TokenStream = tokens.into();
+    let mut iter = tokens.into_iter();
+
+    // The leading namespace path: every token up to the first
+    // top-level `,`. Selects the renderer toolkit module containing
+    // `elements`, `events`, `attrs`, `bind` submodules.
+    let mut namespace_tokens = proc_macro2::TokenStream::new();
+    let mut found_comma = false;
+    for tok in iter.by_ref() {
+        if let proc_macro2::TokenTree::Punct(p) = &tok {
+            if p.as_char() == ',' {
+                found_comma = true;
+                break;
+            }
+        }
+        namespace_tokens.extend(std::iter::once(tok));
+    }
+    if !found_comma || namespace_tokens.is_empty() {
+        proc_macro_error2::abort_call_site!(
+            "raw_view! requires a namespace path as its first argument";
+            help = "use the renderer's `view!` wrapper instead — e.g. `view! {{ ... }}` after `use leptos::prelude::*;` (web) or `use leptos_cocoa::prelude::*;` (native)"
+        );
+    }
+
+    let body: proc_macro2::TokenStream = iter.collect();
+    view_inner(body, namespace_tokens, template)
+}
+
+/// Shared implementation between `raw_view!` (parses namespace from
+/// the leading tokens) and `template!` (web-only, hardcoded
+/// namespace). The `namespace_tokens` is aliased to `__leptos_view`
+/// inside the generated block so the macro's emissions
+/// (which reference `__leptos_view::*`) resolve through it.
+fn view_inner(
+    tokens: proc_macro2::TokenStream,
+    namespace_tokens: proc_macro2::TokenStream,
+    template: bool,
+) -> TokenStream {
     let mut tokens = tokens.into_iter();
 
     let first = tokens.next();
@@ -337,10 +401,17 @@ fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
     // The allow lint needs to be put here instead of at the expansion of
     // view::attribute_value(). Adding this next to the expanded expression
     // seems to break rust-analyzer, but it works when the allow is put here.
+    //
+    // The `use ... as __leptos_view` aliases the user-supplied namespace
+    // path to the name the rest of the macro's emissions reference. This
+    // is the macro-pluggability seam — the per-renderer `view!` wrappers
+    // pre-supply their namespace; tachys/leptos stays renderer-agnostic.
     let output = quote! {
         {
             #[allow(unused_braces)]
             {
+                #[allow(unused_imports)]
+                use #namespace_tokens as __leptos_view;
                 #(#errors;)*
                 #nodes_output
             }
@@ -391,7 +462,11 @@ pub fn include_view(tokens: TokenStream) -> TokenStream {
         });
     let tokens = proc_macro2::TokenStream::from_str(&file)
         .unwrap_or_else(|e| abort!(Span::call_site(), e));
-    view(tokens.into())
+    // include_view! is web-only; synthesize a namespace prefix
+    // pointing at the web renderer so raw_view can do its work.
+    let mut prefixed = TokenStream::from(quote! { ::leptos::__view_namespace , });
+    prefixed.extend(TokenStream::from(tokens));
+    raw_view(prefixed)
 }
 
 /// Annotates a function so that it can be used with your template as a Leptos `<Component/>`.

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -399,7 +399,7 @@ fn inert_element_to_tokens(
     html.finish();
 
     quote! {
-        ::leptos::tachys::html::InertElement::new(#html)
+        __leptos_view::elements::InertElement::new(#html)
     }
 }
 
@@ -513,7 +513,7 @@ fn inert_svg_element_to_tokens(
     html.finish();
 
     quote! {
-        ::leptos::tachys::svg::InertElement::new(#html)
+        __leptos_view::elements::InertElement::new(#html)
     }
 }
 
@@ -688,7 +688,7 @@ fn node_to_tokens(
         Node::Comment(_) => None,
         Node::Doctype(node) => {
             let value = node.value.to_string_best();
-            Some(quote! { ::leptos::tachys::html::doctype(#value) })
+            Some(quote! { __leptos_view::elements::doctype(#value) })
         }
         Node::Fragment(fragment) => fragment_to_tokens(
             &mut fragment.children,
@@ -922,12 +922,20 @@ pub(crate) fn element_to_tokens(
         /* TODO restore this
         let mut ide_helper_close_tag = IdeTagHelper::new();
         let close_tag = node.close_tag.as_ref().map(|c| &c.name);*/
+        // Tag emission routes through the per-renderer
+        // `__leptos_view::elements` namespace. Users bring it in via
+        // `use leptos::view_prelude::*;` (web) or
+        // `use leptos_<backend>::view_prelude::*;` (native). The
+        // macro no longer hard-codes `tachys::html::element::*` /
+        // `tachys::svg::*` / `tachys::mathml::*` — every tag goes
+        // through one configurable path, so a renderer can opt out
+        // of SVG/MathML simply by not exposing those names.
         let is_custom = is_custom_element(&tag);
         let name = if is_custom {
             let name = node.name().to_string();
             // link custom ident to name span for IDE docs
             let custom = Ident::new("custom", name.span());
-            quote_spanned! { node.name().span() => ::leptos::tachys::html::element::#custom(#name) }
+            quote_spanned! { node.name().span() => __leptos_view::elements::#custom(#name) }
         } else if is_svg_element(&tag) {
             parent_type = TagType::Svg;
             let name = if tag == "use" || tag == "use_" {
@@ -935,33 +943,25 @@ pub(crate) fn element_to_tokens(
             } else {
                 name.to_token_stream()
             };
-            quote_spanned! { node.name().span() => ::leptos::tachys::svg::#name() }
+            quote_spanned! { node.name().span() => __leptos_view::elements::#name() }
         } else if is_math_ml_element(&tag) {
             parent_type = TagType::Math;
-            quote_spanned! { node.name().span() => ::leptos::tachys::mathml::#name() }
+            quote_spanned! { node.name().span() => __leptos_view::elements::#name() }
         } else if is_ambiguous_element(&tag) {
+            // Track parent context for downstream attribute/event
+            // dispatch, but the actual element constructor path is
+            // the same in every branch.
             match parent_type {
-                TagType::Unknown => {
-                    // We decided this warning was too aggressive, but I'll leave it here in case we want it later
-                    /* proc_macro_error2::emit_warning!(name.span(), "The view macro is assuming this is an HTML element, \
-                    but it is ambiguous; if it is an SVG or MathML element, prefix with svg:: or math::"); */
-                    quote_spanned! { node.name().span() =>
-                        ::leptos::tachys::html::element::#name()
-                    }
+                TagType::Unknown | TagType::Html => {
+                    quote_spanned! { node.name().span() => __leptos_view::elements::#name() }
                 }
-                TagType::Html => {
-                    quote_spanned! { node.name().span() => ::leptos::tachys::html::element::#name() }
-                }
-                TagType::Svg => {
-                    quote_spanned! { node.name().span() => ::leptos::tachys::svg::#name() }
-                }
-                TagType::Math => {
-                    quote_spanned! { node.name().span() => ::leptos::tachys::math::#name() }
+                TagType::Svg | TagType::Math => {
+                    quote_spanned! { node.name().span() => __leptos_view::elements::#name() }
                 }
             }
         } else {
             parent_type = TagType::Html;
-            quote_spanned! { name.span() => ::leptos::tachys::html::element::#name() }
+            quote_spanned! { name.span() => __leptos_view::elements::#name() }
         };
 
         /* TODO restore this
@@ -1195,7 +1195,7 @@ pub(crate) fn attribute_absolute(
                             let key_name = key.to_string();
                             if key_name == "class" || key_name == "style" {
                                 Some(
-                                    quote! { ::leptos::tachys::html::#key::#key(#value) },
+                                    quote! { __leptos_view::attrs::#key(#value) },
                                 )
                             } else if key_name == "aria" {
                                 let value = attribute_value(node, true);
@@ -1204,7 +1204,7 @@ pub(crate) fn attribute_absolute(
                                 let fn_name = parts_iter.map(|p| p.to_string()).collect::<Vec<String>>().join("_");
                                 let key = Ident::new(&fn_name, key.span());
                                 Some(
-                                    quote! { ::leptos::tachys::html::attribute::#key(#value) },
+                                    quote! { __leptos_view::attrs::#key(#value) },
                                 )
                             } else if multipart {
                                 // e.g., attr:data-foo="bar"
@@ -1213,11 +1213,11 @@ pub(crate) fn attribute_absolute(
                                     End(n) => n.to_string(),
                                 }).collect::<String>();
                                 Some(
-                                    quote! { ::leptos::tachys::html::attribute::custom::custom_attribute(#key_name, #value) },
+                                    quote! { __leptos_view::attrs::custom_attribute(#key_name, #value) },
                                 )
                             } else {
                                 Some(
-                                    quote! { ::leptos::tachys::html::attribute::#key(#value) },
+                                    quote! { __leptos_view::attrs::#key(#value) },
                                 )
                             }
                         } else if id == "use" {
@@ -1229,7 +1229,7 @@ pub(crate) fn attribute_absolute(
                             };
                             Some(
                                 quote! {
-                                    ::leptos::tachys::html::directive::directive(
+                                    __leptos_view::attrs::directive(
                                         #key,
                                         #[allow(clippy::useless_conversion)] #param
                                     )
@@ -1242,14 +1242,14 @@ pub(crate) fn attribute_absolute(
                                 .replacen("style:", "", 1)
                                 .replacen("class:", "", 1);
                             Some(
-                                quote! { ::leptos::tachys::html::#id::#id((#key, #value)) },
+                                quote! { __leptos_view::attrs::#id((#key, #value)) },
                             )
                         } else if id == "prop" {
                             let value = attribute_value(node, false);
                             let key = &node.key.to_string();
                             let key = key.replacen("prop:", "", 1);
                             Some(
-                                quote! { ::leptos::tachys::html::property::#id(#key, #value) },
+                                quote! { __leptos_view::attrs::prop(#key, #value) },
                             )
                         } else if id == "on" {
                             let key = &node.key.to_string();
@@ -1257,7 +1257,7 @@ pub(crate) fn attribute_absolute(
                             let (on, ty, handler) =
                                 event_type_and_handler(&key, node);
                             Some(
-                                quote! { ::leptos::tachys::html::event::#on(#ty, #handler) },
+                                quote! { __leptos_view::events::on(#ty, #handler) },
                             )
                         } else {
                             proc_macro_error2::abort!(
@@ -1281,22 +1281,22 @@ pub(crate) fn attribute_absolute(
             let name = &node.key.to_string();
             if name == "class" || name == "style" {
                 quote! {
-                    ::leptos::tachys::html::#key::#key(#value)
+                    __leptos_view::attrs::#key(#value)
                 }
             }
             else if name.contains('-') && !name.starts_with("aria-") {
                 quote! {
-                    ::leptos::tachys::html::attribute::custom::custom_attribute(#name, #value)
+                    __leptos_view::attrs::custom_attribute(#name, #value)
                 }
             }
             else if name == "node_ref" {
                 quote! {
-                    ::leptos::tachys::html::node_ref::#key(#value)
+                    __leptos_view::attrs::node_ref(#value)
                 }
             }
             else {
                 quote! {
-                    ::leptos::tachys::html::attribute::#key(#value)
+                    __leptos_view::attrs::#key(#value)
                 }
             }
         }),
@@ -1312,14 +1312,8 @@ pub(crate) fn two_way_binding_to_tokens(
     let ident =
         format_ident!("{}", name.to_case(UpperCamel), span = node.key.span());
 
-    if name == "group" {
-        quote! {
-            .bind(leptos::tachys::reactive_graph::bind::#ident, #value)
-        }
-    } else {
-        quote! {
-            .bind(::leptos::attr::#ident, #value)
-        }
+    quote! {
+        .bind(__leptos_view::bind::#ident, #value)
     }
 }
 
@@ -1382,7 +1376,7 @@ pub(crate) fn event_type_and_handler(
     };
 
     let event_type = quote! {
-        ::leptos::tachys::html::event::#event_type
+        __leptos_view::events::#event_type
     };
     let event_type = if options.captured {
         let capture = if let Some(capture) = capture_ident {
@@ -1390,7 +1384,7 @@ pub(crate) fn event_type_and_handler(
         } else {
             quote! { capture }
         };
-        quote! { ::leptos::tachys::html::event::#capture(#event_type) }
+        quote! { __leptos_view::events::#capture(#event_type) }
     } else {
         event_type
     };
@@ -1401,7 +1395,7 @@ pub(crate) fn event_type_and_handler(
         } else {
             quote! { undelegated }
         };
-        quote! { ::leptos::tachys::html::event::#undelegated(#event_type) }
+        quote! { __leptos_view::events::#undelegated(#event_type) }
     } else {
         event_type
     };

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -23,10 +23,57 @@ oco_ref = { workspace = true, optional = true }
 async-trait = { workspace = true, default-features = true }
 paste = { workspace = true, default-features = true }
 erased = { workspace = true, default-features = true }
-wasm-bindgen = { workspace = true, default-features = true }
 html-escape = { workspace = true, default-features = true }
-js-sys = { workspace = true, default-features = true }
-web-sys = { features = [
+drain_filter_polyfill = { workspace = true, default-features = true }
+indexmap = { workspace = true, default-features = true }
+rustc-hash = { workspace = true, default-features = true }
+futures = { workspace = true, default-features = true }
+itertools = { workspace = true, default-features = true }
+send_wrapper = { workspace = true, default-features = true }
+sledgehammer_bindgen = { features = [
+  "web",
+], optional = true, workspace = true, default-features = true }
+sledgehammer_utils = { optional = true, workspace = true, default-features = true }
+tracing = { optional = true, workspace = true, default-features = true }
+serde = { optional = true, workspace = true, default-features = true }
+serde_json = { optional = true, workspace = true, default-features = true }
+
+# macOS-native renderer (activated only when the `native-ui` feature
+# is on; otherwise the cocoa renderer modules in src/ are cfg'd out
+# and cocoa_dom isn't pulled into the build).
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa_dom = { path = "../../leptos-native/cocoa_dom", version = "0.1.0", optional = true }
+
+# iOS-native renderer (activated only when the `native-ui` feature
+# is on; same shape as cocoa_dom above).
+[target.'cfg(target_os = "ios")'.dependencies]
+ios_dom = { path = "../../leptos-native/ios_dom", version = "0.1.0", optional = true }
+
+# Linux-native renderer (activated only when the `native-ui` feature
+# is on; same shape as cocoa_dom above).
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk_dom = { path = "../../leptos-native/gtk_dom", version = "0.1.0", optional = true }
+
+# Web-only deps. Activated by the `web` feature (mutually exclusive
+# with `native-ui`). Gating by feature rather than by `target_os`
+# keeps these out of native-UI builds without misclassifying
+# server-side SSR builds (which run on linux/macos but still need
+# wasm-bindgen-derived types for shared compilation).
+[dependencies.wasm-bindgen]
+workspace = true
+default-features = true
+optional = true
+
+[dependencies.js-sys]
+workspace = true
+default-features = true
+optional = true
+
+[dependencies.web-sys]
+workspace = true
+default-features = true
+optional = true
+features = [
   "Window",
   "Document",
   "HtmlElement",
@@ -147,20 +194,7 @@ web-sys = { features = [
   "HtmlSlotElement",
   "HtmlTemplateElement",
   "HtmlOptionElement",
-], workspace = true, default-features = true }
-drain_filter_polyfill = { workspace = true, default-features = true }
-indexmap = { workspace = true, default-features = true }
-rustc-hash = { workspace = true, default-features = true }
-futures = { workspace = true, default-features = true }
-itertools = { workspace = true, default-features = true }
-send_wrapper = { workspace = true, default-features = true }
-sledgehammer_bindgen = { features = [
-  "web",
-], optional = true, workspace = true, default-features = true }
-sledgehammer_utils = { optional = true, workspace = true, default-features = true }
-tracing = { optional = true, workspace = true, default-features = true }
-serde = { optional = true, workspace = true, default-features = true }
-serde_json = { optional = true, workspace = true, default-features = true }
+]
 
 [dev-dependencies]
 tokio-test = { workspace = true, default-features = true }
@@ -174,11 +208,17 @@ rustc_version = { workspace = true, default-features = true }
 
 [features]
 default = ["testing"]
+
+# `web` is NOT in `default` deliberately: cargo unifies features across
+# the dep graph, and any single transitive consumer that pulls tachys
+# without `default-features = false` would silently activate `web` even
+# in a `native-ui` build.
+web = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-sys"]
 delegation = []                                                       # enables event delegation
 error-hook = []
-hydrate = []
-islands = ["dep:serde", "dep:serde_json"]
-ssr = []
+hydrate = ["web"]
+islands = ["web", "dep:serde", "dep:serde_json"]
+ssr = ["web"]
 oco = ["dep:oco_ref"]
 nightly = ["reactive_graph/nightly"]
 testing = ["dep:slotmap"]
@@ -187,6 +227,17 @@ reactive_stores = ["reactive_graph", "dep:reactive_stores"]
 sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils"]
 tracing = ["dep:tracing"]
 mark_branches = []
+# Activates the native UI rendering backends. The specific backend
+# (Cocoa on macOS, GTK on Linux) is chosen by target_os at compile
+# time. `dep:cocoa_dom` and `dep:gtk_dom` activate the optional
+# native-renderer dependencies; if a target_os doesn't have one of
+# them declared (e.g. there's no gtk_dom dep on macOS), Cargo
+# silently no-ops the activation, so this works correctly on any
+# target. Mutually exclusive with `web`.
+native-ui = ["dep:cocoa_dom", "dep:gtk_dom", "dep:ios_dom"]
+# Enables Taffy's block_layout algorithm + the `<block>` tag/builder.
+# Off by default to keep file size down for apps that only need flex.
+block_layout = ["cocoa_dom?/block_layout"]
 
 [package.metadata.cargo-all-features]
 denylist = ["tracing", "sledgehammer"]

--- a/tachys/build.rs
+++ b/tachys/build.rs
@@ -1,7 +1,8 @@
 use rustc_version::{version_meta, Channel};
 
 fn main() {
-    // Set cfg flags depending on release channel
+    println!("cargo:rustc-check-cfg=cfg(rustc_nightly)");
+
     if matches!(version_meta().unwrap().channel, Channel::Nightly) {
         println!("cargo:rustc-cfg=rustc_nightly");
     }

--- a/tachys/src/html/attribute/any_attribute.rs
+++ b/tachys/src/html/attribute/any_attribute.rs
@@ -2,7 +2,7 @@ use super::{Attribute, NextAttribute};
 use crate::{
     erased::{Erased, ErasedLocal},
     html::attribute::NamedAttributeKey,
-    renderer::{dom::Element, Rndr},
+    renderer::{types::Element, Rndr},
 };
 use std::{any::TypeId, fmt::Debug, mem};
 #[cfg(feature = "ssr")]
@@ -381,11 +381,16 @@ impl Attribute for Vec<AnyAttribute> {
                         Rndr::set_inner_html(&old.el, "");
                     }
                     NamedAttributeKey::Property(prop_name) => {
+                        #[cfg(feature = "web")]
                         Rndr::set_property(
                             &old.el,
                             &prop_name,
                             &wasm_bindgen::JsValue::UNDEFINED,
                         );
+                        // Property removal is a web-only concept; no-op
+                        // on native (see implementation_log.md).
+                        #[cfg(feature = "native-ui")]
+                        let _ = prop_name;
                     }
                     NamedAttributeKey::Attribute(key) => {
                         Rndr::remove_attribute(&old.el, &key);

--- a/tachys/src/html/attribute/mod.rs
+++ b/tachys/src/html/attribute/mod.rs
@@ -1,10 +1,14 @@
 /// A type-erased `AnyAttribute`.
 pub mod any_attribute;
-/// Types for ARIA attributes.
+/// Types for ARIA attributes (web only — uses HTML element types).
+#[cfg(feature = "web")]
 pub mod aria;
-/// Types for custom attributes.
+/// Types for custom attributes (web only).
+#[cfg(feature = "web")]
 pub mod custom;
-/// Traits to define global attribute methods on all HTML elements.
+/// Traits to define global attribute methods on all HTML elements
+/// (web only — uses HTML element types).
+#[cfg(feature = "web")]
 pub mod global;
 mod key;
 pub(crate) mod maybe_next_attr_erasure_macros;
@@ -12,6 +16,13 @@ mod value;
 
 use crate::view::{Position, ToTemplate};
 pub use key::*;
+
+// `bind:` keys (Selection, Value, Checked, Date, Index, Group, …)
+// are now resolved by the macro through `__leptos_view::bind::*`,
+// not via `::leptos::attr::*`. The per-OS glue crates own the
+// native variants of these keys; the web variant lives in
+// `tachys::reactive_graph::bind` (re-exported via leptos's
+// `view_prelude::__leptos_view::bind`).
 use maybe_next_attr_erasure_macros::{
     next_attr_combine, next_attr_output_type,
 };

--- a/tachys/src/html/attribute/value.rs
+++ b/tachys/src/html/attribute/value.rs
@@ -31,6 +31,102 @@ where
     }
 }
 
+// Native-only escape hatches: the native builders accept attribute
+// values that aren't web `AttributeValue`s (e.g. `Vec<&str>` for
+// `<pop_up_button items=...>`). The view! macro wraps every non-
+// literal attribute value through `into_attribute_value`, so we
+// need direct `IntoAttributeValue` impls for these types whose
+// Output is the type itself.
+#[cfg(feature = "native-ui")]
+impl IntoAttributeValue for Vec<&'static str> {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
+#[cfg(feature = "native-ui")]
+impl IntoAttributeValue for Vec<String> {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
+// iOS Color (and the named system colors). Lets the view! macro
+// pass `text_color=Color::SYSTEM_BLUE` etc. through verbatim to the
+// builder's typed `.text_color()` method (which takes
+// `IntoMaybeReactive<Color>`).
+#[cfg(all(target_os = "ios", feature = "native-ui"))]
+impl IntoAttributeValue for ios_dom::Color {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
+// Same for macOS (cocoa_dom::Color), which had the same restriction
+// — kept it from biting future-us if/when a cocoa example uses
+// `text_color=` in a view! macro.
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::Color {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
+// AppKit text-alignment enum, used as a label `alignment=` value.
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::NSTextAlignment {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
+// Sizing dimension type (`Dim`) and other native-only attribute
+// value types that lived in `tachys::cocoa::attr` moved to
+// `leptos_cocoa::attrs` in Phase 5; their `IntoAttributeValue` impls
+// move with them, but only after the G-refactor (skipping
+// `into_attribute_value` for typed builder methods) lands. For now
+// `Dim`-typed attributes can't be used through the `view!` macro on
+// native; they work via the direct builder API.
+
+// Taffy enums used as `<stack>` / `<block>` attribute values
+// (`direction`, `justify_content`, `align`, `wrap`). The `view!`
+// macro wraps non-literal values through `into_attribute_value`,
+// so without these impls a Path expression like
+// `align=AlignItems::Center` fails to type-check.
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::layout::FlexDirection {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::layout::JustifyContent {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::layout::AlignItems {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+impl IntoAttributeValue for cocoa_dom::layout::FlexWrap {
+    type Output = Self;
+    fn into_attribute_value(self) -> Self::Output {
+        self
+    }
+}
+
 /// A possible value for an HTML attribute.
 pub trait AttributeValue: Send {
     /// The state that should be retained between building and rebuilding.

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "web")]
 use self::attribute::Attribute;
+#[cfg(feature = "web")]
 use crate::{
     hydration::Cursor,
     no_attrs,
@@ -9,7 +11,9 @@ use crate::{
     },
     view::{Position, PositionState, Render, RenderHtml},
 };
+#[cfg(feature = "web")]
 use attribute::any_attribute::AnyAttribute;
+#[cfg(feature = "web")]
 use std::borrow::Cow;
 
 /// Diagnostic message shared by event, directive, and property `.expect()` calls.
@@ -19,6 +23,8 @@ use std::borrow::Cow;
 /// panics on multithreaded servers. If these `.expect()` calls fire, it means
 /// the `ssr` feature was activated unintentionally via Cargo feature
 /// unification in a client-side (CSR or hydrate) build.
+///
+/// Only referenced from the web-only event/directive/property modules.
 pub(crate) const FEATURE_CONFLICT_DIAGNOSTIC: &str =
     "Value is None because the `ssr` feature is active. When `ssr` is \
      enabled, tachys skips creating client-side values (event handlers, \
@@ -31,32 +37,52 @@ pub(crate) const FEATURE_CONFLICT_DIAGNOSTIC: &str =
 /// Types for HTML attributes.
 pub mod attribute;
 /// Types for manipulating the `class` attribute and `classList`.
+#[cfg(feature = "web")]
 pub mod class;
 /// Types for creating user-defined attributes with custom behavior (directives).
 pub mod directive;
-/// Types for HTML elements.
+/// Types for HTML elements (web only). After the Phase 4 macro
+/// refactor, native renderers expose their element constructors
+/// through their own glue crate's `view_prelude::__leptos_view::elements`
+/// namespace; `tachys::html::element` is unused on native.
+#[cfg(feature = "web")]
 pub mod element;
-/// Types for DOM events.
+
+/// Types for DOM events. Web-only — native event descriptors live
+/// in the per-renderer glue crate's `events` module (e.g.
+/// `leptos_cocoa::events`).
+#[cfg(feature = "web")]
 pub mod event;
+// Native event descriptors moved to the per-renderer glue crates
+// (`leptos_cocoa::events`, `leptos_ios::events`, `leptos_gtk::events`)
+// in Phase 5.
 /// Types for adding interactive islands to inert HTML pages.
+#[cfg(feature = "web")]
 pub mod islands;
 /// Types for accessing a reference to an HTML element.
+#[cfg(feature = "web")]
 pub mod node_ref;
 /// Types for DOM properties.
+#[cfg(feature = "web")]
 pub mod property;
 /// Types for the `style` attribute and individual style manipulation.
+#[cfg(feature = "web")]
 pub mod style;
 
-/// A `<!DOCTYPE>` declaration.
+/// A `<!DOCTYPE>` declaration. Web-only — disabled on native targets
+/// since the renderer has no concept of inert HTML or doctypes.
+#[cfg(feature = "web")]
 pub struct Doctype {
     value: &'static str,
 }
 
 /// Creates a `<!DOCTYPE>`.
+#[cfg(feature = "web")]
 pub fn doctype(value: &'static str) -> Doctype {
     Doctype { value }
 }
 
+#[cfg(feature = "web")]
 impl Render for Doctype {
     type State = ();
 
@@ -65,8 +91,10 @@ impl Render for Doctype {
     fn rebuild(self, _state: &mut Self::State) {}
 }
 
+#[cfg(feature = "web")]
 no_attrs!(Doctype);
 
+#[cfg(feature = "web")]
 impl RenderHtml for Doctype {
     type AsyncOutput = Self;
     type Owned = Self;
@@ -105,10 +133,12 @@ impl RenderHtml for Doctype {
 }
 
 /// An element that contains no interactivity, and whose contents can be known at compile time.
+#[cfg(feature = "web")]
 pub struct InertElement {
     html: Cow<'static, str>,
 }
 
+#[cfg(feature = "web")]
 impl InertElement {
     /// Creates a new inert element.
     pub fn new(html: impl Into<Cow<'static, str>>) -> Self {
@@ -117,8 +147,10 @@ impl InertElement {
 }
 
 /// Retained view state for [`InertElement`].
+#[cfg(feature = "web")]
 pub struct InertElementState(Cow<'static, str>, Element);
 
+#[cfg(feature = "web")]
 impl Mountable for InertElementState {
     fn unmount(&mut self) {
         self.1.unmount();
@@ -137,6 +169,7 @@ impl Mountable for InertElementState {
     }
 }
 
+#[cfg(feature = "web")]
 impl Render for InertElement {
     type State = InertElementState;
 
@@ -157,6 +190,7 @@ impl Render for InertElement {
     }
 }
 
+#[cfg(feature = "web")]
 impl AddAnyAttr for InertElement {
     type Output<SomeNewAttr: Attribute> = Self;
 
@@ -174,6 +208,7 @@ impl AddAnyAttr for InertElement {
     }
 }
 
+#[cfg(feature = "web")]
 impl RenderHtml for InertElement {
     type AsyncOutput = Self;
     type Owned = Self;

--- a/tachys/src/hydration.rs
+++ b/tachys/src/hydration.rs
@@ -5,6 +5,7 @@ use crate::{
 #[cfg(any(debug_assertions, leptos_debuginfo))]
 use std::cell::Cell;
 use std::{cell::RefCell, panic::Location, rc::Rc};
+#[cfg(feature = "web")]
 use web_sys::{Comment, Element, Node, Text};
 
 #[cfg(feature = "mark_branches")]
@@ -143,6 +144,7 @@ thread_local! {
     static CURRENTLY_HYDRATING: Cell<Option<&'static Location<'static>>> = const { Cell::new(None) };
 }
 
+#[cfg(feature = "web")]
 pub(crate) fn set_currently_hydrating(
     location: Option<&'static Location<'static>>,
 ) {
@@ -156,6 +158,7 @@ pub(crate) fn set_currently_hydrating(
     }
 }
 
+#[cfg(feature = "web")]
 pub(crate) fn failed_to_cast_element(tag_name: &str, node: Node) -> Element {
     #[cfg(not(any(debug_assertions, leptos_debuginfo)))]
     {
@@ -188,6 +191,7 @@ pub(crate) fn failed_to_cast_element(tag_name: &str, node: Node) -> Element {
     }
 }
 
+#[cfg(feature = "web")]
 pub(crate) fn failed_to_cast_marker_node(node: Node) -> Comment {
     #[cfg(not(any(debug_assertions, leptos_debuginfo)))]
     {
@@ -220,6 +224,47 @@ pub(crate) fn failed_to_cast_marker_node(node: Node) -> Comment {
     }
 }
 
+/// Stub for the native target. The text-node cast can fail on the web
+/// when SSR HTML and client view tree disagree; on native there is no
+/// SSR, so this should be unreachable.
+#[cfg(feature = "native-ui")]
+pub(crate) fn failed_to_cast_text_node(
+    _node: crate::renderer::types::Node,
+) -> crate::renderer::types::Text {
+    panic!(
+        "failed_to_cast_text_node called on native — hydration is not \
+         supported on native targets (see implementation_log.md)"
+    );
+}
+
+/// Stub for the native target. See [`failed_to_cast_text_node`] above.
+#[cfg(feature = "native-ui")]
+pub(crate) fn failed_to_cast_marker_node(
+    _node: crate::renderer::types::Node,
+) -> crate::renderer::types::Placeholder {
+    panic!(
+        "failed_to_cast_marker_node called on native — hydration is not \
+         supported on native targets (see implementation_log.md)"
+    );
+}
+
+/// Stub for the native target. See [`failed_to_cast_text_node`] above.
+/// Unreachable on native (hydration is stubbed there); kept so the
+/// type-check passes for the call sites in `html/element/mod.rs` even
+/// though those call sites are themselves cfg'd-out on native.
+#[cfg(feature = "native-ui")]
+#[allow(dead_code)]
+pub(crate) fn failed_to_cast_element(
+    _tag_name: &str,
+    _node: crate::renderer::types::Node,
+) -> crate::renderer::types::Element {
+    panic!(
+        "failed_to_cast_element called on native — hydration is not \
+         supported on native targets (see implementation_log.md)"
+    );
+}
+
+#[cfg(feature = "web")]
 pub(crate) fn failed_to_cast_text_node(node: Node) -> Text {
     #[cfg(not(any(debug_assertions, leptos_debuginfo)))]
     {

--- a/tachys/src/lib.rs
+++ b/tachys/src/lib.rs
@@ -17,6 +17,7 @@
 
 /// Commonly-used traits.
 pub mod prelude {
+    #[cfg(feature = "web")]
     pub use crate::{
         html::{
             attribute::{
@@ -34,45 +35,86 @@ pub mod prelude {
             element::{ElementChild, ElementExt, InnerHtmlAttribute},
             node_ref::NodeRefAttribute,
         },
-        renderer::{dom::Dom, Renderer},
+        renderer::dom::Dom,
+    };
+
+    pub use crate::{
+        renderer::Renderer,
         view::{
             add_attr::AddAnyAttr,
             any_view::{AnyView, IntoAny, IntoMaybeErased},
             IntoRender, Mountable, Render, RenderHtml,
         },
     };
+
+    // Native: re-export the cocoa renderer alias as `Dom` so existing
+    // `use prelude::Dom` sites keep resolving on macOS. Only active
+    // when the `native-ui` feature is enabled (otherwise the cocoa
+    // module isn't compiled).
+    #[cfg(all(target_os = "macos", feature = "native-ui"))]
+    pub use crate::renderer::cocoa::Dom;
+    // Same for iOS — the UIKit renderer alias is also `Dom`.
+    #[cfg(all(target_os = "ios", feature = "native-ui"))]
+    pub use crate::renderer::ios::Dom;
+    // Same for Linux — the GTK renderer alias is also `Dom`.
+    #[cfg(all(target_os = "linux", feature = "native-ui"))]
+    pub use crate::renderer::gtk::Dom;
+
+    #[cfg(feature = "native-ui")]
+    pub use crate::html::attribute::{
+        any_attribute::IntoAnyAttribute, IntoAttributeValue,
+    };
 }
 
+#[cfg(feature = "web")]
 use wasm_bindgen::JsValue;
+#[cfg(feature = "web")]
 use web_sys::Node;
 
-/// Helpers for interacting with the DOM.
+// Per-OS element builder modules (`cocoa`, `ios`, `gtk`) moved to
+// the per-renderer glue crates `leptos_cocoa` / `leptos_ios` /
+// `leptos_gtk` in Phase 5. Tachys keeps only the renderer-protocol
+// adapter in `renderer::{cocoa,ios,gtk}` (used by the `Rndr` type
+// alias for tachys's generic machinery).
+/// Helpers for interacting with the DOM (web only).
+#[cfg(feature = "web")]
 pub mod dom;
 /// Types for building a statically-typed HTML view tree.
 pub mod html;
-/// Supports adding interactivity to HTML.
+/// Supports adding interactivity to HTML. The bulk of this module
+/// is web-only (DOM cursor traversal), but a handful of native-side
+/// stubs and the `Cursor` type are referenced by the trait surface
+/// (`RenderHtml`), so the module compiles unconditionally — its
+/// web-only contents are gated internally on `feature = "web"`.
 pub mod hydration;
-/// Types for MathML.
+/// Types for MathML (web only).
+#[cfg(feature = "web")]
 pub mod mathml;
 /// Defines various backends that can render views.
 pub mod renderer;
-/// Rendering views to HTML.
+/// Rendering views to HTML. The trait surface (`StreamBuilder`,
+/// `RenderHtml::to_html_*`) is referenced unconditionally; web-only
+/// internals are gated on `feature = "web"` within the module.
 pub mod ssr;
-/// Types for SVG.
+/// Types for SVG (web only). Native targets get their `<view>` etc.
+/// element constructors from the per-renderer glue crate's
+/// `view_prelude::__leptos_view::elements` namespace; `tachys::svg`
+/// is unused on native after the Phase 4 macro refactor.
+#[cfg(feature = "web")]
 pub mod svg;
 /// Core logic for manipulating views.
 pub mod view;
 
 pub use either_of as either;
-#[cfg(feature = "islands")]
+#[cfg(all(feature = "islands", feature = "web"))]
 #[doc(hidden)]
 pub use wasm_bindgen;
-#[cfg(feature = "islands")]
+#[cfg(all(feature = "islands", feature = "web"))]
 #[doc(hidden)]
 pub use web_sys;
 
 /// View implementations for the `oco_ref` crate (cheaply-cloned string types).
-#[cfg(feature = "oco")]
+#[cfg(all(feature = "oco", feature = "web"))]
 pub mod oco;
 /// View implementations for the `reactive_graph` crate.
 #[cfg(feature = "reactive_graph")]
@@ -81,6 +123,7 @@ pub mod reactive_graph;
 /// A type-erased container.
 pub mod erased;
 
+#[cfg(feature = "web")]
 pub(crate) trait UnwrapOrDebug {
     type Output;
 
@@ -93,6 +136,7 @@ pub(crate) trait UnwrapOrDebug {
     ) -> Option<Self::Output>;
 }
 
+#[cfg(feature = "web")]
 impl<T> UnwrapOrDebug for Result<T, JsValue> {
     type Output = T;
 

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -15,14 +15,21 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-/// Types for two way data binding.
+/// Types for two way data binding (web only — tied to HTML form
+/// elements; not reachable on the macOS target).
+#[cfg(feature = "web")]
 pub mod bind;
+#[cfg(feature = "web")]
 mod class;
+#[cfg(feature = "web")]
 mod inner_html;
-/// Provides a reactive [`NodeRef`](node_ref::NodeRef) type.
+/// Provides a reactive [`NodeRef`](node_ref::NodeRef) type (web only).
+#[cfg(feature = "web")]
 pub mod node_ref;
 mod owned;
+#[cfg(feature = "web")]
 mod property;
+#[cfg(feature = "web")]
 mod style;
 mod suspense;
 

--- a/tachys/src/renderer/cocoa.rs
+++ b/tachys/src/renderer/cocoa.rs
@@ -1,0 +1,343 @@
+#![allow(missing_docs)]
+
+//! Cocoa/AppKit-backed implementation of the renderer surface.
+//!
+//! This is the macOS analogue of [`super::dom`]. It re-exports the
+//! types from the `cocoa_dom` crate as the names tachys expects
+//! (`Element`, `Node`, `Text`, `Placeholder`, etc.) and adds the
+//! [`Mountable`] / [`CastFrom`] trait impls that have to live here for
+//! orphan-rule reasons.
+//!
+//! `Dom` is a unit struct rather than a type alias so we can attach
+//! tachys-specific methods (`mount_before`, `try_mount_before`) that
+//! depend on the [`Mountable`] trait — orphan rules prevent us from
+//! adding those directly to `cocoa_dom::Renderer`.
+
+use super::CastFrom;
+use crate::view::Mountable;
+use cocoa_dom::{layout::Style, NodeKind, Renderer as CocoaRenderer};
+
+// Type re-exports: the names the rest of tachys expects under
+// `crate::renderer::types::*`.
+pub use cocoa_dom::{
+    ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+    TemplateElement, Text,
+};
+
+/// The renderer surface used by tachys on macOS.
+///
+/// Forwards every method to [`cocoa_dom::Renderer`]; adds
+/// `mount_before` / `try_mount_before` which need tachys' [`Mountable`]
+/// trait in scope.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Dom;
+
+impl Dom {
+    pub fn intern(text: &str) -> &str {
+        CocoaRenderer::intern(text)
+    }
+
+    pub fn create_element(tag: &str, namespace: Option<&str>) -> Element {
+        CocoaRenderer::create_element(tag, namespace)
+    }
+
+    pub fn create_text_node(text: &str) -> Text {
+        CocoaRenderer::create_text_node(text)
+    }
+
+    pub fn create_placeholder() -> Placeholder {
+        CocoaRenderer::create_placeholder()
+    }
+
+    pub fn set_text(node: &Text, text: &str) {
+        CocoaRenderer::set_text(node, text);
+    }
+
+    pub fn set_attribute(node: &Element, name: &str, value: &str) {
+        CocoaRenderer::set_attribute(node, name, value);
+    }
+
+    pub fn remove_attribute(node: &Element, name: &str) {
+        CocoaRenderer::remove_attribute(node, name);
+    }
+
+    pub fn insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) {
+        CocoaRenderer::insert_node(parent, new_child, anchor);
+    }
+
+    pub fn try_insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) -> bool {
+        CocoaRenderer::try_insert_node(parent, new_child, anchor)
+    }
+
+    pub fn remove_node(parent: &Element, child: &Node) -> Option<Node> {
+        CocoaRenderer::remove_node(parent, child)
+    }
+
+    pub fn remove(node: &Node) {
+        CocoaRenderer::remove(node);
+    }
+
+    pub fn get_parent(node: &Node) -> Option<Node> {
+        CocoaRenderer::get_parent(node)
+    }
+
+    pub fn first_child(node: &Node) -> Option<Node> {
+        CocoaRenderer::first_child(node)
+    }
+
+    pub fn next_sibling(node: &Node) -> Option<Node> {
+        CocoaRenderer::next_sibling(node)
+    }
+
+    pub fn log_node(node: &Node) {
+        CocoaRenderer::log_node(node);
+    }
+
+    pub fn clear_children(parent: &Element) {
+        CocoaRenderer::clear_children(parent);
+    }
+
+    pub fn class_list(el: &Element) -> ClassList {
+        CocoaRenderer::class_list(el)
+    }
+    pub fn add_class(list: &ClassList, name: &str) {
+        CocoaRenderer::add_class(list, name);
+    }
+    pub fn remove_class(list: &ClassList, name: &str) {
+        CocoaRenderer::remove_class(list, name);
+    }
+
+    pub fn style(el: &Element) -> CssStyleDeclaration {
+        CocoaRenderer::style(el)
+    }
+    pub fn set_css_property(
+        style: &CssStyleDeclaration,
+        name: &str,
+        value: &str,
+    ) {
+        CocoaRenderer::set_css_property(style, name, value);
+    }
+    pub fn remove_css_property(style: &CssStyleDeclaration, name: &str) {
+        CocoaRenderer::remove_css_property(style, name);
+    }
+
+    pub fn set_inner_html(el: &Element, html: &str) {
+        CocoaRenderer::set_inner_html(el, html);
+    }
+
+    pub fn get_template<V: 'static>() -> TemplateElement {
+        CocoaRenderer::get_template::<V>()
+    }
+
+    pub fn clone_template(tpl: &TemplateElement) -> Element {
+        CocoaRenderer::clone_template(tpl)
+    }
+
+    /// Mount `new_child` immediately before `before` in `before`'s
+    /// parent. Used by dynamic-children diffing in tachys
+    /// (`<For>`, keyed iteration, etc.).
+    ///
+    /// We synthesise a parent `Element` wrapper around `before`'s
+    /// `superview()`. The wrapper's `LayoutHandle` is borrowed from
+    /// the marker's tree (every node in the same Taffy tree shares
+    /// the tree handle, and Taffy can name the parent's NodeId via
+    /// `tree.parent(child_id)`) so the new child registers in the
+    /// right tree and gets a real layout slot.
+    pub fn mount_before<M>(new_child: &mut M, before: &Node)
+    where
+        M: Mountable,
+    {
+        let parent_view = unsafe { before.ns_view().superview() }
+            .expect("cocoa_dom: mount_before — node has no superview");
+        let parent = synthesise_parent_element(parent_view, before);
+        new_child.mount(&parent, Some(before));
+    }
+
+    pub fn try_mount_before<M>(new_child: &mut M, before: &Node) -> bool
+    where
+        M: Mountable,
+    {
+        let superview = unsafe { before.ns_view().superview() };
+        let Some(parent_view) = superview else {
+            return false;
+        };
+        let parent = synthesise_parent_element(parent_view, before);
+        new_child.mount(&parent, Some(before));
+        true
+    }
+}
+
+/// Build an `Element` wrapper around `parent_view` whose
+/// `LayoutHandle` references the same Taffy tree + the parent
+/// `NodeId` that `before` lives under. If `before` isn't registered
+/// in any tree, the parent wrapper also has no handle — falls back
+/// to NSView-only mounting (the new child won't be in any layout
+/// tree, but will at least appear as a subview).
+fn synthesise_parent_element(
+    parent_view: cocoa_dom::Retained<cocoa_dom::NSView>,
+    before: &Node,
+) -> Element {
+    use cocoa_dom::layout::LayoutHandle;
+
+    let parent_handle: Option<LayoutHandle> = {
+        let layout = before.layout_slot().borrow();
+        layout.handle.as_ref().and_then(|h| {
+            let parent_id = h.tree.tree.borrow().parent(h.node_id)?;
+            Some(LayoutHandle {
+                tree: h.tree.clone(),
+                node_id: parent_id,
+            })
+        })
+    };
+
+    let parent_node = match parent_handle {
+        Some(handle) => Node::from_view_with_handle(
+            parent_view,
+            NodeKind::Element,
+            handle,
+        ),
+        None => Node::from_view(
+            parent_view,
+            NodeKind::Element,
+            Style::default(),
+        ),
+    };
+    Element::from_node_unchecked(parent_node)
+}
+
+// ---------------------------------------------------------------------
+// Mountable — wires our DOM-shaped wrappers into the tachys view tree.
+// ---------------------------------------------------------------------
+
+impl Mountable for Node {
+    fn unmount(&mut self) {
+        // Teardown drops the Taffy node + handler-store entry, then
+        // removes the NSView from its superview.
+        self.teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self, marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self, marker)
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        // Used by hydration / dynamic-children diffing to splice a new
+        // node in just before this one. On native we don't have a good
+        // way back from a raw NSView to a typed parent Element, so this
+        // is unimplemented for now (see implementation_log.md).
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Element {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        vec![self.clone()]
+    }
+}
+
+impl Mountable for Text {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Placeholder {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+// ---------------------------------------------------------------------
+// CastFrom — used by hydration (stubbed) and event_target casts.
+// ---------------------------------------------------------------------
+
+impl CastFrom<Node> for Element {
+    fn cast_from(node: Node) -> Option<Element> {
+        match node.kind() {
+            NodeKind::Element => Some(Element::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Text {
+    fn cast_from(node: Node) -> Option<Text> {
+        match node.kind() {
+            NodeKind::Text => Some(Text::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Placeholder {
+    fn cast_from(node: Node) -> Option<Placeholder> {
+        match node.kind() {
+            NodeKind::Placeholder => {
+                Some(Placeholder::from_node_unchecked(node))
+            }
+            _ => None,
+        }
+    }
+}
+
+// Identity cast on Element. The web target has a JsCast-bounded blanket
+// impl `CastFrom<Element> for T: JsCast`; on native there's no JsCast
+// equivalent and the only callers live in the html module (currently
+// disabled — see implementation_log.md).
+impl CastFrom<Element> for Element {
+    fn cast_from(source: Element) -> Option<Element> {
+        Some(source)
+    }
+}

--- a/tachys/src/renderer/gtk.rs
+++ b/tachys/src/renderer/gtk.rs
@@ -1,0 +1,338 @@
+#![allow(missing_docs)]
+
+//! GTK4-backed implementation of the renderer surface.
+//!
+//! This is the Linux analogue of [`super::dom`] (web) and
+//! [`super::cocoa`] (macOS). It re-exports the types from the
+//! `gtk_dom` crate as the names tachys expects (`Element`, `Node`,
+//! `Text`, `Placeholder`, etc.) and adds the [`Mountable`] /
+//! [`CastFrom`] trait impls that have to live here for orphan-rule
+//! reasons.
+//!
+//! `Dom` is a unit struct rather than a type alias so we can attach
+//! tachys-specific methods (`mount_before`, `try_mount_before`) that
+//! depend on the [`Mountable`] trait — orphan rules prevent us from
+//! adding those directly to `gtk_dom::Renderer`.
+//!
+//! Compared with the macOS renderer in [`super::cocoa`], this module
+//! is much shorter: there is no Taffy tree to register against, so
+//! `mount_before` is a straightforward `widget.parent()` lookup
+//! followed by an ordinary `mount` call. None of cocoa's
+//! `synthesise_parent_element` + `LayoutHandle` propagation is
+//! required.
+
+use super::CastFrom;
+use crate::view::Mountable;
+use gtk_dom::{NodeKind, Renderer as GtkRenderer};
+
+// Type re-exports: the names the rest of tachys expects under
+// `crate::renderer::types::*`.
+pub use gtk_dom::{
+    ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+    TemplateElement, Text,
+};
+
+/// The renderer surface used by tachys on Linux.
+///
+/// Forwards every method to [`gtk_dom::Renderer`]; adds `mount_before`
+/// / `try_mount_before` which need tachys' [`Mountable`] trait in
+/// scope.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Dom;
+
+impl Dom {
+    pub fn intern(text: &str) -> &str {
+        GtkRenderer::intern(text)
+    }
+
+    pub fn create_element(tag: &str, namespace: Option<&str>) -> Element {
+        GtkRenderer::create_element(tag, namespace)
+    }
+
+    pub fn create_text_node(text: &str) -> Text {
+        GtkRenderer::create_text_node(text)
+    }
+
+    pub fn create_placeholder() -> Placeholder {
+        GtkRenderer::create_placeholder()
+    }
+
+    pub fn set_text(node: &Text, text: &str) {
+        GtkRenderer::set_text(node, text);
+    }
+
+    pub fn set_attribute(node: &Element, name: &str, value: &str) {
+        GtkRenderer::set_attribute(node, name, value);
+    }
+
+    pub fn remove_attribute(node: &Element, name: &str) {
+        GtkRenderer::remove_attribute(node, name);
+    }
+
+    pub fn insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) {
+        GtkRenderer::insert_node(parent, new_child, anchor);
+    }
+
+    pub fn try_insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) -> bool {
+        GtkRenderer::try_insert_node(parent, new_child, anchor)
+    }
+
+    pub fn remove_node(parent: &Element, child: &Node) -> Option<Node> {
+        GtkRenderer::remove_node(parent, child)
+    }
+
+    pub fn remove(node: &Node) {
+        GtkRenderer::remove(node);
+    }
+
+    pub fn get_parent(node: &Node) -> Option<Node> {
+        GtkRenderer::get_parent(node)
+    }
+
+    pub fn first_child(node: &Node) -> Option<Node> {
+        GtkRenderer::first_child(node)
+    }
+
+    pub fn next_sibling(node: &Node) -> Option<Node> {
+        GtkRenderer::next_sibling(node)
+    }
+
+    pub fn log_node(node: &Node) {
+        GtkRenderer::log_node(node);
+    }
+
+    pub fn clear_children(parent: &Element) {
+        GtkRenderer::clear_children(parent);
+    }
+
+    pub fn class_list(el: &Element) -> ClassList {
+        GtkRenderer::class_list(el)
+    }
+    pub fn add_class(list: &ClassList, name: &str) {
+        GtkRenderer::add_class(list, name);
+    }
+    pub fn remove_class(list: &ClassList, name: &str) {
+        GtkRenderer::remove_class(list, name);
+    }
+
+    pub fn style(el: &Element) -> CssStyleDeclaration {
+        GtkRenderer::style(el)
+    }
+    pub fn set_css_property(
+        style: &CssStyleDeclaration,
+        name: &str,
+        value: &str,
+    ) {
+        GtkRenderer::set_css_property(style, name, value);
+    }
+    pub fn remove_css_property(style: &CssStyleDeclaration, name: &str) {
+        GtkRenderer::remove_css_property(style, name);
+    }
+
+    pub fn set_inner_html(el: &Element, html: &str) {
+        GtkRenderer::set_inner_html(el, html);
+    }
+
+    pub fn get_template<V: 'static>() -> TemplateElement {
+        GtkRenderer::get_template::<V>()
+    }
+
+    pub fn clone_template(tpl: &TemplateElement) -> Element {
+        GtkRenderer::clone_template(tpl)
+    }
+
+    /// Mount `new_child` immediately before `before` in `before`'s
+    /// parent. Used by dynamic-children diffing in tachys (`<For>`,
+    /// keyed iteration, etc.).
+    ///
+    /// Unlike the macOS renderer's equivalent, this is a one-liner:
+    /// GTK has no Taffy tree to register against, so we just look up
+    /// `before`'s parent widget, wrap it as a synthetic Element, and
+    /// call `mount`. The actual insert-before-marker logic lives in
+    /// [`gtk_dom::Element::insert_node`] (it uses
+    /// `gtk::Box::insert_child_after` on the marker's previous
+    /// sibling, so the new child lands immediately before the
+    /// marker).
+    pub fn mount_before<M>(new_child: &mut M, before: &Node)
+    where
+        M: Mountable + ?Sized,
+    {
+        let parent = synthesise_parent_element(before)
+            .expect("gtk_dom: mount_before — node has no parent");
+        new_child.mount(&parent, Some(before));
+    }
+
+    pub fn try_mount_before<M>(new_child: &mut M, before: &Node) -> bool
+    where
+        M: Mountable + ?Sized,
+    {
+        let Some(parent) = synthesise_parent_element(before) else {
+            return false;
+        };
+        new_child.try_mount(&parent, Some(before))
+    }
+}
+
+/// Build an `Element` wrapper around the parent of `before`. Returns
+/// `None` if `before` has no parent (i.e. isn't currently mounted).
+///
+/// On macOS the equivalent helper additionally has to thread a
+/// `LayoutHandle` borrowed from the marker so the new child registers
+/// in the right Taffy tree. On GTK there's nothing to thread — the
+/// parent widget downcasts inside `Element::insert_node` figure out
+/// the correct insertion call (Box::insert_child_after, Window::set_child,
+/// …), and child layout is the parent's responsibility once the
+/// widget is parented.
+fn synthesise_parent_element(before: &Node) -> Option<Element> {
+    use gtk_dom::gtk::prelude::*;
+
+    let parent_widget = before.widget().parent()?;
+    let node = Node::from_widget(parent_widget, NodeKind::Element);
+    Some(Element::from_node_unchecked(node))
+}
+
+// ---------------------------------------------------------------------
+// Mountable — wires our DOM-shaped wrappers into the tachys view tree.
+// ---------------------------------------------------------------------
+
+impl Mountable for Node {
+    fn unmount(&mut self) {
+        // Detach from parent; gobject ref-counting cleans up the
+        // widget when both the wrapping Node clones and any
+        // remaining parent refs drop.
+        self.teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self, marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self, marker)
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        Dom::try_mount_before(child, self)
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Element {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self.as_node(), marker)
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        Dom::try_mount_before(child, self.as_node())
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        vec![self.clone()]
+    }
+}
+
+impl Mountable for Text {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self.as_node(), marker)
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        Dom::try_mount_before(child, self.as_node())
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Placeholder {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self.as_node(), marker)
+    }
+
+    fn insert_before_this(&self, child: &mut dyn Mountable) -> bool {
+        Dom::try_mount_before(child, self.as_node())
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+// ---------------------------------------------------------------------
+// CastFrom — used by hydration (stubbed) and event_target casts.
+// ---------------------------------------------------------------------
+
+impl CastFrom<Node> for Element {
+    fn cast_from(node: Node) -> Option<Element> {
+        match node.kind() {
+            NodeKind::Element => Some(Element::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Text {
+    fn cast_from(node: Node) -> Option<Text> {
+        match node.kind() {
+            NodeKind::Text => Some(Text::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Placeholder {
+    fn cast_from(node: Node) -> Option<Placeholder> {
+        match node.kind() {
+            NodeKind::Placeholder => {
+                Some(Placeholder::from_node_unchecked(node))
+            }
+            _ => None,
+        }
+    }
+}
+
+// Identity cast on Element. The web target has a JsCast-bounded
+// blanket impl `CastFrom<Element> for T: JsCast`; on native there's
+// no JsCast equivalent and the only callers live in the html module
+// (currently disabled on native — see implementation_log.md).
+impl CastFrom<Element> for Element {
+    fn cast_from(source: Element) -> Option<Element> {
+        Some(source)
+    }
+}

--- a/tachys/src/renderer/ios.rs
+++ b/tachys/src/renderer/ios.rs
@@ -1,0 +1,311 @@
+#![allow(missing_docs)]
+
+//! UIKit-backed implementation of the renderer surface.
+//!
+//! This is the iOS analogue of [`super::dom`] and [`super::cocoa`].
+//! It re-exports the types from the `ios_dom` crate as the names
+//! tachys expects and adds the [`Mountable`] / [`CastFrom`] trait
+//! impls that have to live here for orphan-rule reasons.
+
+use super::CastFrom;
+use crate::view::Mountable;
+use ios_dom::{layout::Style, NodeKind, Renderer as IosRenderer};
+
+// Type re-exports: the names the rest of tachys expects under
+// `crate::renderer::types::*`.
+pub use ios_dom::{
+    ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+    TemplateElement, Text,
+};
+
+/// The renderer surface used by tachys on iOS.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Dom;
+
+impl Dom {
+    pub fn intern(text: &str) -> &str {
+        IosRenderer::intern(text)
+    }
+
+    pub fn create_element(tag: &str, namespace: Option<&str>) -> Element {
+        IosRenderer::create_element(tag, namespace)
+    }
+
+    pub fn create_text_node(text: &str) -> Text {
+        IosRenderer::create_text_node(text)
+    }
+
+    pub fn create_placeholder() -> Placeholder {
+        IosRenderer::create_placeholder()
+    }
+
+    pub fn set_text(node: &Text, text: &str) {
+        IosRenderer::set_text(node, text);
+    }
+
+    pub fn set_attribute(node: &Element, name: &str, value: &str) {
+        IosRenderer::set_attribute(node, name, value);
+    }
+
+    pub fn remove_attribute(node: &Element, name: &str) {
+        IosRenderer::remove_attribute(node, name);
+    }
+
+    pub fn insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) {
+        IosRenderer::insert_node(parent, new_child, anchor);
+    }
+
+    pub fn try_insert_node(
+        parent: &Element,
+        new_child: &Node,
+        anchor: Option<&Node>,
+    ) -> bool {
+        IosRenderer::try_insert_node(parent, new_child, anchor)
+    }
+
+    pub fn remove_node(parent: &Element, child: &Node) -> Option<Node> {
+        IosRenderer::remove_node(parent, child)
+    }
+
+    pub fn remove(node: &Node) {
+        IosRenderer::remove(node);
+    }
+
+    pub fn get_parent(node: &Node) -> Option<Node> {
+        IosRenderer::get_parent(node)
+    }
+
+    pub fn first_child(node: &Node) -> Option<Node> {
+        IosRenderer::first_child(node)
+    }
+
+    pub fn next_sibling(node: &Node) -> Option<Node> {
+        IosRenderer::next_sibling(node)
+    }
+
+    pub fn log_node(node: &Node) {
+        IosRenderer::log_node(node);
+    }
+
+    pub fn clear_children(parent: &Element) {
+        IosRenderer::clear_children(parent);
+    }
+
+    pub fn class_list(el: &Element) -> ClassList {
+        IosRenderer::class_list(el)
+    }
+    pub fn add_class(list: &ClassList, name: &str) {
+        IosRenderer::add_class(list, name);
+    }
+    pub fn remove_class(list: &ClassList, name: &str) {
+        IosRenderer::remove_class(list, name);
+    }
+
+    pub fn style(el: &Element) -> CssStyleDeclaration {
+        IosRenderer::style(el)
+    }
+    pub fn set_css_property(
+        style: &CssStyleDeclaration,
+        name: &str,
+        value: &str,
+    ) {
+        IosRenderer::set_css_property(style, name, value);
+    }
+    pub fn remove_css_property(
+        style: &CssStyleDeclaration,
+        name: &str,
+    ) {
+        IosRenderer::remove_css_property(style, name);
+    }
+
+    pub fn set_inner_html(el: &Element, html: &str) {
+        IosRenderer::set_inner_html(el, html);
+    }
+
+    pub fn get_template<V: 'static>() -> TemplateElement {
+        IosRenderer::get_template::<V>()
+    }
+
+    pub fn clone_template(tpl: &TemplateElement) -> Element {
+        IosRenderer::clone_template(tpl)
+    }
+
+    pub fn mount_before<M>(new_child: &mut M, before: &Node)
+    where
+        M: Mountable,
+    {
+        let parent_view = before
+            .ui_view()
+            .superview()
+            .expect("ios_dom: mount_before — node has no superview");
+        let parent = synthesise_parent_element(parent_view, before);
+        new_child.mount(&parent, Some(before));
+    }
+
+    pub fn try_mount_before<M>(new_child: &mut M, before: &Node) -> bool
+    where
+        M: Mountable,
+    {
+        let Some(parent_view) = before.ui_view().superview() else {
+            return false;
+        };
+        let parent = synthesise_parent_element(parent_view, before);
+        new_child.mount(&parent, Some(before));
+        true
+    }
+}
+
+fn synthesise_parent_element(
+    parent_view: ios_dom::Retained<ios_dom::UIView>,
+    before: &Node,
+) -> Element {
+    use ios_dom::layout::LayoutHandle;
+
+    let parent_handle: Option<LayoutHandle> = {
+        let layout = before.layout_slot().borrow();
+        layout.handle.as_ref().and_then(|h| {
+            let parent_id = h.tree.tree.borrow().parent(h.node_id)?;
+            Some(LayoutHandle {
+                tree: h.tree.clone(),
+                node_id: parent_id,
+            })
+        })
+    };
+
+    let parent_node = match parent_handle {
+        Some(handle) => Node::from_view_with_handle(
+            parent_view,
+            NodeKind::Element,
+            handle,
+        ),
+        None => Node::from_view(
+            parent_view,
+            NodeKind::Element,
+            Style::default(),
+        ),
+    };
+    Element::from_node_unchecked(parent_node)
+}
+
+// ---------------------------------------------------------------------
+// Mountable
+// ---------------------------------------------------------------------
+
+impl Mountable for Node {
+    fn unmount(&mut self) {
+        self.teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self, marker);
+    }
+
+    fn try_mount(&mut self, parent: &Element, marker: Option<&Node>) -> bool {
+        Dom::try_insert_node(parent, self, marker)
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Element {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        vec![self.clone()]
+    }
+}
+
+impl Mountable for Text {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+impl Mountable for Placeholder {
+    fn unmount(&mut self) {
+        self.as_node().teardown();
+    }
+
+    fn mount(&mut self, parent: &Element, marker: Option<&Node>) {
+        Dom::insert_node(parent, self.as_node(), marker);
+    }
+
+    fn insert_before_this(&self, _child: &mut dyn Mountable) -> bool {
+        false
+    }
+
+    fn elements(&self) -> Vec<Element> {
+        Vec::new()
+    }
+}
+
+// ---------------------------------------------------------------------
+// CastFrom
+// ---------------------------------------------------------------------
+
+impl CastFrom<Node> for Element {
+    fn cast_from(node: Node) -> Option<Element> {
+        match node.kind() {
+            NodeKind::Element => Some(Element::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Text {
+    fn cast_from(node: Node) -> Option<Text> {
+        match node.kind() {
+            NodeKind::Text => Some(Text::from_node_unchecked(node)),
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Node> for Placeholder {
+    fn cast_from(node: Node) -> Option<Placeholder> {
+        match node.kind() {
+            NodeKind::Placeholder => {
+                Some(Placeholder::from_node_unchecked(node))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl CastFrom<Element> for Element {
+    fn cast_from(source: Element) -> Option<Element> {
+        Some(source)
+    }
+}

--- a/tachys/src/renderer/mod.rs
+++ b/tachys/src/renderer/mod.rs
@@ -1,9 +1,29 @@
-use crate::view::{Mountable, ToTemplate};
-use std::{borrow::Cow, fmt::Debug, marker::PhantomData};
+use crate::view::Mountable;
+#[cfg(feature = "web")]
+use crate::view::ToTemplate;
+#[cfg(feature = "web")]
+use std::borrow::Cow;
+use std::{fmt::Debug, marker::PhantomData};
+#[cfg(feature = "web")]
 use wasm_bindgen::JsValue;
 
-/// A DOM renderer.
+/// A DOM renderer (web target).
+#[cfg(feature = "web")]
 pub mod dom;
+
+/// A Cocoa/AppKit renderer (macOS target). Requires the `native-ui`
+/// feature; otherwise tachys uses the web renderer even on macOS.
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+pub mod cocoa;
+
+/// A UIKit renderer (iOS target). Requires the `native-ui` feature.
+#[cfg(all(target_os = "ios", feature = "native-ui"))]
+pub mod ios;
+
+/// A GTK4 renderer (Linux target). Requires the `native-ui` feature;
+/// otherwise tachys uses the web renderer even on Linux.
+#[cfg(all(target_os = "linux", feature = "native-ui"))]
+pub mod gtk;
 
 /// The renderer being used for the application.
 ///
@@ -17,13 +37,39 @@ pub mod dom;
 /// future, so to the extent possible the rest of the crate tries to stick to using
 /// [`Renderer`].
 /// methods rather than directly manipulating the DOM inline.
+#[cfg(feature = "web")]
 pub type Rndr = dom::Dom;
+/// Renderer alias for the macOS target — points at the Cocoa/AppKit backend.
+#[cfg(all(target_os = "macos", feature = "native-ui"))]
+pub type Rndr = cocoa::Dom;
+/// Renderer alias for the iOS target — points at the UIKit backend.
+#[cfg(all(target_os = "ios", feature = "native-ui"))]
+pub type Rndr = ios::Dom;
+/// Renderer alias for the Linux target — points at the GTK4 backend.
+#[cfg(all(target_os = "linux", feature = "native-ui"))]
+pub type Rndr = gtk::Dom;
 
 /// Types used by the renderer.
 ///
 /// See [`Rndr`] for additional information on this rendering approach.
 pub mod types {
+    #[cfg(feature = "web")]
     pub use super::dom::{
+        ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+        TemplateElement, Text,
+    };
+    #[cfg(all(target_os = "macos", feature = "native-ui"))]
+    pub use super::cocoa::{
+        ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+        TemplateElement, Text,
+    };
+    #[cfg(all(target_os = "linux", feature = "native-ui"))]
+    pub use super::gtk::{
+        ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
+        TemplateElement, Text,
+    };
+    #[cfg(all(target_os = "ios", feature = "native-ui"))]
+    pub use super::ios::{
         ClassList, CssStyleDeclaration, Element, Event, Node, Placeholder,
         TemplateElement, Text,
     };
@@ -128,6 +174,9 @@ pub struct RemoveEventHandler<T>(
     PhantomData<fn() -> T>,
 );
 
+// `new` and `into_inner` are only used by the web renderer; on
+// native we never construct or unwrap a RemoveEventHandler this way.
+#[cfg(feature = "web")]
 impl<T> RemoveEventHandler<T> {
     /// Creates a new container with a function that will be called when it is dropped.
     pub(crate) fn new(remove: impl FnOnce() + Send + Sync + 'static) -> Self {
@@ -151,6 +200,12 @@ impl<T> Drop for RemoveEventHandler<T> {
 }
 
 /// Additional rendering behavior that applies only to DOM nodes.
+///
+/// This trait is web-only: it bakes in `JsValue` and other browser-DOM
+/// concepts that have no native counterpart. On macOS we cfg it out
+/// entirely; the renderer-specific behaviour we still need (events,
+/// styles) lives directly on `cocoa::Dom` as inherent methods.
+#[cfg(feature = "web")]
 pub trait DomRenderer: Renderer {
     /// Generic event type, from which any specific event can be converted.
     type Event;

--- a/tachys/src/view/add_attr.rs
+++ b/tachys/src/view/add_attr.rs
@@ -8,6 +8,9 @@ use crate::html::attribute::Attribute;
 /// Normally, this is used to add an attribute to an HTML element. But it is required to be
 /// implemented for all types that implement [`RenderHtml`], so that attributes can be spread onto
 /// other structures like the return type of a component.
+///
+/// On native targets `RenderHtml` is still present (just unused for SSR), so
+/// the bound stays — splitting it adds churn without removing real code.
 pub trait AddAnyAttr {
     /// The new type once the attribute has been added.
     type Output<SomeNewAttr: Attribute>: RenderHtml;

--- a/tachys/src/view/fragment.rs
+++ b/tachys/src/view/fragment.rs
@@ -2,6 +2,7 @@ use super::{
     any_view::{AnyView, IntoAny},
     iterators::StaticVec,
 };
+#[cfg(feature = "web")]
 use crate::html::element::HtmlElement;
 
 /// A typed-erased collection of different views.
@@ -44,6 +45,7 @@ impl Fragment {
     }
 }
 
+#[cfg(feature = "web")]
 impl<E, At, Ch> IntoFragment for HtmlElement<E, At, Ch>
 where
     HtmlElement<E, At, Ch>: IntoAny,


### PR DESCRIPTION
This is an experimental patch set to enable out-of-tree renderers to be written for different platforms - eg, MacOS, iOS, Linux via GTK, etc.

There's a whole lot of design decisions baked in here, and I want to start a discussion about how we solve this stuff.

At a top level, there's sort of 2 approaches:

1. We add mac, ios, android, etc support in-tree. The leptos git repo grows to contain a bunch of other rendering engines.
2. Leptos allows external renderers to be maintained by the community.

Personally, I think (2) is better if we can do it. The question is how. Leptos is currently very web-specific. The repo bakes in lots of web assumptions:

- There's HTML stuff everywhere
- `view!` macro hardcodes web based components
- tachys renderer stuff

So this patch set does a few things:

1. We introduce a `web` feature flag in the root project. Turning off this feature flag (`default-features=false`) disables lots of stuff that is only relevant on the web. (Though unfortunately there's a lot of ad-hoc conditional compilation because there's a lot of stuff we also want from native code)
2. The `view!` macro has been split into 2 macros:
  - All the logic is in `raw_view!`, which takes a module / namespace argument describing where to look to resolve element names and attributes.
  - `view!` curries that argument, so you can use view! just as you do now. Different libraries can expose - eg - `leptos_cocoa::view` which wraps `raw_view` with the cocoa element set.
3. I make some changes to into_attribute. This needs further discussion. For native code we want more options for attributes - since we aren't limited to stringy DOM attributes. Eg, `width=Pct(50)`.
4. Tachys is a mess. I've currently left in a bunch of cocoa / ios / gtk rendering code in this patch because I can't think of a clean way to rip it out of tachys. It really would be convenient if the code was generic over a backend. Pity about the compile time cost. This needs some discussion.

If we can get these changes in, I can maintain cocoa / ios / etc renderers out of tree in a separate repo. And that would allow leptos to continue to make changes without needing to maintain a fork. I'd love to hear some thoughts about how that can happen.