### PR TITLE
fix: preserve sync chunk order in out-of-order SSR template

### DIFF
--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -403,8 +403,6 @@ impl Stream for StreamBuilder {
                                             .sync_buf
                                             .find(&closing)
                                             .unwrap();
-                                        let chunks_iter =
-                                            chunks.into_iter().rev();
 
                                         // TODO can probably make this more efficient
                                         let (before, replaced) =
@@ -416,18 +414,20 @@ impl Stream for StreamBuilder {
                                         buf.push_str(before);
 
                                         let mut held_chunks = VecDeque::new();
-                                        for chunk in chunks_iter {
+                                        for chunk in chunks {
                                             if let StreamChunk::Sync(ready) =
                                                 chunk
                                             {
                                                 buf.push_str(&ready);
                                             } else {
-                                                held_chunks.push_front(chunk);
+                                                held_chunks.push_back(chunk);
                                             }
                                         }
                                         buf.push_str(after);
                                         this.sync_buf = buf;
-                                        for chunk in held_chunks {
+                                        while let Some(chunk) =
+                                            held_chunks.pop_back()
+                                        {
                                             this.chunks.push_front(chunk);
                                         }
                                     } else {
@@ -435,13 +435,14 @@ impl Stream for StreamBuilder {
                                             &id,
                                             &mut this.sync_buf,
                                         );
-                                        for chunk in chunks.into_iter().rev() {
+                                        let mut held_chunks = VecDeque::new();
+                                        for chunk in chunks {
                                             if let StreamChunk::Sync(ready) =
                                                 chunk
                                             {
                                                 this.sync_buf.push_str(&ready);
                                             } else {
-                                                this.chunks.push_front(chunk);
+                                                held_chunks.push_back(chunk);
                                             }
                                         }
                                         OooChunk::push_end_with_nonce(
@@ -450,6 +451,11 @@ impl Stream for StreamBuilder {
                                             &mut this.sync_buf,
                                             nonce.as_deref(),
                                         );
+                                        while let Some(chunk) =
+                                            held_chunks.pop_back()
+                                        {
+                                            this.chunks.push_front(chunk);
+                                        }
                                     }
                                 }
                                 Poll::Pending => {


### PR DESCRIPTION
## Repro

https://github.com/tysen/leptos-out-of-order-bug

(`cargo run`)

## Bug

In `StreamBuilder`'s `Stream::poll_next` ooo handler, both branches iterated `chunks.into_iter().rev()` and dispatched sync vs. non-sync in the same pass. `.rev()` + `push_front` is correct for non-sync chunks (places them at the head of the main queue in original order), but for `StreamChunk::Sync` it `push_str`s into the buffer in reverse, so a sequence `[Sync(A), OutOfOrder, Sync(B)]` rendered as `"BA"` in the emitted `<template>`.

This shape arises when a resolved `<Suspense>` contains `<ErrorBoundary>` wrapping a nested `<Suspense>`: ErrorBoundary's `buf.append(side_buffer)` flushes the parent's `sync_buf` as a standalone `StreamChunk::Sync`, the nested Suspense pushes an `OutOfOrder` chunk, and `StreamBuilder::finish` can't re-merge the trailing sync into the leading one. The reversed concatenation then shows up as an unrecoverable hydration mismatch on the client.

## Fix

Iterate forward, append sync chunks in order, collect non-sync into a local `VecDeque` via `push_back`, then drain `pop_back` + `push_front` onto `this.chunks` — same head-of-queue invariant, correct order for both kinds. Apply to both branches (placeholder-present and emit-as-template).

## Notes

As might be obvious, I played ~zero part in identifying the root cause nor the proposed fix (thanks claude), but this did happen in my project and this really does fix it, and as far as I can tell the change is sensible and minimal. I've verified the tests pass and the examples build with this change. I've been using this in my project for a couple months with no issues. Seeing your post about the 0.9 RC prompted me to finally cut a repro/PR!