### PR TITLE
Fix five bugs in the `router`

### DIFF
--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -649,7 +649,15 @@ pub fn RoutingProgress(
     const INCREMENT_EVERY_MS: f32 = 5.0;
     let expected_increments =
         max_time.as_secs_f32() / (INCREMENT_EVERY_MS / 1000.0);
-    let percent_per_increment = 100.0 / expected_increments;
+    // `max_time` is optional and defaults to `Duration::ZERO`, which would make
+    // `expected_increments` zero and `100.0 / 0.0` evaluate to `inf` (and then
+    // `NaN`), producing `width: NaN%`. Fill the bar in a single increment when
+    // no positive `max_time` was provided.
+    let percent_per_increment = if expected_increments > 0.0 {
+        100.0 / expected_increments
+    } else {
+        100.0
+    };
 
     let (is_showing, set_is_showing) = signal(false);
     let (progress, set_progress) = signal(0.0);

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -355,9 +355,7 @@ fn extract_form_attributes(
                     form.get_attribute("method")
                         .unwrap_or_else(|| "get".to_string())
                         .to_lowercase(),
-                    form.get_attribute("action")
-                        .unwrap_or_default()
-                        .to_lowercase(),
+                    form.get_attribute("action").unwrap_or_default(),
                     form.get_attribute("enctype")
                         .unwrap_or_else(|| {
                             "application/x-www-form-urlencoded".to_string()
@@ -379,9 +377,7 @@ fn extract_form_attributes(
                             .to_lowercase()
                     }),
                     input.get_attribute("action").unwrap_or_else(|| {
-                        form.get_attribute("action")
-                            .unwrap_or_default()
-                            .to_lowercase()
+                        form.get_attribute("action").unwrap_or_default()
                     }),
                     input.get_attribute("enctype").unwrap_or_else(|| {
                         form.get_attribute("enctype")
@@ -406,9 +402,7 @@ fn extract_form_attributes(
                             .to_lowercase()
                     }),
                     button.get_attribute("action").unwrap_or_else(|| {
-                        form.get_attribute("action")
-                            .unwrap_or_default()
-                            .to_lowercase()
+                        form.get_attribute("action").unwrap_or_default()
                     }),
                     button.get_attribute("enctype").unwrap_or_else(|| {
                         form.get_attribute("enctype")

--- a/router/src/location/history.rs
+++ b/router/src/location/history.rs
@@ -276,19 +276,19 @@ impl LocationProvider for BrowserUrl {
 fn search_params_from_web_url(
     params: &web_sys::UrlSearchParams,
 ) -> Result<ParamsMap, JsValue> {
-    try_iter(params)?
-        .into_iter()
-        .flatten()
-        .map(|pair| {
-            pair.and_then(|pair| {
-                let row = pair.dyn_into::<Array>()?;
-                Ok((
-                    String::from(row.get(0).dyn_into::<JsString>()?),
-                    String::from(row.get(1).dyn_into::<JsString>()?),
-                ))
-            })
-        })
-        .collect()
+    // `URLSearchParams` already percent-decodes its entries, so insert them
+    // as-is. Routing them through `ParamsMap::insert`/`FromIterator` would
+    // decode a second time and corrupt any literal `%xx` sequence, which would
+    // also diverge from the server-side `RequestUrl` parse and break hydration.
+    let mut map = ParamsMap::new();
+    for pair in try_iter(params)?.into_iter().flatten() {
+        let pair = pair?;
+        let row = pair.dyn_into::<Array>()?;
+        let key = String::from(row.get(0).dyn_into::<JsString>()?);
+        let value = String::from(row.get(1).dyn_into::<JsString>()?);
+        map.insert_decoded(key, value);
+    }
+    Ok(map)
 }
 
 /// Resolves a redirect location to an (absolute) URL.

--- a/router/src/location/server.rs
+++ b/router/src/location/server.rs
@@ -33,10 +33,13 @@ impl RequestUrl {
         let base = url::Url::parse(base)?;
         let url = url::Url::options().base_url(Some(&base)).parse(&self.0)?;
 
-        let search_params = url
-            .query_pairs()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect::<ParamsMap>();
+        // `query_pairs()` already percent-decodes the values, so insert them
+        // as-is. Going through `ParamsMap::insert`/`FromIterator` would decode
+        // a second time and corrupt any literal `%xx` sequence.
+        let mut search_params = ParamsMap::new();
+        for (k, v) in url.query_pairs() {
+            search_params.insert_decoded(k.into_owned(), v.into_owned());
+        }
 
         Ok(Url {
             origin: url.origin().unicode_serialization(),
@@ -71,5 +74,21 @@ mod tests {
             .unwrap();
         assert_eq!(url.origin(), "https://www.example.com");
         assert_eq!(url.path(), "/foo/bar");
+    }
+
+    #[test]
+    pub fn should_decode_query_params_exactly_once() {
+        // `%2520` decodes once to `%20`; a second (buggy) decode would turn it
+        // into a space.
+        let url = RequestUrl::new("/?q=100%2520percent").parse().unwrap();
+        assert_eq!(url.search_params().get("q").unwrap(), "100%20percent");
+
+        // A literal percent-encoded slash inside an opaque id must survive.
+        let url = RequestUrl::new("/api?id=foo%252Fbar").parse().unwrap();
+        assert_eq!(url.search_params().get("id").unwrap(), "foo%2Fbar");
+
+        // Base64 padding carried in a signature must not be truncated.
+        let url = RequestUrl::new("/?sig=YWJj%253D%253D").parse().unwrap();
+        assert_eq!(url.search_params().get("sig").unwrap(), "YWJj%3D%3D");
     }
 }

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -292,6 +292,28 @@ mod tests {
     }
 
     #[test]
+    pub fn nested_tuple_preserves_inner_route_match_id() {
+        use crate::matching::MatchNestedRoutes;
+
+        // Each NestedRoute is assigned a unique RouteMatchId at construction.
+        let three = (
+            NestedRoute::new(StaticSegment("a"), || ()),
+            NestedRoute::new(StaticSegment("b"), || ()),
+            NestedRoute::new(StaticSegment("c"), || ()),
+        );
+
+        // For each position, the id returned by the tuple's `match_nested`
+        // must be the matched route's own id (as reported by `as_id`), not the
+        // child's positional index within the tuple.
+        for path in ["/a", "/b", "/c"] {
+            let (matched, _) = three.match_nested(path);
+            let (id, m) = matched
+                .unwrap_or_else(|| panic!("`{path}` should match a route"));
+            assert_eq!(id, m.as_id());
+        }
+    }
+
+    #[test]
     pub fn arbitrary_nested_routes() {
         let routes: RouteDefs<_> = RouteDefs::new_with_base(
             (

--- a/router/src/matching/nested/tuples.rs
+++ b/router/src/matching/nested/tuples.rs
@@ -237,7 +237,7 @@ macro_rules! chain_generated {
 }
 
 macro_rules! tuples {
-    ($either:ident => $($ty:ident = $count:expr),*) => {
+    ($either:ident => $($ty:ident),*) => {
         impl<'a, $($ty,)*> MatchParams for $either <$($ty,)*>
         where
 			$($ty: MatchParams),*,
@@ -300,8 +300,8 @@ macro_rules! tuples {
                 #[allow(non_snake_case)]
 
                 let ($($ty,)*) = &self;
-                $(if let (Some((_, matched)), remaining) = $ty.match_nested(path) {
-                    return (Some((RouteMatchId($count), $either::$ty(matched))), remaining);
+                $(if let (Some((id, matched)), remaining) = $ty.match_nested(path) {
+                    return (Some((id, $either::$ty(matched))), remaining);
                 })*
                 (None, path)
             }
@@ -319,17 +319,17 @@ macro_rules! tuples {
     }
 }
 
-tuples!(EitherOf3 => A = 0, B = 1, C = 2);
-tuples!(EitherOf4 => A = 0, B = 1, C = 2, D = 3);
-tuples!(EitherOf5 => A = 0, B = 1, C = 2, D = 3, E = 4);
-tuples!(EitherOf6 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5);
-tuples!(EitherOf7 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6);
-tuples!(EitherOf8 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7);
-tuples!(EitherOf9 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8);
-tuples!(EitherOf10 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9);
-tuples!(EitherOf11 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10);
-tuples!(EitherOf12 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10, L = 11);
-tuples!(EitherOf13 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10, L = 11, M = 12);
-tuples!(EitherOf14 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10, L = 11, M = 12, N = 13);
-tuples!(EitherOf15 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10, L = 11, M = 12, N = 13, O = 14);
-tuples!(EitherOf16 => A = 0, B = 1, C = 2, D = 3, E = 4, F = 5, G = 6, H = 7, I = 8, J = 9, K = 10, L = 11, M = 12, N = 13, O = 14, P = 15);
+tuples!(EitherOf3 => A, B, C);
+tuples!(EitherOf4 => A, B, C, D);
+tuples!(EitherOf5 => A, B, C, D, E);
+tuples!(EitherOf6 => A, B, C, D, E, F);
+tuples!(EitherOf7 => A, B, C, D, E, F, G);
+tuples!(EitherOf8 => A, B, C, D, E, F, G, H);
+tuples!(EitherOf9 => A, B, C, D, E, F, G, H, I);
+tuples!(EitherOf10 => A, B, C, D, E, F, G, H, I, J);
+tuples!(EitherOf11 => A, B, C, D, E, F, G, H, I, J, K);
+tuples!(EitherOf12 => A, B, C, D, E, F, G, H, I, J, K, L);
+tuples!(EitherOf13 => A, B, C, D, E, F, G, H, I, J, K, L, M);
+tuples!(EitherOf14 => A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+tuples!(EitherOf15 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+tuples!(EitherOf16 => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);

--- a/router/src/matching/resolve_path.rs
+++ b/router/src/matching/resolve_path.rs
@@ -30,17 +30,24 @@ pub fn resolve_path<'a>(
 }
 
 fn has_scheme(path: &str) -> bool {
-    path.starts_with("//")
-        || path.starts_with("tel:")
-        || path.starts_with("mailto:")
-        || path
-            .split_once("://")
-            .map(|(prefix, _)| {
-                prefix.chars().all(
-                    |c: char| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9'),
-                )
-            })
-            .unwrap_or(false)
+    // Protocol-relative URLs.
+    if path.starts_with("//") {
+        return true;
+    }
+    // RFC 3986 §3.1: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    // This covers both authority-based schemes (`https://`) and opaque ones
+    // (`mailto:`, `tel:`, `javascript:`, `data:`, `view-source:`), as well as
+    // compound schemes such as `git+ssh` that the previous check rejected.
+    let Some((scheme, _)) = path.split_once(':') else {
+        return false;
+    };
+    let mut chars = scheme.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_alphabetic()
+        && chars
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
 }
 
 #[doc(hidden)]
@@ -96,5 +103,47 @@ mod tests {
     #[test]
     fn normalize_dedup_trailing_slashes() {
         assert_eq!(normalize("foo/bar/////", false), "/foo/bar/");
+    }
+
+    #[test]
+    fn has_scheme_detects_authority_and_opaque_schemes() {
+        // Authority-based schemes.
+        assert!(has_scheme("https://example.com"));
+        assert!(has_scheme("ws://x/sock"));
+        assert!(has_scheme("//example.com"));
+        // Opaque schemes (no `://`) that the previous check missed.
+        assert!(has_scheme("mailto:foo@bar.com"));
+        assert!(has_scheme("tel:+15551234"));
+        assert!(has_scheme("javascript:alert(1)"));
+        assert!(has_scheme("data:text/html,<h1>x</h1>"));
+        assert!(has_scheme("view-source:https://example.com"));
+        assert!(has_scheme("blob:https://example.com/abc"));
+        // Compound schemes with `+`/`-`/`.` that the previous filter rejected.
+        assert!(has_scheme("git+ssh://host/x.git"));
+        assert!(has_scheme("coap+tcp://host"));
+    }
+
+    #[test]
+    fn has_scheme_rejects_relative_paths() {
+        assert!(!has_scheme("/foo/bar"));
+        assert!(!has_scheme("foo/bar"));
+        assert!(!has_scheme("?query=1"));
+        assert!(!has_scheme("#fragment"));
+        // A scheme must start with a letter, not a digit.
+        assert!(!has_scheme("1foo:bar"));
+        // Empty scheme.
+        assert!(!has_scheme(":nothing"));
+    }
+
+    #[test]
+    fn resolve_path_leaves_opaque_schemes_untouched() {
+        assert_eq!(
+            resolve_path("/", "javascript:alert(1)", None),
+            "javascript:alert(1)"
+        );
+        assert_eq!(
+            resolve_path("/", "data:text/html,<h1>x</h1>", None),
+            "data:text/html,<h1>x</h1>"
+        );
     }
 }

--- a/router/src/params.rs
+++ b/router/src/params.rs
@@ -36,6 +36,26 @@ impl ParamsMap {
         }
     }
 
+    /// Inserts an already-decoded value into the map without performing an
+    /// additional percent-decoding pass.
+    ///
+    /// Query-string pairs are produced pre-decoded by both the browser's
+    /// `URLSearchParams` (client) and the `url` crate's `query_pairs` (server).
+    /// Routing them through [`insert`](Self::insert) would decode them a second
+    /// time, corrupting any value that legitimately contains a `%xx` sequence.
+    pub(crate) fn insert_decoded(
+        &mut self,
+        key: impl Into<Cow<'static, str>>,
+        value: String,
+    ) {
+        let key = key.into();
+        if let Some(prev) = self.0.iter_mut().find(|(k, _)| k == &key) {
+            prev.1.push(value);
+        } else {
+            self.0.push((key, vec![value]));
+        }
+    }
+
     /// Inserts a value into the map, replacing any existing value for that key.
     pub fn replace(
         &mut self,


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

## Changes:

### 1. `<Form>` no longer lowercases the action URL
`extract_form_attributes` applied `.to_lowercase()` to the form `action` (and the `<input>`/`<button>` `formaction` fallbacks). Unlike `method`/`enctype`, the action is a URL, only scheme and host are case-insensitive (RFC 3986), so this silently corrupted case-sensitive paths and query values (e.g. `/API/v1/Users/AbC123` → `/api/v1/users/abc123`, broken HMAC/JWT signatures). Removed `.to_lowercase()` from the three action sites; kept it for `method`/`enctype`.

### 2. Query parameters are now decoded exactly once
Both URL sources hand back already-decoded values, `url::query_pairs()` (server) and `URLSearchParams` (browser), but each was re-decoded a second time via `ParamsMap::insert` → `Url::unescape`. This corrupted any value containing a literal `%xx` (e.g. `id=foo%252Fbar` → `foo/bar` instead of `foo%2Fbar`, truncated base64 padding, a parameter-smuggling surface). Added a crate-internal `ParamsMap::insert_decoded` and used it for query pairs on **both** server and client (fixing only one side would desync hydration). Path params are unchanged, they're extracted raw and correctly rely on `insert`'s single decode.

### 3. `RoutingProgress` no longer produces NaN width
`max_time` is optional and defaults to `Duration::ZERO`, making the per-tick step `100.0 / 0.0` = `inf`/`NaN` and rendering `width: NaN%`. Guarded the division to fill the bar in a single increment when `max_time` isn't positive.

### 4. `has_scheme` detects opaque and compound schemes
`resolve_path` treated absolute URLs with opaque schemes (`data:`, `javascript:`, `view-source:`, `blob:`) and compound schemes (`git+ssh`) as relative paths and mangled them. Rewrote `has_scheme` to follow RFC 3986 §3.1 (split on first `:`, validate the scheme prefix), keeping the `//` protocol-relative shortcut.

### 5. Route tuples (arity 3–16) preserve the inner `RouteMatchId`
The `tuples!` macro substituted a route's positional index for its real `RouteMatchId`, so routes at the same position in different sub-trees compared equal (stale-view risk for id-based cache/transition logic). The 2-tuple impl was already correct; aligned the macro with it and removed the now-unused `$count`.