### PR TITLE
fix(server_fn): avoid panic on invalid path bytes in error_response

### DIFF
--- a/server_fn/src/response/generic.rs
+++ b/server_fn/src/response/generic.rs
@@ -93,12 +93,24 @@ where
 
 impl Res for Response<Body> {
     fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self {
-        Response::builder()
-            .status(err.status_code)
-            .header(SERVER_FN_ERROR_HEADER, path)
-            .header(header::CONTENT_TYPE, err.content_type)
-            .body(err.body.into())
-            .unwrap()
+        let status_code = err.status_code;
+        let content_type = err.content_type;
+        let body = err.body;
+        let mut builder = Response::builder()
+            .status(status_code)
+            .header(header::CONTENT_TYPE, content_type);
+        // `path` originates from the request URI and could in principle
+        // contain bytes that are not valid in an HTTP header value
+        // (control bytes, etc.). Skip the diagnostic header rather than
+        // letting the builder error propagate to an `unwrap()` panic.
+        if let Ok(path_value) = HeaderValue::from_str(path) {
+            builder = builder.header(SERVER_FN_ERROR_HEADER, path_value);
+        }
+        builder.body(Body::Sync(body.clone())).unwrap_or_else(|_| {
+            let mut fallback = Response::new(Body::Sync(body));
+            *fallback.status_mut() = status_code;
+            fallback
+        })
     }
 
     fn redirect(&mut self, path: &str) {
@@ -106,5 +118,51 @@ impl Res for Response<Body> {
             self.headers_mut().insert(header::LOCATION, path);
             *self.status_mut() = StatusCode::FOUND;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_parts() -> ServerFnErrorResponseParts {
+        ServerFnErrorResponseParts::builder()
+            .body(Bytes::from_static(b"oops"))
+            .content_type("text/plain")
+            .status_code(StatusCode::INTERNAL_SERVER_ERROR)
+            .build()
+    }
+
+    #[test]
+    fn error_response_does_not_panic_on_invalid_path_header_bytes() {
+        // CR/LF are forbidden in HTTP header values. The previous
+        // implementation called `.unwrap()` on the builder and panicked
+        // for any path that could not be encoded as a `HeaderValue`.
+        let resp = <Response<Body> as Res>::error_response(
+            "/api/foo\r\nX-Evil: y",
+            build_parts(),
+        );
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        // The malformed path must not have been inserted as a header.
+        assert!(resp.headers().get(SERVER_FN_ERROR_HEADER).is_none());
+    }
+
+    #[test]
+    fn error_response_includes_path_header_when_valid() {
+        let resp =
+            <Response<Body> as Res>::error_response("/api/foo", build_parts());
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            resp.headers()
+                .get(SERVER_FN_ERROR_HEADER)
+                .map(|v| v.as_bytes()),
+            Some(&b"/api/foo"[..]),
+        );
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .map(|v| v.as_bytes()),
+            Some(&b"text/plain"[..]),
+        );
     }
 }

--- a/server_fn/src/response/http.rs
+++ b/server_fn/src/response/http.rs
@@ -53,12 +53,24 @@ where
 
 impl Res for Response<Body> {
     fn error_response(path: &str, err: ServerFnErrorResponseParts) -> Self {
-        Response::builder()
-            .status(err.status_code)
-            .header(SERVER_FN_ERROR_HEADER, path)
-            .header(header::CONTENT_TYPE, err.content_type)
-            .body(err.body.into())
-            .unwrap()
+        let status_code = err.status_code;
+        let content_type = err.content_type;
+        let body = err.body;
+        let mut builder = Response::builder()
+            .status(status_code)
+            .header(header::CONTENT_TYPE, content_type);
+        // `path` originates from the request URI and could in principle
+        // contain bytes that are not valid in an HTTP header value
+        // (control bytes, etc.). Skip the diagnostic header rather than
+        // letting the builder error propagate to an `unwrap()` panic.
+        if let Ok(path_value) = HeaderValue::from_str(path) {
+            builder = builder.header(SERVER_FN_ERROR_HEADER, path_value);
+        }
+        builder.body(Body::from(body.clone())).unwrap_or_else(|_| {
+            let mut fallback = Response::new(Body::from(body));
+            *fallback.status_mut() = status_code;
+            fallback
+        })
     }
 
     fn redirect(&mut self, path: &str) {
@@ -66,5 +78,51 @@ impl Res for Response<Body> {
             self.headers_mut().insert(header::LOCATION, path);
             *self.status_mut() = StatusCode::FOUND;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_parts() -> ServerFnErrorResponseParts {
+        ServerFnErrorResponseParts::builder()
+            .body(Bytes::from_static(b"oops"))
+            .content_type("text/plain")
+            .status_code(StatusCode::INTERNAL_SERVER_ERROR)
+            .build()
+    }
+
+    #[test]
+    fn error_response_does_not_panic_on_invalid_path_header_bytes() {
+        // CR/LF are forbidden in HTTP header values. The previous
+        // implementation called `.unwrap()` on the builder and panicked
+        // for any path that could not be encoded as a `HeaderValue`.
+        let resp = <Response<Body> as Res>::error_response(
+            "/api/foo\r\nX-Evil: y",
+            build_parts(),
+        );
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        // The malformed path must not have been inserted as a header.
+        assert!(resp.headers().get(SERVER_FN_ERROR_HEADER).is_none());
+    }
+
+    #[test]
+    fn error_response_includes_path_header_when_valid() {
+        let resp =
+            <Response<Body> as Res>::error_response("/api/foo", build_parts());
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            resp.headers()
+                .get(SERVER_FN_ERROR_HEADER)
+                .map(|v| v.as_bytes()),
+            Some(&b"/api/foo"[..]),
+        );
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_TYPE)
+                .map(|v| v.as_bytes()),
+            Some(&b"text/plain"[..]),
+        );
     }
 }


### PR DESCRIPTION
Both `http::Response::error_response` and
`generic::Response::error_response` set the `serverfnerror` header directly from the request `path` and then called `.unwrap()` on the builder:

    Response::builder()
        .status(err.status_code)
        .header(SERVER_FN_ERROR_HEADER, path)
        .header(header::CONTENT_TYPE, err.content_type)
        .body(err.body.into())
        .unwrap()

`http::Response::builder` accumulates header errors and surfaces them at `.body(...)`. Any caller that passes a string with bytes that `HeaderValue` rejects (control bytes, etc.) crashes the worker on the error path. The public function is also reachable from custom code that does not pre-validate the path through hyper's URI parser.

Fix: validate `path` via `HeaderValue::from_str` and drop the diagnostic header on failure; keep an `unwrap_or_else` backstop that preserves the status code and body, so the client still sees a meaningful error response instead of a panic.

Add regression tests in both modules that call `error_response` with a path containing `\r\n` and assert the response is well-formed with the malformed header omitted.