### PR TITLE
Add Declarative Shadow DOM Support to Leptos

### DIFF
--- a/tachys/src/html/attribute/key.rs
+++ b/tachys/src/html/attribute/key.rs
@@ -405,6 +405,8 @@ attributes! {
     scoped "scoped",
     /// The `selected` attribute indicates that the option is selected.
     selected "selected",
+    /// Creates a shadow root for the parent element. It is a declarative version of the Element.attachShadow() method and accepts the same enumerated values.
+    shadowrootmode "shadowrootmode",
     /// The `shape` attribute specifies the shape of the area.
     shape "shape",
     /// The `size` attribute specifies the width of the input element.

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -401,7 +401,7 @@ html_elements! {
     /// The `<td>` HTML element defines a cell of a table that contains data. It participates in the table model.
     td HtmlTableCellElement [colspan, headers, rowspan] true,
     /// The `<template>` HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript.
-    template HtmlTemplateElement [] true,
+    template HtmlTemplateElement [shadowrootmode] true,
     /// The `<textarea>` HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
     textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] false,
     /// The `<tfoot>` HTML element defines a set of rows summarizing the columns of the table.


### PR DESCRIPTION
This is a **DRAFT PR** for the work of integrating support for declarative shadow dom in Leptos.

Declarative shadow dom is not he same as web components, but you can still attach  the shadow root to a custom tag.

## DESIGN

1. When rendered in SSR, there will be no changes to the current rendering logic.
1. When rendering in the browser (CSR) such as during dom updates, Leptos will look for if a shadowroot instance exists per node in the browser. 
   a.  If the shadowroot instance doesn't exist, standard rendering will happen
   b. If the shadowroot instance exists, Leptos will iterate over the leptos nodes, where if a node is of type template/shadowroot, its children will be rendered/updated to the shadow root instance.  All other elements will be rendered as standard child nodes so that slotting works.

## EXAMPLE

https://web.dev/articles/declarative-shadow-dom

```html
<host-element>
  <template shadowrootmode="open">
    <slot></slot>
  </template>
  <h2>Light content</h2>
</host-element>
```

The browser on initial render of the static html will take the template element with shadowrootmode and create a shadowroot instance on the host-element, removing the original dom node.  Current rendering of leptops is enough for the initial render.  

But on update, since the template tag disappears and the child elements of the template tag  are added to the shadow root instance, Leptos becomes unable to handle the relationship of the child nodes in the next render... they are in a different spot than existed.  Leptos likely still tries to render the nodes to the `host-element` as children, which will not show up unless there is some lucky `<slot>` match.


## Future and Out of Scope for this work

Once implemented, most of the styles as code libraries will lose a lot of their utility and the build size of many projects should drop.


Future things to consider;
1. The style tags as part of the html will not be minified without some kind of build extension
2. The ergonimics of an inline style tag can problably be improved, particularly in a way that enables syntax highlighting and linting