### PR TITLE
Harden Leptos server integrations (axum): panics, info leaks, path traversal & resource leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
+ "mime",
  "or_poisoned",
  "reqwest",
  "server_fn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
+ "lru",
  "mime",
  "or_poisoned",
  "reqwest",
@@ -2375,6 +2376,12 @@ name = "longest-increasing-subsequence"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bd0dd2cd90571056fdb71f6275fada10131182f84899f4b2a916e565d81d86"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 
 [[package]]
 name = "lru-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ pin-project-lite = { default-features = false, version = "0.2" }
 send_wrapper = { default-features = false, version = "0.6" }
 tokio-test = { default-features = false, version = "0.4" }
 html-escape = { default-features = false, version = "0.2" }
+lru = { default-features = false, version = "0.18" }
 mime = { default-features = false, version = "0.3" }
 proc-macro-error2 = { default-features = false, version = "2.0" }
 const_format = { default-features = false, version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ pin-project-lite = { default-features = false, version = "0.2" }
 send_wrapper = { default-features = false, version = "0.6" }
 tokio-test = { default-features = false, version = "0.4" }
 html-escape = { default-features = false, version = "0.2" }
+mime = { default-features = false, version = "0.3" }
 proc-macro-error2 = { default-features = false, version = "2.0" }
 const_format = { default-features = false, version = "0.2" }
 gloo-net = { default-features = false, version = "0.7" }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1235,7 +1235,7 @@ fn was_404(owner: &Owner) -> bool {
     false
 }
 
-fn static_path(options: &LeptosOptions, path: &str) -> String {
+fn static_path(options: &LeptosOptions, path: &str) -> Option<String> {
     use leptos_integration_utils::static_file_path;
 
     // If the path ends with a trailing slash, we generate the path
@@ -1253,6 +1253,15 @@ async fn write_static_route(
     path: &str,
     html: &str,
 ) -> Result<(), std::io::Error> {
+    // Reject anything that would escape the site root before caching headers
+    // or touching the filesystem.
+    let Some(file_path) = static_path(options, path) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to write static file for a path-traversal request",
+        ));
+    };
+
     if let Some(options) = response_options {
         STATIC_HEADERS
             .write()
@@ -1260,8 +1269,7 @@ async fn write_static_route(
             .insert(path.to_string(), options);
     }
 
-    let path = static_path(options, path);
-    let path = Path::new(&path);
+    let path = Path::new(&file_path);
     if let Some(path) = path.parent() {
         tokio::fs::create_dir_all(path).await?;
     }
@@ -1286,8 +1294,18 @@ where
             async move {
                 let options = data.into_inner();
                 let orig_path = req.uri().path();
-                let path = static_path(&options, orig_path);
-                let path = Path::new(&path);
+                // A `None` here means the request path would escape the site
+                // root (path traversal); decline it before any filesystem
+                // access.
+                let Some(file_path) = static_path(&options, orig_path) else {
+                    #[cfg(feature = "tracing")]
+                    tracing::warn!(
+                        "rejected static route request with path traversal: \
+                         {orig_path}"
+                    );
+                    return HttpResponse::NotFound().finish();
+                };
+                let path = Path::new(&file_path);
                 let exists = tokio::fs::try_exists(path).await.unwrap_or(false);
 
                 let (response_options, html) = if !exists {

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -21,6 +21,7 @@ leptos_macro = { workspace = true, features = ["axum"] }
 leptos_meta = { workspace = true, features = ["ssr", "nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_integration_utils = { workspace = true }
+lru = { workspace = true, optional = true }
 mime = { workspace = true }
 tachys = { workspace = true }
 tokio = { default-features = false, workspace = true }
@@ -45,6 +46,7 @@ tokio = { features = [
 [features]
 wasm = []
 default = [
+  "dep:lru",
   "tokio/fs",
   "tokio/sync",
   "tower-http/fs",

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -21,6 +21,7 @@ leptos_macro = { workspace = true, features = ["axum"] }
 leptos_meta = { workspace = true, features = ["ssr", "nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_integration_utils = { workspace = true }
+mime = { workspace = true }
 tachys = { workspace = true }
 tokio = { default-features = false, workspace = true }
 tower = { features = ["util"], workspace = true, default-features = true }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -2528,7 +2528,21 @@ where
                 let options = LeptosOptions::from_ref(&state);
                 let res =
                     get_static_file(uri, &options.site_root, req.headers());
-                let res = res.await.unwrap();
+                // `get_static_file` returns `Err` if the underlying `ServeDir`
+                // fails. This handler is the documented "reasonable default"
+                // fallback, so it must not panic: log and serve a generic 500.
+                let res = match res.await {
+                    Ok(res) => res,
+                    Err((status, err)) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "static file handler failed: {status} {err}"
+                        );
+                        #[cfg(not(feature = "tracing"))]
+                        let _ = (status, err);
+                        return internal_server_error();
+                    }
+                };
 
                 if res.status() == StatusCode::OK {
                     let owner = Owner::new();

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -181,6 +181,13 @@ pub(crate) fn extend_response<ResBody>(
         .extend(std::mem::take(&mut res_options.headers));
 }
 
+/// A generic `500 Internal Server Error` response with no body details, used
+/// when an integration handler hits an unrecoverable but non-fatal condition
+/// that previously panicked.
+fn internal_server_error() -> Response<Body> {
+    (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+}
+
 struct AxumResponse(Response<Body>);
 
 impl ExtendResponse for AxumResponse {
@@ -732,22 +739,49 @@ where
     );
 
     move |state, req| {
-        // 1. Process route to match the values in routeListing
-        let path = req
+        // 1. Process route to match the values in routeListing.
+        //
+        // `MatchedPath` is only present when the request flowed through Axum's
+        // matcher; mounting this handler outside the router (manual tower
+        // composition, `nest`/`route_service`, direct calls in tests) leaves it
+        // absent. Rather than panic — which would kill the worker and 500 every
+        // affected request — log and return a generic 500 so the misconfigured
+        // route is diagnosable without taking the process down.
+        let Some(path) = req
             .extensions()
             .get::<MatchedPath>()
-            .expect("Failed to get Axum router rule")
-            .as_str();
+            .map(|p| p.as_str().to_owned())
+        else {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                "render_route handler invoked without a MatchedPath; the \
+                 handler must be mounted through the Axum router."
+            );
+            #[cfg(not(feature = "tracing"))]
+            eprintln!(
+                "render_route handler invoked without a MatchedPath; the \
+                 handler must be mounted through the Axum router."
+            );
+            return Box::pin(async { internal_server_error() });
+        };
         // 2. Find RouteListing in paths. This should probably be optimized, we probably don't want to
         // search for this every time
-        let listing: &AxumRouteListing =
-            paths.iter().find(|r| r.path() == path).unwrap_or_else(|| {
-                panic!(
-                    "Failed to find the route {path} requested by the user. \
-                     This suggests that the routing rules in the Router that \
-                     call this handler needs to be edited!"
-                )
-            });
+        let Some(listing) = paths.iter().find(|r| r.path() == path.as_str())
+        else {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                "Failed to find the route {path} requested by the user. This \
+                 suggests that the routing rules in the Router that call this \
+                 handler need to be edited."
+            );
+            #[cfg(not(feature = "tracing"))]
+            eprintln!(
+                "Failed to find the route {path} requested by the user. This \
+                 suggests that the routing rules in the Router that call this \
+                 handler need to be edited."
+            );
+            return Box::pin(async { internal_server_error() });
+        };
         // 3. Match listing mode against known, and choose function
         match listing.mode() {
             SsrMode::OutOfOrder => ooo(req),
@@ -2587,5 +2621,28 @@ mod tests {
             parts.headers.get(LOCATION).map(|v| v.as_bytes()),
             Some(&b"/dashboard"[..])
         );
+    }
+
+    // When the render_route handler is mounted such that Axum's `MatchedPath`
+    // is absent (e.g. invoked outside the router), it must return a generic
+    // 500 instead of panicking and killing the worker.
+    #[cfg(feature = "default")]
+    #[tokio::test]
+    async fn render_route_without_matched_path_returns_500() {
+        let options = leptos::config::get_configuration(None)
+            .unwrap()
+            .leptos_options;
+
+        let handler = render_route_with_context(
+            Vec::<AxumRouteListing>::new(),
+            || {},
+            || "app",
+        );
+
+        // No `MatchedPath` extension is attached to this request.
+        let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+
+        let res = handler(State(options), req).await;
+        assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -245,12 +245,27 @@ pub fn redirect(path: &str) {
     if let (Some(req), Some(res)) =
         (use_context::<Parts>(), use_context::<ResponseOptions>())
     {
+        // The path ultimately derives from user input (e.g. a `next` URL
+        // parameter), so it may contain bytes that are illegal in a header
+        // value (CR, LF, NUL, ...). `HeaderValue::from_str` rejects those, and
+        // turning that recoverable error into a panic would let any client take
+        // down the worker handling the request. Skip the redirect instead.
+        let location = match header::HeaderValue::from_str(path) {
+            Ok(location) => location,
+            Err(_) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                #[cfg(not(feature = "tracing"))]
+                eprintln!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                return;
+            }
+        };
         // insert the Location header in any case
-        res.insert_header(
-            header::LOCATION,
-            header::HeaderValue::from_str(path)
-                .expect("Failed to create HeaderValue"),
-        );
+        res.insert_header(header::LOCATION, location);
 
         let accepts_html = req
             .headers
@@ -2518,4 +2533,51 @@ pub fn site_pkg_dir_service_route_path(options: &LeptosOptions) -> String {
     }
     path.push_str("{*path}");
     path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+
+    // A target URL that contains a newline cannot be encoded as a header
+    // value. `redirect` must skip the redirect instead of panicking, otherwise
+    // any client able to influence the target (e.g. a `next` parameter) can
+    // crash the request handler.
+    #[test]
+    fn redirect_ignores_invalid_header_value() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            provide_context(parts);
+            provide_context(res.clone());
+
+            redirect("/login\r\nSet-Cookie: pwned=1");
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert!(parts.headers.get(LOCATION).is_none());
+        assert!(parts.status.is_none());
+    }
+
+    // A well-formed target is still applied.
+    #[test]
+    fn redirect_sets_location_for_valid_target() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            provide_context(parts);
+            provide_context(res.clone());
+
+            redirect("/dashboard");
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert_eq!(
+            parts.headers.get(LOCATION).map(|v| v.as_bytes()),
+            Some(&b"/dashboard"[..])
+        );
+    }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -507,7 +507,17 @@ async fn handle_server_fns_inner(
                  function type, somewhere in your `main` function.",
             )))
     }
-    .expect("could not build Response")
+    .unwrap_or_else(|err| {
+        // The branches above only set a status and a string body, so this is
+        // not reachable today; handle it gracefully anyway so a future edit
+        // that adds a fallible header to the builder cannot turn this
+        // diagnostic into a panic.
+        #[cfg(feature = "tracing")]
+        tracing::error!("could not build server function response: {err}");
+        #[cfg(not(feature = "tracing"))]
+        let _ = err;
+        internal_server_error()
+    })
 }
 
 /// A stream of bytes of HTML.

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -2628,7 +2628,19 @@ async fn get_static_file(
         None => req,
     };
 
-    let req = req.body(Body::empty()).unwrap();
+    let req = match req.body(Body::empty()) {
+        Ok(req) => req,
+        Err(err) => {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("failed to build static file request: {err}");
+            #[cfg(not(feature = "tracing"))]
+            let _ = err;
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "could not build static file request".to_string(),
+            ));
+        }
+    };
     // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
     // This path is relative to the cargo root
     match ServeDir::new(root)

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -949,7 +949,15 @@ where
             move || {
                 // Need to get the path and query string of the Request
                 // For reasons that escape me, if the incoming URI protocol is https, it provides the absolute URI
-                let path = req.uri().path_and_query().unwrap().as_str();
+                //
+                // `path_and_query` is `None` for authority-form URIs (e.g. a
+                // `CONNECT host:port` request from a misconfigured proxy or a
+                // health probe). Fall back to the root rather than panicking.
+                let path = req
+                    .uri()
+                    .path_and_query()
+                    .map(|p| p.as_str())
+                    .unwrap_or("/");
 
                 let full_path = format!("http://leptos.dev{path}");
                 let (_, req_parts) = generate_request_and_parts(req);

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -72,9 +72,9 @@ use leptos_router::{
 use or_poisoned::OrPoisoned;
 use server_fn::{error::ServerFnErrorErr, redirect::REDIRECT_HEADER};
 #[cfg(feature = "default")]
-use std::sync::LazyLock;
+use std::path::Path;
 #[cfg(feature = "default")]
-use std::{collections::HashMap, path::Path};
+use std::sync::LazyLock;
 use std::{
     collections::HashSet,
     fmt::Debug,
@@ -1565,10 +1565,38 @@ impl StaticRouteGenerator {
     }
 }
 
+/// Default upper bound on the number of per-path [`ResponseOptions`] entries
+/// cached for static routes. Without a bound the cache grew for the life of the
+/// process, one entry per unique static path served (e.g. attacker-driven slugs
+/// on a regenerated `/posts/{slug}` route).
+///
+/// Eviction is graceful: the static file is still served from disk, the cache
+/// only drops the custom headers/status captured at generation time for the
+/// evicted path (re-populated on the next regeneration). 1024 covers a typical
+/// static site's working set for a worst case on the order of ~1 MB.
+#[cfg(feature = "default")]
+const STATIC_HEADERS_DEFAULT_CAPACITY: std::num::NonZeroUsize =
+    match std::num::NonZeroUsize::new(1024) {
+        Some(capacity) => capacity,
+        None => unreachable!(),
+    };
+
+/// Environment variable that overrides [`STATIC_HEADERS_DEFAULT_CAPACITY`].
+/// A missing, unparseable, or zero value falls back to the default.
+#[cfg(feature = "default")]
+const STATIC_HEADERS_CAPACITY_ENV: &str = "LEPTOS_STATIC_HEADERS_CACHE_SIZE";
+
 #[cfg(feature = "default")]
 static STATIC_HEADERS: LazyLock<
-    std::sync::RwLock<HashMap<String, ResponseOptions>>,
-> = LazyLock::new(Default::default);
+    std::sync::RwLock<lru::LruCache<String, ResponseOptions>>,
+> = LazyLock::new(|| {
+    let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(std::num::NonZeroUsize::new)
+        .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
+    std::sync::RwLock::new(lru::LruCache::new(capacity))
+});
 
 #[cfg(feature = "default")]
 fn was_404(owner: &Owner) -> bool {
@@ -1615,7 +1643,7 @@ async fn write_static_route(
         STATIC_HEADERS
             .write()
             .or_poisoned()
-            .insert(path.to_string(), options);
+            .put(path.to_string(), options);
     }
 
     let path = Path::new(&file_path);
@@ -1700,8 +1728,12 @@ where
                     .await;
                 (owner.with(use_context::<ResponseOptions>), html)
             } else {
-                let headers =
-                    STATIC_HEADERS.read().or_poisoned().get(orig_path).cloned();
+                // `LruCache::get` updates recency, so it needs a write lock.
+                let headers = STATIC_HEADERS
+                    .write()
+                    .or_poisoned()
+                    .get(orig_path)
+                    .cloned();
                 (headers, None)
             };
 
@@ -2736,5 +2768,27 @@ mod tests {
         assert!(!accept_header_includes_html("application/x-text/html-fake"));
         assert!(!accept_header_includes_html("application/json"));
         assert!(!accept_header_includes_html("*/*"));
+    }
+
+    // The per-path header cache must never grow without bound: serving many
+    // unique static paths (e.g. attacker-driven slugs) used to leak one entry
+    // per path for the life of the process.
+    #[cfg(feature = "default")]
+    #[test]
+    fn static_headers_cache_is_bounded() {
+        let mut cache: lru::LruCache<String, ResponseOptions> =
+            lru::LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
+        let capacity = STATIC_HEADERS_DEFAULT_CAPACITY.get();
+
+        for i in 0..(capacity + 10) {
+            cache.put(format!("/post/{i}"), ResponseOptions::default());
+        }
+
+        // never grows past capacity
+        assert_eq!(cache.len(), capacity);
+        // the earliest-inserted entries have been evicted
+        assert!(cache.get(&"/post/0".to_string()).is_none());
+        // a recently-inserted entry is still present
+        assert!(cache.get(&format!("/post/{}", capacity + 9)).is_some());
     }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1711,7 +1711,18 @@ where
             // this if for thing like 404s, where we do not want to cache an endless series of
             // typos (or malicious requests)
             let mut res = AxumResponse(match html {
-                Some(html) => axum::response::Html(html).into_response(),
+                // `html` is `Some` only for an uncached error response (the
+                // `was_404` predicate gated the build). `Html(..)` defaults to
+                // 200, so make the error status explicit rather than relying
+                // on the captured `ResponseOptions` to carry it. A custom
+                // status set by the app still overrides this via
+                // `extend_response` below.
+                Some(html) => {
+                    let mut response =
+                        axum::response::Html(html).into_response();
+                    *response.status_mut() = StatusCode::NOT_FOUND;
+                    response
+                }
                 None => match ServeFile::new(path).oneshot(req).await {
                     Ok(res) => res.into_response(),
                     // The cached file can be removed between the `try_exists`

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1583,7 +1583,7 @@ fn was_404(owner: &Owner) -> bool {
 }
 
 #[cfg(feature = "default")]
-fn static_path(options: &LeptosOptions, path: &str) -> String {
+fn static_path(options: &LeptosOptions, path: &str) -> Option<String> {
     use leptos_integration_utils::static_file_path;
 
     // If the path ends with a trailing slash, we generate the path
@@ -1602,6 +1602,15 @@ async fn write_static_route(
     path: &str,
     html: &str,
 ) -> Result<(), std::io::Error> {
+    // Reject anything that would escape the site root before caching headers
+    // or touching the filesystem.
+    let Some(file_path) = static_path(options, path) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to write static file for a path-traversal request",
+        ));
+    };
+
     if let Some(options) = response_options {
         STATIC_HEADERS
             .write()
@@ -1609,8 +1618,7 @@ async fn write_static_route(
             .insert(path.to_string(), options);
     }
 
-    let path = static_path(options, path);
-    let path = Path::new(&path);
+    let path = Path::new(&file_path);
     if let Some(path) = path.parent() {
         tokio::fs::create_dir_all(path).await?;
     }
@@ -1645,8 +1653,17 @@ where
         Box::pin(async move {
             let options = LeptosOptions::from_ref(&state);
             let orig_path = req.uri().path();
-            let path = static_path(&options, orig_path);
-            let path = Path::new(&path);
+            // A `None` here means the request path would escape the site root
+            // (path traversal); decline it before any filesystem access.
+            let Some(file_path) = static_path(&options, orig_path) else {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "rejected static route request with path traversal: \
+                     {orig_path}"
+                );
+                return (StatusCode::NOT_FOUND, "Not Found").into_response();
+            };
+            let path = Path::new(&file_path);
             let exists = tokio::fs::try_exists(path).await.unwrap_or(false);
 
             let (response_options, html) = if !exists {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -181,6 +181,33 @@ pub(crate) fn extend_response<ResBody>(
         .extend(std::mem::take(&mut res_options.headers));
 }
 
+/// Returns whether an `Accept` header value indicates the client will accept
+/// an HTML response — i.e. an ordinary browser navigation or a plain `<form>`
+/// submission, as opposed to a programmatic client expecting structured data.
+///
+/// Unlike a naive `contains("text/html")` check, each comma-separated media
+/// range is parsed with the [`mime`] crate and an explicit `q=0` refusal is
+/// honoured. So `text/html;q=0` (the client refusing HTML) and
+/// `application/x-text/html-fake` (an unrelated, unparseable range) are both
+/// correctly treated as *not* accepting HTML.
+fn accept_header_includes_html(accept: &str) -> bool {
+    accept.split(',').any(|range| {
+        let Ok(media) = range.trim().parse::<mime::Mime>() else {
+            return false;
+        };
+        if media.type_() != mime::TEXT || media.subtype() != mime::HTML {
+            return false;
+        }
+        // honour an explicit `q=0`, which means the client refuses HTML
+        match media.get_param("q") {
+            Some(q) => {
+                q.as_str().parse::<f32>().map(|w| w > 0.0).unwrap_or(true)
+            }
+            None => true,
+        }
+    })
+}
+
 /// A generic `500 Internal Server Error` response with no body details, used
 /// when an integration handler hits an unrecoverable but non-fatal condition
 /// that previously panicked.
@@ -278,7 +305,7 @@ pub fn redirect(path: &str) {
             .headers
             .get(ACCEPT)
             .and_then(|v| v.to_str().ok())
-            .map(|v| v.contains("text/html"))
+            .map(accept_header_includes_html)
             .unwrap_or(false);
         if accepts_html {
             // if the request accepts text/html, it's a plain form request and needs
@@ -442,7 +469,7 @@ async fn handle_server_fns_inner(
                         .headers()
                         .get(ACCEPT)
                         .and_then(|v| v.to_str().ok())
-                        .map(|v| v.contains("text/html"))
+                        .map(accept_header_includes_html)
                         .unwrap_or(false);
                     let referrer = req.headers().get(REFERER).cloned();
 
@@ -2644,5 +2671,33 @@ mod tests {
 
         let res = handler(State(options), req).await;
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn accept_header_plain_navigation_is_html() {
+        // typical browser navigation
+        assert!(accept_header_includes_html(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        ));
+        assert!(accept_header_includes_html("text/html"));
+        assert!(accept_header_includes_html("text/html; charset=utf-8"));
+        assert!(accept_header_includes_html("text/html;q=0.1"));
+    }
+
+    #[test]
+    fn accept_header_explicit_refusal_is_not_html() {
+        // `q=0` means the client explicitly does not want HTML
+        assert!(!accept_header_includes_html(
+            "text/html;q=0, application/json"
+        ));
+        assert!(!accept_header_includes_html("text/html;q=0.0"));
+    }
+
+    #[test]
+    fn accept_header_substring_is_not_html() {
+        // these contain the literal substring "text/html" but are not it
+        assert!(!accept_header_includes_html("application/x-text/html-fake"));
+        assert!(!accept_header_includes_html("application/json"));
+        assert!(!accept_header_includes_html("*/*"));
     }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1714,11 +1714,20 @@ where
                 Some(html) => axum::response::Html(html).into_response(),
                 None => match ServeFile::new(path).oneshot(req).await {
                     Ok(res) => res.into_response(),
-                    Err(err) => (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Something went wrong: {err}"),
-                    )
-                        .into_response(),
+                    // The cached file can be removed between the `try_exists`
+                    // check above and this read (a TOCTOU race). Do not render
+                    // the raw filesystem error into the body — that leaks
+                    // server paths — log it and return a generic 500.
+                    Err(err) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "failed to serve static file {}: {err}",
+                            path.display()
+                        );
+                        #[cfg(not(feature = "tracing"))]
+                        let _ = &err;
+                        internal_server_error()
+                    }
                 },
             });
 

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -17,6 +17,51 @@ pub type PinnedStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 pub type PinnedFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 pub type BoxedFnOnce<T> = Box<dyn FnOnce() -> T + Send>;
 
+/// Wraps a response body stream and ties cleanup of the reactive [`Owner`] to
+/// the stream's `Drop`, rather than to a chained terminal future.
+///
+/// The previous approach appended an `owner.unset_with_forced_cleanup()` future
+/// as the last item of the stream. That only runs if the stream is polled to
+/// completion, so a client disconnecting mid-response (slow client, browser
+/// cancel, proxy timeout) would drop the body before the terminal future ran,
+/// leaking the `Owner` and everything it transitively keeps alive. Cleaning up
+/// on `Drop` runs whether the stream finishes or is cancelled.
+struct OwnerCleanupStream {
+    inner: Pin<Box<dyn Stream<Item = String> + Send>>,
+    owner: Option<Owner>,
+}
+
+impl OwnerCleanupStream {
+    fn new(
+        inner: impl Stream<Item = String> + Send + 'static,
+        owner: Owner,
+    ) -> Self {
+        Self {
+            inner: Box::pin(inner),
+            owner: Some(owner),
+        }
+    }
+}
+
+impl Stream for OwnerCleanupStream {
+    type Item = String;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next(cx)
+    }
+}
+
+impl Drop for OwnerCleanupStream {
+    fn drop(&mut self) {
+        if let Some(owner) = self.owner.take() {
+            owner.unset_with_forced_cleanup();
+        }
+    }
+}
+
 pub trait ExtendResponse: Sized {
     type ResponseOptions: Send;
 
@@ -115,16 +160,14 @@ pub trait ExtendResponse: Sized {
             // wait for the first chunk of the stream, then set the status and headers
             let first_chunk = stream.next().await.unwrap_or_default();
 
-            let mut res = Self::from_stream(Sandboxed::new(
-                once(async move { first_chunk })
-                    .chain(stream)
-                    // drop the owner, cleaning up the reactive runtime,
-                    // once the stream is over
-                    .chain(once(async move {
-                        owner.unset_with_forced_cleanup();
-                        Default::default()
-                    })),
-            ));
+            // Cleanup of the owner is tied to `OwnerCleanupStream`'s `Drop`, so
+            // it runs whether the body streams to completion or the client
+            // disconnects early and the body is dropped.
+            let mut res =
+                Self::from_stream(Sandboxed::new(OwnerCleanupStream::new(
+                    once(async move { first_chunk }).chain(stream),
+                    owner,
+                )));
 
             res.extend_response(&res_options);
 

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -200,12 +200,85 @@ where
     (owner, stream)
 }
 
-pub fn static_file_path(options: &LeptosOptions, path: &str) -> String {
+/// Returns `true` if `path` could escape the site root once interpolated into
+/// an on-disk path.
+///
+/// The static handlers build a filesystem path by concatenating the request
+/// path onto the site root (`{site_root}/{path}.html`). The request path is not
+/// percent-decoded upstream, so we reject a literal `..` segment, the
+/// percent-encoded dot/separator sequences a later decoding step could turn
+/// into one (`%2e`, `%2f`, `%5c`), and a backslash (a path separator on
+/// Windows).
+fn is_path_traversal(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    if lower.contains("%2e") || lower.contains("%2f") || lower.contains("%5c") {
+        return true;
+    }
+    path.split('/')
+        .any(|segment| segment == ".." || segment.contains('\\'))
+}
+
+/// Builds the on-disk path for the static file backing `path`, or returns
+/// `None` if `path` would escape `options.site_root` via directory traversal.
+///
+/// Callers must treat `None` as a rejected request (respond `404` on the read
+/// side, refuse to write on the generation side); the helper performs no
+/// filesystem access and never returns a path outside the site root.
+pub fn static_file_path(options: &LeptosOptions, path: &str) -> Option<String> {
+    if is_path_traversal(path) {
+        return None;
+    }
     let trimmed_path = path.trim_start_matches('/');
     let path = if trimmed_path.is_empty() {
         "index"
     } else {
         trimmed_path
     };
-    format!("{}/{}.html", options.site_root, path)
+    Some(format!("{}/{}.html", options.site_root, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leptos_config::LeptosOptions;
+
+    fn opts() -> LeptosOptions {
+        LeptosOptions::builder()
+            .output_name("ignored")
+            .site_root("/var/www/site/static")
+            .build()
+    }
+
+    #[test]
+    fn static_file_path_rejects_traversal() {
+        let options = opts();
+        // literal `..` segments
+        assert_eq!(static_file_path(&options, "/../../etc/passwd"), None);
+        assert_eq!(static_file_path(&options, "/posts/../../secret"), None);
+        assert_eq!(static_file_path(&options, ".."), None);
+        // percent-encoded dot / separators (path is not decoded upstream)
+        assert_eq!(static_file_path(&options, "/..%2f..%2fetc"), None);
+        assert_eq!(static_file_path(&options, "/%2e%2e/secret"), None);
+        assert_eq!(static_file_path(&options, "/foo%2Fbar"), None);
+        // backslash separator (Windows)
+        assert_eq!(static_file_path(&options, "/..\\..\\secret"), None);
+    }
+
+    #[test]
+    fn static_file_path_allows_legitimate_paths() {
+        let options = opts();
+        assert_eq!(
+            static_file_path(&options, "/"),
+            Some("/var/www/site/static/index.html".into())
+        );
+        assert_eq!(
+            static_file_path(&options, "/posts/my-first-post"),
+            Some("/var/www/site/static/posts/my-first-post.html".into())
+        );
+        // a single dot is harmless (stays in the same directory)
+        assert_eq!(
+            static_file_path(&options, "/a/./b"),
+            Some("/var/www/site/static/a/./b.html".into())
+        );
+    }
 }


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

This is all about axum integration with a shared fix for actix.

### Changes

| Area                    | Fix                                                                                                                                                                                                                         |
| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Path traversal**      | `static_file_path` now validates centrally, returning `Option` (`None` rejects `..`, `%2e`/`%2f`/`%5c`, backslash). Axum + Actix read handlers answer `404`; generation refuses to write.                                   |
| **Info disclosure**     | Static-route serving no longer renders raw `std::io::Error` (server paths) into the response body — logs at `warn`, returns generic 500.                                                                                    |
| **Unbounded memory**    | Per-path static-header cache switched from an unbounded `HashMap` to a bounded `lru::LruCache` (capacity via `LEPTOS_STATIC_HEADERS_CACHE_SIZE`, default 1024).                                                             |
| **Resource leak**       | Reactive `Owner` cleanup moved from a trailing stream item to a `Drop` guard, so it runs on client disconnect, not only on full stream drain.                                                                               |
| **DoS via panic**       | `redirect()` no longer panics on an invalid `Location` value (CRLF/control chars).                                                                                                                                          |
| **Panics → graceful**   | Missing path-and-query treated as `/`; `render_route` returns 500 instead of panicking on a missing matched-path; server-fn / static-file / request-build / response-builder paths return 500 instead of `unwrap`/`expect`. |
| **Content negotiation** | `Accept` header parsed with the `mime` crate (honors `q=0`) instead of substring-matching `"text/html"`, fixing wrong 302/HTML decisions.                                                                                   |
| **Correctness**         | Static-route 404 status set explicitly rather than relying on `ResponseOptions` sequencing.                                                                                                                                 |

### Threat model

- **Path traversal (`f3eb2621`)** — *Attacker:* a client whose request path (or a slug feeding static generation) reaches a static route. *Vector:* `..` segments or percent-encoded separators in the raw, undecoded URI. *Scope note:* `static_file_path` always appends `.html` and there is no NUL-truncation vector, so this is **not** arbitrary file read — the reachable set is limited to `.html` files. *Impact:* (1) **write-side** — generation does `create_dir_all` + `fs::write`, so an attacker-influenced path can create dirs and write/overwrite `.html` files outside `site_root` (defacement, **stored XSS** via the rendered body, clobbering another app's files); (2) **read-side** — `ServeFile` can return `.html` files outside the intended subtree (cross-tenant or not-yet-public pre-rendered pages). *Mitigation:* central rejection at the single helper that builds the on-disk path; percent-encoding rejection is defense-in-depth for any layer that decodes.
- **Info disclosure (`8fea649e`)** — *Attacker:* client triggering a TOCTOU file-removal race on a static route. *Impact:* raw filesystem error (absolute server paths) leaked in the response body. *Mitigation:* generic 500, details only in server logs.
- **Memory exhaustion / DoS (`8bb803a3`)** — *Attacker:* driving many unique static paths (e.g. attacker-chosen slugs). *Impact:* one cache entry leaked per path for the process lifetime → unbounded RSS growth. *Mitigation:* bounded LRU eviction.
- **Resource leak / DoS (`145c4ad7`)** — *Attacker (or routine condition):* disconnecting mid-response (slow client, browser cancel, proxy timeout). *Impact:* the `Owner` and everything it transitively holds leaks per aborted request → unbounded RSS growth on the main render path. *Mitigation:* `Drop`-based cleanup runs regardless of how the stream ends.
- **Panic-based DoS (`2c85b74e` and others)** — *Attacker:* crafting inputs (invalid header values, authority-form URIs) reaching `unwrap`/`expect`/`panic!`. *Impact:* request-handler panic. *Mitigation:* graceful error propagation / generic 500.

The remaining commits (Accept-header parsing, 404 status) are correctness fixes without a direct attacker path.
