### PR TITLE
Fix HTML-injection (XSS) sinks in tachys and leptos_macro

### DIFF
--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -205,3 +205,39 @@ fn ssr_option() {
 
     assert_eq!(rendered.to_html(), "<option></option>");
 }
+
+#[cfg(feature = "ssr")]
+#[test]
+fn ssr_textarea_escapes_static_content() {
+    use leptos::prelude::*;
+
+    // Nested (non-top-level) static textarea exercises the macro's inert
+    // HTML path; its content must be HTML-escaped.
+    let rendered: View<HtmlElement<_, _, _>> = view! {
+        <div><textarea>"a < b & c"</textarea></div>
+    };
+
+    assert_eq!(
+        rendered.to_html(),
+        "<div><textarea>a &lt; b &amp; c</textarea></div>"
+    );
+}
+
+#[cfg(feature = "ssr")]
+#[test]
+fn ssr_textarea_escapes_dynamic_content() {
+    use leptos::prelude::*;
+
+    // A dynamic child makes the textarea non-inert, exercising the runtime
+    // render path; its content must also be HTML-escaped.
+    let untrusted = "</textarea><script>alert('xss')</script>".to_string();
+    let rendered: View<HtmlElement<_, _, _>> = view! {
+        <textarea>{untrusted}</textarea>
+    };
+
+    assert_eq!(
+        rendered.to_html(),
+        "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;\
+         /script&gt;</textarea>"
+    );
+}

--- a/leptos/tests/ssr.rs
+++ b/leptos/tests/ssr.rs
@@ -237,7 +237,7 @@ fn ssr_textarea_escapes_dynamic_content() {
 
     assert_eq!(
         rendered.to_html(),
-        "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;\
-         /script&gt;</textarea>"
+        "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;/script&gt;\
+         </textarea>"
     );
 }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -337,8 +337,7 @@ fn inert_element_to_tokens(
                     Node::Element(node) => {
                         let self_closing = is_self_closing(node);
                         let el_name = node.name().to_string();
-                        let escape = el_name != "script"
-                            && el_name != "style";
+                        let escape = el_name != "script" && el_name != "style";
 
                         // opening tag
                         html.push('<');
@@ -447,8 +446,7 @@ fn inert_svg_element_to_tokens(
                             .map(str::to_string)
                             .unwrap_or(el_name);
 
-                        let escape = el_name != "script"
-                            && el_name != "style";
+                        let escape = el_name != "script" && el_name != "style";
 
                         // opening tag
                         html.push('<');
@@ -702,8 +700,7 @@ fn node_to_tokens(
         Node::Element(el_node) => {
             if !top_level && is_inert {
                 let el_name = el_node.name().to_string();
-                let escape = el_name != "script"
-                    && el_name != "style";
+                let escape = el_name != "script" && el_name != "style";
 
                 let el_name = el_node.name().to_string();
                 if is_svg_element(&el_name) && el_name != "svg" {

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -338,8 +338,7 @@ fn inert_element_to_tokens(
                         let self_closing = is_self_closing(node);
                         let el_name = node.name().to_string();
                         let escape = el_name != "script"
-                            && el_name != "style"
-                            && el_name != "textarea";
+                            && el_name != "style";
 
                         // opening tag
                         html.push('<');
@@ -449,8 +448,7 @@ fn inert_svg_element_to_tokens(
                             .unwrap_or(el_name);
 
                         let escape = el_name != "script"
-                            && el_name != "style"
-                            && el_name != "textarea";
+                            && el_name != "style";
 
                         // opening tag
                         html.push('<');
@@ -705,8 +703,7 @@ fn node_to_tokens(
             if !top_level && is_inert {
                 let el_name = el_node.name().to_string();
                 let escape = el_name != "script"
-                    && el_name != "style"
-                    && el_name != "textarea";
+                    && el_name != "style";
 
                 let el_name = el_node.name().to_string();
                 if is_svg_element(&el_name) && el_name != "svg" {

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -403,7 +403,7 @@ html_elements! {
     /// The `<template>` HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript.
     template HtmlTemplateElement [] true,
     /// The `<textarea>` HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
-    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] false,
+    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] true,
     /// The `<tfoot>` HTML element defines a set of rows summarizing the columns of the table.
     tfoot HtmlTableSectionElement [] true,
     /// The `<th>` HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.
@@ -429,4 +429,27 @@ html_elements! {
 html_element_inner! {
     /// The `<option>` HTML element is used to define an item contained in a `<select>`, an` <optgroup>`, or a `<datalist>` element. As such, `<option>` can represent menu items in popups and other lists of items in an HTML document.
     option Option_ HtmlOptionElement [disabled, label, selected, value] true
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use crate::{
+        html::element::{textarea, ElementChild},
+        view::RenderHtml,
+    };
+
+    #[test]
+    fn textarea_escapes_child_content() {
+        // `<textarea>` content is escapable raw text per the HTML spec, so a
+        // child string containing `</textarea>` or `<script>` must be escaped
+        // rather than written verbatim.
+        let untrusted =
+            "</textarea><script>alert('xss')</script>".to_string();
+        let html = textarea().child(untrusted).to_html();
+        assert_eq!(
+            html,
+            "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;\
+             /script&gt;</textarea>"
+        );
+    }
 }

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -434,7 +434,7 @@ html_element_inner! {
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
     use crate::{
-        html::element::{textarea, ElementChild},
+        html::element::{ElementChild, textarea},
         view::RenderHtml,
     };
 
@@ -443,13 +443,12 @@ mod tests {
         // `<textarea>` content is escapable raw text per the HTML spec, so a
         // child string containing `</textarea>` or `<script>` must be escaped
         // rather than written verbatim.
-        let untrusted =
-            "</textarea><script>alert('xss')</script>".to_string();
+        let untrusted = "</textarea><script>alert('xss')</script>".to_string();
         let html = textarea().child(untrusted).to_html();
         assert_eq!(
             html,
-            "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;\
-             /script&gt;</textarea>"
+            "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;/script&\
+             gt;</textarea>"
         );
     }
 }

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -18,7 +18,7 @@ use std::{
 
 // any changes here should also be made in src/reactive_graph/guards.rs
 macro_rules! render_primitive {
-  ($($child_type:ty),* $(,)?) => {
+  ($escape:literal; $($child_type:ty),* $(,)?) => {
     $(
 		paste::paste! {
 			pub struct [<$child_type:camel State>](crate::renderer::types::Text, $child_type);
@@ -80,12 +80,24 @@ macro_rules! render_primitive {
                     self
                 }
 
-				fn to_html_with_buf(self, buf: &mut String, position: &mut Position, _escape: bool, _mark_branches: bool, _extra_attrs: Vec<AnyAttribute>) {
+				fn to_html_with_buf(self, buf: &mut String, position: &mut Position, escape: bool, _mark_branches: bool, _extra_attrs: Vec<AnyAttribute>) {
 					// add a comment node to separate from previous sibling, if any
 					if matches!(position, Position::NextChildAfterText) {
 						buf.push_str("<!>")
 					}
-					_ = write!(buf, "{}", self);
+					// `$escape` is `true` only for types whose `Display` output can
+					// contain HTML-significant characters (e.g. `char`). Numeric
+					// primitives emit a syntactic subset of HTML text and are written
+					// directly to avoid an intermediate allocation.
+					if $escape {
+						if escape {
+							buf.push_str(&html_escape::encode_text(&self.to_string()));
+						} else {
+							_ = write!(buf, "{}", self);
+						}
+					} else {
+						_ = write!(buf, "{}", self);
+					}
 					*position = Position::NextChildAfterText;
 				}
 
@@ -145,6 +157,7 @@ macro_rules! render_primitive {
 }
 
 render_primitive![
+    false;
     usize,
     u8,
     u16,
@@ -159,7 +172,6 @@ render_primitive![
     i128,
     f32,
     f64,
-    char,
     bool,
     IpAddr,
     SocketAddr,
@@ -180,3 +192,54 @@ render_primitive![
     NonZeroIsize,
     NonZeroUsize,
 ];
+
+// `char` can be any Unicode scalar value, including HTML-significant
+// characters such as `<`, `>`, `&`, `"`, and `'`. Its body output must be
+// escaped to avoid an HTML-injection sink.
+render_primitive![true; char];
+
+#[cfg(test)]
+mod tests {
+    use crate::view::{Position, RenderHtml};
+
+    #[test]
+    fn char_escapes_html_special_characters() {
+        let mut buf = String::new();
+        '<'.to_html_with_buf(
+            &mut buf,
+            &mut Position::FirstChild,
+            true,
+            false,
+            vec![],
+        );
+        assert_eq!(buf, "&lt;");
+    }
+
+    #[test]
+    fn char_not_escaped_in_raw_text_context() {
+        // When the enclosing element opts out of escaping (e.g. `<script>`),
+        // the char must be written verbatim.
+        let mut buf = String::new();
+        '<'.to_html_with_buf(
+            &mut buf,
+            &mut Position::FirstChild,
+            false,
+            false,
+            vec![],
+        );
+        assert_eq!(buf, "<");
+    }
+
+    #[test]
+    fn numeric_primitive_renders_unescaped() {
+        let mut buf = String::new();
+        42u32.to_html_with_buf(
+            &mut buf,
+            &mut Position::FirstChild,
+            true,
+            false,
+            vec![],
+        );
+        assert_eq!(buf, "42");
+    }
+}


### PR DESCRIPTION
This PR closes cases where untrusted data could reach the HTML body without escaping, across both the runtime renderer and the `view!` macro's static-HTML path.

### 1. `char` rendered without escaping (`tachys`)
`RenderHtml::to_html_with_buf` for primitive types ignored the `escape` flag and wrote values directly. For numeric/`bool`/`IpAddr`/`NonZero*` types this is harmless, their `Display` output is a subset of HTML text. But a `char` can be any Unicode scalar value, including `<`, `>`, `&`, `"`, `'`, so an attacker-controlled `char` rendered into an element body was an injection vector.

The `render_primitive!` macro is now parametrized with an escaping flag: `char` is escaped via `html_escape::encode_text` when the enclosing element escapes its children, and written verbatim only in raw-text contexts (`escape == false`). All other primitives keep their original allocation-free direct write, output is byte-identical.

### 2. `<textarea>` children not escaped (`tachys`)
`<textarea>` was declared with `ESCAPE_CHILDREN: false`, grouping it with the true raw-text elements `<script>`/`<style>`/`<noscript>`. But per the HTML spec, textarea content is *escapable* raw text, any `</textarea>` closes the element, so input like `</textarea><script>alert('xss')</script>` broke out and injected live markup. The flag is now `true`. This path handles all **dynamic** textarea content.

### 3. `<textarea>` not escaped in the macro's inert path (`leptos_macro`)
The `view!` macro has a separate compile-time static-HTML generator that *also* lumped `textarea` with `script`/`style` as non-escaping. This only affects fully-static ("inert") textarea content (not untrusted input), but it diverged from the runtime path and is incorrect per spec. Dropped `textarea` from the raw-text exemption at all three inert sites (element, SVG element, node dispatcher), so static textarea content is now escaped consistently with the runtime path.