### PR TITLE
fix(server_fn): apply back-pressure in websocket forwarding loop

### DIFF
--- a/server_fn/src/request/actix.rs
+++ b/server_fn/src/request/actix.rs
@@ -6,7 +6,7 @@ use crate::{
 use actix_web::{web::Payload, HttpRequest};
 use actix_ws::Message;
 use bytes::Bytes;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{FutureExt, SinkExt, Stream, StreamExt};
 use send_wrapper::SendWrapper;
 use std::{borrow::Cow, future::Future};
 
@@ -143,9 +143,11 @@ where
                         let Some(incoming) = incoming else {
                             break;
                         };
-                                if let Err(err) = session.binary(incoming).await {
-                                    _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body));
-                                }
+                        if let Err(err) = session.binary(incoming).await {
+                            if response_stream_tx.send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body)).await.is_err() {
+                                break;
+                            }
+                        }
                     },
                     outgoing = msg_stream.next().fuse() => {
                         let Some(outgoing) = outgoing else {
@@ -158,13 +160,14 @@ where
                                 }
                             }
                             Ok(Message::Binary(bytes)) => {
-                                _ = response_stream_tx
-                                    .start_send(
-                                        Ok(bytes),
-                                    );
+                                if response_stream_tx.send(Ok(bytes)).await.is_err() {
+                                    break;
+                                }
                             }
                             Ok(Message::Text(text)) => {
-                                _ = response_stream_tx.start_send(Ok(text.into_bytes()));
+                                if response_stream_tx.send(Ok(text.into_bytes())).await.is_err() {
+                                    break;
+                                }
                             }
                             Ok(Message::Close(_)) => {
                                 break;
@@ -172,7 +175,9 @@ where
                             Ok(_other) => {
                             }
                             Err(e) => {
-                                _ = response_stream_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body));
+                                if response_stream_tx.send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body)).await.is_err() {
+                                    break;
+                                }
                             }
                         }
                     }

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -6,6 +6,8 @@ use axum::{
     body::{Body, Bytes},
     response::Response,
 };
+#[cfg(feature = "axum")]
+use futures::SinkExt;
 use futures::{Sink, Stream, StreamExt};
 use http::{
     header::{ACCEPT, CONTENT_TYPE, REFERER},
@@ -136,7 +138,9 @@ where
                             break;
                         };
                         if let Err(err) = session.send(Message::Binary(incoming)).await {
-                            _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body));
+                            if outgoing_tx.send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Request(err.to_string())).ser().body)).await.is_err() {
+                                break;
+                            }
                         }
                     },
                         outgoing = session.recv().fuse() => {
@@ -145,13 +149,14 @@ where
                         };
                         match outgoing {
                             Ok(Message::Binary(bytes)) => {
-                                _ = outgoing_tx
-                                    .start_send(
-                                        Ok(bytes),
-                                    );
+                                if outgoing_tx.send(Ok(bytes)).await.is_err() {
+                                    break;
+                                }
                             }
                             Ok(Message::Text(text)) => {
-                                _ = outgoing_tx.start_send(Ok(Bytes::from(text)));
+                                if outgoing_tx.send(Ok(Bytes::from(text))).await.is_err() {
+                                    break;
+                                }
                             }
                             Ok(Message::Ping(bytes)) => {
                                 if session.send(Message::Pong(bytes)).await.is_err() {
@@ -160,7 +165,9 @@ where
                             }
                             Ok(_other) => {}
                             Err(e) => {
-                                _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body));
+                                if outgoing_tx.send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(e.to_string())).ser().body)).await.is_err() {
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Both the axum and actix websocket adapters create a bounded `futures::channel::mpsc` channel (capacity 2048) to forward messages from the underlying session into the server-function output stream, then called `start_send` directly on the sender inside the forwarding loop. Per the `Sink` contract, `start_send` requires a prior `poll_ready` returning `Ready`; calling it on a full bounded sender returns `Err(TrySendError)`. The previous code swallowed that error with `_ = ...`, so once the consumer of the output stream fell behind, incoming WebSocket frames were silently dropped with no error surfaced to either side and no back-pressure on the producer.

Switch each forwarding call to `SinkExt::send(...).await`, which awaits capacity via `poll_ready` before placing the item, pausing the forwarding loop when the consumer is slow instead of dropping frames. When `send` reports the receiver has been dropped, break the loop and close the session cleanly rather than spinning on a dead channel.