### PR TITLE
Quality of life fixes for `reactive_stores_macro`

### DIFF
--- a/reactive_stores/tests/enum_patch.rs
+++ b/reactive_stores/tests/enum_patch.rs
@@ -1,0 +1,154 @@
+//! Regression test: the `Patch` derive supports enums.
+//! - patching within the same variant updates fields in place and only
+//!   notifies the fields that changed,
+//! - patching across variants replaces the value and notifies subscribers.
+
+use reactive_graph::{
+    effect::Effect,
+    owner::Owner,
+    traits::{Get, Read, ReadUntracked},
+};
+use reactive_stores::{Patch, Store};
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Debug, Clone, PartialEq, Patch, Store, Default)]
+enum Mode {
+    #[default]
+    Idle,
+    Running {
+        progress: u32,
+        label: String,
+    },
+    Done(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Patch, Store, Default)]
+struct State {
+    mode: Mode,
+}
+
+async fn tick() {
+    tokio::time::sleep(std::time::Duration::from_micros(1)).await;
+}
+
+#[tokio::test]
+async fn same_variant_patch_only_notifies_changed_field() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        mode: Mode::Running {
+            progress: 1,
+            label: "a".into(),
+        },
+    });
+
+    let progress_count = Arc::new(AtomicUsize::new(0));
+    let label_count = Arc::new(AtomicUsize::new(0));
+
+    let progress_sf = store.mode().running_progress().unwrap();
+    let label_sf = store.mode().running_label().unwrap();
+
+    Effect::new_sync({
+        let c = Arc::clone(&progress_count);
+        move |_: Option<()>| {
+            let _ = progress_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    Effect::new_sync({
+        let c = Arc::clone(&label_count);
+        move |_: Option<()>| {
+            let _ = label_sf.read();
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+
+    // Patch within the same variant, changing only `progress`.
+    store.patch(State {
+        mode: Mode::Running {
+            progress: 2,
+            label: "a".into(),
+        },
+    });
+    tick().await;
+
+    assert_eq!(
+        store.mode().running_progress().unwrap().get(),
+        2,
+        "progress should be patched in place"
+    );
+    assert_eq!(
+        progress_count.load(Ordering::Relaxed),
+        2,
+        "progress effect should re-run after its field changed"
+    );
+    assert_eq!(
+        label_count.load(Ordering::Relaxed),
+        1,
+        "label effect should not re-run when only progress changed"
+    );
+}
+
+#[tokio::test]
+async fn cross_variant_patch_replaces_and_notifies() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State { mode: Mode::Idle });
+
+    let is_running_count = Arc::new(AtomicUsize::new(0));
+    let is_running = Arc::new(AtomicUsize::new(0));
+
+    Effect::new_sync({
+        let c = Arc::clone(&is_running_count);
+        let r = Arc::clone(&is_running);
+        move |_: Option<()>| {
+            r.store(store.mode().running() as usize, Ordering::Relaxed);
+            c.fetch_add(1, Ordering::Relaxed);
+        }
+    });
+    tick().await;
+    assert_eq!(is_running.load(Ordering::Relaxed), 0);
+
+    // Patch across variants: Idle -> Running.
+    store.patch(State {
+        mode: Mode::Running {
+            progress: 5,
+            label: "x".into(),
+        },
+    });
+    tick().await;
+
+    assert_eq!(
+        is_running_count.load(Ordering::Relaxed),
+        2,
+        "variant-matcher effect should re-run after a variant change"
+    );
+    assert_eq!(is_running.load(Ordering::Relaxed), 1);
+    assert!(matches!(
+        store.read_untracked().mode,
+        Mode::Running { progress: 5, .. }
+    ));
+}
+
+#[tokio::test]
+async fn unnamed_variant_patches_in_place() {
+    _ = any_spawner::Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        mode: Mode::Done(1),
+    });
+    store.patch(State {
+        mode: Mode::Done(7),
+    });
+    assert!(matches!(store.read_untracked().mode, Mode::Done(7)));
+}

--- a/reactive_stores/tests/patch_skip.rs
+++ b/reactive_stores/tests/patch_skip.rs
@@ -1,0 +1,37 @@
+//! Regression test: a `#[store(skip)]` field is opted out of patching. Its
+//! type need not implement `PatchField`, and `patch` leaves it untouched.
+
+use reactive_graph::{owner::Owner, traits::ReadUntracked};
+use reactive_stores::{Patch, Store};
+
+// Deliberately implements neither `PatchField` nor `PartialEq`.
+#[derive(Debug, Default)]
+struct Handle(i32);
+
+#[derive(Debug, Store, reactive_stores::Patch, Default)]
+struct State {
+    #[store(skip)]
+    handle: Handle,
+    value: i32,
+}
+
+#[test]
+fn skip_field_is_not_patched() {
+    let owner = Owner::new();
+    owner.set();
+
+    let store = Store::new(State {
+        handle: Handle(7),
+        value: 1,
+    });
+
+    store.patch(State {
+        handle: Handle(99),
+        value: 42,
+    });
+
+    let guard = store.read_untracked();
+    // The skipped field keeps its original value; the rest is patched.
+    assert_eq!(guard.handle.0, 7);
+    assert_eq!(guard.value, 42);
+}

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -783,7 +783,29 @@ impl ToTokens for PatchModel {
                             })
                         }).flatten();
 
-                    if let Some(closure) = closure {
+                    // A field marked `#[store(skip)]` is opted out of store-field
+                    // generation; it must also be opted out of patching, so the
+                    // field's type need not implement `PatchField`.
+                    let skip = attrs.iter().any(|attr| {
+                        attr.meta.path().is_ident("store")
+                            && matches!(&attr.meta, Meta::List(list)
+                                if Punctuated::<SubfieldMode, Comma>::parse_terminated
+                                    .parse2(list.tokens.clone())
+                                    .map(|modes| {
+                                        modes.iter().any(|mode| {
+                                            matches!(mode, SubfieldMode::Skip)
+                                        })
+                                    })
+                                    .unwrap_or(false))
+                    });
+
+                    if skip {
+                        // leave the field untouched; only keep the running
+                        // path segment aligned for the following fields.
+                        quote! {
+                            new_path.replace_last(#idx + 1);
+                        }
+                    } else if let Some(closure) = closure {
                         let params = closure.inputs;
                         let body = closure.body;
                         quote! {

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -653,12 +653,8 @@ struct PatchModel {
 }
 
 enum PatchModelTy {
-    Struct {
-        fields: Vec<Field>,
-    },
-    Enum {
-        variants: Vec<Variant>,
-    },
+    Struct { fields: Vec<Field> },
+    Enum { variants: Vec<Variant> },
 }
 
 impl Parse for PatchModel {

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -656,7 +656,6 @@ enum PatchModelTy {
     Struct {
         fields: Vec<Field>,
     },
-    #[allow(dead_code)]
     Enum {
         variants: Vec<Variant>,
     },
@@ -682,14 +681,9 @@ impl Parse for PatchModel {
 
                 PatchModelTy::Struct { fields }
             }
-            syn::Data::Enum(_e) => {
-                abort_call_site!("only structs can be used with `Patch`");
-
-                // TODO: support enums later on
-                // PatchModelTy::Enum {
-                //     variants: e.variants.into_iter().collect(),
-                // }
-            }
+            syn::Data::Enum(e) => PatchModelTy::Enum {
+                variants: e.variants.into_iter().collect(),
+            },
             _ => {
                 abort_call_site!(
                     "only structs and enums can be used with `Store`"
@@ -710,9 +704,9 @@ impl ToTokens for PatchModel {
         let library_path = quote! { reactive_stores };
         let PatchModel { name, generics, ty } = &self;
 
-        let fields = match ty {
+        let body = match ty {
             PatchModelTy::Struct { fields } => {
-                fields.iter().enumerate().map(|(idx, field)| {
+                let fields = fields.iter().enumerate().map(|(idx, field)| {
                     let Field {
                         attrs, ident, ..
                     } = &field;
@@ -855,10 +849,118 @@ impl ToTokens for PatchModel {
                             new_path.replace_last(#idx + 1);
                         }
                     }
-                }).collect::<Vec<_>>()
+                }).collect::<Vec<_>>();
+                quote! {
+                    let mut new_path = path.clone();
+                    new_path.push(0);
+                    #(#fields)*
+                }
             }
-            PatchModelTy::Enum { variants: _ } => {
-                unreachable!("not implemented currently")
+            PatchModelTy::Enum { variants } => {
+                // Number every variant field with a path segment that is
+                // unique across the whole enum, mirroring the numbering used
+                // by the `Store` derive, so that `notify` targets the same
+                // triggers the field accessors subscribe to.
+                let mut next_segment = 0usize;
+                let arms = variants.iter().map(|variant| {
+                    let Variant { ident, fields, .. } = variant;
+                    let base = next_segment;
+                    match fields {
+                        Fields::Unit => {
+                            next_segment += 0;
+                            // same variant, no payload: nothing to patch
+                            quote! {
+                                (#name::#ident, #name::#ident) => {}
+                            }
+                        }
+                        Fields::Named(named) => {
+                            next_segment += named.named.len();
+                            let self_binds = named.named.iter().map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                let bind = Ident::new(&format!("self_{id}"), id.span());
+                                quote! { #id: #bind }
+                            });
+                            let new_binds = named.named.iter().map(|f| {
+                                let id = f.ident.as_ref().unwrap();
+                                let bind = Ident::new(&format!("new_{id}"), id.span());
+                                quote! { #id: #bind }
+                            });
+                            let patches = named.named.iter().enumerate().map(|(i, f)| {
+                                let id = f.ident.as_ref().unwrap();
+                                let self_bind = Ident::new(&format!("self_{id}"), id.span());
+                                let new_bind = Ident::new(&format!("new_{id}"), id.span());
+                                let segment = base + i;
+                                let advance = if i == 0 {
+                                    quote! { new_path.push(#segment); }
+                                } else {
+                                    quote! { new_path.replace_last(#segment); }
+                                };
+                                quote! {
+                                    #advance
+                                    #library_path::PatchField::patch_field(
+                                        #self_bind, #new_bind, &new_path, notify, keys,
+                                    );
+                                }
+                            });
+                            quote! {
+                                (
+                                    #name::#ident { #(#self_binds),* },
+                                    #name::#ident { #(#new_binds),* },
+                                ) => {
+                                    let mut new_path = path.clone();
+                                    #(#patches)*
+                                }
+                            }
+                        }
+                        Fields::Unnamed(unnamed) => {
+                            next_segment += unnamed.unnamed.len();
+                            let self_binds = (0..unnamed.unnamed.len()).map(|i| {
+                                Ident::new(&format!("self_{i}"), Span::call_site())
+                            });
+                            let new_binds = (0..unnamed.unnamed.len()).map(|i| {
+                                Ident::new(&format!("new_{i}"), Span::call_site())
+                            });
+                            let patches = (0..unnamed.unnamed.len()).map(|i| {
+                                let self_bind = Ident::new(&format!("self_{i}"), Span::call_site());
+                                let new_bind = Ident::new(&format!("new_{i}"), Span::call_site());
+                                let segment = base + i;
+                                let advance = if i == 0 {
+                                    quote! { new_path.push(#segment); }
+                                } else {
+                                    quote! { new_path.replace_last(#segment); }
+                                };
+                                quote! {
+                                    #advance
+                                    #library_path::PatchField::patch_field(
+                                        #self_bind, #new_bind, &new_path, notify, keys,
+                                    );
+                                }
+                            });
+                            quote! {
+                                (
+                                    #name::#ident( #(#self_binds),* ),
+                                    #name::#ident( #(#new_binds),* ),
+                                ) => {
+                                    let mut new_path = path.clone();
+                                    #(#patches)*
+                                }
+                            }
+                        }
+                    }
+                }).collect::<Vec<_>>();
+
+                quote! {
+                    match (&mut *self, new) {
+                        #(#arms)*
+                        // discriminant changed: replace the whole value and
+                        // notify the enum's own path, which wakes subscribers of
+                        // every variant accessor (they track `this` on this path).
+                        (this, new) => {
+                            *this = new;
+                            notify(path);
+                        }
+                    }
+                }
             }
         };
 
@@ -879,9 +981,7 @@ impl ToTokens for PatchModel {
                     notify: &mut dyn FnMut(&#library_path::StorePath),
                     keys: Option<&#library_path::KeyMap>,
                 ) {
-                    let mut new_path = path.clone();
-                    new_path.push(0);
-                    #(#fields)*
+                    #body
                 }
             }
         });

--- a/reactive_stores_macro/src/lib.rs
+++ b/reactive_stores_macro/src/lib.rs
@@ -1,5 +1,5 @@
 use convert_case::{Case, Casing};
-use proc_macro_error2::{OptionExt, abort, abort_call_site, proc_macro_error};
+use proc_macro_error2::{abort, abort_call_site, proc_macro_error};
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, quote};
 use syn::{
@@ -733,7 +733,14 @@ impl ToTokens for PatchModel {
                                                 .parse2(list.tokens.clone())
                                             {
                                                 Ok(closures) => {
-                                                    let closure = closures.iter().next().cloned().expect_or_abort("should have ONE closure");
+                                                    let mut iter = closures.iter();
+                                                    let closure = match iter.next() {
+                                                        Some(closure) => closure.clone(),
+                                                        None => abort!(list, "expected one closure, as in `#[patch(|this, new| ...)]`"),
+                                                    };
+                                                    if let Some(extra) = iter.next() {
+                                                        abort!(extra, "expected exactly one closure in `#[patch(...)]`, but found more than one");
+                                                    }
                                                     if closure.inputs.len() != 2 {
                                                         abort!(closure.inputs, "patch closure should have TWO params as in #[patch(|this, new| ...)]");
                                                     }


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

## Changes

### 1. Enums are now supported
|||
| ---------- | ---------------------------------------------------------------------------------- |
| **Before** | `#[derive(Patch)]` on an enum aborted: *"only structs can be used with `Patch`"*   |
| **After**  | The derive generates a `match` over `(old, new)` and patches each variant's fields |

- Variant fields are numbered with path segments **unique across the whole enum** (mirrors the `Store` derive), so `notify` hits the same triggers the field accessors subscribe to.
- Same-variant unit case → no-op. Mismatched variants → full replace.

### 2. `#[store(skip)]` is now honored
|||
| ---------- | ------------------------------------------------------------------------------------------------- |
| **Before** | Skipped fields were still patched → forced their type to implement `PatchField`                   |
| **After**  | Skipped fields are left untouched; only the path segment is advanced to keep later fields aligned |

### 3. No more panic on malformed `#[patch(...)]`
|||
| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
| **Before** | `expect_or_abort` **panicked the proc-macro** on missing/duplicate closures                                             |
| **After**  | Explicit, span-targeted errors pointing at the offending tokens, naming the expected form `#[patch(\|this, new\| ...)]` |