### PR TITLE
fix(server_fn): browser and reqwest client prepend server_url for form_data and streaming requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "wasm-streams",
  "web-sys",
  "xxhash-rust",

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -101,6 +101,9 @@ rustc_version = { workspace = true, default-features = true }
 [dev-dependencies]
 trybuild = { workspace = true, default-features = true }
 
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = { workspace = true, default-features = true }
+
 [features]
 axum-no-default = [
   "ssr",

--- a/server_fn/src/request/browser.rs
+++ b/server_fn/src/request/browser.rs
@@ -108,14 +108,7 @@ where
         method: http::Method,
     ) -> Result<Self, E> {
         let (abort_ctrl, abort_signal) = abort_signal();
-        let server_url = get_server_url();
-        let mut url = String::with_capacity(
-            server_url.len() + path.len() + 1 + query.len(),
-        );
-        url.push_str(server_url);
-        url.push_str(path);
-        url.push('?');
-        url.push_str(query);
+        let url = format!("{}{path}?{query}", get_server_url());
         Ok(Self(SendWrapper::new(RequestInner {
             request: match method {
                 Method::GET => Request::get(&url),
@@ -152,10 +145,7 @@ where
         method: Method,
     ) -> Result<Self, E> {
         let (abort_ctrl, abort_signal) = abort_signal();
-        let server_url = get_server_url();
-        let mut url = String::with_capacity(server_url.len() + path.len());
-        url.push_str(server_url);
-        url.push_str(path);
+        let url = format!("{}{path}", get_server_url());
         Ok(Self(SendWrapper::new(RequestInner {
             request: match method {
                 Method::POST => Request::post(&url),
@@ -190,10 +180,7 @@ where
         method: Method,
     ) -> Result<Self, E> {
         let (abort_ctrl, abort_signal) = abort_signal();
-        let server_url = get_server_url();
-        let mut url = String::with_capacity(server_url.len() + path.len());
-        url.push_str(server_url);
-        url.push_str(path);
+        let url = format!("{}{path}", get_server_url());
         let body: &[u8] = &body;
         let body = Uint8Array::from(body).buffer();
         Ok(Self(SendWrapper::new(RequestInner {
@@ -229,10 +216,7 @@ where
         method: Method,
     ) -> Result<Self, E> {
         let (abort_ctrl, abort_signal) = abort_signal();
-        let server_url = get_server_url();
-        let mut url = String::with_capacity(server_url.len() + path.len());
-        url.push_str(server_url);
-        url.push_str(path);
+        let url = format!("{}{path}", get_server_url());
         Ok(Self(SendWrapper::new(RequestInner {
             request: match method {
                 Method::POST => Request::post(&url),
@@ -266,6 +250,7 @@ where
         method: Method,
     ) -> Result<Self, E> {
         let (abort_ctrl, abort_signal) = abort_signal();
+        let url = format!("{}{path}", get_server_url());
         let form_data = body.0.take();
         let url_params =
             UrlSearchParams::new_with_str_sequence_sequence(&form_data)
@@ -279,9 +264,9 @@ where
                 })?;
         Ok(Self(SendWrapper::new(RequestInner {
             request: match method {
-                Method::POST => Request::post(path),
-                Method::PUT => Request::put(path),
-                Method::PATCH => Request::patch(path),
+                Method::POST => Request::post(&url),
+                Method::PUT => Request::put(&url),
+                Method::PATCH => Request::patch(&url),
                 m => {
                     return Err(E::from_server_fn_error(
                         ServerFnErrorErr::UnsupportedRequestMethod(
@@ -319,9 +304,10 @@ where
                 ))
             }
         }
+        let url = format!("{}{path}", get_server_url());
         // TODO abort signal
         let (request, abort_ctrl) =
-            streaming_request(path, accepts, content_type, body, method)
+            streaming_request(&url, accepts, content_type, body, method)
                 .map_err(|e| {
                     E::from_server_fn_error(ServerFnErrorErr::Request(format!(
                         "{e:?}"
@@ -335,7 +321,7 @@ where
 }
 
 fn streaming_request(
-    path: &str,
+    url: &str,
     accepts: &str,
     content_type: &str,
     body: impl Stream<Item = Bytes> + 'static,
@@ -365,6 +351,6 @@ fn streaming_request(
         &JsValue::from_str("duplex"),
         &JsValue::from_str("half"),
     )?;
-    let req = web_sys::Request::new_with_str_and_init(path, &init)?;
+    let req = web_sys::Request::new_with_str_and_init(url, &init)?;
     Ok((Request::from(req), abort_ctrl))
 }

--- a/server_fn/src/request/reqwest.rs
+++ b/server_fn/src/request/reqwest.rs
@@ -110,10 +110,11 @@ where
         body: Self::FormData,
         method: Method,
     ) -> Result<Self, E> {
+        let url = format!("{}{}", get_server_url(), path);
         match method {
-            Method::POST => CLIENT.post(path),
-            Method::PUT => CLIENT.put(path),
-            Method::PATCH => CLIENT.patch(path),
+            Method::POST => CLIENT.post(url),
+            Method::PUT => CLIENT.put(url),
+            Method::PATCH => CLIENT.patch(url),
             m => {
                 return Err(E::from_server_fn_error(
                     ServerFnErrorErr::UnsupportedRequestMethod(m.to_string()),
@@ -133,10 +134,11 @@ where
         body: Self::FormData,
         method: Method,
     ) -> Result<Self, E> {
+        let url = format!("{}{}", get_server_url(), path);
         match method {
-            Method::POST => CLIENT.post(path),
-            Method::PATCH => CLIENT.patch(path),
-            Method::PUT => CLIENT.put(path),
+            Method::POST => CLIENT.post(url),
+            Method::PATCH => CLIENT.patch(url),
+            Method::PUT => CLIENT.put(url),
             m => {
                 return Err(E::from_server_fn_error(
                     ServerFnErrorErr::UnsupportedRequestMethod(m.to_string()),

--- a/server_fn/tests/reqwest_client.rs
+++ b/server_fn/tests/reqwest_client.rs
@@ -1,0 +1,133 @@
+//! Regression tests for the native `reqwest` client request builders.
+//!
+//! These tests assert that `try_new_req_multipart` and
+//! `try_new_req_form_data` honour `server_fn::client::set_server_url(...)`.
+//! Prior to the fix, those two constructors
+//! passed the bare `path` to `reqwest::Client::post/put/patch`, which
+//! caused `reqwest::Url::parse` to fail with `RelativeUrlWithoutBase`
+//! (or send to the wrong host if `path` happened to be absolute).
+//!
+//! Sibling constructors (`try_new_req_query`, `try_new_req_text`,
+//! `try_new_req_bytes`, `try_new_req_streaming`) already applied the
+//! prefix; they are covered here as smoke tests.
+
+#![cfg(feature = "reqwest")]
+
+use bytes::Bytes;
+use futures::stream;
+use http::Method;
+use server_fn::{
+    client::set_server_url,
+    error::ServerFnError,
+    request::{reqwest::Form, ClientReq},
+};
+use std::sync::OnceLock;
+
+type Req = reqwest::Request;
+
+const SERVER: &str = "https://api.example.com";
+static INIT: OnceLock<()> = OnceLock::new();
+
+fn ensure_server_url_set() {
+    INIT.get_or_init(|| set_server_url(SERVER));
+}
+
+fn assert_full_url(actual: &reqwest::Url, expected_path: &str) {
+    let actual_str = actual.as_str();
+    let expected_prefix = format!("{SERVER}{expected_path}");
+    assert!(
+        actual_str == expected_prefix
+            || actual_str.starts_with(&expected_prefix),
+        "expected URL {actual_str:?} to start with {expected_prefix:?}"
+    );
+}
+
+#[test]
+fn multipart_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_multipart(
+        "/api/foo_multipart",
+        "*/*",
+        Form::new(),
+        Method::POST,
+    )
+    .expect("should build multipart request");
+    assert_full_url(req.url(), "/api/foo_multipart");
+}
+
+#[test]
+fn form_data_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_form_data(
+        "/api/foo_form",
+        "*/*",
+        "application/x-www-form-urlencoded",
+        Form::new(),
+        Method::POST,
+    )
+    .expect("should build form-data request");
+    assert_full_url(req.url(), "/api/foo_form");
+}
+
+#[test]
+fn query_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_query(
+        "/api/foo_query",
+        "application/json",
+        "*/*",
+        "x=1",
+        Method::GET,
+    )
+    .expect("should build query request");
+    let url = req.url();
+    let url_str = url.as_str();
+    assert!(
+        url_str.starts_with(&format!("{SERVER}/api/foo_query")),
+        "expected URL to start with server URL + path, got {url_str:?}"
+    );
+    assert_eq!(url.query(), Some("x=1"));
+}
+
+#[test]
+fn text_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_text(
+        "/api/foo_text",
+        "application/json",
+        "*/*",
+        "{}".to_string(),
+        Method::POST,
+    )
+    .expect("should build text request");
+    assert_full_url(req.url(), "/api/foo_text");
+}
+
+#[test]
+fn bytes_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_bytes(
+        "/api/foo_bytes",
+        "application/octet-stream",
+        "*/*",
+        Bytes::from_static(b""),
+        Method::POST,
+    )
+    .expect("should build bytes request");
+    assert_full_url(req.url(), "/api/foo_bytes");
+}
+
+#[test]
+fn streaming_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let body = stream::empty::<Bytes>();
+    let req = <Req as ClientReq<ServerFnError>>::try_new_req_streaming(
+        "/api/foo_stream",
+        "*/*",
+        "application/octet-stream",
+        body,
+        Method::POST,
+    )
+    .expect("should build streaming request");
+    assert_full_url(req.url(), "/api/foo_stream");
+}

--- a/server_fn/tests/wasm_browser_request.rs
+++ b/server_fn/tests/wasm_browser_request.rs
@@ -1,0 +1,108 @@
+//! Regression tests for the WASM browser client request builders.
+//!
+//! These tests assert that `try_new_req_form_data` and
+//! `try_new_req_streaming` honour `server_fn::client::set_server_url(...)`.
+//! Prior to the fix, these two constructors
+//! ignored the configured server URL and built requests against the
+//! page's own origin, causing 404/CORS failures for cross-origin clients.
+//!
+//! The other constructors in the same impl already applied the prefix,
+//! so we cover them too as smoke tests to make sure they don't regress.
+
+#![cfg(all(feature = "browser", target_family = "wasm"))]
+
+use bytes::Bytes;
+use futures::stream;
+use http::Method;
+use server_fn::{
+    client::set_server_url,
+    error::ServerFnError,
+    request::{
+        browser::{BrowserFormData, BrowserRequest},
+        ClientReq,
+    },
+};
+use std::sync::OnceLock;
+use wasm_bindgen_test::*;
+use web_sys::FormData;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const SERVER: &str = "https://api.example.com";
+static INIT: OnceLock<()> = OnceLock::new();
+
+fn ensure_server_url_set() {
+    INIT.get_or_init(|| set_server_url(SERVER));
+}
+
+fn assert_full_url(url: &str, path: &str) {
+    assert!(
+        url.starts_with(SERVER),
+        "expected URL to start with {SERVER:?}, got {url:?}"
+    );
+    assert!(
+        url.ends_with(path),
+        "expected URL to end with {path:?}, got {url:?}"
+    );
+}
+
+#[wasm_bindgen_test]
+fn form_data_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let form_data = FormData::new().expect("create FormData");
+    let body: BrowserFormData = form_data.into();
+    let req =
+        <BrowserRequest as ClientReq<ServerFnError>>::try_new_req_form_data(
+            "/api/foo_form",
+            "*/*",
+            "application/x-www-form-urlencoded",
+            body,
+            Method::POST,
+        )
+        .expect("should build form-data request");
+    assert_full_url(&req.url(), "/api/foo_form");
+}
+
+#[wasm_bindgen_test]
+fn streaming_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let body = stream::empty::<Bytes>();
+    let req =
+        <BrowserRequest as ClientReq<ServerFnError>>::try_new_req_streaming(
+            "/api/foo_stream",
+            "*/*",
+            "application/octet-stream",
+            body,
+            Method::POST,
+        )
+        .expect("should build streaming request");
+    assert_full_url(&req.url(), "/api/foo_stream");
+}
+
+#[wasm_bindgen_test]
+fn text_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <BrowserRequest as ClientReq<ServerFnError>>::try_new_req_text(
+        "/api/foo_text",
+        "application/json",
+        "*/*",
+        "{}".to_string(),
+        Method::POST,
+    )
+    .expect("should build text request");
+    assert_full_url(&req.url(), "/api/foo_text");
+}
+
+#[wasm_bindgen_test]
+fn bytes_request_prepends_configured_server_url() {
+    ensure_server_url_set();
+    let req = <BrowserRequest as ClientReq<ServerFnError>>::try_new_req_bytes(
+        "/api/foo_bytes",
+        "application/octet-stream",
+        "*/*",
+        Bytes::from_static(b""),
+        Method::POST,
+    )
+    .expect("should build bytes request");
+    assert_full_url(&req.url(), "/api/foo_bytes");
+}


### PR DESCRIPTION
In server_fn/src/request/browser.rs, the WASM `BrowserRequest` client implements 6 request constructors. Four of them (`try_new_req_query`, `try_new_req_text`, `try_new_req_bytes`, `try_new_req_multipart`) prepend `client::get_server_url()` to the caller-supplied `path` before building the `Request`. Two of them silently did not:

  - `try_new_req_form_data` passed the bare `path` to
    `Request::post/put/patch`.
  - `try_new_req_streaming` passed the bare `path` to the private
    `streaming_request` helper, which then handed it to
    `web_sys::Request::new_with_str_and_init`.

For cross-origin clients (which call `server_fn::client::set_server_url("https://api.example.com")` so the WASM client can talk to a separate API host), URL-encoded form submissions and streaming requests were dispatched against the page's own origin instead of the configured API host. This produced 404/CORS failures that were very hard to diagnose because the other request types in the same struct continued to work.

Apply the exact pattern already used by the four sibling constructors in the same file:

    let url = format!("{}{}", get_server_url(), path);

Then build the gloo/`web_sys` request from `&url` rather than `path`.

It is the same for the `reqwest` implementation.
