### PR TITLE
Fix several `leptos_server` correctness bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "serde_json",
  "server_fn",
  "tachys",
+ "tokio",
  "tracing",
  "wasm-bindgen",
 ]

--- a/leptos_server/Cargo.toml
+++ b/leptos_server/Cargo.toml
@@ -29,6 +29,14 @@ js-sys = { optional = true, workspace = true, default-features = true }
 wasm-bindgen = { workspace = true, optional = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 
+[dev-dependencies]
+tokio = { features = [
+  "rt-multi-thread",
+  "macros",
+  "time",
+], workspace = true, default-features = true }
+any_spawner = { workspace = true, features = ["futures-executor", "tokio"] }
+
 [features]
 ssr = []
 hydration = []

--- a/leptos_server/src/action.rs
+++ b/leptos_server/src/action.rs
@@ -147,6 +147,7 @@ where
     S::Error: Send + Sync + 'static,
 {
     /// Creates a new [`Action`] that will call the server function `S` when dispatched.
+    #[track_caller]
     pub fn new() -> Self {
         let err = use_context::<ServerActionError>().and_then(|error| {
             (error.path() == S::PATH)

--- a/leptos_server/src/multi_action.rs
+++ b/leptos_server/src/multi_action.rs
@@ -118,6 +118,7 @@ where
     S::Error: Send + Sync + 'static,
 {
     /// Creates a new [`MultiAction`] which, when dispatched, will call the server function `S`.
+    #[track_caller]
     pub fn new() -> Self {
         Self {
             inner: MultiAction::new(|input: &S| {

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -159,8 +159,31 @@ where
                     Box::pin(async move {
                         ready_fut.await;
                         let value = value.read().or_poisoned();
-                        let value = value.as_ref().unwrap();
-                        Ser::encode(value).unwrap().into_encoded_string()
+                        match value.as_ref() {
+                            Some(value) => match Ser::encode(value) {
+                                Ok(encoded) => encoded.into_encoded_string(),
+                                #[allow(unused)]
+                                Err(e) => {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::error!(
+                                        "error serializing resource for \
+                                         hydration: {e:?}"
+                                    );
+                                    String::new()
+                                }
+                            },
+                            // Emit an empty payload that fails to decode on the
+                            // client (so it reloads) instead of panicking and
+                            // aborting the SSR response stream.
+                            None => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(
+                                    "resource value missing while serializing \
+                                     for hydration"
+                                );
+                                String::new()
+                            }
+                        }
                     }),
                 );
             }

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -353,10 +353,21 @@ where
             self.suspenses.write().or_poisoned().push(suspense_context);
         }
 
+        // Register the waker while holding the `wakers` lock, and check
+        // `loading` inside the same critical section. The loading task clears
+        // `loading` and then drains this list under the same lock, so taking
+        // the lock here makes "check the flag, then register" atomic with
+        // respect to that drain: we either observe `loading == false` (the
+        // value is ready), or we push a waker that the drain is guaranteed to
+        // see and wake. Without this, the loader could drain the (still empty)
+        // list between our check and our push, losing the wake-up and hanging
+        // the future forever.
+        let mut wakers = self.wakers.write().or_poisoned();
         if self.loading.load(Ordering::Relaxed) {
-            self.wakers.write().or_poisoned().push(waker.clone());
+            wakers.push(waker.clone());
             Poll::Pending
         } else {
+            drop(wakers);
             Poll::Ready(
                 self.value.read().or_poisoned().as_ref().unwrap().clone(),
             )

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -133,7 +133,12 @@ where
                     fut.await
                 };
                 *value.write().or_poisoned() = Some(loaded);
-                loading.store(false, Ordering::Relaxed);
+                // `Release` pairs with the `Acquire` load in
+                // `OnceResourceFuture::poll`: a poller that observes
+                // `loading == false` is then guaranteed to see the value write
+                // above. With `Relaxed` the value write could be invisible on
+                // weakly-ordered targets, panicking the `unwrap()` in `poll`.
+                loading.store(false, Ordering::Release);
                 for waker in mem::take(&mut *wakers.write().or_poisoned()) {
                     waker.wake();
                 }
@@ -363,7 +368,7 @@ where
         // list between our check and our push, losing the wake-up and hanging
         // the future forever.
         let mut wakers = self.wakers.write().or_poisoned();
-        if self.loading.load(Ordering::Relaxed) {
+        if self.loading.load(Ordering::Acquire) {
             wakers.push(waker.clone());
             Poll::Pending
         } else {

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -1,6 +1,5 @@
 use crate::{
-    FromEncodedStr, IS_SUPPRESSING_RESOURCE_LOAD, IntoEncodedString,
-    initial_value,
+    FromEncodedStr, IntoEncodedString, initial_value, suppressing_resource_load,
 };
 #[cfg(feature = "serde-lite")]
 use codee::SerdeLite;
@@ -117,7 +116,7 @@ where
 
         let fut = ScopedFuture::new(fut);
 
-        if !is_ready && !IS_SUPPRESSING_RESOURCE_LOAD.load(Ordering::Relaxed) {
+        if !is_ready && !suppressing_resource_load() {
             let value = Arc::clone(&value);
             let wakers = Arc::clone(&wakers);
             let loading = Arc::clone(&loading);

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -31,7 +31,7 @@ use reactive_graph::{
     unwrap_signal,
 };
 use std::{
-    future::IntoFuture,
+    future::{IntoFuture, pending},
     mem,
     panic::Location,
     pin::Pin,
@@ -116,13 +116,22 @@ where
 
         let fut = ScopedFuture::new(fut);
 
-        if !is_ready && !suppressing_resource_load() {
+        if !is_ready {
             let value = Arc::clone(&value);
             let wakers = Arc::clone(&wakers);
             let loading = Arc::clone(&loading);
             let trigger = trigger.clone();
             reactive_graph::spawn(async move {
-                let loaded = fut.await;
+                // Check suppression when the loader is polled, not when the
+                // resource is constructed. Checking at construction time made
+                // a resource created inside a `SuppressResourceLoad` scope
+                // never load, even after the guard dropped; `Resource` checks
+                // at fetch time, and this keeps the two consistent.
+                let loaded = if suppressing_resource_load() {
+                    pending().await
+                } else {
+                    fut.await
+                };
                 *value.write().or_poisoned() = Some(loaded);
                 loading.store(false, Ordering::Relaxed);
                 for waker in mem::take(&mut *wakers.write().or_poisoned()) {

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -400,7 +400,6 @@ where
     {
         use std::borrow::Borrow;
 
-        let shared_context = Owner::current_shared_context();
         if let Some(shared_context) = shared_context {
             let value = shared_context.read_data(id);
             if let Some(value) = value {

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -30,21 +30,33 @@ use std::{
     panic::Location,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
-pub(crate) static IS_SUPPRESSING_RESOURCE_LOAD: AtomicBool =
-    AtomicBool::new(false);
+/// The number of live [`SuppressResourceLoad`] guards. Resource loading is
+/// suppressed while this is greater than zero. A counter rather than a boolean
+/// is used so that nested guards compose correctly.
+pub(crate) static SUPPRESS_RESOURCE_LOAD_COUNT: AtomicUsize =
+    AtomicUsize::new(0);
+
+/// Returns whether resource loading is currently suppressed by one or more
+/// live [`SuppressResourceLoad`] guards.
+pub(crate) fn suppressing_resource_load() -> bool {
+    SUPPRESS_RESOURCE_LOAD_COUNT.load(Ordering::Acquire) > 0
+}
 
 /// Used to prevent resources from actually loading, in environments (like server route generation)
 /// where they are not needed.
+///
+/// Guards are reentrant: nesting two of them keeps suppression active until the
+/// outermost guard is dropped.
 pub struct SuppressResourceLoad;
 
 impl SuppressResourceLoad {
-    /// Prevents resources from loading until this is dropped.
+    /// Prevents resources from loading until this (and any outer guard) is dropped.
     pub fn new() -> Self {
-        IS_SUPPRESSING_RESOURCE_LOAD.store(true, Ordering::Relaxed);
+        SUPPRESS_RESOURCE_LOAD_COUNT.fetch_add(1, Ordering::Release);
         Self
     }
 }
@@ -57,7 +69,7 @@ impl Default for SuppressResourceLoad {
 
 impl Drop for SuppressResourceLoad {
     fn drop(&mut self) {
-        IS_SUPPRESSING_RESOURCE_LOAD.store(false, Ordering::Relaxed);
+        SUPPRESS_RESOURCE_LOAD_COUNT.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -314,7 +326,7 @@ where
                 let (_, source) = source.get();
                 let fut = fetcher(source);
                 async move {
-                    if IS_SUPPRESSING_RESOURCE_LOAD.load(Ordering::Relaxed) {
+                    if suppressing_resource_load() {
                         pending().await
                     } else {
                         fut.await
@@ -1447,5 +1459,35 @@ where
     /// value by reference.
     pub fn by_ref(&self) -> AsyncDerivedRefFuture<T> {
         self.data.by_ref()
+    }
+}
+
+#[cfg(test)]
+mod suppress_resource_load_tests {
+    use super::{SuppressResourceLoad, suppressing_resource_load};
+
+    // Touches the process-global suppression counter, so it is kept as a
+    // single test to avoid interfering with any other in-crate test.
+    #[test]
+    fn nested_guards_suppress_until_outermost_drops() {
+        assert!(!suppressing_resource_load());
+
+        let outer = SuppressResourceLoad::new();
+        assert!(suppressing_resource_load());
+
+        {
+            let _inner = SuppressResourceLoad::new();
+            assert!(suppressing_resource_load());
+        }
+        // The inner guard has dropped, but the outer one is still alive, so
+        // suppression must remain active. (With the previous boolean flag this
+        // assertion failed: the inner drop cleared it.)
+        assert!(
+            suppressing_resource_load(),
+            "suppression cleared while an outer guard was still alive"
+        );
+
+        drop(outer);
+        assert!(!suppressing_resource_load());
     }
 }

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -346,11 +346,30 @@ where
                     Box::pin(async move {
                         ready_fut.await;
                         value.with_untracked(|data| match &data {
-                            // TODO handle serialization errors
-                            Some(val) => {
-                                Ser::encode(val).unwrap().into_encoded_string()
+                            Some(val) => match Ser::encode(val) {
+                                Ok(encoded) => encoded.into_encoded_string(),
+                                #[allow(unused)]
+                                Err(e) => {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::error!(
+                                        "error serializing resource for \
+                                         hydration: {e:?}"
+                                    );
+                                    String::new()
+                                }
+                            },
+                            // The value can be taken out from under the SSR
+                            // task (e.g. via `try_write_untracked`). Emit an
+                            // empty payload that fails to decode on the client
+                            // (so it reloads) instead of aborting the stream.
+                            None => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(
+                                    "resource value missing while serializing \
+                                     for hydration"
+                                );
+                                String::new()
                             }
-                            _ => unreachable!(),
                         })
                     }),
                 );

--- a/leptos_server/tests/once_resource.rs
+++ b/leptos_server/tests/once_resource.rs
@@ -1,0 +1,45 @@
+//! Regression guard for the poll/wake handshake in `OnceResourceFuture`.
+//!
+//! The loader task publishes the value, clears the `loading` flag and then
+//! drains the registered wakers. The poll side has to register its waker and
+//! check `loading` atomically with respect to that drain; otherwise a waker
+//! registered just after the (empty) drain is never woken and the future hangs
+//! forever. This lost-wake interleaving only exists with genuine multi-thread
+//! scheduling, hence the multi-thread runtime with a fixed worker count (so it
+//! behaves the same regardless of the host's core count).
+//!
+//! On correct code every resource resolves, so the test is deterministic: it
+//! never depends on timing, and the timeout is only ever reached if a wake-up
+//! is genuinely lost.
+
+use any_spawner::Executor;
+use leptos_server::ArcOnceResource;
+use reactive_graph::owner::Owner;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn once_resource_resolves_across_threads() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    for i in 0..256u32 {
+        // The loader runs as its own task (spawned by `ArcOnceResource::new`),
+        // so on a multi-thread runtime it races against this awaiter on a
+        // separate worker, exercising the check-then-register handshake.
+        let resource = ArcOnceResource::<u32>::new(async move {
+            // Yield once so the awaiter typically reaches its `loading` check
+            // before the loader publishes its value.
+            Executor::tick().await;
+            i
+        });
+
+        let value = tokio::time::timeout(Duration::from_secs(5), async move {
+            resource.await
+        })
+        .await
+        .expect("OnceResource await hung (lost wake-up)");
+
+        assert_eq!(value, i);
+    }
+}

--- a/leptos_server/tests/suppress_resource_load.rs
+++ b/leptos_server/tests/suppress_resource_load.rs
@@ -1,0 +1,39 @@
+//! Regression test for the suppression timing of `OnceResource`.
+//!
+//! `Resource` evaluates `SuppressResourceLoad` when its fetcher future is
+//! polled, while `OnceResource` used to evaluate it once, at construction. A
+//! `OnceResource` created inside a suppression scope therefore never loaded —
+//! not even after the guard dropped — because the loader task was skipped at
+//! construction. The fetch-time check makes the two consistent.
+
+use any_spawner::Executor;
+use leptos_server::{ArcOnceResource, SuppressResourceLoad};
+use reactive_graph::owner::Owner;
+use std::time::Duration;
+
+#[tokio::test]
+async fn once_resource_constructed_under_suppression_loads_after_guard_drops() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    // Construct the resource while suppression is active, then drop the guard
+    // before the spawned loader is ever polled.
+    let resource = {
+        let _guard = SuppressResourceLoad::new();
+        ArcOnceResource::<u32>::new(async { 42 })
+    };
+
+    // By the time the loader is first polled the guard is gone, so the value
+    // loads. Before the fix this hung forever, because construction-time
+    // suppression skipped spawning the loader entirely.
+    let value =
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            async move { resource.await },
+        )
+        .await
+        .expect("OnceResource created under suppression should still load");
+
+    assert_eq!(value, 42);
+}


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

## Changes

### Concurrency
- **Lost-wake race in `OnceResourceFuture::poll`**: the waker was registered *after* checking the `loading` flag with no synchronization, so the loader could drain the (empty) waker list in between and the future would hang forever. Now the `loading` check and waker push happen under the same `wakers` lock that the loader drains under.
- **Memory ordering on the `loading` flag**: the flag was stored/loaded with `Relaxed`, so a poller could see `loading == false` before the value write was visible and panic in `unwrap()` on weakly-ordered targets. Now uses `Release`/`Acquire`.

### Resource loading / suppression
- **`SuppressResourceLoad` is now reentrant**: replaced the backing `AtomicBool` with a reference count so nested guards no longer clear suppression early on the inner guard's drop.
- **Unified suppression timing for `OnceResource`**: it checked suppression once at construction (skipping the loader entirely); it now checks at fetch time inside the loader, matching `Resource`, so a resource created inside a suppression scope still loads after the guard drops.

### Robustness / correctness
- **No more panics on the SSR serialization path**: `Ser::encode(...).unwrap()` and `unreachable!()` in the hydration write path are replaced with graceful handling (log + empty payload that simply reloads on the client) instead of aborting the response stream.
- **`initial_value` honors its `shared_context` argument**: it was shadowing the parameter with `Owner::current_shared_context()`, silently ignoring an explicitly passed context.
- **`#[track_caller]` on `ServerAction::new` / `ServerMultiAction::new`**: so `defined_at()` points to the caller, matching the `Arc*` variants.
