### PR TITLE
feat(leptos_macro): Adding a `lazy_preload` macro

### DIFF
--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -1,13 +1,20 @@
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use proc_macro_error2::abort;
+use proc_macro_error2::{OptionExt, ResultExt, abort};
 use quote::{format_ident, quote};
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     mem,
 };
-use syn::{parse_macro_input, parse_quote, ItemFn, ReturnType, Stmt};
+use syn::{
+    parse::Parse, parse_macro_input, parse_quote, ItemFn, Path, ReturnType,
+    Stmt,
+};
+
+fn preload_name(ident: &Ident) -> Ident {
+    format_ident!("__preload_{}", ident)
+}
 
 pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     let name = if !args.is_empty() {
@@ -69,7 +76,7 @@ pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
                 return_wrapper(let future = _; { future.await } #async_output),
             });
         }
-        let preload_name = format_ident!("__preload_{}", fun.sig.ident);
+        let preload_name = preload_name(&fun.sig.ident);
 
         quote! {
             #[::leptos::wasm_split::wasm_split(
@@ -94,5 +101,42 @@ pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
         statements.extend(old_statements);
         quote! { #fun }
     }
+    .into()
+}
+
+struct LazyPath(Path);
+
+impl Parse for LazyPath {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self(Path::parse_mod_style(input)?))
+    }
+}
+
+pub fn lazy_preload_impl(s: proc_macro::TokenStream) -> TokenStream {
+    let LazyPath(mut path) = syn::parse::<LazyPath>(s).expect_or_abort("`lazy_preload` only takes a function path as argument");
+    let last_segment = path.segments.last_mut().expect_or_abort(
+        "`lazy_preload` needs a path ending with an identifier",
+    );
+    last_segment.ident = preload_name(&last_segment.ident);
+
+    let preload_call = if cfg!(feature = "hydrate") {
+        quote! {
+            ::leptos::task::spawn_local(async move {
+
+                #path().await;
+                set_loaded.set(true);
+            });
+        }
+    } else {
+        quote! {}
+    };
+
+    quote! {{
+        use ::leptos::prelude::Set;
+
+        let (loaded, set_loaded) = ::leptos::prelude::signal(false);
+        #preload_call
+        loaded
+    }}
     .into()
 }

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -1,7 +1,7 @@
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use proc_macro_error2::{OptionExt, ResultExt, abort};
+use proc_macro_error2::{abort, OptionExt, ResultExt};
 use quote::{format_ident, quote};
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
@@ -113,7 +113,9 @@ impl Parse for LazyPath {
 }
 
 pub fn lazy_preload_impl(s: proc_macro::TokenStream) -> TokenStream {
-    let LazyPath(mut path) = syn::parse::<LazyPath>(s).expect_or_abort("`lazy_preload` only takes a function path as argument");
+    let LazyPath(mut path) = syn::parse::<LazyPath>(s).expect_or_abort(
+        "`lazy_preload` only takes a function path as argument",
+    );
     let last_segment = path.segments.last_mut().expect_or_abort(
         "`lazy_preload` needs a path ending with an identifier",
     );

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -1,7 +1,7 @@
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use proc_macro_error2::{abort, OptionExt, ResultExt};
+use proc_macro_error2::abort;
 use quote::{format_ident, quote};
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
@@ -113,12 +113,17 @@ impl Parse for LazyPath {
 }
 
 pub fn lazy_preload_impl(s: proc_macro::TokenStream) -> TokenStream {
-    let LazyPath(mut path) = syn::parse::<LazyPath>(s).expect_or_abort(
-        "`lazy_preload` only takes a function path as argument",
-    );
-    let last_segment = path.segments.last_mut().expect_or_abort(
-        "`lazy_preload` needs a path ending with an identifier",
-    );
+    let LazyPath(mut path) = syn::parse::<LazyPath>(s).unwrap_or_else(|e| {
+        abort!(
+            e.span(),
+            "`lazy_preload` only takes a function path as argument"
+        )
+    });
+    let last_segment = path.segments.last_mut().unwrap_or_else(|| {
+        abort_call_site!(
+            "`lazy_preload` needs a path ending with an identifier"
+        )
+    });
     last_segment.ident = preload_name(&last_segment.ident);
 
     let preload_call = if cfg!(feature = "hydrate") {

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -1102,8 +1102,7 @@ pub fn lazy(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// mod scoped
-/// {
+/// mod scoped {
 ///     # use leptos_macro::lazy;
 ///     #[lazy]
 ///     pub fn lazy_func() {}
@@ -1113,7 +1112,6 @@ pub fn lazy(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 /// fn preload_scoped_lazy() {
 ///     let is_loaded = lazy_preload!(scoped::lazy_func);
 /// }
-///
 /// ```
 #[proc_macro]
 #[proc_macro_error]

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -1074,3 +1074,49 @@ pub fn memo(input: TokenStream) -> TokenStream {
 pub fn lazy(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     lazy::lazy_impl(args, s)
 }
+
+/// Preloads a lazy function and returns a signal that evaluates to `true` once the function is loaded.
+///
+/// The first time a signal is created through this macro, the WebAssembly (WASM) binary containing
+/// the lazy function will be loaded and ready to call. This can be useful when the WASM binary is big
+/// and you want to display a placeholder view while it is loading.
+///
+/// When called from a server, the signal returned by `lazy_preload` will always return false to match
+/// with the client's expectation on first render.
+///
+/// Only a function marked as `#[lazy]` can be passed to `lazy_preload`.
+///
+/// ```rust
+/// # use leptos_macro::{lazy, lazy_preload};
+/// # use leptos::prelude::Get;
+///
+/// #[lazy]
+/// fn lazy_func() {}
+///
+/// fn preload_lazy() -> &'static str {
+///     let is_loaded = lazy_preload!(lazy_func);
+///     if is_loaded.get() {
+///         "Loaded"
+///     } else {
+///         "Loading..."
+///     }
+/// }
+///
+/// mod scoped
+/// {
+///     # use leptos_macro::lazy;
+///     #[lazy]
+///     pub fn lazy_func() {}
+/// }
+///
+/// // Also works with scoped lazy functions
+/// fn preload_scoped_lazy() {
+///     let is_loaded = lazy_preload!(scoped::lazy_func);
+/// }
+///
+/// ```
+#[proc_macro]
+#[proc_macro_error]
+pub fn lazy_preload(s: TokenStream) -> TokenStream {
+    lazy::lazy_preload_impl(s)
+}


### PR DESCRIPTION
Closes #4727 

Adds a `lazy_preload` convenience macro to explicitly download lazy function's split WASM and react to it's loading status.