### PR TITLE
docs(axum): remove unused LeptosOptions import from render_app_to_stream_with_context example

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -609,7 +609,7 @@ where
 ///     http::Request,
 ///     response::{IntoResponse, Response},
 /// };
-/// use leptos::{config::LeptosOptions, context::provide_context, prelude::*};
+/// use leptos::{context::provide_context, prelude::*};
 ///
 /// async fn custom_handler(
 ///     Path(id): Path<String>,


### PR DESCRIPTION
Closes #3585. The `render_app_to_stream_with_context` doc example imports `config::LeptosOptions` but never uses it, since the function no longer takes `LeptosOptions`. Per @gbj in the issue ("PR welcome to remove it from the example"), this drops the unused import. All 11 `leptos_axum` doctests pass locally.