### PR TITLE
Fix bugs in `reactive_stores` and `reactive_stores_macro`

### DIFF
--- a/reactive_stores/src/arc_field.rs
+++ b/reactive_stores/src/arc_field.rs
@@ -40,6 +40,7 @@ where
     keys: Arc<dyn Fn() -> Option<KeyMap> + Send + Sync>,
     track_field: Arc<dyn Fn() + Send + Sync>,
     notify: Arc<dyn Fn() + Send + Sync>,
+    is_disposed: Arc<dyn Fn() -> bool + Send + Sync>,
 }
 
 impl<T> Debug for ArcField<T>
@@ -155,6 +156,7 @@ where
             keys: Arc::new(move || value.keys()),
             track_field: Arc::new(move || value.track_field()),
             notify: Arc::new(move || value.notify()),
+            is_disposed: Arc::new(move || value.is_disposed()),
         }
     }
 }
@@ -204,6 +206,10 @@ where
                 let value = value.clone();
                 move || value.notify()
             }),
+            is_disposed: Arc::new({
+                let value = value.clone();
+                move || value.is_disposed()
+            }),
         }
     }
 }
@@ -212,7 +218,7 @@ impl<Inner, Prev, T> From<Subfield<Inner, Prev, T>> for ArcField<T>
 where
     T: Send + Sync,
     Subfield<Inner, Prev, T>: Clone,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: 'static,
 {
     #[track_caller]
@@ -256,13 +262,17 @@ where
                 let value = value.clone();
                 move || value.notify()
             }),
+            is_disposed: Arc::new({
+                let value = value.clone();
+                move || value.is_disposed()
+            }),
         }
     }
 }
 
 impl<Inner, T> From<DerefedField<Inner>> for ArcField<T>
 where
-    Inner: Clone + StoreField + Send + Sync + 'static,
+    Inner: Clone + StoreField + IsDisposed + Send + Sync + 'static,
     Inner::Value: Deref<Target = T> + DerefMut,
     T: Sized + 'static,
 {
@@ -307,6 +317,10 @@ where
                 let value = value.clone();
                 move || value.notify()
             }),
+            is_disposed: Arc::new({
+                let value = value.clone();
+                move || value.is_disposed()
+            }),
         }
     }
 }
@@ -314,7 +328,7 @@ where
 impl<Inner, Prev> From<AtIndex<Inner, Prev>> for ArcField<Prev::Output>
 where
     AtIndex<Inner, Prev>: Clone,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: IndexMut<usize> + Send + Sync + 'static,
     Prev::Output: Sized + Send + Sync,
 {
@@ -359,6 +373,10 @@ where
                 let value = value.clone();
                 move || value.notify()
             }),
+            is_disposed: Arc::new({
+                let value = value.clone();
+                move || value.is_disposed()
+            }),
         }
     }
 }
@@ -370,7 +388,7 @@ where
     KeyedSubfield<Inner, Prev, K, T>: Clone,
     T: KeyedIterable,
     for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: 'static,
     T: KeyedAccess<K> + 'static,
     T::Value: Sized,
@@ -416,6 +434,10 @@ where
                 let value = value.clone();
                 move || value.notify()
             }),
+            is_disposed: Arc::new({
+                let value = value.clone();
+                move || value.is_disposed()
+            }),
         }
     }
 }
@@ -434,6 +456,7 @@ impl<T> Clone for ArcField<T> {
             keys: Arc::clone(&self.keys),
             track_field: Arc::clone(&self.track_field),
             notify: Arc::clone(&self.notify),
+            is_disposed: Arc::clone(&self.is_disposed),
         }
     }
 }
@@ -489,6 +512,35 @@ impl<T> Write for ArcField<T> {
 
 impl<T> IsDisposed for ArcField<T> {
     fn is_disposed(&self) -> bool {
-        false
+        (self.is_disposed)()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{self as reactive_stores, ArcField, Store};
+    use reactive_graph::{owner::Owner, traits::IsDisposed};
+
+    #[derive(Default, reactive_stores_macro::Store)]
+    struct State {
+        value: i32,
+    }
+
+    #[test]
+    fn arc_field_reports_disposal_of_underlying_store() {
+        let owner = Owner::new();
+        let field: ArcField<i32> = owner.with(|| {
+            let store = Store::new(State { value: 42 });
+            store.value().into()
+        });
+
+        // while the owner is alive, the field is not disposed
+        assert!(!field.is_disposed());
+
+        // once the owner is disposed, the underlying store is gone and the
+        // field must report it, instead of always returning `false`
+        owner.cleanup();
+        drop(owner);
+        assert!(field.is_disposed());
     }
 }

--- a/reactive_stores/src/arc_field.rs
+++ b/reactive_stores/src/arc_field.rs
@@ -329,7 +329,7 @@ impl<Inner, Prev> From<AtIndex<Inner, Prev>> for ArcField<Prev::Output>
 where
     AtIndex<Inner, Prev>: Clone,
     Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
-    Prev: IndexMut<usize> + Send + Sync + 'static,
+    Prev: IndexMut<usize> + crate::len::Len + Send + Sync + 'static,
     Prev::Output: Sized + Send + Sync,
 {
     #[track_caller]

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -178,7 +178,7 @@ where
     AtIndex<Inner, Prev>: Clone,
     S: Storage<ArcField<Prev::Output>>,
     Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
-    Prev: IndexMut<usize> + Send + Sync + 'static,
+    Prev: IndexMut<usize> + crate::len::Len + Send + Sync + 'static,
     Prev::Output: Sized + Send + Sync,
 {
     #[track_caller]

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -271,7 +271,10 @@ where
     }
 }
 
-impl<T> Write for Field<T> {
+impl<T, S> Write for Field<T, S>
+where
+    S: Storage<ArcField<T>>,
+{
     type Value = T;
 
     fn try_write(&self) -> Option<impl UntrackableGuard<Target = Self::Value>> {
@@ -292,5 +295,32 @@ impl<T> Write for Field<T> {
 impl<T, S> IsDisposed for Field<T, S> {
     fn is_disposed(&self) -> bool {
         self.inner.is_disposed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{self as reactive_stores, Field, Store};
+    use reactive_graph::{
+        owner::{LocalStorage, Owner},
+        traits::{ReadUntracked, Write},
+    };
+
+    #[derive(Default, reactive_stores_macro::Store)]
+    struct State {
+        value: i32,
+    }
+
+    #[test]
+    fn write_is_available_for_non_default_storage() {
+        let owner = Owner::new();
+        owner.set();
+
+        let store: Store<State, LocalStorage> =
+            Store::new_local(State::default());
+        let field: Field<i32, LocalStorage> = store.value().into();
+
+        *field.write() = 7;
+        assert_eq!(*field.read_untracked(), 7);
     }
 }

--- a/reactive_stores/src/field.rs
+++ b/reactive_stores/src/field.rs
@@ -144,7 +144,7 @@ where
     T: Send + Sync,
     S: Storage<ArcField<T>>,
     Subfield<Inner, Prev, T>: Clone,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: 'static,
 {
     #[track_caller]
@@ -159,7 +159,7 @@ where
 
 impl<Inner, T> From<DerefedField<Inner>> for Field<T>
 where
-    Inner: Clone + StoreField + Send + Sync + 'static,
+    Inner: Clone + StoreField + IsDisposed + Send + Sync + 'static,
     Inner::Value: Deref<Target = T> + DerefMut,
     T: Sized + 'static,
 {
@@ -177,7 +177,7 @@ impl<Inner, Prev, S> From<AtIndex<Inner, Prev>> for Field<Prev::Output, S>
 where
     AtIndex<Inner, Prev>: Clone,
     S: Storage<ArcField<Prev::Output>>,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: IndexMut<usize> + Send + Sync + 'static,
     Prev::Output: Sized + Send + Sync,
 {
@@ -200,7 +200,7 @@ where
     KeyedSubfield<Inner, Prev, K, T>: Clone,
     T: KeyedIterable,
     for<'a> &'a T: IntoIterator<Item = <T as KeyedIterable>::IterItem<'a>>,
-    Inner: StoreField<Value = Prev> + Send + Sync + 'static,
+    Inner: StoreField<Value = Prev> + IsDisposed + Send + Sync + 'static,
     Prev: 'static,
     T: KeyedAccess<K> + 'static,
     T::Value: Sized,

--- a/reactive_stores/src/iter.rs
+++ b/reactive_stores/src/iter.rs
@@ -65,7 +65,7 @@ impl<Inner, Prev> AtIndex<Inner, Prev> {
 impl<Inner, Prev> StoreField for AtIndex<Inner, Prev>
 where
     Inner: StoreField<Value = Prev>,
-    Prev: IndexMut<usize> + 'static,
+    Prev: IndexMut<usize> + Len + 'static,
     Prev::Output: Sized,
 {
     type Value = Prev::Output;
@@ -98,6 +98,13 @@ where
     fn reader(&self) -> Option<Self::Reader> {
         let inner = self.inner.reader()?;
         let index = self.index;
+        // The reader holds the inner lock for its whole lifetime, so the
+        // length cannot change before the (lazy) projection runs on deref.
+        // Bail out with `None` if the index is out of bounds, instead of
+        // handing back a guard that panics when first dereferenced.
+        if index >= inner.len() {
+            return None;
+        }
         Some(MappedMutArc::new(
             inner,
             move |n| &n[index],
@@ -109,6 +116,11 @@ where
         let trigger = self.get_trigger(self.path().into_iter().collect());
         let inner = WriteGuard::new(trigger.children, self.inner.writer()?);
         let index = self.index;
+        // See `reader`: the write guard holds the inner lock, so a single
+        // bounds check here is sufficient to keep the projection panic-free.
+        if index >= inner.len() {
+            return None;
+        }
         Some(MappedMutArc::new(
             inner,
             move |n| &n[index],
@@ -167,7 +179,7 @@ where
 impl<Inner, Prev> Notify for AtIndex<Inner, Prev>
 where
     Inner: StoreField<Value = Prev>,
-    Prev: IndexMut<usize> + 'static,
+    Prev: IndexMut<usize> + Len + 'static,
     Prev::Output: Sized,
 {
     fn notify(&self) {
@@ -179,7 +191,7 @@ where
 impl<Inner, Prev> Track for AtIndex<Inner, Prev>
 where
     Inner: StoreField<Value = Prev> + Send + Sync + Clone + 'static,
-    Prev: IndexMut<usize> + 'static,
+    Prev: IndexMut<usize> + Len + 'static,
     Prev::Output: Sized + 'static,
 {
     fn track(&self) {
@@ -190,7 +202,7 @@ where
 impl<Inner, Prev> ReadUntracked for AtIndex<Inner, Prev>
 where
     Inner: StoreField<Value = Prev>,
-    Prev: IndexMut<usize> + 'static,
+    Prev: IndexMut<usize> + Len + 'static,
     Prev::Output: Sized,
 {
     type Value = <Self as StoreField>::Reader;
@@ -203,7 +215,7 @@ where
 impl<Inner, Prev> Write for AtIndex<Inner, Prev>
 where
     Inner: StoreField<Value = Prev>,
-    Prev: IndexMut<usize> + 'static,
+    Prev: IndexMut<usize> + Len + 'static,
     Prev::Output: Sized + 'static,
 {
     type Value = Prev::Output;
@@ -306,5 +318,54 @@ where
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{self as reactive_stores, AtIndex, Store};
+    use reactive_graph::{
+        owner::Owner,
+        traits::{ReadUntracked, Write},
+    };
+
+    #[derive(Default, reactive_stores_macro::Store)]
+    struct State {
+        items: Vec<i32>,
+    }
+
+    #[test]
+    fn out_of_bounds_index_reads_as_none_without_panicking() {
+        let owner = Owner::new();
+        owner.set();
+
+        let store = Store::new(State {
+            items: vec![1, 2, 3],
+        });
+
+        // an index that has never been valid
+        let at = AtIndex::new(store.items(), 5);
+        let guard = at.try_read_untracked();
+        assert!(guard.is_none());
+        // forcing the (lazy) projection must not panic
+        assert!(guard.map(|g| *g).is_none());
+
+        // an index that was valid at construction but is shrunk away before read
+        let at = AtIndex::new(store.items(), 2);
+        store.items().write().clear();
+        assert!(at.try_read_untracked().is_none());
+    }
+
+    #[test]
+    fn in_bounds_index_still_reads() {
+        let owner = Owner::new();
+        owner.set();
+
+        let store = Store::new(State {
+            items: vec![10, 20, 30],
+        });
+        let at = AtIndex::new(store.items(), 1);
+        let guard = at.try_read_untracked().expect("index 1 is in bounds");
+        assert_eq!(*guard, 20);
     }
 }

--- a/reactive_stores/src/option.rs
+++ b/reactive_stores/src/option.rs
@@ -1,6 +1,229 @@
-use crate::{StoreField, Subfield};
-use reactive_graph::traits::{FlattenOptionRefOption, Read, ReadUntracked};
-use std::ops::Deref;
+use crate::{
+    KeyMap, StoreField, StoreFieldTrigger,
+    path::{StorePath, StorePathSegment},
+};
+use reactive_graph::{
+    signal::{
+        ArcTrigger,
+        guards::{Mapped, MappedMut, WriteGuard},
+    },
+    traits::{
+        DefinedAt, FlattenOptionRefOption, IsDisposed, Notify, Read,
+        ReadUntracked, Track, UntrackableGuard, Write,
+    },
+};
+use std::{
+    iter,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    panic::Location,
+};
+
+/// Accesses the inner value of an `Option`-typed store field.
+///
+/// Unlike a plain [`Subfield`](crate::Subfield), this projection is fallible:
+/// its [`reader`](StoreField::reader)/[`writer`](StoreField::writer) return
+/// `None` when the underlying field is currently `None`, instead of handing
+/// back a guard that panics when dereferenced.
+pub struct OptionSubfield<Inner, T> {
+    #[cfg(any(debug_assertions, leptos_debuginfo))]
+    defined_at: &'static Location<'static>,
+    path_segment: StorePathSegment,
+    inner: Inner,
+    ty: PhantomData<T>,
+}
+
+impl<Inner, T> Clone for OptionSubfield<Inner, T>
+where
+    Inner: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: self.defined_at,
+            path_segment: self.path_segment,
+            inner: self.inner.clone(),
+            ty: self.ty,
+        }
+    }
+}
+
+impl<Inner, T> Copy for OptionSubfield<Inner, T> where Inner: Copy {}
+
+impl<Inner, T> OptionSubfield<Inner, T> {
+    /// Creates an accessor for the inner value of an `Option`-typed field.
+    #[track_caller]
+    pub fn new(inner: Inner) -> Self {
+        Self {
+            #[cfg(any(debug_assertions, leptos_debuginfo))]
+            defined_at: Location::caller(),
+            path_segment: 0.into(),
+            inner,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<Inner, T> StoreField for OptionSubfield<Inner, T>
+where
+    Inner: StoreField<Value = Option<T>>,
+    T: 'static,
+{
+    type Value = T;
+    type Reader = Mapped<Inner::Reader, T>;
+    type Writer = MappedMut<WriteGuard<Vec<ArcTrigger>, Inner::Writer>, T>;
+
+    fn path(&self) -> impl IntoIterator<Item = StorePathSegment> {
+        self.inner
+            .path()
+            .into_iter()
+            .chain(iter::once(self.path_segment))
+    }
+
+    fn path_unkeyed(&self) -> impl IntoIterator<Item = StorePathSegment> {
+        self.inner
+            .path_unkeyed()
+            .into_iter()
+            .chain(iter::once(self.path_segment))
+    }
+
+    fn get_trigger(&self, path: StorePath) -> StoreFieldTrigger {
+        self.inner.get_trigger(path)
+    }
+
+    fn get_trigger_unkeyed(&self, path: StorePath) -> StoreFieldTrigger {
+        self.inner.get_trigger_unkeyed(path)
+    }
+
+    fn reader(&self) -> Option<Self::Reader> {
+        let inner = self.inner.reader()?;
+        // The reader holds the inner lock for its whole lifetime, so the
+        // value cannot toggle to `None` before the (lazy) projection runs on
+        // deref. Bail out here instead of handing back a guard that would
+        // panic in `as_ref().unwrap()`.
+        if inner.is_none() {
+            return None;
+        }
+        Some(Mapped::new_with_guard(inner, |t| t.as_ref().unwrap()))
+    }
+
+    fn writer(&self) -> Option<Self::Writer> {
+        let mut parent = self.inner.writer()?;
+        // See `reader`: the write guard holds the inner lock, so a single
+        // check here keeps the `as_mut().unwrap()` projection panic-free.
+        if parent.is_none() {
+            return None;
+        }
+        // untrack the parent so it doesn't notify its `this` trigger (which
+        // would notify siblings); the path triggers are included below.
+        parent.untrack();
+        let triggers = self.triggers_for_current_path();
+        let guard = WriteGuard::new(triggers, parent);
+        Some(MappedMut::new(
+            guard,
+            |t| t.as_ref().unwrap(),
+            |t| t.as_mut().unwrap(),
+        ))
+    }
+
+    #[inline(always)]
+    fn keys(&self) -> Option<KeyMap> {
+        self.inner.keys()
+    }
+
+    #[track_caller]
+    fn track_field(&self) {
+        let mut full_path = self.path().into_iter().collect::<StorePath>();
+        let trigger = self.get_trigger(self.path().into_iter().collect());
+        trigger.this.track();
+        trigger.children.track();
+
+        while !full_path.is_empty() {
+            full_path.pop();
+            let inner = self.get_trigger(full_path.clone());
+            inner.this.track();
+        }
+    }
+}
+
+impl<Inner, T> DefinedAt for OptionSubfield<Inner, T> {
+    fn defined_at(&self) -> Option<&'static Location<'static>> {
+        #[cfg(any(debug_assertions, leptos_debuginfo))]
+        {
+            Some(self.defined_at)
+        }
+        #[cfg(not(any(debug_assertions, leptos_debuginfo)))]
+        {
+            None
+        }
+    }
+}
+
+impl<Inner, T> IsDisposed for OptionSubfield<Inner, T>
+where
+    Inner: IsDisposed,
+{
+    fn is_disposed(&self) -> bool {
+        self.inner.is_disposed()
+    }
+}
+
+impl<Inner, T> Notify for OptionSubfield<Inner, T>
+where
+    Inner: StoreField<Value = Option<T>>,
+    T: 'static,
+{
+    #[track_caller]
+    fn notify(&self) {
+        let trigger = self.get_trigger(self.path().into_iter().collect());
+        trigger.this.notify();
+        trigger.children.notify();
+    }
+}
+
+impl<Inner, T> Track for OptionSubfield<Inner, T>
+where
+    Inner: StoreField<Value = Option<T>> + Track + 'static,
+    T: 'static,
+{
+    #[track_caller]
+    fn track(&self) {
+        self.track_field();
+    }
+}
+
+impl<Inner, T> ReadUntracked for OptionSubfield<Inner, T>
+where
+    Inner: StoreField<Value = Option<T>>,
+    T: 'static,
+{
+    type Value = <Self as StoreField>::Reader;
+
+    fn try_read_untracked(&self) -> Option<Self::Value> {
+        self.reader()
+    }
+}
+
+impl<Inner, T> Write for OptionSubfield<Inner, T>
+where
+    Inner: StoreField<Value = Option<T>>,
+    T: 'static,
+{
+    type Value = T;
+
+    fn try_write(&self) -> Option<impl UntrackableGuard<Target = Self::Value>> {
+        self.writer()
+    }
+
+    fn try_write_untracked(
+        &self,
+    ) -> Option<impl DerefMut<Target = Self::Value>> {
+        self.writer().map(|mut writer| {
+            writer.untrack();
+            writer
+        })
+    }
+}
 
 /// Extends optional store fields, with the ability to unwrap or map over them.
 pub trait OptionStoreExt
@@ -11,24 +234,26 @@ where
     type Output;
 
     /// Provides access to the inner value, as a subfield, unwrapping the outer value.
-    fn unwrap(self) -> Subfield<Self, Option<Self::Output>, Self::Output>;
+    ///
+    /// The returned field reads and writes fallibly: if the outer value becomes
+    /// `None` before the projection runs, its reader/writer yield `None` rather
+    /// than panicking.
+    fn unwrap(self) -> OptionSubfield<Self, Self::Output>;
 
     /// Inverts a subfield of an `Option` to an `Option` of a subfield.
-    fn invert(
-        self,
-    ) -> Option<Subfield<Self, Option<Self::Output>, Self::Output>> {
+    fn invert(self) -> Option<OptionSubfield<Self, Self::Output>> {
         self.map(|f| f)
     }
 
     /// Reactively maps over the field.
     ///
     /// This returns `None` if the subfield is currently `None`,
-    /// and a new store subfield with the inner value if it is `Some`. This can be used in some  
+    /// and a new store subfield with the inner value if it is `Some`. This can be used in some
     /// other reactive context, which will cause it to re-run if the field toggles between `None`
     /// and `Some(_)`.
     fn map<U>(
         self,
-        map_fn: impl FnOnce(Subfield<Self, Option<Self::Output>, Self::Output>) -> U,
+        map_fn: impl FnOnce(OptionSubfield<Self, Self::Output>) -> U,
     ) -> Option<U>;
 
     /// Unreactively maps over the field.
@@ -38,7 +263,7 @@ where
     /// `[OptionStoreExt::map]`, and will not cause the reactive context to re-run if the field changes.
     fn map_untracked<U>(
         self,
-        map_fn: impl FnOnce(Subfield<Self, Option<Self::Output>, Self::Output>) -> U,
+        map_fn: impl FnOnce(OptionSubfield<Self, Self::Output>) -> U,
     ) -> Option<U>;
 }
 
@@ -50,18 +275,13 @@ where
 {
     type Output = T;
 
-    fn unwrap(self) -> Subfield<Self, Option<Self::Output>, Self::Output> {
-        Subfield::new(
-            self,
-            0.into(),
-            |t| t.as_ref().unwrap(),
-            |t| t.as_mut().unwrap(),
-        )
+    fn unwrap(self) -> OptionSubfield<Self, Self::Output> {
+        OptionSubfield::new(self)
     }
 
     fn map<U>(
         self,
-        map_fn: impl FnOnce(Subfield<S, Option<T>, T>) -> U,
+        map_fn: impl FnOnce(OptionSubfield<S, T>) -> U,
     ) -> Option<U> {
         if self.try_read().as_deref().flatten().is_some() {
             Some(map_fn(self.unwrap()))
@@ -72,7 +292,7 @@ where
 
     fn map_untracked<U>(
         self,
-        map_fn: impl FnOnce(Subfield<S, Option<T>, T>) -> U,
+        map_fn: impl FnOnce(OptionSubfield<S, T>) -> U,
     ) -> Option<U> {
         if self.try_read_untracked().as_deref().flatten().is_some() {
             Some(map_fn(self.unwrap()))
@@ -367,5 +587,38 @@ mod tests {
         assert_eq!(parent_count.load(Ordering::Relaxed), 4);
         assert_eq!(inner_first_count.load(Ordering::Relaxed), 2);
         assert_eq!(inner_second_count.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn unwrap_reads_as_none_after_option_is_cleared() {
+        use crate::OptionStoreExt;
+        use reactive_graph::owner::Owner;
+
+        #[derive(Debug, Clone, Store)]
+        struct State {
+            value: Option<i32>,
+        }
+
+        let owner = Owner::new();
+        owner.set();
+
+        let store = Store::new(State { value: Some(1) });
+
+        // Capture the unwrapped inner field while the option is `Some`.
+        let inner = OptionStoreExt::unwrap(store.value());
+        assert_eq!(inner.try_read_untracked().map(|g| *g), Some(1));
+
+        // Another writer clears the option after the inner field was captured.
+        *store.value().write() = None;
+
+        // The previously valid projection must now read as `None` instead of
+        // panicking with "called `Option::unwrap()` on a `None` value".
+        let guard = inner.try_read_untracked();
+        assert!(guard.is_none());
+        // Forcing the (lazy) projection must not panic.
+        assert!(guard.map(|g| *g).is_none());
+
+        // The writer side is fallible in the same way.
+        assert!(inner.try_write().is_none());
     }
 }

--- a/reactive_stores/src/patch.rs
+++ b/reactive_stores/src/patch.rs
@@ -184,6 +184,31 @@ macro_rules! patch_primitives {
     };
 }
 
+macro_rules! patch_floats {
+    ($($ty:ty),*) => {
+        $(impl PatchField for $ty {
+            fn patch_field(
+                &mut self,
+                new: Self,
+                path: &StorePath,
+                notify: &mut dyn FnMut(&StorePath),
+                _keys: Option<&KeyMap>
+            ) {
+                // `!=` is wrong for floats: `NaN != NaN` is `true` (spurious
+                // notify on NaN -> NaN) while `+0.0 == -0.0` is `true` (no
+                // notify even though the bit pattern changed). `total_cmp`
+                // gives a strict total order with the intended semantics.
+                if new.total_cmp(self) != core::cmp::Ordering::Equal {
+                    *self = new;
+                    notify(path);
+                }
+            }
+        })*
+    };
+}
+
+patch_floats! { f32, f64 }
+
 patch_primitives! {
     &str,
     String,
@@ -202,8 +227,6 @@ patch_primitives! {
     i32,
     i64,
     i128,
-    f32,
-    f64,
     char,
     bool,
     IpAddr,
@@ -660,3 +683,31 @@ patch_tuple!(
     A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y,
     Z
 );
+
+#[cfg(test)]
+mod tests {
+    use super::PatchField;
+    use crate::path::StorePath;
+
+    fn notify_count<T: PatchField>(mut value: T, new: T) -> usize {
+        let path = StorePath::default();
+        let mut count = 0usize;
+        value.patch_field(new, &path, &mut |_| count += 1, None);
+        count
+    }
+
+    #[test]
+    fn patching_float_uses_total_cmp_semantics() {
+        // NaN -> NaN is the same value, so it must not notify
+        assert_eq!(notify_count(f32::NAN, f32::NAN), 0);
+        assert_eq!(notify_count(f64::NAN, f64::NAN), 0);
+
+        // +0.0 -> -0.0 is observably different, so it must notify
+        assert_eq!(notify_count(0.0f32, -0.0f32), 1);
+        assert_eq!(notify_count(0.0f64, -0.0f64), 1);
+
+        // ordinary distinct/equal values behave as expected
+        assert_eq!(notify_count(1.0f32, 2.0f32), 1);
+        assert_eq!(notify_count(1.0f64, 1.0f64), 0);
+    }
+}

--- a/reactive_stores/tests/enum_patch.rs
+++ b/reactive_stores/tests/enum_patch.rs
@@ -1,0 +1,154 @@
+//! Regression test: the `Patch` derive supports enums.
+//! - patching within the same variant updates fields in place and only
+//!   notifies the fields that changed,
+//! - patching across variants replaces the value and notifies subscribers.
+
+use reactive_graph::{
+    effect::Effect,
+    owner::Owner,
+    traits::{Get, Read, ReadUntracked},
+};
+use reactive_stores::{Patch, Store};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Debug, Clone, PartialEq, Patch, Store, Default)]
+enum Mode {
+    #[default]
+    Idle,
+    Running {
+        progress: u32,
+        label: String,
+    },
+    Done(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Patch, Store, Default)]
+struct State {
+    mode: Mode,
+}
+
+async fn tick() {
+    tokio::time::sleep(std::time::Duration::from_micros(1)).await;
+}
+
+#[tokio::test]
+async fn same_variant_patch_only_notifies_changed_field() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        mode: Mode::Running {
+            progress: 1,
+            label: "a".into(),
+        },
+    });
+
+    let progress_count = Arc::new(AtomicUsize::new(0));
+    let label_count = Arc::new(AtomicUsize::new(0));
+
+    let progress_sf = store.mode().running_progress().unwrap();
+    let label_sf = store.mode().running_label().unwrap();
+
+    Effect::new_sync({
+        let c = Arc::clone(&progress_count);
+        move |_: Option<()>| {
+            let _ = progress_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    Effect::new_sync({
+        let c = Arc::clone(&label_count);
+        move |_: Option<()>| {
+            let _ = label_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+
+    // Patch within the same variant, changing only `progress`.
+    store.patch(State {
+        mode: Mode::Running {
+            progress: 2,
+            label: "a".into(),
+        },
+    });
+    tick().await;
+
+    assert_eq!(
+        store.mode().running_progress().unwrap().get(),
+        2,
+        "progress should be patched in place"
+    );
+    assert_eq!(
+        progress_count.load(Ordering::Relaxed),
+        2,
+        "progress effect should re-run after its field changed"
+    );
+    assert_eq!(
+        label_count.load(Ordering::Relaxed),
+        1,
+        "label effect should not re-run when only progress changed"
+    );
+}
+
+#[tokio::test]
+async fn cross_variant_patch_replaces_and_notifies() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State { mode: Mode::Idle });
+
+    let is_running_count = Arc::new(AtomicUsize::new(0));
+    let is_running = Arc::new(AtomicUsize::new(0));
+
+    Effect::new_sync({
+        let c = Arc::clone(&is_running_count);
+        let r = Arc::clone(&is_running);
+        move |_: Option<()>| {
+            r.store(store.mode().running() as usize, Ordering::Relaxed);
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+    assert_eq!(is_running.load(Ordering::Relaxed), 0);
+
+    // Patch across variants: Idle -> Running.
+    store.patch(State {
+        mode: Mode::Running {
+            progress: 5,
+            label: "x".into(),
+        },
+    });
+    tick().await;
+
+    assert_eq!(
+        is_running_count.load(Ordering::Relaxed),
+        2,
+        "variant-matcher effect should re-run after a variant change"
+    );
+    assert_eq!(is_running.load(Ordering::Relaxed), 1);
+    assert!(matches!(
+        store.read_untracked().mode,
+        Mode::Running { progress: 5, .. }
+    ));
+}
+
+#[tokio::test]
+async fn unnamed_variant_patches_in_place() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        mode: Mode::Done(1),
+    });
+    store.patch(State {
+        mode: Mode::Done(7),
+    });
+    assert!(matches!(store.read_untracked().mode, Mode::Done(7)));
+}

--- a/reactive_stores/tests/enum_subfield_paths.rs
+++ b/reactive_stores/tests/enum_subfield_paths.rs
@@ -1,0 +1,82 @@
+//! Regression test: fields of an enum variant must each have a distinct
+//! reactive path, so that writing one field does not wake subscribers of a
+//! sibling field.
+
+use reactive_graph::{
+    effect::Effect,
+    owner::Owner,
+    traits::{Read, Write},
+};
+use reactive_stores::Store;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Store, Default)]
+enum Form {
+    #[default]
+    Empty,
+    Loaded {
+        name: String,
+        age: u32,
+    },
+}
+
+#[derive(Store, Default)]
+struct State {
+    form: Form,
+}
+
+async fn tick() {
+    tokio::time::sleep(std::time::Duration::from_micros(1)).await;
+}
+
+#[tokio::test]
+async fn writing_one_variant_field_does_not_wake_sibling() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        form: Form::Loaded {
+            name: "x".into(),
+            age: 1,
+        },
+    });
+
+    let name_count = Arc::new(AtomicUsize::new(0));
+    let age_count = Arc::new(AtomicUsize::new(0));
+
+    let name_sf = store.form().loaded_name().unwrap();
+    let age_sf = store.form().loaded_age().unwrap();
+
+    Effect::new_sync({
+        let c = Arc::clone(&name_count);
+        move |_: Option<()>| {
+            let _ = name_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    Effect::new_sync({
+        let c = Arc::clone(&age_count);
+        move |_: Option<()>| {
+            let _ = age_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+
+    // Write only to `age`.
+    *store.form().loaded_age().unwrap().write() = 99;
+    tick().await;
+
+    // The `name` effect must not have re-run (initial run only).
+    assert_eq!(
+        name_count.load(Ordering::Relaxed),
+        1,
+        "name effect woke on an age-only write (path collision)"
+    );
+    // The `age` effect re-ran: initial + after the write.
+    assert_eq!(age_count.load(Ordering::Relaxed), 2);
+}

--- a/reactive_stores/tests/enum_subfield_paths.rs
+++ b/reactive_stores/tests/enum_subfield_paths.rs
@@ -5,7 +5,7 @@
 use reactive_graph::{
     effect::Effect,
     owner::Owner,
-    traits::{Read, Track, Write},
+    traits::{Read, Write},
 };
 use reactive_stores::Store;
 use std::sync::{
@@ -79,80 +79,4 @@ async fn writing_one_variant_field_does_not_wake_sibling() {
     );
     // The `age` effect re-ran: initial + after the write.
     assert_eq!(age_count.load(Ordering::Relaxed), 2);
-}
-
-// Two single-field variants. Each field must get a path segment that is unique
-// across the *whole* enum, not just within its own variant. Without the
-// per-variant base offset, `A::a` and `B::b` both collapse onto segment `0`,
-// so writing one falsely wakes a subscriber of the other.
-#[derive(Store, Default)]
-enum Multi {
-    #[default]
-    Empty,
-    A {
-        a: u32,
-    },
-    B {
-        b: u32,
-    },
-}
-
-#[derive(Store, Default)]
-struct MultiState {
-    multi: Multi,
-}
-
-#[tokio::test]
-async fn writing_one_variant_field_does_not_wake_a_different_variants_sibling()
-{
-    _ = any_spawner::Executor::init_tokio();
-    let owner = Owner::new();
-    owner.set();
-
-    let store = Store::new(MultiState {
-        multi: Multi::A { a: 1 },
-    });
-
-    let a_count = Arc::new(AtomicUsize::new(0));
-
-    // Subfield for `A::a`. We only *track* it (never read), so its subscription
-    // can outlive a switch to a different variant -- reading a non-matching
-    // variant would panic on the "accessed an enum field that is no longer
-    // matched" guard.
-    let a_sf = store.multi().a_a().unwrap();
-
-    Effect::new_sync({
-        let c = Arc::clone(&a_count);
-        move |_: Option<()>| {
-            a_sf.track();
-            c.fetch_add(1, Ordering::Relaxed);
-        }
-    });
-    tick().await;
-    assert_eq!(a_count.load(Ordering::Relaxed), 1, "initial run");
-
-    // Switch `A` -> `B`. This writes the whole `multi` field and legitimately
-    // wakes the tracker once, via the ancestor `this@[multi]` trigger.
-    *store.multi().write() = Multi::B { b: 0 };
-    tick().await;
-    let after_switch = a_count.load(Ordering::Relaxed);
-    assert_eq!(
-        after_switch, 2,
-        "the variant switch should wake the tracker exactly once"
-    );
-
-    // Now write the *other* variant's field. `B::b` has a path distinct from
-    // `A::a`, so these writes must NOT wake the `A::a` tracker. If the two
-    // fields shared segment `0`, each write here would falsely wake it.
-    *store.multi().b_b().unwrap().write() = 7;
-    tick().await;
-    *store.multi().b_b().unwrap().write() = 8;
-    tick().await;
-
-    assert_eq!(
-        a_count.load(Ordering::Relaxed),
-        after_switch,
-        "writing a different variant's field woke a cross-variant subscriber \
-         (path collision across variants)"
-    );
 }

--- a/reactive_stores/tests/enum_subfield_paths.rs
+++ b/reactive_stores/tests/enum_subfield_paths.rs
@@ -5,7 +5,7 @@
 use reactive_graph::{
     effect::Effect,
     owner::Owner,
-    traits::{Read, Write},
+    traits::{Read, Track, Write},
 };
 use reactive_stores::Store;
 use std::sync::{
@@ -79,4 +79,80 @@ async fn writing_one_variant_field_does_not_wake_sibling() {
     );
     // The `age` effect re-ran: initial + after the write.
     assert_eq!(age_count.load(Ordering::Relaxed), 2);
+}
+
+// Two single-field variants. Each field must get a path segment that is unique
+// across the *whole* enum, not just within its own variant. Without the
+// per-variant base offset, `A::a` and `B::b` both collapse onto segment `0`,
+// so writing one falsely wakes a subscriber of the other.
+#[derive(Store, Default)]
+enum Multi {
+    #[default]
+    Empty,
+    A {
+        a: u32,
+    },
+    B {
+        b: u32,
+    },
+}
+
+#[derive(Store, Default)]
+struct MultiState {
+    multi: Multi,
+}
+
+#[tokio::test]
+async fn writing_one_variant_field_does_not_wake_a_different_variants_sibling()
+{
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(MultiState {
+        multi: Multi::A { a: 1 },
+    });
+
+    let a_count = Arc::new(AtomicUsize::new(0));
+
+    // Subfield for `A::a`. We only *track* it (never read), so its subscription
+    // can outlive a switch to a different variant -- reading a non-matching
+    // variant would panic on the "accessed an enum field that is no longer
+    // matched" guard.
+    let a_sf = store.multi().a_a().unwrap();
+
+    Effect::new_sync({
+        let c = Arc::clone(&a_count);
+        move |_: Option<()>| {
+            a_sf.track();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+    assert_eq!(a_count.load(Ordering::Relaxed), 1, "initial run");
+
+    // Switch `A` -> `B`. This writes the whole `multi` field and legitimately
+    // wakes the tracker once, via the ancestor `this@[multi]` trigger.
+    *store.multi().write() = Multi::B { b: 0 };
+    tick().await;
+    let after_switch = a_count.load(Ordering::Relaxed);
+    assert_eq!(
+        after_switch, 2,
+        "the variant switch should wake the tracker exactly once"
+    );
+
+    // Now write the *other* variant's field. `B::b` has a path distinct from
+    // `A::a`, so these writes must NOT wake the `A::a` tracker. If the two
+    // fields shared segment `0`, each write here would falsely wake it.
+    *store.multi().b_b().unwrap().write() = 7;
+    tick().await;
+    *store.multi().b_b().unwrap().write() = 8;
+    tick().await;
+
+    assert_eq!(
+        a_count.load(Ordering::Relaxed),
+        after_switch,
+        "writing a different variant's field woke a cross-variant subscriber \
+         (path collision across variants)"
+    );
 }

--- a/reactive_stores/tests/patch_skip.rs
+++ b/reactive_stores/tests/patch_skip.rs
@@ -1,0 +1,37 @@
+//! Regression test: a `#[store(skip)]` field is opted out of patching. Its
+//! type need not implement `PatchField`, and `patch` leaves it untouched.
+
+use reactive_graph::{owner::Owner, traits::ReadUntracked};
+use reactive_stores::{Patch, Store};
+
+// Deliberately implements neither `PatchField` nor `PartialEq`.
+#[derive(Debug, Default)]
+struct Handle(i32);
+
+#[derive(Debug, Store, reactive_stores::Patch, Default)]
+struct State {
+    #[store(skip)]
+    handle: Handle,
+    value: i32,
+}
+
+#[test]
+fn skip_field_is_not_patched() {
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        handle: Handle(7),
+        value: 1,
+    });
+
+    store.patch(State {
+        handle: Handle(99),
+        value: 42,
+    });
+
+    let guard = store.read_untracked();
+    // The skipped field keeps its original value; the rest is patched.
+    assert_eq!(guard.handle.0, 7);
+    assert_eq!(guard.value, 42);
+}

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -783,7 +783,29 @@ impl ToTokens for PatchModel {
                             })
                         }).flatten();
 
-                    if let Some(closure) = closure {
+                    // A field marked `#[store(skip)]` is opted out of store-field
+                    // generation; it must also be opted out of patching, so the
+                    // field's type need not implement `PatchField`.
+                    let skip = attrs.iter().any(|attr| {
+                        attr.meta.path().is_ident("store")
+                            && matches!(&attr.meta, Meta::List(list)
+                                if Punctuated::<SubfieldMode, Comma>::parse_terminated
+                                    .parse2(list.tokens.clone())
+                                    .map(|modes| {
+                                        modes.iter().any(|mode| {
+                                            matches!(mode, SubfieldMode::Skip)
+                                        })
+                                    })
+                                    .unwrap_or(false))
+                    });
+
+                    if skip {
+                        // leave the field untouched; only keep the running
+                        // path segment aligned for the following fields.
+                        quote! {
+                            new_path.replace_last(#idx + 1);
+                        }
+                    } else if let Some(closure) = closure {
                         let params = closure.inputs;
                         let body = closure.body;
                         quote! {

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -653,12 +653,8 @@ struct PatchModel {
 }
 
 enum PatchModelTy {
-    Struct {
-        fields: Vec<Field>,
-    },
-    Enum {
-        variants: Vec<Variant>,
-    },
+    Struct { fields: Vec<Field> },
+    Enum { variants: Vec<Variant> },
 }
 
 impl Parse for PatchModel {

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -331,35 +331,58 @@ impl ModelTy {
                     )
                 })
                 .unzip(),
-            ModelTy::Enum { variants } => variants
-                .iter()
-                .map(|variant| {
-                    let Variant { ident, fields, .. } = variant;
+            ModelTy::Enum { variants } => {
+                // Assign every variant field a distinct path segment that is
+                // unique across the whole enum. Without this, all variant
+                // fields collapse onto segment `0`, so writing one field wakes
+                // subscribers of every other field (see sibling-wake bug).
+                let mut next_segment = 0usize;
+                let bases = variants
+                    .iter()
+                    .map(|variant| {
+                        let base = next_segment;
+                        next_segment += match &variant.fields {
+                            Fields::Unit => 0,
+                            Fields::Named(fields) => fields.named.len(),
+                            Fields::Unnamed(fields) => fields.unnamed.len(),
+                        };
+                        base
+                    })
+                    .collect::<Vec<_>>();
 
-                    (
-                        variant_to_tokens(
-                            false,
-                            library_path,
-                            ident,
-                            generics,
-                            clear_generics,
-                            any_store_field,
-                            name,
-                            fields,
-                        ),
-                        variant_to_tokens(
-                            true,
-                            library_path,
-                            ident,
-                            generics,
-                            clear_generics,
-                            any_store_field,
-                            name,
-                            fields,
-                        ),
-                    )
-                })
-                .unzip(),
+                variants
+                    .iter()
+                    .zip(bases)
+                    .map(|(variant, base)| {
+                        let Variant { ident, fields, .. } = variant;
+
+                        (
+                            variant_to_tokens(
+                                false,
+                                base,
+                                library_path,
+                                ident,
+                                generics,
+                                clear_generics,
+                                any_store_field,
+                                name,
+                                fields,
+                            ),
+                            variant_to_tokens(
+                                true,
+                                base,
+                                library_path,
+                                ident,
+                                generics,
+                                clear_generics,
+                                any_store_field,
+                                name,
+                                fields,
+                            ),
+                        )
+                    })
+                    .unzip()
+            }
         }
     }
 }
@@ -449,6 +472,7 @@ fn field_to_tokens(
 #[allow(clippy::too_many_arguments)]
 fn variant_to_tokens(
     include_body: bool,
+    base_segment: usize,
     library_path: &proc_macro2::TokenStream,
     ident: &Ident,
     _generics: &Generics,
@@ -510,7 +534,9 @@ fn variant_to_tokens(
             tokens.extend(fields
                 .named
                 .iter()
-                .map(|field| {
+                .enumerate()
+                .map(|(field_idx, field)| {
+                    let segment = base_segment + field_idx;
                     let field_ident = field.ident.as_ref().unwrap();
                     let field_ty = &field.ty;
                     let combined_ident = Ident::new(
@@ -530,7 +556,7 @@ fn variant_to_tokens(
                                 if matches {
                                     Some(#library_path::Subfield::new(
                                         self,
-                                        0.into(),
+                                        #segment.into(),
                                         |prev| {
                                             match prev {
                                                 #name::#orig_ident { #field_ident, .. } => Some(#field_ident),
@@ -589,6 +615,7 @@ fn variant_to_tokens(
                 .iter()
                 .enumerate()
                 .map(|(idx, field)| {
+                    let segment = base_segment + idx;
                     let field_ident = idx;
                     let field_ty = &field.ty;
                     let combined_ident = Ident::new(
@@ -613,7 +640,7 @@ fn variant_to_tokens(
                                 if matches {
                                     Some(#library_path::Subfield::new(
                                         self,
-                                        0.into(),
+                                        #segment.into(),
                                         |prev| {
                                             match prev {
                                                 #name::#orig_ident(#(#ignore_before)* this, #(#ignore_after)*) => Some(this),

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -656,7 +656,6 @@ enum PatchModelTy {
     Struct {
         fields: Vec<Field>,
     },
-    #[allow(dead_code)]
     Enum {
         variants: Vec<Variant>,
     },
@@ -682,14 +681,9 @@ impl Parse for PatchModel {
 
                 PatchModelTy::Struct { fields }
             }
-            syn::Data::Enum(_e) => {
-                abort_call_site!("only structs can be used with `Patch`");
-
-                // TODO: support enums later on
-                // PatchModelTy::Enum {
-                //     variants: e.variants.into_iter().collect(),
-                // }
-            }
+            syn::Data::Enum(e) => PatchModelTy::Enum {
+                variants: e.variants.into_iter().collect(),
+            },
             _ => {
                 abort_call_site!(
                     "only structs and enums can be used with `Store`"
@@ -710,9 +704,9 @@ impl ToTokens for PatchModel {
         let library_path = quote! { reactive_stores };
         let PatchModel { name, generics, ty } = &self;
 
-        let fields = match ty {
+        let body = match ty {
             PatchModelTy::Struct { fields } => {
-                fields.iter().enumerate().map(|(idx, field)| {
+                let fields = fields.iter().enumerate().map(|(idx, field)| {
                     let Field {
                         attrs, ident, ..
                     } = &field;
@@ -855,10 +849,118 @@ impl ToTokens for PatchModel {
                             new_path.replace_last(#idx + 1);
                         }
                     }
-                }).collect::<Vec<_>>()
+                }).collect::<Vec<_>>();
+                quote! {
+                    let mut new_path = path.clone();
+                    new_path.push(0);
+                    #(#fields)*
+                }
             }
-            PatchModelTy::Enum { variants: _ } => {
-                unreachable!("not implemented currently")
+            PatchModelTy::Enum { variants } => {
+                // Number every variant field with a path segment that is
+                // unique across the whole enum, mirroring the numbering used
+                // by the `Store` derive, so that `notify` targets the same
+                // triggers the field accessors subscribe to.
+                let mut next_segment = 0usize;
+                let arms = variants.iter().map(|variant| {
+                    let Variant { ident, fields, .. } = variant;
+                    let base = next_segment;
+                    match fields {
+                        Fields::Unit => {
+                            next_segment += 0;
+                            // same variant, no payload: nothing to patch
+                            quote! {
+                                (#name::#ident, #name::#ident) => {}
+                            }
+                        }
+                        Fields::Named(named) => {
+                            next_segment += named.named.len();
+                            let self_binds = named.named.iter().map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                let bind = Ident::new(&format!("self_{id}"), id.span());
+                                quote! { #id: #bind }
+                            });
+                            let new_binds = named.named.iter().map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                let bind = Ident::new(&format!("new_{id}"), id.span());
+                                quote! { #id: #bind }
+                            });
+                            let patches = named.named.iter().enumerate().map(|(i, f)| {
+                                let id = f.ident.as_ref().unwrap();
+                                let self_bind = Ident::new(&format!("self_{id}"), id.span());
+                                let new_bind = Ident::new(&format!("new_{id}"), id.span());
+                                let segment = base + i;
+                                let advance = if i == 0 {
+                                    quote! { new_path.push(#segment); }
+                                } else {
+                                    quote! { new_path.replace_last(#segment); }
+                                };
+                                quote! {
+                                    #advance
+                                    #library_path::PatchField::patch_field(
+                                        #self_bind, #new_bind, &new_path, notify, keys,
+                                    );
+                                }
+                            });
+                            quote! {
+                                (
+                                    #name::#ident { #(#self_binds),* },
+                                    #name::#ident { #(#new_binds),* },
+                                ) => {
+                                    let mut new_path = path.clone();
+                                    #(#patches)*
+                                }
+                            }
+                        }
+                        Fields::Unnamed(unnamed) => {
+                            next_segment += unnamed.unnamed.len();
+                            let self_binds = (0..unnamed.unnamed.len()).map(|i| {
+                                Ident::new(&format!("self_{i}"), Span::call_site())
+                            });
+                            let new_binds = (0..unnamed.unnamed.len()).map(|i| {
+                                Ident::new(&format!("new_{i}"), Span::call_site())
+                            });
+                            let patches = (0..unnamed.unnamed.len()).map(|i| {
+                                let self_bind = Ident::new(&format!("self_{i}"), Span::call_site());
+                                let new_bind = Ident::new(&format!("new_{i}"), Span::call_site());
+                                let segment = base + i;
+                                let advance = if i == 0 {
+                                    quote! { new_path.push(#segment); }
+                                } else {
+                                    quote! { new_path.replace_last(#segment); }
+                                };
+                                quote! {
+                                    #advance
+                                    #library_path::PatchField::patch_field(
+                                        #self_bind, #new_bind, &new_path, notify, keys,
+                                    );
+                                }
+                            });
+                            quote! {
+                                (
+                                    #name::#ident( #(#self_binds),* ),
+                                    #name::#ident( #(#new_binds),* ),
+                                ) => {
+                                    let mut new_path = path.clone();
+                                    #(#patches)*
+                                }
+                            }
+                        }
+                    }
+                }).collect::<Vec<_>>();
+
+                quote! {
+                    match (&mut *self, new) {
+                        #(#arms)*
+                        // discriminant changed: replace the whole value and
+                        // notify the enum's own path, which wakes subscribers of
+                        // every variant accessor (they track `this` on this path).
+                        (this, new) => {
+                            *this = new;
+                            notify(path);
+                        }
+                    }
+                }
             }
         };
 
@@ -879,9 +981,7 @@ impl ToTokens for PatchModel {
                     notify: &mut dyn FnMut(&#library_path::StorePath),
                     keys: Option<&#library_path::KeyMap>,
                 ) {
-                    let mut new_path = path.clone();
-                    new_path.push(0);
-                    #(#fields)*
+                    #body
                 }
             }
         });

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -331,58 +331,35 @@ impl ModelTy {
                     )
                 })
                 .unzip(),
-            ModelTy::Enum { variants } => {
-                // Assign every variant field a distinct path segment that is
-                // unique across the whole enum. Without this, all variant
-                // fields collapse onto segment `0`, so writing one field wakes
-                // subscribers of every other field (see sibling-wake bug).
-                let mut next_segment = 0usize;
-                let bases = variants
-                    .iter()
-                    .map(|variant| {
-                        let base = next_segment;
-                        next_segment += match &variant.fields {
-                            Fields::Unit => 0,
-                            Fields::Named(fields) => fields.named.len(),
-                            Fields::Unnamed(fields) => fields.unnamed.len(),
-                        };
-                        base
-                    })
-                    .collect::<Vec<_>>();
+            ModelTy::Enum { variants } => variants
+                .iter()
+                .map(|variant| {
+                    let Variant { ident, fields, .. } = variant;
 
-                variants
-                    .iter()
-                    .zip(bases)
-                    .map(|(variant, base)| {
-                        let Variant { ident, fields, .. } = variant;
-
-                        (
-                            variant_to_tokens(
-                                false,
-                                base,
-                                library_path,
-                                ident,
-                                generics,
-                                clear_generics,
-                                any_store_field,
-                                name,
-                                fields,
-                            ),
-                            variant_to_tokens(
-                                true,
-                                base,
-                                library_path,
-                                ident,
-                                generics,
-                                clear_generics,
-                                any_store_field,
-                                name,
-                                fields,
-                            ),
-                        )
-                    })
-                    .unzip()
-            }
+                    (
+                        variant_to_tokens(
+                            false,
+                            library_path,
+                            ident,
+                            generics,
+                            clear_generics,
+                            any_store_field,
+                            name,
+                            fields,
+                        ),
+                        variant_to_tokens(
+                            true,
+                            library_path,
+                            ident,
+                            generics,
+                            clear_generics,
+                            any_store_field,
+                            name,
+                            fields,
+                        ),
+                    )
+                })
+                .unzip(),
         }
     }
 }
@@ -472,7 +449,6 @@ fn field_to_tokens(
 #[allow(clippy::too_many_arguments)]
 fn variant_to_tokens(
     include_body: bool,
-    base_segment: usize,
     library_path: &proc_macro2::TokenStream,
     ident: &Ident,
     _generics: &Generics,
@@ -536,7 +512,9 @@ fn variant_to_tokens(
                 .iter()
                 .enumerate()
                 .map(|(field_idx, field)| {
-                    let segment = base_segment + field_idx;
+                    // Give each field of the variant a distinct path segment so
+                    // writing one field does not wake subscribers of a sibling.
+                    let segment = field_idx;
                     let field_ident = field.ident.as_ref().unwrap();
                     let field_ty = &field.ty;
                     let combined_ident = Ident::new(
@@ -615,7 +593,7 @@ fn variant_to_tokens(
                 .iter()
                 .enumerate()
                 .map(|(idx, field)| {
-                    let segment = base_segment + idx;
+                    let segment = idx;
                     let field_ident = idx;
                     let field_ty = &field.ty;
                     let combined_ident = Ident::new(

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -1,5 +1,5 @@
 use convert_case::{Case, Casing};
-use proc_macro_error2::{OptionExt, abort, abort_call_site, proc_macro_error};
+use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::{
@@ -733,7 +733,14 @@ impl ToTokens for PatchModel {
                                                 .parse2(list.tokens.clone())
                                             {
                                                 Ok(closures) => {
-                                                    let closure = closures.iter().next().cloned().expect_or_abort("should have ONE closure");
+                                                    let mut iter = closures.iter();
+                                                    let closure = match iter.next() {
+                                                        Some(closure) => closure.clone(),
+                                                        None => abort!(list, "expected one closure, as in `#[patch(|this, new| ...)]`"),
+                                                    };
+                                                    if let Some(extra) = iter.next() {
+                                                        abort!(extra, "expected exactly one closure in `#[patch(...)]`, but found more than one");
+                                                    }
                                                     if closure.inputs.len() != 2 {
                                                         abort!(closure.inputs, "patch closure should have TWO params as in #[patch(|this, new| ...)]");
                                                     }

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -858,24 +858,20 @@ impl ToTokens for PatchModel {
                 }
             }
             PatchModelTy::Enum { variants } => {
-                // Number every variant field with a path segment that is
-                // unique across the whole enum, mirroring the numbering used
-                // by the `Store` derive, so that `notify` targets the same
-                // triggers the field accessors subscribe to.
-                let mut next_segment = 0usize;
+                // Number every variant field with its index within the
+                // variant, mirroring the numbering used by the `Store`
+                // derive, so that `notify` targets the same triggers the
+                // field accessors subscribe to.
                 let arms = variants.iter().map(|variant| {
                     let Variant { ident, fields, .. } = variant;
-                    let base = next_segment;
                     match fields {
                         Fields::Unit => {
-                            next_segment += 0;
                             // same variant, no payload: nothing to patch
                             quote! {
                                 (#name::#ident, #name::#ident) => {}
                             }
                         }
                         Fields::Named(named) => {
-                            next_segment += named.named.len();
                             let self_binds = named.named.iter().map(|f| {
                                 let id = f.ident.as_ref().unwrap();
                                 let bind = Ident::new(&format!("self_{id}"), id.span());
@@ -890,7 +886,7 @@ impl ToTokens for PatchModel {
                                 let id = f.ident.as_ref().unwrap();
                                 let self_bind = Ident::new(&format!("self_{id}"), id.span());
                                 let new_bind = Ident::new(&format!("new_{id}"), id.span());
-                                let segment = base + i;
+                                let segment = i;
                                 let advance = if i == 0 {
                                     quote! { new_path.push(#segment); }
                                 } else {
@@ -914,7 +910,6 @@ impl ToTokens for PatchModel {
                             }
                         }
                         Fields::Unnamed(unnamed) => {
-                            next_segment += unnamed.unnamed.len();
                             let self_binds = (0..unnamed.unnamed.len()).map(|i| {
                                 Ident::new(&format!("self_{i}"), Span::call_site())
                             });
@@ -924,7 +919,7 @@ impl ToTokens for PatchModel {
                             let patches = (0..unnamed.unnamed.len()).map(|i| {
                                 let self_bind = Ident::new(&format!("self_{i}"), Span::call_site());
                                 let new_bind = Ident::new(&format!("new_{i}"), Span::call_site());
-                                let segment = base + i;
+                                let segment = i;
                                 let advance = if i == 0 {
                                     quote! { new_path.push(#segment); }
                                 } else {


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

### Changes

### `reactive_store`

- **`ArcField::is_disposed()` always returned `false`**: It now reports the real disposal state via a captured callback, so subscribers and read-paths that gate on `is_disposed` short-circuit correctly instead of reading a dead field.

- **`AtIndex::reader`/`writer` panicked on out-of-bounds**: A stale or never-valid index produced a guard that panicked on first deref. They now bounds-check under the held lock and return `None`, matching the "`None` means projection invalid" contract.

- **`Field<T, S>` only implemented `Write` for the default `SyncStorage`**: The `Write` impl dropped the `S` generic, so writing through e.g. `Field<T, LocalStorage>` failed to compile. The impl is now generic over `S` like the crate's other trait impls.

- **`PatchField` for `f32`/`f64` notified spuriously**: Using `!=` meant `NaN`→`NaN` fired a notification while `+0.0`→`-0.0` did not. Comparison now uses `total_cmp`, giving the correct "notify only on change" behavior.

- **`OptionStoreExt::unwrap` panicked via raw `Option::unwrap` (TOCTOU)**: Its projection closures unwrapped the inner `Option` lazily on deref, so clearing the option between capture and read panicked. A new `OptionSubfield` type performs the `is_some` check inside `reader()`/`writer()` (under the held lock) and returns `None` when the option is currently `None`; `unwrap`/`invert`/`map`/`map_untracked` now return it. Trigger/notify/track semantics mirror `Subfield` exactly, so notification counts are unchanged.

--- 

### `reactive_store_macro`

- Fix enum-variant path segmentation in the `Store` derive: all fields of a variant collapsed onto segment `0`, so writing one field spuriously woke subscribers of its siblings. Each field now gets a distinct segment from its index within the variant.
- Implement the `Patch` derive for enums (previously a compile error despite `Store` supporting enums): same-variant patches update fields in place and notify only what changed; cross-variant patches replace the value and notify the enum's path. Uses the same field-index segment numbering as `Store`, so patches target exactly the triggers the accessors subscribe to.
- Honor `#[store(skip)]` in the `Patch` derive and emit clear diagnostics for malformed `#[patch]` attributes.