### PR TITLE
Remove unused unstable FromWasmAbi bound

### DIFF
--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -15,7 +15,6 @@ use std::{
     ops::{Deref, DerefMut},
     rc::Rc,
 };
-use wasm_bindgen::convert::FromWasmAbi;
 
 /// A cloneable event callback.
 pub type SharedEventCallback<E> = Rc<RefCell<dyn FnMut(E)>>;
@@ -396,7 +395,7 @@ impl<E, F> ToTemplate for On<E, F> {
 /// A trait for converting types into [web_sys events](web_sys).
 pub trait EventDescriptor: Clone {
     /// The [`web_sys`] event type, such as [`web_sys::MouseEvent`].
-    type EventType: FromWasmAbi;
+    type EventType;
 
     /// Indicates if this event bubbles. For example, `click` bubbles,
     /// but `focus` does not.
@@ -450,13 +449,13 @@ impl<E: EventDescriptor> EventDescriptor for Capture<E> {
 
 /// A custom event.
 #[derive(Debug)]
-pub struct Custom<E: FromWasmAbi = web_sys::Event> {
+pub struct Custom<E = web_sys::Event> {
     name: Cow<'static, str>,
     options: Option<SendWrapper<web_sys::AddEventListenerOptions>>,
     _event_type: PhantomData<fn() -> E>,
 }
 
-impl<E: FromWasmAbi> Clone for Custom<E> {
+impl<E> Clone for Custom<E> {
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
@@ -466,7 +465,7 @@ impl<E: FromWasmAbi> Clone for Custom<E> {
     }
 }
 
-impl<E: FromWasmAbi> EventDescriptor for Custom<E> {
+impl<E> EventDescriptor for Custom<E> {
     type EventType = E;
 
     fn name(&self) -> Cow<'static, str> {
@@ -485,7 +484,7 @@ impl<E: FromWasmAbi> EventDescriptor for Custom<E> {
     }
 }
 
-impl<E: FromWasmAbi> Custom<E> {
+impl<E> Custom<E> {
     /// Creates a custom event type that can be used within
     /// [`OnAttribute::on`](crate::prelude::OnAttribute::on), for events
     /// which are not covered in the [`ev`](crate::html::event) module.


### PR DESCRIPTION
Tachys relies on FromWasmAbi which is an unstable api from wasm bindgen under the convert module. It appears to be completely unused. This PR removes it so tachys doesn't break if it updates in a minor version in the future