### PR TITLE
Quality of life fixes for `leptos_macro`

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1,3 +1,4 @@
+use crate::stable_hash::fnv1a_64;
 use attribute_derive::FromAttr;
 use convert_case::{
     Case::{Pascal, Snake},
@@ -9,7 +10,6 @@ use leptos_hot_reload::parsing::value_to_string;
 use proc_macro_error2::abort;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt, format_ident, quote, quote_spanned};
-use std::hash::DefaultHasher;
 use syn::{
     AngleBracketedGenericArguments, Attribute, FnArg, GenericArgument,
     GenericParam, Item, ItemFn, LitStr, Meta, Pat, PatIdent, Path,
@@ -291,12 +291,9 @@ impl ToTokens for Model {
 
         let component_id = name.to_string();
         let hydrate_fn_name = is_island.then(|| {
-            use std::hash::{Hash, Hasher};
-
-            let mut hasher = DefaultHasher::new();
-            island.hash(&mut hasher);
-            let caller = hasher.finish() as usize;
-            Ident::new(&format!("{component_id}_{caller:?}"), name.span())
+            let caller: u64 =
+                fnv1a_64(island.as_deref().unwrap_or_default().as_bytes());
+            Ident::new(&format!("{component_id}_{caller:016x}"), name.span())
         });
 
         let island_serialize_props = if is_island_with_other_props {

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -1,12 +1,10 @@
+use crate::stable_hash::fnv1a_64;
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro_error2::abort;
 use proc_macro2::Ident;
 use quote::{format_ident, quote};
-use std::{
-    hash::{DefaultHasher, Hash, Hasher},
-    mem,
-};
+use std::mem;
 use syn::{ItemFn, ReturnType, Stmt, parse_macro_input, parse_quote};
 
 pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
@@ -31,11 +29,13 @@ pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
 
     let (unique_name, unique_name_str) = {
         let span = proc_macro::Span::call_site();
-        let location = (span.line(), span.start().column(), span.file());
-
-        let mut hasher = DefaultHasher::new();
-        location.hash(&mut hasher);
-        let hash = hasher.finish();
+        let location = format!(
+            "{}:{}:{}",
+            span.line(),
+            span.start().column(),
+            span.file()
+        );
+        let hash = fnv1a_64(location.as_bytes());
 
         let unique_name_str = format!("{converted_name}_{hash}");
 

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -27,6 +27,7 @@ mod lazy;
 mod memo;
 mod slice;
 mod slot;
+mod stable_hash;
 
 /// The `view` macro uses RSX (like JSX, but Rust!) It follows most of the
 /// same rules as HTML, with the following differences:

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -386,13 +386,34 @@ pub fn include_view(tokens: TokenStream) -> TokenStream {
             "the only supported argument is a string literal"
         );
     });
-    let file =
-        std::fs::read_to_string(file_name.value()).unwrap_or_else(|_| {
-            abort!(Span::call_site(), "could not open file");
-        });
+    let file = std::fs::read_to_string(file_name.value()).unwrap_or_else(|e| {
+        abort!(
+            Span::call_site(),
+            "could not open file `{}`: {e}",
+            file_name.value()
+        );
+    });
     let tokens = proc_macro2::TokenStream::from_str(&file)
         .unwrap_or_else(|e| abort!(Span::call_site(), e));
-    view(tokens.into())
+    let view = proc_macro2::TokenStream::from(view(tokens.into()));
+
+    // Register the included file in Cargo's recompilation graph. Like
+    // `read_to_string` above, the path is resolved relative to the crate
+    // root (the proc-macro's working directory), which is `CARGO_MANIFEST_DIR`
+    // in the consuming crate; absolute paths are passed through unchanged.
+    let tracked_path = if std::path::Path::new(&file_name.value()).is_absolute()
+    {
+        quote! { #file_name }
+    } else {
+        quote! { concat!(env!("CARGO_MANIFEST_DIR"), "/", #file_name) }
+    };
+    quote! {
+        {
+            const _: &[u8] = include_bytes!(#tracked_path);
+            #view
+        }
+    }
+    .into()
 }
 
 /// Annotates a function so that it can be used with your template as a Leptos `<Component/>`.

--- a/leptos_macro/src/params.rs
+++ b/leptos_macro/src/params.rs
@@ -68,8 +68,11 @@ pub fn params_impl(ast: &syn::DeriveInput) -> proc_macro::TokenStream {
 
     let num_fields = fields_to_map.len();
 
+    let (impl_generics, ty_generics, where_clause) =
+        ast.generics.split_for_impl();
+
     let r#gen = quote! {
-        impl Params for #name {
+        impl #impl_generics Params for #name #ty_generics #where_clause {
             fn from_map(map: &::leptos_router::params::ParamsMap) -> ::core::result::Result<Self, ::leptos_router::params::ParamsError> {
                 use ::leptos_router::params::macro_helpers::Fallback as _;
 

--- a/leptos_macro/src/stable_hash.rs
+++ b/leptos_macro/src/stable_hash.rs
@@ -1,0 +1,78 @@
+//! A deterministic, dependency-free hash used to derive identifiers that must
+//! agree across separate builds (e.g. the server and the wasm client of an
+//! islands or `#[lazy]` app).
+//!
+//! `std::hash::DefaultHasher` is explicitly documented as not stable across
+//! Rust releases, and `Hash` integer writes are native-endian, so neither is
+//! safe for cross-build/cross-target identifiers. FNV-1a is a fixed algorithm
+//! with constant offset/prime, so the same bytes always produce the same
+//! 64-bit value regardless of toolchain, platform, or target word size.
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// 64-bit FNV-1a hash of `bytes`, with a final avalanche step.
+///
+/// Plain FNV-1a has weak bit diffusion on short, low-entropy inputs (the
+/// `line:col:file` and component-name strings hashed here are exactly that),
+/// so the low bits can cluster for inputs that differ by a single byte. The
+/// `fmix64` finalizer (MurmurHash3's mixing step) spreads every input bit
+/// across all 64 output bits, so the realistic collision probability matches
+/// the ideal-random birthday bound (~3e-14 for 1000 distinct identifiers).
+pub fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET_BASIS;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    fmix64(hash)
+}
+
+/// MurmurHash3 64-bit finalizer: a fixed, reversible avalanche mix.
+fn fmix64(mut h: u64) -> u64 {
+    h ^= h >> 33;
+    h = h.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    h ^= h >> 33;
+    h = h.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    h ^= h >> 33;
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fnv1a_64;
+    use std::collections::HashSet;
+
+    #[test]
+    fn deterministic() {
+        // The whole point: identical bytes always hash to the same value, so
+        // the server and client builds agree on the generated identifier.
+        assert_eq!(fnv1a_64(b"my_island_42"), fnv1a_64(b"my_island_42"));
+    }
+
+    #[test]
+    fn no_collisions_on_near_identical_inputs() {
+        // The inputs we hash differ only by a few low-entropy bytes
+        // (line/column numbers, sequential component names). After the
+        // avalanche finalizer these must all map to distinct values.
+        let mut seen = HashSet::new();
+        for line in 0..1_000u32 {
+            for col in 0..32u32 {
+                let key = format!("{line}:{col}:src/app.rs");
+                assert!(
+                    seen.insert(fnv1a_64(key.as_bytes())),
+                    "collision for {key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn single_byte_change_avalanches() {
+        // A one-byte difference should flip roughly half the output bits;
+        // require at least a quarter to catch any regression to weak mixing.
+        let a = fnv1a_64(b"component_a");
+        let b = fnv1a_64(b"component_b");
+        assert!((a ^ b).count_ones() >= 16, "weak avalanche: {a:x} vs {b:x}");
+    }
+}

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -1598,21 +1598,50 @@ fn is_ambiguous_element(tag: &str) -> bool {
 }
 
 fn parse_event(event_name: &str) -> (String, EventNameOptions) {
-    let undelegated = event_name.contains(":undelegated");
-    let targeted = event_name.contains(":target");
-    let captured = event_name.contains(":capture");
-    let event_name = event_name
-        .replace(":undelegated", "")
-        .replace(":target", "")
-        .replace(":capture", "");
-    (
-        event_name,
+    match try_parse_event(event_name) {
+        Ok(parsed) => parsed,
+        Err(modifier) => abort!(
+            Span::call_site(),
+            "unknown event modifier `:{}`; expected one of `:undelegated`, \
+             `:target`, or `:capture`",
+            modifier
+        ),
+    }
+}
+
+/// Splits an event name into its base name and modifier flags.
+///
+/// The base event name is everything before the first `:`; each remaining
+/// `:`-separated fragment must be one of the three known modifiers. Returns
+/// `Err(fragment)` for any unrecognized modifier so the caller can report it,
+/// rather than matching modifiers as substrings (which silently accepted
+/// typos like `:targeted` and mangled the event name).
+fn try_parse_event(
+    event_name: &str,
+) -> Result<(String, EventNameOptions), String> {
+    let mut fragments = event_name.split(':');
+    let name = fragments.next().unwrap_or_default().to_string();
+
+    let mut undelegated = false;
+    let mut targeted = false;
+    let mut captured = false;
+    for modifier in fragments {
+        match modifier {
+            "undelegated" => undelegated = true,
+            "target" => targeted = true,
+            "capture" => captured = true,
+            other => return Err(other.to_string()),
+        }
+    }
+
+    Ok((
+        name,
         EventNameOptions {
             undelegated,
             targeted,
             captured,
         },
-    )
+    ))
 }
 
 /// Escapes Rust keywords that are also HTML attribute names
@@ -1804,7 +1833,7 @@ const TYPED_EVENTS: [&str; 127] = [
 
 const CUSTOM_EVENT: &str = "Custom";
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct EventNameOptions {
     undelegated: bool,
     targeted: bool,
@@ -1973,5 +2002,49 @@ mod inert_element_tests {
         assert!(!is_inert(quote! { <input bind:value="x" /> }));
         assert!(!is_inert(quote! { <div style:color="red" /> }));
         assert!(!is_inert(quote! { <div prop:foo="bar" /> }));
+    }
+}
+
+#[cfg(test)]
+mod parse_event_tests {
+    use super::try_parse_event;
+
+    fn parse(name: &str) -> (String, (bool, bool, bool)) {
+        let (name, opts) = try_parse_event(name).unwrap();
+        (name, (opts.undelegated, opts.targeted, opts.captured))
+    }
+
+    #[test]
+    fn plain_and_modified_events() {
+        assert_eq!(parse("click"), ("click".into(), (false, false, false)));
+        assert_eq!(
+            parse("click:target"),
+            ("click".into(), (false, true, false))
+        );
+        assert_eq!(
+            parse("click:undelegated"),
+            ("click".into(), (true, false, false))
+        );
+        assert_eq!(
+            parse("click:capture"),
+            ("click".into(), (false, false, true))
+        );
+        assert_eq!(
+            parse("click:undelegated:capture"),
+            ("click".into(), (true, false, true))
+        );
+    }
+
+    #[test]
+    fn unknown_modifier_is_rejected_not_substring_matched() {
+        // `:targeted` is a typo for `:target`; substring matching used to
+        // accept it (and mangle the event name to `clicked`). Exact matching
+        // surfaces it as an error instead.
+        assert_eq!(try_parse_event("click:targeted"), Err("targeted".into()));
+        assert_eq!(
+            try_parse_event("click:capturefoo"),
+            Err("capturefoo".into())
+        );
+        assert_eq!(try_parse_event("click:capture2"), Err("capture2".into()));
     }
 }

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -157,7 +157,7 @@ fn is_inert_element(orig_node: &Node<impl CustomNode>) -> bool {
                                             matches!(&value.value, KVAttributeValue::Expr(expr) if {
                                                 if let Expr::Lit(lit) = expr {
                                                     let key = attr.key.to_string();
-                                                    if key.starts_with("style:") || key.starts_with("prop:") || key.starts_with("on:") || key.starts_with("use:") || key.starts_with("bind") {
+                                                    if key.starts_with("style:") || key.starts_with("prop:") || key.starts_with("on:") || key.starts_with("use:") || key.starts_with("bind:") {
                                                         false
                                                     } else {
                                                         matches!(&lit.lit, Lit::Str(_))
@@ -1943,4 +1943,35 @@ enum TupleName {
     None,
     Str(String),
     Array(Vec<String>),
+}
+
+#[cfg(test)]
+mod inert_element_tests {
+    use super::is_inert_element;
+    use quote::quote;
+
+    fn is_inert(tokens: proc_macro2::TokenStream) -> bool {
+        let config = rstml::ParserConfig::default().recover_block(true);
+        let parser = rstml::Parser::new(config);
+        let (nodes, _) = parser.parse_recoverable(tokens).split_vec();
+        is_inert_element(&nodes[0])
+    }
+
+    #[test]
+    fn plain_string_attribute_is_inert() {
+        // `binding` merely starts with the letters "bind"; it is a normal
+        // string-literal attribute, not the `bind:` two-way directive, so an
+        // element carrying only such attributes must take the inert fast path.
+        assert!(is_inert(quote! { <custom-element binding="foo" /> }));
+        assert!(is_inert(quote! { <div bind-target="x" /> }));
+    }
+
+    #[test]
+    fn leptos_directives_are_not_inert() {
+        // The genuine namespaced directives must keep excluding the element
+        // from the inert path, matching `attribute_to_tokens`.
+        assert!(!is_inert(quote! { <input bind:value="x" /> }));
+        assert!(!is_inert(quote! { <div style:color="red" /> }));
+        assert!(!is_inert(quote! { <div prop:foo="bar" /> }));
+    }
 }

--- a/leptos_macro/tests/params.rs
+++ b/leptos_macro/tests/params.rs
@@ -80,3 +80,23 @@ struct MyParams {
     bar: usize,
     baz: String,
 }
+
+// Regression: `#[derive(Params)]` must thread the struct's generic
+// parameters (here a const generic) into the generated `impl`. Before the
+// fix the macro emitted `impl Params for PagedParams` without `<const N>`,
+// which failed to compile with `error[E0107]: missing generics`.
+#[derive(PartialEq, Debug, Params)]
+struct PagedParams<const N: usize> {
+    page: Option<i32>,
+}
+
+#[test]
+fn params_generic_const() {
+    let mut map = leptos_router::params::ParamsMap::new();
+    map.insert("page", "3".to_owned());
+    let params = PagedParams::<10>::from_map(&map).unwrap();
+    assert_eq!(PagedParams::<10> { page: Some(3) }, params);
+
+    let round_trip = params.to_map().unwrap();
+    assert_eq!(Some("3"), round_trip.get_str("page"));
+}


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

### `#[derive(Params)]`

**Generics/lifetimes dropped from impl → threaded through**
```rust
#[derive(Params)]
struct PagedParams<const N: usize> { page: Option<i32> }
// before: impl Params for PagedParams { ... }  → E0107 missing generics
// now:    impl<const N: usize> Params for PagedParams<N> { ... }
```
(Same fix covers `<T>`, lifetimes, and where-clauses.)

### `#[component]`

### `#[lazy]` / `#[island]`

**Identifiers hashed with `DefaultHasher` → deterministic FNV-1a + fmix64**
```rust
// DefaultHasher is not stable across Rust releases and is native-endian,
// so a server/wasm toolchain skew silently breaks prefetch/hydrate lookup.
// before: let mut h = DefaultHasher::new(); location.hash(&mut h); h.finish();
// now:    fnv1a_64(location.as_bytes())  → byte-identical across builds/targets
```

### `include_view!`

**Edits to the included file triggered no rebuild → dependency registered**
```rust
include_view!("views/hello.rs");
// before: edit views/hello.rs alone → cargo build recompiles nothing
// now:    emits const _: &[u8] = include_bytes!(<path>) → Cargo rebuilds
```

**Opaque read error → path + OS cause**
```rust
include_view!("views/does_not_exist.rs");
// before: "could not open file"
// now:    "could not open file `views/does_not_exist.rs`: No such file or directory (os error 2)"
```

### `view!` — inert elements

**`bind` prefix matched any attribute → matches `bind:` exactly**
```rust
view! { <custom-element binding="foo" /> }
// before: "binding" treated as a directive → forced onto slow dynamic path
// now:    inert fast path (only real bind: directives are excluded)
```

### `view!` — event modifiers

**Modifiers matched by substring → matched exactly**
```rust
view! { <button on:click:targeted=move |_| {}>"click"</button> }
// before: contains(":target") → activates :target on event "clicked", fails deep in codegen
// now:    error: unknown event modifier `:targeted`; expected `:undelegated`, `:target`, or `:capture`
```
(Real usage like `on:input:target` is unaffected.)
