### PR TITLE
Quality of life fixes for `router_macro`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "trybuild",
 ]
 
 [[package]]

--- a/router_macro/Cargo.toml
+++ b/router_macro/Cargo.toml
@@ -22,6 +22,7 @@ syn = { features = ["full"], workspace = true, default-features = true }
 leptos = { path = "../leptos" }
 leptos_router = { path = "../router" }
 leptos_macro = { path = "../leptos_macro" }
+trybuild = { workspace = true, default-features = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(leptos_debuginfo)'] }

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -9,7 +9,8 @@ use proc_macro_error2::{abort, proc_macro_error, set_dummy};
 use proc_macro2::Span;
 use quote::{ToTokens, format_ident, quote};
 use syn::{
-    FnArg, Ident, ImplItem, ItemImpl, Path, Type, TypePath, spanned::Spanned,
+    FnArg, Ident, ImplItem, ItemImpl, Path, Type, TypePath, parse_quote,
+    spanned::Spanned,
 };
 
 const RFC3986_UNRESERVED: [char; 4] = ['-', '.', '_', '~'];
@@ -359,33 +360,33 @@ fn lazy_route_impl(
             }
             fun.sig.asyncness = Some(Default::default());
 
-            let first_arg = fun.sig.inputs.first().unwrap_or_else(|| {
-                abort!(fun.sig.span(), "must have an argument")
-            });
-            let FnArg::Typed(first_arg) = first_arg else {
-                abort!(
-                    first_arg.span(),
+            let first_arg = match fun.sig.inputs.first_mut() {
+                Some(FnArg::Typed(arg)) => arg,
+                Some(other) => abort!(
+                    other.span(),
                     "this must be a typed argument like `this: Self`"
-                )
+                ),
+                None => abort!(fun.sig.span(), "must have an argument"),
             };
-            let first_arg_pat = &*first_arg.pat;
+
+            // Preserve the user's binding pattern (`mut this`, `Self { .. }`,
+            // `_`, …) on the generated lazy function, where pattern syntax is
+            // valid. The trait `view` method instead binds a fresh identifier
+            // and forwards it as an *expression*, since interpolating an
+            // arbitrary pattern into call position produces invalid code.
+            let user_pat = (*first_arg.pat).clone();
+            let this_ident = Ident::new("__this", Span::call_site());
+            first_arg.pat = Box::new(parse_quote!(#this_ident));
+
             let body = std::mem::replace(
                 &mut fun.block,
-                syn::parse(
-                    quote! {
-                        {
-                            #lazy_view_ident(#first_arg_pat).await
-                        }
-                    }
-                    .into(),
-                )
-                .unwrap(),
+                parse_quote!({ #lazy_view_ident(#this_ident).await }),
             );
 
             quote! {
                 #[allow(non_snake_case)]
                 #[::leptos::lazy]
-                fn #lazy_view_ident(#first_arg_pat: #self_ty) -> ::leptos::prelude::AnyView {
+                fn #lazy_view_ident(#user_pat: #self_ty) -> ::leptos::prelude::AnyView {
                     #body
                 }
 

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -94,8 +94,23 @@ impl SegmentParser {
                         );
                     }
                     parsed = true;
-                    let lit = lit.to_string();
-                    if lit.contains("//") {
+
+                    // Parse via `syn::LitStr` so we operate on the literal's
+                    // *value*, not its source text. This handles raw strings
+                    // (`r"…"`, `r#"…"#`) and escapes uniformly, whereas
+                    // `Literal::to_string()` returns the `r`/`#`/quote
+                    // characters as part of the text.
+                    let lit_str: syn::LitStr =
+                        syn::parse(TokenStream::from(TokenTree::Literal(lit)))
+                            .unwrap_or_else(|e| {
+                                abort!(
+                                    e.span(),
+                                    "`path!` expects a string literal"
+                                )
+                            });
+                    let value = lit_str.value();
+
+                    if value.contains("//") {
                         abort!(
                             proc_macro2::Span::call_site(),
                             "Consecutive '/' is not allowed"
@@ -103,10 +118,9 @@ impl SegmentParser {
                     }
                     Self::parse_str(
                         &mut self.segments,
-                        lit.trim_start_matches(['"', '/'])
-                            .trim_end_matches(['"', '/']),
+                        value.trim_start_matches('/').trim_end_matches('/'),
                     );
-                    if lit.ends_with(r#"/""#) && lit != r#""/""# {
+                    if value.ends_with('/') && value != "/" {
                         self.segments.push(Segment::Static("/".to_string()));
                     }
                 }

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -100,9 +100,14 @@ impl SegmentParser {
                         self.segments.push(Segment::Static("/".to_string()));
                     }
                 }
-                TokenTree::Group(_) => unimplemented!(),
-                TokenTree::Ident(_) => unimplemented!(),
-                TokenTree::Punct(_) => unimplemented!(),
+                other => {
+                    let span: Span = other.span().into();
+                    abort!(
+                        span,
+                        "`path!` expects a string literal, e.g. \
+                         `path!(\"/users/:id\")`"
+                    );
+                }
             }
         }
     }

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -13,7 +13,13 @@ use syn::{
 };
 
 const RFC3986_UNRESERVED: [char; 4] = ['-', '.', '_', '~'];
-const RFC3986_PCHAR_OTHER: [char; 1] = ['@'];
+// RFC 3986 `pchar` also allows `:`, `@`, and the `sub-delims` set
+// (`! $ & ' ( ) * + , ; =`). `*` is intentionally excluded here because the
+// `path!` DSL reserves it as the wildcard sigil (see `Segment::Wildcard`);
+// allowing it inside a static segment would mask misplaced-wildcard mistakes
+// such as `path!("/home/any*")`.
+const RFC3986_PCHAR_OTHER: [char; 12] =
+    ['@', ':', '!', '$', '&', '\'', '(', ')', '+', ',', ';', '='];
 
 /// Constructs a path for use in a [`Route`] definition.
 ///

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -351,6 +351,12 @@ fn lazy_route_impl(
             if let Some(a) = fun.sig.asyncness {
                 abort!(a.span(), "`view` method should not be async")
             }
+            if fun.sig.inputs.len() != 1 {
+                abort!(
+                    fun.sig.inputs.span(),
+                    "`view` must take exactly one argument (`this: Self`)"
+                )
+            }
             fun.sig.asyncness = Some(Default::default());
 
             let first_arg = fun.sig.inputs.first().unwrap_or_else(|| {

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -50,12 +50,19 @@ const RFC3986_PCHAR_OTHER: [char; 12] =
 pub fn path(tokens: TokenStream) -> TokenStream {
     let mut parser = SegmentParser::new(tokens);
     parser.parse_all();
-    let segments = Segments(parser.segments);
+    let segments = Segments {
+        span: parser.span,
+        segments: parser.segments,
+    };
     segments.into_token_stream().into()
 }
 
-#[derive(Debug, PartialEq)]
-struct Segments(pub Vec<Segment>);
+struct Segments {
+    segments: Vec<Segment>,
+    // Span of the path string literal, used to anchor validation errors at the
+    // literal rather than the whole `path!(...)` invocation.
+    span: Span,
+}
 
 #[derive(Debug, PartialEq)]
 enum Segment {
@@ -68,6 +75,7 @@ enum Segment {
 struct SegmentParser {
     input: proc_macro::token_stream::IntoIter,
     segments: Vec<Segment>,
+    span: Span,
 }
 
 impl SegmentParser {
@@ -75,6 +83,7 @@ impl SegmentParser {
         Self {
             input: input.into_iter(),
             segments: Vec::new(),
+            span: Span::call_site(),
         }
     }
 }
@@ -108,13 +117,11 @@ impl SegmentParser {
                                     "`path!` expects a string literal"
                                 )
                             });
+                    self.span = lit_str.span();
                     let value = lit_str.value();
 
                     if value.contains("//") {
-                        abort!(
-                            proc_macro2::Span::call_site(),
-                            "Consecutive '/' is not allowed"
-                        );
+                        abort!(self.span, "Consecutive '/' is not allowed");
                     }
                     Self::parse_str(
                         &mut self.segments,
@@ -170,16 +177,16 @@ impl Segment {
                 }))
     }
 
-    fn ensure_valid(&self) {
+    fn ensure_valid(&self, span: Span) {
         match self {
             Self::Wildcard(s) if !Self::is_valid(s) => {
-                abort!(Span::call_site(), "Invalid wildcard segment: {}", s)
+                abort!(span, "Invalid wildcard segment: {}", s)
             }
             Self::Static(s) if !Self::is_valid(s) => {
-                abort!(Span::call_site(), "Invalid static segment: {}", s)
+                abort!(span, "Invalid static segment: {}", s)
             }
             Self::Param(s) if !Self::is_valid(s) => {
-                abort!(Span::call_site(), "Invalid param segment: {}", s)
+                abort!(span, "Invalid param segment: {}", s)
             }
             _ => (),
         }
@@ -188,18 +195,20 @@ impl Segment {
 
 impl Segments {
     fn ensure_valid(&self) {
-        if let Some((_last, segments)) = self.0.split_last()
+        if let Some((_last, segments)) = self.segments.split_last()
             && let Some(Segment::Wildcard(s)) =
                 segments.iter().find(|s| matches!(s, Segment::Wildcard(_)))
         {
-            abort!(Span::call_site(), "Wildcard must be at end: {}", s)
+            abort!(self.span, "Wildcard must be at end: {}", s)
+        }
+        for segment in &self.segments {
+            segment.ensure_valid(self.span);
         }
     }
 }
 
 impl ToTokens for Segment {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        self.ensure_valid();
         match self {
             Segment::Wildcard(s) => {
                 tokens.extend(quote! { leptos_router::WildcardSegment(#s) });
@@ -221,7 +230,7 @@ impl ToTokens for Segment {
 impl ToTokens for Segments {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         self.ensure_valid();
-        match self.0.as_slice() {
+        match self.segments.as_slice() {
             [] => tokens.extend(quote! { () }),
             [segment] => tokens.extend(quote! { (#segment,) }),
             segments => tokens.extend(quote! { (#(#segments),*) }),

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -376,7 +376,7 @@ fn lazy_route_impl(
             // arbitrary pattern into call position produces invalid code.
             let user_pat = (*first_arg.pat).clone();
             let this_ident = Ident::new("__this", Span::call_site());
-            first_arg.pat = Box::new(parse_quote!(#this_ident));
+            first_arg.pat = parse_quote!(#this_ident);
 
             let body = std::mem::replace(
                 &mut fun.block,

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -343,7 +343,10 @@ fn lazy_route_impl(
     });
 
     match item {
-        None => s,
+        None => abort!(
+            im.span(),
+            "`#[lazy_route]` requires a `view` method on the impl block"
+        ),
         Some(fun) => {
             if let Some(a) = fun.sig.asyncness {
                 abort!(a.span(), "`view` method should not be async")

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -130,14 +130,15 @@ impl SegmentParser {
 
 impl Segment {
     fn is_valid(segment: &str) -> bool {
-        segment == "/"
-            || segment.chars().all(|c| {
-                c.is_ascii_digit()
-                    || c.is_ascii_lowercase()
-                    || c.is_ascii_uppercase()
-                    || RFC3986_UNRESERVED.contains(&c)
-                    || RFC3986_PCHAR_OTHER.contains(&c)
-            })
+        !segment.is_empty()
+            && (segment == "/"
+                || segment.chars().all(|c| {
+                    c.is_ascii_digit()
+                        || c.is_ascii_lowercase()
+                        || c.is_ascii_uppercase()
+                        || RFC3986_UNRESERVED.contains(&c)
+                        || RFC3986_PCHAR_OTHER.contains(&c)
+                }))
     }
 
     fn ensure_valid(&self) {

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -81,9 +81,19 @@ impl SegmentParser {
 
 impl SegmentParser {
     pub fn parse_all(&mut self) {
+        let mut parsed = false;
         for input in self.input.by_ref() {
             match input {
                 TokenTree::Literal(lit) => {
+                    if parsed {
+                        let span: Span = lit.span().into();
+                        abort!(
+                            span,
+                            "`path!` accepts a single string literal; use \
+                             `concat!` to build one from several pieces"
+                        );
+                    }
+                    parsed = true;
                     let lit = lit.to_string();
                     if lit.contains("//") {
                         abort!(

--- a/router_macro/tests/lazy_route.rs
+++ b/router_macro/tests/lazy_route.rs
@@ -1,0 +1,45 @@
+use leptos::prelude::*;
+use leptos_router::{LazyRoute, lazy_route};
+
+struct MutRoute {
+    value: u32,
+}
+
+#[lazy_route]
+impl LazyRoute for MutRoute {
+    fn data() -> Self {
+        Self { value: 41 }
+    }
+
+    // `mut this` is a binding-mode pattern, which is not valid in expression
+    // position. The macro must forward the argument through a fresh binding
+    // rather than splicing this pattern into the generated call expression.
+    fn view(mut this: Self) -> AnyView {
+        this.value += 1;
+        let _ = this.value;
+        ().into_any()
+    }
+}
+
+struct DestructuredRoute {
+    value: u32,
+}
+
+#[lazy_route]
+impl LazyRoute for DestructuredRoute {
+    fn data() -> Self {
+        Self { value: 0 }
+    }
+
+    // A struct-destructuring pattern is likewise invalid as an expression.
+    fn view(DestructuredRoute { value }: Self) -> AnyView {
+        let _ = value;
+        ().into_any()
+    }
+}
+
+#[test]
+fn lazy_route_data_constructs() {
+    assert_eq!(MutRoute::data().value, 41);
+    assert_eq!(DestructuredRoute::data().value, 0);
+}

--- a/router_macro/tests/path.rs
+++ b/router_macro/tests/path.rs
@@ -181,22 +181,38 @@ fn parses_complex() {
     );
 }
 
-// #[test]
-// fn deny_consecutive_slashes() {
-//     let _ = path!("/////foo///bar/////baz/");
-// }
-//
-// #[test]
-// fn deny_invalid_segment() {
-//     let _ = path!("/foo/^/");
-// }
-//
-// #[test]
-// fn deny_non_trailing_wildcard_segment() {
-//     let _ = path!("/home/*any/end");
-// }
-//
-// #[test]
-// fn deny_invalid_wildcard() {
-//     let _ = path!("/home/any*");
-// }
+#[test]
+fn parses_raw_string() {
+    let output = path!(r"/home");
+    assert_eq!(output, (StaticSegment("home"),));
+}
+
+#[test]
+fn parses_raw_string_with_hashes() {
+    let output = path!(r#"/home/"#);
+    assert_eq!(output, (StaticSegment("home"), StaticSegment("/")));
+}
+
+#[test]
+fn parses_raw_single_slash() {
+    let output = path!(r"/");
+    assert!(output.eq(&()));
+}
+
+#[test]
+fn parses_rfc3986_sub_delims_and_colon() {
+    let output = path!("/v1:beta/items;color=red/$5/me!/(a+b)");
+    assert_eq!(
+        output,
+        (
+            StaticSegment("v1:beta"),
+            StaticSegment("items;color=red"),
+            StaticSegment("$5"),
+            StaticSegment("me!"),
+            StaticSegment("(a+b)"),
+        )
+    );
+}
+
+// Negative cases (the macro must reject these at compile time) are covered by
+// the `trybuild` suite in `tests/ui.rs` / `tests/ui/`.

--- a/router_macro/tests/ui.rs
+++ b/router_macro/tests/ui.rs
@@ -1,0 +1,10 @@
+//! Compile-fail coverage for the `path!` macro's rejection rules.
+//!
+//! Each `.rs` file in `tests/ui/` is expected to fail compilation with the
+//! diagnostic recorded in its sibling `.stderr` file.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/router_macro/tests/ui/consecutive_slashes.rs
+++ b/router_macro/tests/ui/consecutive_slashes.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/////foo///bar/////baz/");
+}

--- a/router_macro/tests/ui/consecutive_slashes.stderr
+++ b/router_macro/tests/ui/consecutive_slashes.stderr
@@ -1,0 +1,5 @@
+error: Consecutive '/' is not allowed
+ --> tests/ui/consecutive_slashes.rs:4:19
+  |
+4 |     let _ = path!("/////foo///bar/////baz/");
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/router_macro/tests/ui/empty_param.rs
+++ b/router_macro/tests/ui/empty_param.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/:");
+}

--- a/router_macro/tests/ui/empty_param.stderr
+++ b/router_macro/tests/ui/empty_param.stderr
@@ -1,0 +1,5 @@
+error: Invalid param segment:
+ --> tests/ui/empty_param.rs:4:19
+  |
+4 |     let _ = path!("/:");
+  |                   ^^^^

--- a/router_macro/tests/ui/invalid_segment.rs
+++ b/router_macro/tests/ui/invalid_segment.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/foo/^/");
+}

--- a/router_macro/tests/ui/invalid_segment.stderr
+++ b/router_macro/tests/ui/invalid_segment.stderr
@@ -1,0 +1,5 @@
+error: Invalid static segment: ^
+ --> tests/ui/invalid_segment.rs:4:19
+  |
+4 |     let _ = path!("/foo/^/");
+  |                   ^^^^^^^^^

--- a/router_macro/tests/ui/invalid_wildcard.rs
+++ b/router_macro/tests/ui/invalid_wildcard.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/home/any*");
+}

--- a/router_macro/tests/ui/invalid_wildcard.stderr
+++ b/router_macro/tests/ui/invalid_wildcard.stderr
@@ -1,0 +1,5 @@
+error: Invalid static segment: any*
+ --> tests/ui/invalid_wildcard.rs:4:19
+  |
+4 |     let _ = path!("/home/any*");
+  |                   ^^^^^^^^^^^^

--- a/router_macro/tests/ui/multiple_literals.rs
+++ b/router_macro/tests/ui/multiple_literals.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/foo" "/bar");
+}

--- a/router_macro/tests/ui/multiple_literals.stderr
+++ b/router_macro/tests/ui/multiple_literals.stderr
@@ -1,0 +1,5 @@
+error: `path!` accepts a single string literal; use `concat!` to build one from several pieces
+ --> tests/ui/multiple_literals.rs:4:26
+  |
+4 |     let _ = path!("/foo" "/bar");
+  |                          ^^^^^^

--- a/router_macro/tests/ui/non_literal_token.rs
+++ b/router_macro/tests/ui/non_literal_token.rs
@@ -1,0 +1,7 @@
+use leptos_router_macro::path;
+
+const ROUTE: &str = "/foo";
+
+fn main() {
+    let _ = path!(ROUTE);
+}

--- a/router_macro/tests/ui/non_literal_token.stderr
+++ b/router_macro/tests/ui/non_literal_token.stderr
@@ -1,0 +1,5 @@
+error: `path!` expects a string literal, e.g. `path!("/users/:id")`
+ --> tests/ui/non_literal_token.rs:6:19
+  |
+6 |     let _ = path!(ROUTE);
+  |                   ^^^^^

--- a/router_macro/tests/ui/non_trailing_wildcard.rs
+++ b/router_macro/tests/ui/non_trailing_wildcard.rs
@@ -1,0 +1,5 @@
+use leptos_router_macro::path;
+
+fn main() {
+    let _ = path!("/home/*any/end");
+}

--- a/router_macro/tests/ui/non_trailing_wildcard.stderr
+++ b/router_macro/tests/ui/non_trailing_wildcard.stderr
@@ -1,0 +1,5 @@
+error: Wildcard must be at end: any
+ --> tests/ui/non_trailing_wildcard.rs:4:19
+  |
+4 |     let _ = path!("/home/*any/end");
+  |                   ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

### `path!` macro

**Panic on non-literal input → diagnostic**
```rust
const ROUTE: &str = "/foo";
path!(ROUTE);   // before: proc-macro panic "not implemented"; now: clean compile error
```

**Multiple literals silently concatenated → rejected**
```rust
path!("/foo" "/bar");  // before: (StaticSegment("foo"), StaticSegment("bar")); now: error
```

**Raw strings mishandled → parsed by value**
```rust
path!(r"/home");     // before: error `Invalid static segment: r"home`; now: (StaticSegment("home"),)
path!(r"/");         // before: (StaticSegment("/"),); now: ()
```

**Errors pointed at whole invocation → at the literal**
```rust
path!("/foo/^/");    // caret now highlights the path string, not the entire path!(...) call
```

**Empty segments accepted → rejected**
```rust
path!("/:");         // before: ParamSegment(""); now: error "Invalid param segment:"
```

**RFC 3986 `pchar` set incomplete → completed**
```rust
path!("/v1:beta/items;color=red/$5/me!/(a+b)");  // before: "Invalid static segment"; now: OK
```
(`*` stays disallowed inside a segment — it's the wildcard sigil.)

### `lazy_route` macro

**Argument pattern spliced into call position → forwarded by value**
```rust
fn view(mut this: Self) -> AnyView { ... }          // before: broken `__View(mut this)`; now: OK
fn view(Self { id, body }: Self) -> AnyView { ... }  // before: broken; now: OK
```

**Missing `view` silently dropped work → aborts**
```rust
#[lazy_route]
impl LazyRoute for R { fn data() -> Self { Self } }  // now: "requires a `view` method"
```

**Extra `view` params silently dropped → rejected**
```rust
fn view(this: Self, extra: u32) -> AnyView { ... }   // now: "view must take exactly one argument"
```
