### PR TITLE
Fix several bugs in `reactive_graph`

### DIFF
--- a/reactive_graph/src/actions/action.rs
+++ b/reactive_graph/src/actions/action.rs
@@ -5,7 +5,10 @@ use crate::{
     owner::{ArcStoredValue, ArenaItem, Owner},
     send_wrapper_ext::SendOption,
     signal::{ArcMappedSignal, ArcRwSignal, MappedSignal, RwSignal},
-    traits::{DefinedAt, Dispose, Get, GetUntracked, GetValue, Update, Write},
+    traits::{
+        DefinedAt, Dispose, Get, GetUntracked, GetValue, Update, UpdateValue,
+        Write,
+    },
     unwrap_signal,
 };
 use any_spawner::Executor;
@@ -266,6 +269,9 @@ where
 
             // Update the state before loading
             self.in_flight.update(|n| *n += 1);
+            // Bump the dispatch counter and snapshot it for this dispatch, so a
+            // later dispatch (higher counter) can tell this one it is stale.
+            self.dispatched.update_value(|n| *n += 1);
             let current_version = self.dispatched.get_value();
             self.input.try_update(|inp| **inp = Some(input));
 
@@ -285,7 +291,7 @@ where
                         // otherwise, update the value
                         result = fut => {
                             in_flight.update(|n| *n = n.saturating_sub(1));
-                            let is_latest = dispatched.get_value() <= current_version;
+                            let is_latest = dispatched.get_value() == current_version;
                             if is_latest {
                                 version.update(|n| *n += 1);
                                 value.update(|n| **n = Some(result));
@@ -318,6 +324,9 @@ where
 
             // Update the state before loading
             self.in_flight.update(|n| *n += 1);
+            // Bump the dispatch counter and snapshot it for this dispatch, so a
+            // later dispatch (higher counter) can tell this one it is stale.
+            self.dispatched.update_value(|n| *n += 1);
             let current_version = self.dispatched.get_value();
             self.input.try_update(|inp| **inp = Some(input));
 
@@ -337,7 +346,7 @@ where
                         // otherwise, update the value
                         result = fut => {
                             in_flight.update(|n| *n = n.saturating_sub(1));
-                            let is_latest = dispatched.get_value() <= current_version;
+                            let is_latest = dispatched.get_value() == current_version;
                             if is_latest {
                                 version.update(|n| *n += 1);
                                 value.update(|n| **n = Some(result));

--- a/reactive_graph/src/computed/arc_memo.rs
+++ b/reactive_graph/src/computed/arc_memo.rs
@@ -228,7 +228,7 @@ where
     S: Storage<T>,
 {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::ptr::hash(&Arc::as_ptr(&self.inner), state);
+        std::ptr::hash(Arc::as_ptr(&self.inner), state);
     }
 }
 

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -257,6 +257,16 @@ impl Owner {
             #[cfg(feature = "hydration")]
             shared_context: self.shared_context.clone(),
         };
+        // When the children list is about to grow its allocation, drop the
+        // `Weak`s whose owners have already been dropped. `children` is
+        // otherwise append-only, so a long-lived parent would accumulate dead
+        // weak refs without bound and pay for walking them on cleanup. Pruning
+        // only at a reallocation boundary keeps this amortized O(1).
+        if !inner.children.is_empty()
+            && inner.children.len() == inner.children.capacity()
+        {
+            inner.children.retain(|child| child.strong_count() > 0);
+        }
         inner.children.push(Arc::downgrade(&child.inner));
         child
     }
@@ -632,6 +642,25 @@ mod tests {
         assert!(
             len <= 64,
             "owner accumulated {len} dead NodeIds after dispose-heavy loop"
+        );
+    }
+
+    // A long-lived parent under which many short-lived children are created and
+    // dropped must not accumulate dead `Weak` refs: `child` prunes them when
+    // the `children` Vec would otherwise grow.
+    #[test]
+    fn dropped_children_do_not_leak_weak_refs() {
+        let parent = Owner::new();
+
+        for _ in 0..10_000 {
+            let child = parent.child();
+            drop(child);
+        }
+
+        let len = parent.inner.read().or_poisoned().children.len();
+        assert!(
+            len <= 64,
+            "parent accumulated {len} dead child Weak refs"
         );
     }
 }

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -327,7 +327,28 @@ impl Owner {
     }
 
     fn register(&self, node: NodeId) {
-        self.inner.write().or_poisoned().nodes.push(node);
+        let mut inner = self.inner.write().or_poisoned();
+        // When the node list is about to grow its allocation, drop the ids
+        // whose arena entries have already been disposed. `ArenaItem::dispose`
+        // removes the arena entry but cannot reach back into the owner, so
+        // without this a long-lived owner that allocates and disposes many
+        // values would accumulate dead ids unboundedly. Pruning only at a
+        // reallocation boundary keeps this amortized O(1) and bounds `nodes` to
+        // roughly the live set.
+        if !inner.nodes.is_empty() && inner.nodes.len() == inner.nodes.capacity()
+        {
+            #[cfg(not(feature = "sandboxed-arenas"))]
+            Arena::with(|arena| {
+                inner.nodes.retain(|n| arena.contains_key(*n));
+            });
+            #[cfg(feature = "sandboxed-arenas")]
+            {
+                let arena = Arc::clone(&inner.arena);
+                let arena = arena.read().or_poisoned();
+                inner.nodes.retain(|n| arena.contains_key(*n));
+            }
+        }
+        inner.nodes.push(node);
     }
 
     /// Returns the current `Owner`, if any.
@@ -586,5 +607,31 @@ impl Cleanup for RwLock<OwnerInner> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Dispose;
+
+    // A long-lived owner under which many values are allocated and immediately
+    // disposed must not accumulate dead `NodeId`s: `register` prunes disposed
+    // ids when the `nodes` Vec would otherwise grow.
+    #[test]
+    fn dispose_does_not_leak_node_ids_into_owner() {
+        let owner = Owner::new();
+        owner.set();
+
+        for _ in 0..10_000 {
+            let value = StoredValue::new(0u32);
+            value.dispose();
+        }
+
+        let len = owner.inner.read().or_poisoned().nodes.len();
+        assert!(
+            len <= 64,
+            "owner accumulated {len} dead NodeIds after dispose-heavy loop"
+        );
     }
 }

--- a/reactive_graph/src/owner.rs
+++ b/reactive_graph/src/owner.rs
@@ -345,7 +345,8 @@ impl Owner {
         // values would accumulate dead ids unboundedly. Pruning only at a
         // reallocation boundary keeps this amortized O(1) and bounds `nodes` to
         // roughly the live set.
-        if !inner.nodes.is_empty() && inner.nodes.len() == inner.nodes.capacity()
+        if !inner.nodes.is_empty()
+            && inner.nodes.len() == inner.nodes.capacity()
         {
             #[cfg(not(feature = "sandboxed-arenas"))]
             Arena::with(|arena| {
@@ -658,9 +659,6 @@ mod tests {
         }
 
         let len = parent.inner.read().or_poisoned().children.len();
-        assert!(
-            len <= 64,
-            "parent accumulated {len} dead child Weak refs"
-        );
+        assert!(len <= 64, "parent accumulated {len} dead child Weak refs");
     }
 }

--- a/reactive_graph/src/owner/arc_stored_value.rs
+++ b/reactive_graph/src/owner/arc_stored_value.rs
@@ -64,7 +64,7 @@ impl<T> Eq for ArcStoredValue<T> {}
 
 impl<T> Hash for ArcStoredValue<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::ptr::hash(&Arc::as_ptr(&self.value), state);
+        std::ptr::hash(Arc::as_ptr(&self.value), state);
     }
 }
 

--- a/reactive_graph/src/owner/arena.rs
+++ b/reactive_graph/src/owner/arena.rs
@@ -155,6 +155,27 @@ pub mod sandboxed {
         }
     }
 
+    /// RAII guard that snapshots the current thread-local arena and restores it
+    /// on drop, so polling a `Sandboxed` future does not leak its arena into the
+    /// caller's context (including across `await` points and panics).
+    struct RestoreArena(Option<Weak<RwLock<ArenaMap>>>);
+
+    impl Drop for RestoreArena {
+        fn drop(&mut self) {
+            MAP.with_borrow_mut(|m| *m = self.0.take());
+        }
+    }
+
+    impl RestoreArena {
+        fn install(arena: Option<&Arc<RwLock<ArenaMap>>>) -> Self {
+            let guard = MAP.with_borrow(|m| RestoreArena(m.clone()));
+            if let Some(arena) = arena {
+                Arena::set(arena);
+            }
+            guard
+        }
+    }
+
     impl<Fut> Future for Sandboxed<Fut>
     where
         Fut: Future,
@@ -165,9 +186,7 @@ pub mod sandboxed {
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
         ) -> Poll<Self::Output> {
-            if let Some(arena) = self.arena.as_ref() {
-                Arena::set(arena);
-            }
+            let _restore = RestoreArena::install(self.arena.as_ref());
             let this = self.project();
             this.inner.poll(cx)
         }
@@ -183,9 +202,7 @@ pub mod sandboxed {
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
         ) -> Poll<Option<Self::Item>> {
-            if let Some(arena) = self.arena.as_ref() {
-                Arena::set(arena);
-            }
+            let _restore = RestoreArena::install(self.arena.as_ref());
             let this = self.project();
             this.inner.poll_next(cx)
         }

--- a/reactive_graph/src/owner/storage.rs
+++ b/reactive_graph/src/owner/storage.rs
@@ -136,9 +136,13 @@ where
 
     fn try_with<U>(node: NodeId, fun: impl FnOnce(&T) -> U) -> Option<U> {
         Arena::with(|arena| {
-            let m = arena.get(node);
-            m.and_then(|n| n.downcast_ref::<SendWrapper<T>>())
-                .map(|inner| fun(inner))
+            let n = arena.get(node)?.downcast_ref::<SendWrapper<T>>()?;
+            // Accessing the value from another thread would panic in the
+            // `SendWrapper` deref; the trait contract is to return `None`.
+            if !n.valid() {
+                return None;
+            }
+            Some(fun(n))
         })
     }
 
@@ -147,27 +151,42 @@ where
         fun: impl FnOnce(&mut T) -> U,
     ) -> Option<U> {
         Arena::with_mut(|arena| {
-            let m = arena.get_mut(node);
-            m.and_then(|n| n.downcast_mut::<SendWrapper<T>>())
-                .map(|inner| fun(&mut *inner))
+            let n = arena.get_mut(node)?.downcast_mut::<SendWrapper<T>>()?;
+            if !n.valid() {
+                return None;
+            }
+            Some(fun(&mut *n))
         })
     }
 
     fn try_set(node: NodeId, value: T) -> Option<T> {
         Arena::with_mut(|arena| {
-            let m = arena.get_mut(node);
-            match m.and_then(|n| n.downcast_mut::<SendWrapper<T>>()) {
-                Some(inner) => {
+            match arena
+                .get_mut(node)
+                .and_then(|n| n.downcast_mut::<SendWrapper<T>>())
+            {
+                // Replacing the value drops the old `SendWrapper`, which would
+                // panic off-thread; only do so when accessed from its thread.
+                Some(inner) if inner.valid() => {
                     *inner = SendWrapper::new(value);
                     None
                 }
-                None => Some(value),
+                _ => Some(value),
             }
         })
     }
 
     fn take(node: NodeId) -> Option<T> {
         Arena::with_mut(|arena| {
+            // Check thread validity before removing: taking the value off its
+            // owning thread would panic, so leave the entry in place instead.
+            let valid = arena
+                .get(node)
+                .and_then(|n| n.downcast_ref::<SendWrapper<T>>())
+                .map(|inner| inner.valid());
+            if valid != Some(true) {
+                return None;
+            }
             let m = arena.remove(node)?;
             match m.downcast::<SendWrapper<T>>() {
                 Ok(inner) => Some(inner.take()),

--- a/reactive_graph/src/signal/arc_read.rs
+++ b/reactive_graph/src/signal/arc_read.rs
@@ -103,7 +103,7 @@ impl<T> Eq for ArcReadSignal<T> {}
 
 impl<T> Hash for ArcReadSignal<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::ptr::hash(&Arc::as_ptr(&self.value), state);
+        std::ptr::hash(Arc::as_ptr(&self.value), state);
     }
 }
 

--- a/reactive_graph/src/signal/arc_rw.rs
+++ b/reactive_graph/src/signal/arc_rw.rs
@@ -131,7 +131,7 @@ impl<T> Eq for ArcRwSignal<T> {}
 
 impl<T> Hash for ArcRwSignal<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::ptr::hash(&Arc::as_ptr(&self.value), state);
+        std::ptr::hash(Arc::as_ptr(&self.value), state);
     }
 }
 

--- a/reactive_graph/src/signal/arc_write.rs
+++ b/reactive_graph/src/signal/arc_write.rs
@@ -91,7 +91,7 @@ impl<T> Eq for ArcWriteSignal<T> {}
 
 impl<T> Hash for ArcWriteSignal<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        std::ptr::hash(&Arc::as_ptr(&self.value), state);
+        std::ptr::hash(Arc::as_ptr(&self.value), state);
     }
 }
 

--- a/reactive_graph/src/transition.rs
+++ b/reactive_graph/src/transition.rs
@@ -108,9 +108,8 @@ where
         }
 
         let mut this = self.project();
-        let _restore = TRANSITION.with_borrow_mut(|slot| {
-            Restore(slot.replace(this.inner.clone()))
-        });
+        let _restore = TRANSITION
+            .with_borrow_mut(|slot| Restore(slot.replace(this.inner.clone())));
         if let Some(action) = this.action.take() {
             this.future.set(Some(action()));
         }

--- a/reactive_graph/src/transition.rs
+++ b/reactive_graph/src/transition.rs
@@ -1,16 +1,23 @@
 //! Utilities to wait for asynchronous primitives to resolve.
 
 use futures::{channel::oneshot, future::join_all};
-use or_poisoned::OrPoisoned;
+use pin_project_lite::pin_project;
 use std::{
+    cell::RefCell,
     future::Future,
-    sync::{OnceLock, RwLock, mpsc},
+    pin::Pin,
+    sync::mpsc,
+    task::{Context, Poll},
 };
 
-static TRANSITION: OnceLock<RwLock<Option<TransitionInner>>> = OnceLock::new();
-
-fn global_transition() -> &'static RwLock<Option<TransitionInner>> {
-    TRANSITION.get_or_init(|| RwLock::new(None))
+thread_local! {
+    // The transition that is *currently being polled* on this thread. It is
+    // installed for the duration of each poll of the action future and removed
+    // again when that poll returns, so overlapping transitions (whether on the
+    // same thread or on different threads of a multi-threaded executor) never
+    // observe one another's slot.
+    static TRANSITION: RefCell<Option<TransitionInner>> =
+        const { RefCell::new(None) };
 }
 
 #[derive(Debug, Clone)]
@@ -35,36 +42,81 @@ impl AsyncTransition {
         T: Future<Output = U>,
     {
         let (tx, rx) = mpsc::channel();
-        let global_transition = global_transition();
         let inner = TransitionInner { tx };
-        let prev = Option::replace(
-            &mut *global_transition.write().or_poisoned(),
-            inner.clone(),
-        );
-        let value = action().await;
-        _ = std::mem::replace(
-            &mut *global_transition.write().or_poisoned(),
-            prev,
-        );
+
+        // While the action is being run and its future polled, install `inner`
+        // as the current transition. The guard inside `ScopedTransition::poll`
+        // restores the previous value on every poll exit, so this is safe to
+        // run concurrently with other transitions. `action` itself is invoked
+        // inside that scope (on the first poll) so resources created
+        // synchronously by it are registered too.
+        let value = ScopedTransition {
+            inner,
+            action: Some(action),
+            future: None,
+        }
+        .await;
+
         let mut pending = Vec::new();
-        while let Ok(tx) = rx.try_recv() {
-            pending.push(tx);
+        while let Ok(rx) = rx.try_recv() {
+            pending.push(rx);
         }
         join_all(pending).await;
         value
     }
 
     pub(crate) fn register(rx: oneshot::Receiver<()>) {
-        if let Some(tx) = global_transition()
-            .read()
-            .or_poisoned()
-            .as_ref()
-            .map(|n| &n.tx)
-        {
-            // if it's an Err, that just means the Receiver was dropped
-            // i.e., the transition is no longer listening, in which case it doesn't matter if we
-            // successfully register with it or not
-            _ = tx.send(rx);
+        TRANSITION.with_borrow(|current| {
+            if let Some(inner) = current.as_ref() {
+                // if it's an Err, that just means the Receiver was dropped
+                // i.e., the transition is no longer listening, in which case it
+                // doesn't matter if we successfully register with it or not
+                _ = inner.tx.send(rx);
+            }
+        });
+    }
+}
+
+pin_project! {
+    /// Runs `action` and polls the future it produces with `inner` installed as
+    /// the current transition for the duration of each poll, restoring the
+    /// previous transition afterwards. The future is built lazily on the first
+    /// poll so that `action` runs inside the transition scope.
+    struct ScopedTransition<F, Fut> {
+        inner: TransitionInner,
+        action: Option<F>,
+        #[pin]
+        future: Option<Fut>,
+    }
+}
+
+impl<F, Fut> Future for ScopedTransition<F, Fut>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future,
+{
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // RAII guard: restore the previous transition no matter how `poll`
+        // exits (return, `?`, or a panic in the polled future).
+        struct Restore(Option<TransitionInner>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                TRANSITION.with_borrow_mut(|slot| *slot = self.0.take());
+            }
         }
+
+        let mut this = self.project();
+        let _restore = TRANSITION.with_borrow_mut(|slot| {
+            Restore(slot.replace(this.inner.clone()))
+        });
+        if let Some(action) = this.action.take() {
+            this.future.set(Some(action()));
+        }
+        this.future
+            .as_pin_mut()
+            .expect("ScopedTransition polled after completion")
+            .poll(cx)
     }
 }

--- a/reactive_graph/tests/action_dispatch_order.rs
+++ b/reactive_graph/tests/action_dispatch_order.rs
@@ -1,0 +1,87 @@
+//! Regression test for the out-of-order completion guard in `ArcAction`.
+//!
+//! Two dispatches can complete in the opposite order they were issued. The
+//! action keeps a `version`/`value` pair guarded by a `dispatched` counter so
+//! that a stale (older) dispatch cannot overwrite the value produced by a
+//! newer one. The counter has to actually be incremented on every dispatch for
+//! the guard to work.
+
+use any_spawner::Executor;
+use reactive_graph::{
+    actions::ArcAction,
+    owner::Owner,
+    traits::GetUntracked,
+};
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+/// Drive the executor until `cond` holds. The bound just turns a genuinely
+/// stuck future into a loud failure instead of a hang.
+async fn tick_until(mut cond: impl FnMut() -> bool) {
+    for _ in 0..10_000 {
+        if cond() {
+            return;
+        }
+        Executor::tick().await;
+    }
+    panic!("condition was never satisfied within the tick budget");
+}
+
+#[tokio::test]
+async fn older_dispatch_does_not_clobber_newer_result() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    // The future for input `1` blocks on `gate`; the future for any other
+    // input resolves immediately. This lets us force the *first* dispatch to
+    // finish *after* the second one.
+    let gate = Arc::new(Notify::new());
+    let action = {
+        let gate = gate.clone();
+        ArcAction::<u32, u32>::new(move |n: &u32| {
+            let n = *n;
+            let gate = gate.clone();
+            async move {
+                if n == 1 {
+                    gate.notified().await;
+                }
+                n
+            }
+        })
+    };
+
+    let value = action.value();
+    let input = action.input();
+
+    // Dispatch the "old" call; it parks on the gate. (`Notify` stores a permit
+    // if `notify_one` is called before the waiter registers, so this future is
+    // guaranteed to make progress once released regardless of poll ordering.)
+    action.dispatch(1);
+
+    // Dispatch the "new" call; it resolves immediately and commits `2`. Wait
+    // for the value to actually be committed instead of assuming a fixed
+    // number of ticks is enough to drive the spawned future.
+    action.dispatch(2);
+    tick_until(|| value.get_untracked() == Some(2)).await;
+    assert_eq!(
+        value.get_untracked(),
+        Some(2),
+        "newer dispatch should have committed its value"
+    );
+
+    // Now release the older call. With a working guard it must recognise that
+    // a newer dispatch already completed and leave the value untouched.
+    // `input` is reset to `None` only once the last in-flight dispatch has
+    // resolved and its completion path (including the guarded value commit) has
+    // run, so observing `None` is a synchronisation point strictly after any
+    // clobber would have happened.
+    gate.notify_one();
+    tick_until(|| input.get_untracked().is_none()).await;
+
+    assert_eq!(
+        value.get_untracked(),
+        Some(2),
+        "stale dispatch must not overwrite the newer result"
+    );
+}

--- a/reactive_graph/tests/action_dispatch_order.rs
+++ b/reactive_graph/tests/action_dispatch_order.rs
@@ -7,11 +7,7 @@
 //! the guard to work.
 
 use any_spawner::Executor;
-use reactive_graph::{
-    actions::ArcAction,
-    owner::Owner,
-    traits::GetUntracked,
-};
+use reactive_graph::{actions::ArcAction, owner::Owner, traits::GetUntracked};
 use std::sync::Arc;
 use tokio::sync::Notify;
 

--- a/reactive_graph/tests/hash_eq_contract.rs
+++ b/reactive_graph/tests/hash_eq_contract.rs
@@ -1,0 +1,72 @@
+//! Regression tests for the `Hash`/`Eq` contract on pointer-identity handles.
+//!
+//! These types implement `PartialEq` via `Arc::ptr_eq`, so two clones that
+//! share the same allocation compare equal. The `Hash` impl must therefore
+//! hash the shared heap pointer, not the address of a stack temporary.
+
+use reactive_graph::{
+    computed::ArcMemo,
+    owner::{ArcStoredValue, Owner},
+    signal::{ArcReadSignal, ArcRwSignal, ArcWriteSignal},
+    traits::Get,
+};
+use std::{
+    collections::HashMap,
+    hash::{BuildHasher, BuildHasherDefault, Hash},
+};
+
+fn hash_of<T: Hash>(t: &T) -> u64 {
+    BuildHasherDefault::<rustc_hash::FxHasher>::default().hash_one(t)
+}
+
+/// `a == a.clone()` must imply `hash(a) == hash(a.clone())`, and a `HashMap`
+/// keyed by the handle must find an entry inserted under a clone.
+fn assert_hash_eq_contract<T>(a: T)
+where
+    T: Clone + Eq + Hash + std::fmt::Debug,
+{
+    let b = a.clone();
+    assert_eq!(a, b, "clones must compare equal");
+    assert_eq!(
+        hash_of(&a),
+        hash_of(&b),
+        "Hash/Eq contract violated: equal values hashed differently"
+    );
+
+    let mut map: HashMap<T, &'static str> = HashMap::new();
+    map.insert(a, "value");
+    assert_eq!(map.get(&b), Some(&"value"), "lookup with a clone must hit");
+}
+
+#[test]
+fn arc_rw_signal_hash_eq_contract() {
+    assert_hash_eq_contract(ArcRwSignal::new(0_u32));
+}
+
+#[test]
+fn arc_read_signal_hash_eq_contract() {
+    let (read, _write) = reactive_graph::signal::arc_signal(0_u32);
+    let _ = read.get();
+    assert_hash_eq_contract::<ArcReadSignal<u32>>(read);
+}
+
+#[test]
+fn arc_write_signal_hash_eq_contract() {
+    let (_read, write) = reactive_graph::signal::arc_signal(0_u32);
+    assert_hash_eq_contract::<ArcWriteSignal<u32>>(write);
+}
+
+#[test]
+fn arc_memo_hash_eq_contract() {
+    let owner = Owner::new();
+    owner.set();
+    let memo = ArcMemo::new(|_| 0_u32);
+    assert_hash_eq_contract(memo);
+}
+
+#[test]
+fn arc_stored_value_hash_eq_contract() {
+    let owner = Owner::new();
+    owner.set();
+    assert_hash_eq_contract(ArcStoredValue::new(0_u32));
+}

--- a/reactive_graph/tests/local_storage_off_thread.rs
+++ b/reactive_graph/tests/local_storage_off_thread.rs
@@ -1,0 +1,56 @@
+//! Regression test for `LocalStorage` access from the wrong thread.
+//!
+//! `StoredValue<T, LocalStorage>` stores its value in a `SendWrapper`, which
+//! may only be dereferenced on the thread that created it. The `try_*` methods
+//! are documented to return `None` when the value "can[not] be accessed from
+//! this thread" — they must not panic.
+
+use reactive_graph::{
+    owner::{LocalStorage, Owner, StoredValue},
+    traits::{ReadValue, UpdateValue, WriteValue},
+};
+
+#[test]
+fn local_storage_try_access_off_thread_returns_none() {
+    let owner = Owner::new();
+    owner.set();
+
+    let value: StoredValue<String, LocalStorage> =
+        StoredValue::new_local("created on thread A".to_string());
+
+    // On the creating thread, access works.
+    assert_eq!(
+        value.try_read_value().as_deref(),
+        Some(&"created on thread A".to_string())
+    );
+
+    // On another thread every `try_*` access must report `None`, not panic.
+    // A clone of the owner is re-activated on the spawned thread so it has a
+    // live arena (required under the `sandboxed-arenas` feature); the value
+    // itself still lives in a `SendWrapper` bound to thread A, so access must
+    // fail. The original owner stays alive here to keep the arena valid for the
+    // final on-thread assertion.
+    let owner_b = owner.clone();
+    let results = std::thread::spawn(move || {
+        owner_b.set();
+        let read = value.try_read_value().is_none();
+        let updated = value.try_update_value(|s| s.push('!')).is_none();
+        let written = value.try_write_value().is_none();
+        (read, updated, written)
+    })
+    .join()
+    .expect("accessing LocalStorage off-thread must not panic");
+
+    assert_eq!(
+        results,
+        (true, true, true),
+        "off-thread try_* access should return None"
+    );
+
+    // The value on the original thread is untouched by the failed off-thread
+    // attempts.
+    assert_eq!(
+        value.try_read_value().as_deref(),
+        Some(&"created on thread A".to_string())
+    );
+}

--- a/reactive_graph/tests/sandboxed_arena.rs
+++ b/reactive_graph/tests/sandboxed_arena.rs
@@ -1,0 +1,42 @@
+//! Regression test for `Sandboxed` arena restoration.
+//!
+//! Polling a `Sandboxed` future installs the arena it was created under for the
+//! duration of the poll. It must restore the caller's arena afterwards;
+//! otherwise the sandboxed arena bleeds into whatever runs next on the same
+//! thread, breaking the per-request isolation the `sandboxed-arenas` feature
+//! exists to provide.
+#![cfg(feature = "sandboxed-arenas")]
+
+use futures::executor::block_on;
+use reactive_graph::{
+    owner::{Owner, StoredValue},
+    traits::ReadValue,
+};
+
+#[test]
+fn sandboxed_poll_restores_callers_arena() {
+    // Two independent owners, each with its own arena. `owner_b` is created
+    // before `owner_a` is set as current, so it does not inherit A's arena.
+    let owner_a = Owner::new();
+    let owner_b = Owner::new();
+
+    // Build a future bound to arena B.
+    owner_b.set();
+    let sandboxed = reactive_graph::owner::Sandboxed::new(async { 42_u32 });
+
+    // Switch to arena A and create a value there.
+    owner_a.set();
+    let a_value = StoredValue::new(1_u32);
+    assert_eq!(a_value.try_read_value().as_deref(), Some(&1));
+
+    // Polling the sandboxed future installs arena B during the poll. After it
+    // returns, arena A must be active again.
+    let out = block_on(sandboxed);
+    assert_eq!(out, 42);
+
+    assert_eq!(
+        a_value.try_read_value().as_deref(),
+        Some(&1),
+        "Sandboxed::poll leaked arena B into the caller's context"
+    );
+}

--- a/reactive_graph/tests/transition.rs
+++ b/reactive_graph/tests/transition.rs
@@ -1,0 +1,93 @@
+//! Regression tests for `AsyncTransition`.
+//!
+//! A transition must wait for the async resources created during it, and two
+//! transitions that overlap in time must not observe one another's
+//! registration slot.
+
+use any_spawner::Executor;
+use reactive_graph::{
+    computed::ArcAsyncDerived, owner::Owner, transition::AsyncTransition,
+};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::Barrier;
+
+/// The transition must not return until the resource created inside it has
+/// resolved.
+#[tokio::test]
+async fn transition_waits_for_resource_created_inside() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let resolved = Arc::new(AtomicBool::new(false));
+    let flag = resolved.clone();
+
+    // The resource is created but deliberately *not* awaited here; the
+    // transition itself is responsible for waiting until it resolves.
+    let derived = AsyncTransition::run(move || async move {
+        ArcAsyncDerived::new(move || {
+            let flag = flag.clone();
+            async move {
+                Executor::tick().await;
+                Executor::tick().await;
+                flag.store(true, Ordering::SeqCst);
+                42_u32
+            }
+        })
+    })
+    .await;
+
+    assert!(
+        resolved.load(Ordering::SeqCst),
+        "transition returned before its resource resolved"
+    );
+    assert_eq!(derived.await, 42);
+}
+
+/// Two transitions forced to overlap must each independently wait for the
+/// resource created within them; with the previous process-global slot, a
+/// resource created during one transition could register against the other.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn overlapping_transitions_are_isolated() {
+    _ = Executor::init_tokio();
+
+    fn run_one(barrier: Arc<Barrier>) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let owner = Owner::new();
+            owner.set();
+            let resolved = Arc::new(AtomicBool::new(false));
+            let flag = resolved.clone();
+
+            AsyncTransition::run(move || async move {
+                // Force the two transitions to be "open" simultaneously.
+                barrier.wait().await;
+                let derived = ArcAsyncDerived::new(move || {
+                    let flag = flag.clone();
+                    async move {
+                        Executor::tick().await;
+                        Executor::tick().await;
+                        flag.store(true, Ordering::SeqCst);
+                        7_u32
+                    }
+                });
+                let v = derived.await;
+                assert_eq!(v, 7);
+            })
+            .await;
+
+            assert!(
+                resolved.load(Ordering::SeqCst),
+                "transition returned before its own resource resolved"
+            );
+        })
+    }
+
+    let barrier = Arc::new(Barrier::new(2));
+    let t1 = run_one(barrier.clone());
+    let t2 = run_one(barrier.clone());
+    t1.await.unwrap();
+    t2.await.unwrap();
+}


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

### Fixes

- **Hash/Eq contract on pointer-identity handles**: `ArcRwSignal`, `ArcReadSignal`, `ArcWriteSignal`, `ArcMemo`, and `ArcStoredValue` compare equal via `Arc::ptr_eq`, but their `Hash` impls hashed the address of a stack temporary instead of the shared heap pointer. Equal handles could hash differently, breaking `HashMap`/`HashSet` lookups. Now hashes the `Arc` pointer.

- **`ArcAction` out-of-order dispatch guard**: the dispatch counter was never incremented, so the last-write-wins check never fired and a slower earlier dispatch could clobber the result of a newer one. The counter is now bumped per dispatch and the guard compares versions exactly.

- **`AsyncTransition` scoping**: transition state was held in a process global, so concurrent transitions on different tasks interfered with each other. It's now scoped to the running task via a thread-local restored around each poll, keeping it executor-agnostic.

- **`Sandboxed` arena restoration**: polling a `Sandboxed` future installed its arena but never restored the caller's, leaking the sandboxed arena into whatever ran next on the thread and breaking per-request isolation. The caller's arena is now restored on drop (across `await` points and panics).

- **Off-thread `LocalStorage` access**: `try_read_value`/`try_update_value`/`try_write_value` on a `StoredValue<T, LocalStorage>` panicked in the `SendWrapper` when called from another thread, instead of returning `None` as documented. They now check thread validity and return `None`.

- **Owner `NodeId` leak**: disposed nodes' ids accumulated in their owner indefinitely. Dead ids are now pruned at the `Vec` reallocation boundary (amortized O(1)).

- **Owner child `Weak` leak**: dropped child owners left dangling `Weak` references that accumulated in a long-lived owner. These are pruned at the same boundary.
