### PR TITLE
Harden leptos actix server integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,6 @@ dependencies = [
  "leptos_meta",
  "leptos_router",
  "lru",
- "mime",
  "or_poisoned",
  "send_wrapper",
  "serde_json",
@@ -2133,7 +2132,6 @@ dependencies = [
  "leptos_meta",
  "leptos_router",
  "lru",
- "mime",
  "or_poisoned",
  "reqwest",
  "server_fn",
@@ -2201,6 +2199,7 @@ dependencies = [
  "leptos_config",
  "leptos_meta",
  "leptos_router",
+ "mime",
  "reactive_graph",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "leptos_router",
  "mime",
  "reactive_graph",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,7 @@ dependencies = [
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
+ "mime",
  "or_poisoned",
  "send_wrapper",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,7 @@ dependencies = [
  "leptos_macro",
  "leptos_meta",
  "leptos_router",
+ "lru",
  "mime",
  "or_poisoned",
  "send_wrapper",

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -21,7 +21,6 @@ leptos_macro = { workspace = true, features = ["actix"] }
 leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 lru = { workspace = true }
-mime = { workspace = true }
 server_fn = { workspace = true, features = ["actix-no-default"] }
 tachys = { workspace = true }
 serde_json = { workspace = true, default-features = true }

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -20,6 +20,7 @@ leptos_integration_utils = { workspace = true }
 leptos_macro = { workspace = true, features = ["actix"] }
 leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
+lru = { workspace = true }
 mime = { workspace = true }
 server_fn = { workspace = true, features = ["actix-no-default"] }
 tachys = { workspace = true }

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -16,7 +16,7 @@ futures = { workspace = true, default-features = true }
 any_spawner = { workspace = true, features = ["tokio"] }
 hydration_context = { workspace = true }
 leptos = { workspace = true, features = ["nonce", "ssr"] }
-leptos_integration_utils = { workspace = true }
+leptos_integration_utils = { workspace = true, features = ["fs"] }
 leptos_macro = { workspace = true, features = ["actix"] }
 leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }

--- a/integrations/actix/Cargo.toml
+++ b/integrations/actix/Cargo.toml
@@ -20,6 +20,7 @@ leptos_integration_utils = { workspace = true }
 leptos_macro = { workspace = true, features = ["actix"] }
 leptos_meta = { workspace = true, features = ["nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
+mime = { workspace = true }
 server_fn = { workspace = true, features = ["actix-no-default"] }
 tachys = { workspace = true }
 serde_json = { workspace = true, default-features = true }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -204,6 +204,33 @@ impl ExtendResponse for ActixResponse {
     }
 }
 
+/// Returns whether an `Accept` header value indicates the client will accept
+/// an HTML response — i.e. an ordinary browser navigation or a plain `<form>`
+/// submission, as opposed to a programmatic client expecting structured data.
+///
+/// Unlike a naive `contains("text/html")` check, each comma-separated media
+/// range is parsed with the [`mime`] crate and an explicit `q=0` refusal is
+/// honoured. So `text/html;q=0` (the client refusing HTML) and
+/// `application/x-text/html-fake` (an unrelated, unparseable range) are both
+/// correctly treated as *not* accepting HTML.
+fn accept_header_includes_html(accept: &str) -> bool {
+    accept.split(',').any(|range| {
+        let Ok(media) = range.trim().parse::<mime::Mime>() else {
+            return false;
+        };
+        if media.type_() != mime::TEXT || media.subtype() != mime::HTML {
+            return false;
+        }
+        // honour an explicit `q=0`, which means the client refuses HTML
+        match media.get_param("q") {
+            Some(q) => {
+                q.as_str().parse::<f32>().map(|w| w > 0.0).unwrap_or(true)
+            }
+            None => true,
+        }
+    })
+}
+
 /// Provides an easy way to redirect the user from within a server function.
 ///
 /// Calling `redirect` in a server function will redirect the browser in three
@@ -266,7 +293,7 @@ pub fn redirect(path: &str) {
             .headers()
             .get(ACCEPT)
             .and_then(|v| v.to_str().ok())
-            .map(|v| v.contains("text/html"))
+            .map(accept_header_includes_html)
             .unwrap_or(false);
         if accepts_html {
             // if the request accepts text/html, it's a plain form request and needs
@@ -388,7 +415,7 @@ pub fn handle_server_fns_with_context(
                                 .headers()
                                 .get(ACCEPT)
                                 .and_then(|v| v.to_str().ok())
-                                .map(|v| v.contains("text/html"))
+                                .map(accept_header_includes_html)
                                 .unwrap_or(false);
                             let referrer = req.headers().get(REFERER).cloned();
 
@@ -1708,7 +1735,8 @@ mod tests {
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
         ActixResponse, ExtendResponse, HttpResponse, LOCATION, OrPoisoned,
-        Owner, Request, ResponseOptions, header, provide_context, redirect,
+        Owner, Request, ResponseOptions, accept_header_includes_html, header,
+        provide_context, redirect,
     };
     use actix_web::test::TestRequest;
 
@@ -1774,5 +1802,33 @@ mod tests {
                 .map(|v| v.as_bytes()),
             Some(&b"text/html; charset=utf-8"[..])
         );
+    }
+
+    #[test]
+    fn accept_header_plain_navigation_is_html() {
+        // typical browser navigation
+        assert!(accept_header_includes_html(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        ));
+        assert!(accept_header_includes_html("text/html"));
+        assert!(accept_header_includes_html("text/html; charset=utf-8"));
+        assert!(accept_header_includes_html("text/html;q=0.1"));
+    }
+
+    #[test]
+    fn accept_header_explicit_refusal_is_not_html() {
+        // `q=0` means the client explicitly does not want HTML
+        assert!(!accept_header_includes_html(
+            "text/html;q=0, application/json"
+        ));
+        assert!(!accept_header_includes_html("text/html;q=0.0"));
+    }
+
+    #[test]
+    fn accept_header_substring_is_not_html() {
+        // these contain the literal substring "text/html" but are not it
+        assert!(!accept_header_includes_html("application/x-text/html-fake"));
+        assert!(!accept_header_includes_html("application/json"));
+        assert!(!accept_header_includes_html("*/*"));
     }
 }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1341,6 +1341,8 @@ async fn write_static_route(
     path: &str,
     html: &str,
 ) -> Result<(), std::io::Error> {
+    use leptos_integration_utils::write_file_atomic;
+
     // Reject anything that would escape the site root before caching headers
     // or touching the filesystem.
     let Some(file_path) = static_path(options, path) else {
@@ -1358,37 +1360,9 @@ async fn write_static_route(
     }
 
     let path = Path::new(&file_path);
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-
-    // Write to a uniquely-named temp file in the same directory and rename it
-    // over the target. `rename` is atomic on POSIX filesystems (and replaces
-    // the destination on Windows), so a concurrent reader or a crash never
-    // observes a half-written or truncated file. `tokio::fs::write` truncates
-    // the target up front, which would leave an empty file visible (and served
-    // with `try_exists == true`) if the process died mid-write.
-    let tmp_path = {
-        static COUNTER: std::sync::atomic::AtomicU64 =
-            std::sync::atomic::AtomicU64::new(0);
-        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let mut file_name = path
-            .file_name()
-            .map(|name| name.to_os_string())
-            .unwrap_or_default();
-        file_name.push(format!(".tmp.{}.{n}", std::process::id()));
-        path.with_file_name(file_name)
-    };
-
-    tokio::fs::write(&tmp_path, html).await?;
-    if let Err(err) = tokio::fs::rename(&tmp_path, path).await {
-        // Best-effort cleanup so a failed rename does not leave temp files
-        // accumulating in the site root.
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(err);
-    }
-
-    Ok(())
+    // Write atomically: a crash mid-write must never leave a truncated or empty
+    // file that is then served (because `try_exists` reports it as present).
+    write_file_atomic(path, html.as_bytes()).await
 }
 
 fn handle_static_route<IV>(

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -44,7 +44,7 @@ use server_fn::{
     request::actix::ActixRequest,
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     fmt::{Debug, Display},
     future::Future,
     ops::{Deref, DerefMut},
@@ -1301,9 +1301,35 @@ impl StaticRouteGenerator {
     }
 }
 
+/// Default upper bound on the number of per-path [`ResponseOptions`] entries
+/// cached for static routes. Without a bound the cache grew for the life of the
+/// process, one entry per unique static path served (e.g. attacker-driven slugs
+/// on a regenerated `/posts/{slug}` route).
+///
+/// Eviction is graceful: the static file is still served from disk, the cache
+/// only drops the custom headers/status captured at generation time for the
+/// evicted path (re-populated on the next regeneration). 1024 covers a typical
+/// static site's working set for a worst case on the order of ~1 MB.
+const STATIC_HEADERS_DEFAULT_CAPACITY: std::num::NonZeroUsize =
+    match std::num::NonZeroUsize::new(1024) {
+        Some(capacity) => capacity,
+        None => unreachable!(),
+    };
+
+/// Environment variable that overrides [`STATIC_HEADERS_DEFAULT_CAPACITY`].
+/// A missing, unparseable, or zero value falls back to the default.
+const STATIC_HEADERS_CAPACITY_ENV: &str = "LEPTOS_STATIC_HEADERS_CACHE_SIZE";
+
 static STATIC_HEADERS: LazyLock<
-    std::sync::RwLock<HashMap<String, ResponseOptions>>,
-> = LazyLock::new(Default::default);
+    std::sync::RwLock<lru::LruCache<String, ResponseOptions>>,
+> = LazyLock::new(|| {
+    let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .and_then(std::num::NonZeroUsize::new)
+        .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
+    std::sync::RwLock::new(lru::LruCache::new(capacity))
+});
 
 fn was_404(owner: &Owner) -> bool {
     let resp = owner.with(|| expect_context::<ResponseOptions>());
@@ -1347,7 +1373,7 @@ async fn write_static_route(
         STATIC_HEADERS
             .write()
             .or_poisoned()
-            .insert(path.to_string(), options);
+            .put(path.to_string(), options);
     }
 
     let path = Path::new(&file_path);
@@ -1423,8 +1449,9 @@ where
                         .await;
                     (owner.with(use_context::<ResponseOptions>), html)
                 } else {
+                    // `LruCache::get` updates recency, so it needs a write lock.
                     let headers = STATIC_HEADERS
-                        .read()
+                        .write()
                         .or_poisoned()
                         .get(orig_path)
                         .cloned();
@@ -1782,9 +1809,9 @@ mod tests {
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
         ActixResponse, ExtendResponse, HttpResponse, LOCATION, Method,
-        OrPoisoned, Owner, Request, ResponseOptions, SsrMode,
-        accept_header_includes_html, header, provide_context, redirect,
-        unsupported_ssr_mode_route,
+        OrPoisoned, Owner, Request, ResponseOptions,
+        STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, accept_header_includes_html,
+        header, provide_context, redirect, unsupported_ssr_mode_route,
     };
     use actix_web::test::TestRequest;
 
@@ -1878,6 +1905,27 @@ mod tests {
         assert!(!accept_header_includes_html("application/x-text/html-fake"));
         assert!(!accept_header_includes_html("application/json"));
         assert!(!accept_header_includes_html("*/*"));
+    }
+
+    // The per-path header cache must never grow without bound: serving many
+    // unique static paths (e.g. attacker-driven slugs) used to leak one entry
+    // per path for the life of the process.
+    #[test]
+    fn static_headers_cache_is_bounded() {
+        let mut cache: lru::LruCache<String, ResponseOptions> =
+            lru::LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
+        let capacity = STATIC_HEADERS_DEFAULT_CAPACITY.get();
+
+        for i in 0..(capacity + 10) {
+            cache.put(format!("/post/{i}"), ResponseOptions::default());
+        }
+
+        // never grows past capacity
+        assert_eq!(cache.len(), capacity);
+        // the earliest-inserted entries have been evicted
+        assert!(cache.get(&"/post/0".to_string()).is_none());
+        // a recently-inserted entry is still present
+        assert!(cache.get(&format!("/post/{}", capacity + 9)).is_some());
     }
 
     // An unknown `SsrMode` must serve a 500 rather than panicking the worker

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -38,6 +38,7 @@ use leptos_router::{
     location::RequestUrl,
     static_routes::{RegenerationFn, ResolvedStaticPath},
 };
+use lru::LruCache;
 use or_poisoned::OrPoisoned;
 use send_wrapper::SendWrapper;
 use server_fn::{
@@ -48,6 +49,7 @@ use std::{
     collections::HashSet,
     fmt::{Debug, Display},
     future::Future,
+    num::NonZeroUsize,
     ops::{Deref, DerefMut},
     path::Path,
     sync::{Arc, LazyLock, RwLock},
@@ -1290,8 +1292,8 @@ impl StaticRouteGenerator {
 /// only drops the custom headers/status captured at generation time for the
 /// evicted path (re-populated on the next regeneration). 1024 covers a typical
 /// static site's working set for a worst case on the order of ~1 MB.
-const STATIC_HEADERS_DEFAULT_CAPACITY: std::num::NonZeroUsize =
-    match std::num::NonZeroUsize::new(1024) {
+const STATIC_HEADERS_DEFAULT_CAPACITY: NonZeroUsize =
+    match NonZeroUsize::new(1024) {
         Some(capacity) => capacity,
         None => unreachable!(),
     };
@@ -1300,16 +1302,15 @@ const STATIC_HEADERS_DEFAULT_CAPACITY: std::num::NonZeroUsize =
 /// A missing, unparseable, or zero value falls back to the default.
 const STATIC_HEADERS_CAPACITY_ENV: &str = "LEPTOS_STATIC_HEADERS_CACHE_SIZE";
 
-static STATIC_HEADERS: LazyLock<
-    std::sync::RwLock<lru::LruCache<String, ResponseOptions>>,
-> = LazyLock::new(|| {
-    let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
-        .ok()
-        .and_then(|value| value.parse::<usize>().ok())
-        .and_then(std::num::NonZeroUsize::new)
-        .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
-    std::sync::RwLock::new(lru::LruCache::new(capacity))
-});
+static STATIC_HEADERS: LazyLock<RwLock<LruCache<String, ResponseOptions>>> =
+    LazyLock::new(|| {
+        let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .and_then(NonZeroUsize::new)
+            .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
+        RwLock::new(LruCache::new(capacity))
+    });
 
 fn was_404(owner: &Owner) -> bool {
     let resp = owner.with(|| expect_context::<ResponseOptions>());
@@ -1819,6 +1820,7 @@ mod tests {
         unsupported_ssr_mode_route, write_static_route,
     };
     use actix_web::test::TestRequest;
+    use lru::LruCache;
 
     // A redirect target containing CR/LF cannot be encoded as a header value.
     // `redirect` must skip the redirect instead of panicking, otherwise any
@@ -1889,8 +1891,8 @@ mod tests {
     // per path for the life of the process.
     #[test]
     fn static_headers_cache_is_bounded() {
-        let mut cache: lru::LruCache<String, ResponseOptions> =
-            lru::LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
+        let mut cache: LruCache<String, ResponseOptions> =
+            LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
         let capacity = STATIC_HEADERS_DEFAULT_CAPACITY.get();
 
         for i in 0..(capacity + 10) {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1377,10 +1377,35 @@ async fn write_static_route(
     }
 
     let path = Path::new(&file_path);
-    if let Some(path) = path.parent() {
-        tokio::fs::create_dir_all(path).await?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
     }
-    tokio::fs::write(path, &html).await?;
+
+    // Write to a uniquely-named temp file in the same directory and rename it
+    // over the target. `rename` is atomic on POSIX filesystems (and replaces
+    // the destination on Windows), so a concurrent reader or a crash never
+    // observes a half-written or truncated file. `tokio::fs::write` truncates
+    // the target up front, which would leave an empty file visible (and served
+    // with `try_exists == true`) if the process died mid-write.
+    let tmp_path = {
+        static COUNTER: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut file_name = path
+            .file_name()
+            .map(|name| name.to_os_string())
+            .unwrap_or_default();
+        file_name.push(format!(".tmp.{}.{n}", std::process::id()));
+        path.with_file_name(file_name)
+    };
+
+    tokio::fs::write(&tmp_path, html).await?;
+    if let Err(err) = tokio::fs::rename(&tmp_path, path).await {
+        // Best-effort cleanup so a failed rename does not leave temp files
+        // accumulating in the site root.
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(err);
+    }
 
     Ok(())
 }
@@ -1808,10 +1833,11 @@ mod tests {
     // Targeted imports rather than `use super::*`: the crate root glob-imports
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
-        ActixResponse, ExtendResponse, HttpResponse, LOCATION, Method,
-        OrPoisoned, Owner, Request, ResponseOptions,
+        ActixResponse, ExtendResponse, HttpResponse, LOCATION, LeptosOptions,
+        Method, OrPoisoned, Owner, Request, ResponseOptions,
         STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, accept_header_includes_html,
         header, provide_context, redirect, unsupported_ssr_mode_route,
+        write_static_route,
     };
     use actix_web::test::TestRequest;
 
@@ -1926,6 +1952,47 @@ mod tests {
         assert!(cache.get(&"/post/0".to_string()).is_none());
         // a recently-inserted entry is still present
         assert!(cache.get(&format!("/post/{}", capacity + 9)).is_some());
+    }
+
+    // A static route must be written atomically: the file appears with its
+    // full contents or not at all, and no temp file is left behind. Writing in
+    // place would let a crash mid-write leave a truncated/empty file that is
+    // then served (because `try_exists` reports it as present).
+    #[actix_web::test]
+    async fn write_static_route_is_atomic() {
+        let dir = std::env::temp_dir().join(format!(
+            "leptos_actix_static_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let options = LeptosOptions::builder()
+            .output_name("test")
+            .site_root(dir.to_string_lossy().into_owned())
+            .build();
+
+        let html = "<html><body>hello</body></html>";
+        write_static_route(&options, None, "/page", html)
+            .await
+            .unwrap();
+
+        // the target was written in full
+        let written = std::fs::read_to_string(dir.join("page.html")).unwrap();
+        assert_eq!(written, html);
+
+        // no temp file was left behind
+        let leftovers = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .count();
+        assert_eq!(leftovers, 0);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     // An unknown `SsrMode` must serve a 500 rather than panicking the worker

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -909,7 +909,13 @@ where
         }
     };
     match method {
-        Method::Get => web::get().to(handler),
+        // Per RFC 9110 §9.3.2 a HEAD must return the same status and headers
+        // as the equivalent GET. Actix does not run a GET handler for HEAD on
+        // its own, so register the GET render handler for both methods; the
+        // HTTP/1 encoder drops the body for HEAD responses.
+        Method::Get => web::route()
+            .guard(guard::Any(guard::Get()).or(guard::Head()))
+            .to(handler),
         Method::Post => web::post().to(handler),
         Method::Put => web::put().to(handler),
         Method::Delete => web::delete().to(handler),
@@ -1633,7 +1639,6 @@ where
                     )
                 } else {
                     router
-                        .route(path, web::head().to(HttpResponse::Ok))
                         .route(
                             path,
                             match mode {
@@ -1836,8 +1841,8 @@ mod tests {
         ActixResponse, ExtendResponse, HttpResponse, LOCATION, LeptosOptions,
         Method, OrPoisoned, Owner, Request, ResponseOptions,
         STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, accept_header_includes_html,
-        header, provide_context, redirect, unsupported_ssr_mode_route,
-        write_static_route,
+        header, provide_context, redirect, render_app_to_stream_with_context,
+        unsupported_ssr_mode_route, write_static_route,
     };
     use actix_web::test::TestRequest;
 
@@ -1952,6 +1957,39 @@ mod tests {
         assert!(cache.get(&"/post/0".to_string()).is_none());
         // a recently-inserted entry is still present
         assert!(cache.get(&format!("/post/{}", capacity + 9)).is_some());
+    }
+
+    // A HEAD request to a render route must reach the GET handler and return
+    // the same status (RFC 9110 §9.3.2), not a hardcoded 200 or a 404. Both
+    // `App` and `&mut ServiceConfig` route HEAD through the same render path.
+    #[actix_web::test]
+    async fn head_request_reaches_render_handler() {
+        use actix_web::{App, http::Method as HttpMethod, test, web::Data};
+
+        // the render path spawns futures on the global executor
+        let _ = any_spawner::Executor::init_tokio();
+
+        let options = LeptosOptions::builder().output_name("test").build();
+        let route =
+            render_app_to_stream_with_context(|| {}, || "hello", Method::Get);
+
+        let app = test::init_service(
+            App::new().app_data(Data::new(options)).route("/", route),
+        )
+        .await;
+
+        let get = test::TestRequest::get().uri("/").to_request();
+        let get_status = test::call_service(&app, get).await.status();
+
+        let head = TestRequest::default()
+            .method(HttpMethod::HEAD)
+            .uri("/")
+            .to_request();
+        let head_status = test::call_service(&app, head).await.status();
+
+        // HEAD reaches the handler rather than 404-ing, and mirrors GET.
+        assert_ne!(head_status, actix_web::http::StatusCode::NOT_FOUND);
+        assert_eq!(head_status, get_status);
     }
 
     // A static route must be written atomically: the file appears with its

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -29,6 +29,7 @@ use leptos::{
 };
 use leptos_integration_utils::{
     BoxedFnOnce, ExtendResponse, PinnedFuture, PinnedStream,
+    accept_header_includes_html,
 };
 use leptos_meta::ServerMetaContext;
 use leptos_router::{
@@ -202,33 +203,6 @@ impl ExtendResponse for ActixResponse {
             }
         }
     }
-}
-
-/// Returns whether an `Accept` header value indicates the client will accept
-/// an HTML response — i.e. an ordinary browser navigation or a plain `<form>`
-/// submission, as opposed to a programmatic client expecting structured data.
-///
-/// Unlike a naive `contains("text/html")` check, each comma-separated media
-/// range is parsed with the [`mime`] crate and an explicit `q=0` refusal is
-/// honoured. So `text/html;q=0` (the client refusing HTML) and
-/// `application/x-text/html-fake` (an unrelated, unparseable range) are both
-/// correctly treated as *not* accepting HTML.
-fn accept_header_includes_html(accept: &str) -> bool {
-    accept.split(',').any(|range| {
-        let Ok(media) = range.trim().parse::<mime::Mime>() else {
-            return false;
-        };
-        if media.type_() != mime::TEXT || media.subtype() != mime::HTML {
-            return false;
-        }
-        // honour an explicit `q=0`, which means the client refuses HTML
-        match media.get_param("q") {
-            Some(q) => {
-                q.as_str().parse::<f32>().map(|w| w > 0.0).unwrap_or(true)
-            }
-            None => true,
-        }
-    })
 }
 
 /// Provides an easy way to redirect the user from within a server function.
@@ -1840,8 +1814,8 @@ mod tests {
     use super::{
         ActixResponse, ExtendResponse, HttpResponse, LOCATION, LeptosOptions,
         Method, OrPoisoned, Owner, Request, ResponseOptions,
-        STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, accept_header_includes_html,
-        header, provide_context, redirect, render_app_to_stream_with_context,
+        STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, header, provide_context,
+        redirect, render_app_to_stream_with_context,
         unsupported_ssr_mode_route, write_static_route,
     };
     use actix_web::test::TestRequest;
@@ -1908,34 +1882,6 @@ mod tests {
                 .map(|v| v.as_bytes()),
             Some(&b"text/html; charset=utf-8"[..])
         );
-    }
-
-    #[test]
-    fn accept_header_plain_navigation_is_html() {
-        // typical browser navigation
-        assert!(accept_header_includes_html(
-            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-        ));
-        assert!(accept_header_includes_html("text/html"));
-        assert!(accept_header_includes_html("text/html; charset=utf-8"));
-        assert!(accept_header_includes_html("text/html;q=0.1"));
-    }
-
-    #[test]
-    fn accept_header_explicit_refusal_is_not_html() {
-        // `q=0` means the client explicitly does not want HTML
-        assert!(!accept_header_includes_html(
-            "text/html;q=0, application/json"
-        ));
-        assert!(!accept_header_includes_html("text/html;q=0.0"));
-    }
-
-    #[test]
-    fn accept_header_substring_is_not_html() {
-        // these contain the literal substring "text/html" but are not it
-        assert!(!accept_header_includes_html("application/x-text/html-fake"));
-        assert!(!accept_header_includes_html("application/json"));
-        assert!(!accept_header_includes_html("*/*"));
     }
 
     // The per-path header cache must never grow without bound: serving many

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1442,8 +1442,22 @@ where
                     }
                     None => match NamedFile::open(path) {
                         Ok(res) => res.into_response(&req),
-                        Err(err) => HttpResponse::InternalServerError()
-                            .body(err.to_string()),
+                        // The cached file can be removed or replaced between
+                        // the `try_exists` check above and this open (a TOCTOU
+                        // race). Do not render the raw filesystem error into
+                        // the body — that leaks server-side path and OS error
+                        // details — log it and return a generic 500.
+                        Err(err) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(
+                                "failed to serve static file {}: {err}",
+                                path.display()
+                            );
+                            #[cfg(not(feature = "tracing"))]
+                            let _ = &err;
+                            HttpResponse::InternalServerError()
+                                .body("Internal Server Error")
+                        }
                     },
                 });
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -186,11 +186,20 @@ impl ExtendResponse for ActixResponse {
         let headers = self.0.headers_mut();
         if !headers.contains_key(header::CONTENT_TYPE) {
             // Set the Content Type headers on all responses. This makes Firefox show the page source
-            // without complaining
-            headers.insert(
-                header::CONTENT_TYPE,
-                HeaderValue::from_str(content_type).unwrap(),
-            );
+            // without complaining.
+            //
+            // `content_type` is a `&str`, so it may not be a valid header
+            // value (e.g. if it contains a NUL byte). Skip the header rather
+            // than unwrapping, which would panic and take down the worker.
+            if let Ok(value) = HeaderValue::from_str(content_type) {
+                headers.insert(header::CONTENT_TYPE, value);
+            } else {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "skipped default Content-Type: {content_type:?} is not a \
+                     valid header value"
+                );
+            }
         }
     }
 }
@@ -1698,8 +1707,8 @@ mod tests {
     // Targeted imports rather than `use super::*`: the crate root glob-imports
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
-        LOCATION, OrPoisoned, Owner, Request, ResponseOptions, provide_context,
-        redirect,
+        ActixResponse, ExtendResponse, HttpResponse, LOCATION, OrPoisoned,
+        Owner, Request, ResponseOptions, header, provide_context, redirect,
     };
     use actix_web::test::TestRequest;
 
@@ -1741,6 +1750,29 @@ mod tests {
         assert_eq!(
             parts.headers.get(LOCATION).map(|v| v.as_bytes()),
             Some(&b"/dashboard"[..])
+        );
+    }
+
+    // A content type that is not a valid header value (e.g. it contains a NUL
+    // byte) must be skipped rather than unwrapped, which would panic.
+    #[test]
+    fn set_default_content_type_skips_invalid_value() {
+        let mut res = ActixResponse(HttpResponse::Ok().finish());
+        res.set_default_content_type("text/html\0bad");
+        assert!(res.0.headers().get(header::CONTENT_TYPE).is_none());
+    }
+
+    // A valid content type is still applied when none is set yet.
+    #[test]
+    fn set_default_content_type_sets_valid_value() {
+        let mut res = ActixResponse(HttpResponse::Ok().finish());
+        res.set_default_content_type("text/html; charset=utf-8");
+        assert_eq!(
+            res.0
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .map(|v| v.as_bytes()),
+            Some(&b"text/html; charset=utf-8"[..])
         );
     }
 }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -917,6 +917,35 @@ where
     }
 }
 
+/// Builds a route that responds with `500 Internal Server Error` for an
+/// [`SsrMode`] this integration does not know how to render.
+///
+/// `SsrMode` is a public, non-`#[non_exhaustive]` enum in `leptos_router`, but
+/// the rendering `match` used a `_ => unreachable!()` catch-all. That defeats
+/// the compiler's exhaustiveness check: a newly added variant would compile
+/// here and then panic the worker at runtime the first time a route used it.
+/// Serve a typed 500 instead of panicking.
+fn unsupported_ssr_mode_route(method: Method, mode: &SsrMode) -> Route {
+    #[cfg(feature = "tracing")]
+    tracing::error!(
+        "unsupported SSR mode {mode:?} for this route; serving 500"
+    );
+    #[cfg(not(feature = "tracing"))]
+    let _ = mode;
+
+    let handler = || async {
+        HttpResponse::InternalServerError()
+            .body("This rendering mode is not supported.")
+    };
+    match method {
+        Method::Get => web::get().to(handler),
+        Method::Post => web::post().to(handler),
+        Method::Put => web::put().to(handler),
+        Method::Delete => web::delete().to(handler),
+        Method::Patch => web::patch().to(handler),
+    }
+}
+
 /// Generates a list of all routes defined in Leptos's Router in your app. We can then use this to automatically
 /// create routes in Actix's App without having to use wildcard matching or fallbacks. Takes in your root app Element
 /// as an argument so it can walk you app tree. This version is tailored to generated Actix compatible paths.
@@ -1569,7 +1598,9 @@ where
                                     app_fn.clone(),
                                     method,
                                 ),
-                                _ => unreachable!()
+                                ref mode => {
+                                    unsupported_ssr_mode_route(method, mode)
+                                }
                             },
                         )
                 };
@@ -1675,7 +1706,9 @@ impl LeptosRoutes for &mut ServiceConfig {
                                     app_fn.clone(),
                                     method,
                                 ),
-                                _ => unreachable!()
+                                ref mode => {
+                                    unsupported_ssr_mode_route(method, mode)
+                                }
                             },
                         );
                 }
@@ -1734,9 +1767,10 @@ mod tests {
     // Targeted imports rather than `use super::*`: the crate root glob-imports
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
-        ActixResponse, ExtendResponse, HttpResponse, LOCATION, OrPoisoned,
-        Owner, Request, ResponseOptions, accept_header_includes_html, header,
-        provide_context, redirect,
+        ActixResponse, ExtendResponse, HttpResponse, LOCATION, Method,
+        OrPoisoned, Owner, Request, ResponseOptions, SsrMode,
+        accept_header_includes_html, header, provide_context, redirect,
+        unsupported_ssr_mode_route,
     };
     use actix_web::test::TestRequest;
 
@@ -1830,5 +1864,24 @@ mod tests {
         assert!(!accept_header_includes_html("application/x-text/html-fake"));
         assert!(!accept_header_includes_html("application/json"));
         assert!(!accept_header_includes_html("*/*"));
+    }
+
+    // An unknown `SsrMode` must serve a 500 rather than panicking the worker
+    // via `unreachable!()`. `SsrMode::Async` stands in for "some variant the
+    // dedicated arms don't handle" — the route the helper builds is what a
+    // future variant would fall through to.
+    #[actix_web::test]
+    async fn unsupported_ssr_mode_serves_500() {
+        use actix_web::{App, http::StatusCode, test};
+
+        let app = test::init_service(App::new().route(
+            "/",
+            unsupported_ssr_mode_route(Method::Get, &SsrMode::Async),
+        ))
+        .await;
+
+        let req = test::TestRequest::get().uri("/").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -230,12 +230,28 @@ pub fn redirect(path: &str) {
     if let (Some(req), Some(res)) =
         (use_context::<Request>(), use_context::<ResponseOptions>())
     {
+        // The target string ultimately derives from user input (e.g. a `next`
+        // URL parameter or a form field), so it may contain bytes that are
+        // illegal in a header value (CR, LF, NUL, ...). `HeaderValue::from_str`
+        // rejects those, and turning that recoverable error into a panic would
+        // let any client able to influence the target take down the worker
+        // handling the request. Skip the redirect instead.
+        let location = match header::HeaderValue::from_str(path) {
+            Ok(location) => location,
+            Err(_) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                #[cfg(not(feature = "tracing"))]
+                eprintln!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                return;
+            }
+        };
         // insert the Location header in any case
-        res.insert_header(
-            header::LOCATION,
-            header::HeaderValue::from_str(path)
-                .expect("Failed to create HeaderValue"),
-        );
+        res.insert_header(header::LOCATION, location);
 
         let accepts_html = req
             .headers()
@@ -1675,4 +1691,56 @@ where
             .map_err(|e| ServerFnErrorErr::ServerError(e.to_string()))
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    // Targeted imports rather than `use super::*`: the crate root glob-imports
+    // `actix_web::test`, which would shadow the `#[test]` attribute macro.
+    use super::{
+        LOCATION, OrPoisoned, Owner, Request, ResponseOptions, provide_context,
+        redirect,
+    };
+    use actix_web::test::TestRequest;
+
+    // A redirect target containing CR/LF cannot be encoded as a header value.
+    // `redirect` must skip the redirect instead of panicking, otherwise any
+    // client able to influence the target (e.g. a `next` parameter) can crash
+    // the request handler.
+    #[test]
+    fn redirect_ignores_invalid_header_value() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let http_req = TestRequest::default().to_http_request();
+            provide_context(Request::new(&http_req));
+            provide_context(res.clone());
+
+            redirect("/login\r\nSet-Cookie: pwned=1");
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert!(parts.headers.get(LOCATION).is_none());
+        assert!(parts.status.is_none());
+    }
+
+    // A well-formed target is still applied.
+    #[test]
+    fn redirect_sets_location_for_valid_target() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let http_req = TestRequest::default().to_http_request();
+            provide_context(Request::new(&http_req));
+            provide_context(res.clone());
+
+            redirect("/dashboard");
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert_eq!(
+            parts.headers.get(LOCATION).map(|v| v.as_bytes()),
+            Some(&b"/dashboard"[..])
+        );
+    }
 }

--- a/integrations/actix/tests/extract_routes.rs
+++ b/integrations/actix/tests/extract_routes.rs
@@ -1,153 +1,40 @@
-// TODO these tests relate to trailing-slash logic, which is still TBD for 0.7
+//! Coverage for converting `leptos_router` paths into Actix path syntax via
+//! `generate_route_list` / `to_actix_path`.
+//!
+//! Trailing-slash normalization is still undecided, so these cases avoid
+//! trailing slashes and exercise only the stable conversions: static segments
+//! pass through, `:param` becomes `{param}`, and `*splat` becomes
+//! `{splat:.*}`.
 
-// use leptos::*;
-// use leptos_actix::generate_route_list;
-// use leptos_router::{
-//     components::{Route, Router, Routes},
-//     path,
-// };
-//
-// #[component]
-// fn DefaultApp() -> impl IntoView {
-//     let view = || view! { "" };
-//     view! {
-//         <Router>
-//             <Routes>
-//                 <Route path=path!("/foo") view/>
-//                 <Route path=path!("/bar/") view/>
-//                 <Route path=path!("/baz/:id") view/>
-//                 <Route path=path!("/baz/:name/") view/>
-//                 <Route path=path!("/baz/*any") view/>
-//             </Routes>
-//         </Router>
-//     }
-// }
-//
-// #[test]
-// fn test_default_app() {
-//     let routes = generate_route_list(DefaultApp);
-//
-//     // We still have access to the original (albeit normalized) Leptos paths:
-//     assert_same(
-//         &routes,
-//         |r| r.leptos_path(),
-//         &["/bar", "/baz/*any", "/baz/:id", "/baz/:name", "/foo"],
-//     );
-//
-//     // ... But leptos-actix has also reformatted "paths" to work for Actix.
-//     assert_same(
-//         &routes,
-//         |r| r.path(),
-//         &["/bar", "/baz/{id}", "/baz/{name}", "/baz/{tail:.*}", "/foo"],
-//     );
-// }
-//
-// #[component]
-// fn ExactApp() -> impl IntoView {
-//     let view = || view! { "" };
-//     //let trailing_slash = TrailingSlash::Exact;
-//     view! {
-//         <Router>
-//             <Routes>
-//                 <Route path=path!("/foo") view/>
-//                 <Route path=path!("/bar/") view/>
-//                 <Route path=path!("/baz/:id") view/>
-//                 <Route path=path!("/baz/:name/") view/>
-//                 <Route path=path!("/baz/*any") view/>
-//             </Routes>
-//         </Router>
-//     }
-// }
-//
-// #[test]
-// fn test_exact_app() {
-//     let routes = generate_route_list(ExactApp);
-//
-//     // In Exact mode, the Leptos paths no longer have their trailing slashes stripped:
-//     assert_same(
-//         &routes,
-//         |r| r.leptos_path(),
-//         &["/bar/", "/baz/*any", "/baz/:id", "/baz/:name/", "/foo"],
-//     );
-//
-//     // Actix paths also have trailing slashes as a result:
-//     assert_same(
-//         &routes,
-//         |r| r.path(),
-//         &[
-//             "/bar/",
-//             "/baz/{id}",
-//             "/baz/{name}/",
-//             "/baz/{tail:.*}",
-//             "/foo",
-//         ],
-//     );
-// }
-//
-// #[component]
-// fn RedirectApp() -> impl IntoView {
-//     let view = || view! { "" };
-//     //let trailing_slash = TrailingSlash::Redirect;
-//     view! {
-//         <Router>
-//             <Routes>
-//                 <Route path=path!("/foo") view/>
-//                 <Route path=path!("/bar/") view/>
-//                 <Route path=path!("/baz/:id") view/>
-//                 <Route path=path!("/baz/:name/") view/>
-//                 <Route path=path!("/baz/*any") view/>
-//             </Routes>
-//         </Router>
-//     }
-// }
-//
-// #[test]
-// fn test_redirect_app() {
-//     let routes = generate_route_list(RedirectApp);
-//
-//     assert_same(
-//         &routes,
-//         |r| r.leptos_path(),
-//         &[
-//             "/bar",
-//             "/bar/",
-//             "/baz/*any",
-//             "/baz/:id",
-//             "/baz/:id/",
-//             "/baz/:name",
-//             "/baz/:name/",
-//             "/foo",
-//             "/foo/",
-//         ],
-//     );
-//
-//     // ... But leptos-actix has also reformatted "paths" to work for Actix.
-//     assert_same(
-//         &routes,
-//         |r| r.path(),
-//         &[
-//             "/bar",
-//             "/bar/",
-//             "/baz/{id}",
-//             "/baz/{id}/",
-//             "/baz/{name}",
-//             "/baz/{name}/",
-//             "/baz/{tail:.*}",
-//             "/foo",
-//             "/foo/",
-//         ],
-//     );
-// }
-//
-// fn assert_same<'t, T, F, U>(
-//     input: &'t Vec<T>,
-//     mapper: F,
-//     expected_sorted_values: &[U],
-// ) where
-//     F: Fn(&'t T) -> U + 't,
-//     U: Ord + std::fmt::Debug,
-// {
-//     let mut values: Vec<U> = input.iter().map(mapper).collect();
-//     values.sort();
-//     assert_eq!(values, expected_sorted_values);
-// }
+use leptos::prelude::*;
+use leptos_actix::generate_route_list;
+use leptos_router::{
+    components::{Route, Router, Routes},
+    path,
+};
+
+#[component]
+fn App() -> impl IntoView {
+    view! {
+        <Router>
+            <Routes fallback=|| "not found">
+                <Route path=path!("/foo") view=|| ""/>
+                <Route path=path!("/baz/:id") view=|| ""/>
+                <Route path=path!("/baz/*any") view=|| ""/>
+            </Routes>
+        </Router>
+    }
+}
+
+#[test]
+fn converts_router_paths_to_actix_paths() {
+    let routes = generate_route_list(App);
+
+    let mut paths = routes
+        .iter()
+        .map(|r| r.path().to_string())
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    assert_eq!(paths, ["/baz/{any:.*}", "/baz/{id}", "/foo"]);
+}

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -51,6 +51,7 @@ default = [
   "tower-http/fs",
   "tower/util",
   "server_fn/axum",
+  "leptos_integration_utils/fs",
 ]
 islands-router = ["tachys/islands"]
 tracing = ["dep:tracing"]

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -22,7 +22,6 @@ leptos_meta = { workspace = true, features = ["ssr", "nonce"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_integration_utils = { workspace = true }
 lru = { workspace = true, optional = true }
-mime = { workspace = true }
 tachys = { workspace = true }
 tokio = { default-features = false, workspace = true }
 tower = { features = ["util"], workspace = true, default-features = true }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1614,6 +1614,8 @@ async fn write_static_route(
     path: &str,
     html: &str,
 ) -> Result<(), std::io::Error> {
+    use leptos_integration_utils::write_file_atomic;
+
     // Reject anything that would escape the site root before caching headers
     // or touching the filesystem.
     let Some(file_path) = static_path(options, path) else {
@@ -1631,12 +1633,9 @@ async fn write_static_route(
     }
 
     let path = Path::new(&file_path);
-    if let Some(path) = path.parent() {
-        tokio::fs::create_dir_all(path).await?;
-    }
-    tokio::fs::write(path, &html).await?;
-
-    Ok(())
+    // Write atomically: a crash mid-write must never leave a truncated or empty
+    // file that is then served (because `try_exists` reports it as present).
+    write_file_atomic(path, html.as_bytes()).await
 }
 
 #[cfg(feature = "default")]

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -60,6 +60,7 @@ use leptos::{
 };
 use leptos_integration_utils::{
     BoxedFnOnce, ExtendResponse, PinnedFuture, PinnedStream,
+    accept_header_includes_html,
 };
 use leptos_meta::ServerMetaContext;
 #[cfg(feature = "default")]
@@ -179,33 +180,6 @@ pub(crate) fn extend_response<ResBody>(
     }
     res.headers_mut()
         .extend(std::mem::take(&mut res_options.headers));
-}
-
-/// Returns whether an `Accept` header value indicates the client will accept
-/// an HTML response — i.e. an ordinary browser navigation or a plain `<form>`
-/// submission, as opposed to a programmatic client expecting structured data.
-///
-/// Unlike a naive `contains("text/html")` check, each comma-separated media
-/// range is parsed with the [`mime`] crate and an explicit `q=0` refusal is
-/// honoured. So `text/html;q=0` (the client refusing HTML) and
-/// `application/x-text/html-fake` (an unrelated, unparseable range) are both
-/// correctly treated as *not* accepting HTML.
-fn accept_header_includes_html(accept: &str) -> bool {
-    accept.split(',').any(|range| {
-        let Ok(media) = range.trim().parse::<mime::Mime>() else {
-            return false;
-        };
-        if media.type_() != mime::TEXT || media.subtype() != mime::HTML {
-            return false;
-        }
-        // honour an explicit `q=0`, which means the client refuses HTML
-        match media.get_param("q") {
-            Some(q) => {
-                q.as_str().parse::<f32>().map(|w| w > 0.0).unwrap_or(true)
-            }
-            None => true,
-        }
-    })
 }
 
 /// A generic `500 Internal Server Error` response with no body details, used
@@ -2776,34 +2750,6 @@ mod tests {
 
         let res = handler(State(options), req).await;
         assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    #[test]
-    fn accept_header_plain_navigation_is_html() {
-        // typical browser navigation
-        assert!(accept_header_includes_html(
-            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-        ));
-        assert!(accept_header_includes_html("text/html"));
-        assert!(accept_header_includes_html("text/html; charset=utf-8"));
-        assert!(accept_header_includes_html("text/html;q=0.1"));
-    }
-
-    #[test]
-    fn accept_header_explicit_refusal_is_not_html() {
-        // `q=0` means the client explicitly does not want HTML
-        assert!(!accept_header_includes_html(
-            "text/html;q=0, application/json"
-        ));
-        assert!(!accept_header_includes_html("text/html;q=0.0"));
-    }
-
-    #[test]
-    fn accept_header_substring_is_not_html() {
-        // these contain the literal substring "text/html" but are not it
-        assert!(!accept_header_includes_html("application/x-text/html-fake"));
-        assert!(!accept_header_includes_html("application/json"));
-        assert!(!accept_header_includes_html("*/*"));
     }
 
     // The per-path header cache must never grow without bound: serving many

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -15,6 +15,7 @@ leptos = { workspace = true, features = ["nonce"] }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }
+mime = { workspace = true }
 reactive_graph = { workspace = true, features = ["sandboxed-arenas"] }
 
 [package.metadata.docs.rs]

--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -17,6 +17,17 @@ leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }
 mime = { workspace = true }
 reactive_graph = { workspace = true, features = ["sandboxed-arenas"] }
+tokio = { workspace = true, default-features = false, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, default-features = false, features = [
+  "macros",
+  "rt",
+  "fs",
+] }
+
+[features]
+fs = ["dep:tokio", "tokio/fs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -243,6 +243,33 @@ where
     (owner, stream)
 }
 
+/// Returns whether an `Accept` header value indicates the client will accept
+/// an HTML response — i.e. an ordinary browser navigation or a plain `<form>`
+/// submission, as opposed to a programmatic client expecting structured data.
+///
+/// Unlike a naive `contains("text/html")` check, each comma-separated media
+/// range is parsed with the [`mime`] crate and an explicit `q=0` refusal is
+/// honoured. So `text/html;q=0` (the client refusing HTML) and
+/// `application/x-text/html-fake` (an unrelated, unparseable range) are both
+/// correctly treated as *not* accepting HTML.
+pub fn accept_header_includes_html(accept: &str) -> bool {
+    accept.split(',').any(|range| {
+        let Ok(media) = range.trim().parse::<mime::Mime>() else {
+            return false;
+        };
+        if media.type_() != mime::TEXT || media.subtype() != mime::HTML {
+            return false;
+        }
+        // honour an explicit `q=0`, which means the client refuses HTML
+        match media.get_param("q") {
+            Some(q) => {
+                q.as_str().parse::<f32>().map(|w| w > 0.0).unwrap_or(true)
+            }
+            None => true,
+        }
+    })
+}
+
 /// Returns `true` if `path` could escape the site root once interpolated into
 /// an on-disk path.
 ///
@@ -323,5 +350,33 @@ mod tests {
             static_file_path(&options, "/a/./b"),
             Some("/var/www/site/static/a/./b.html".into())
         );
+    }
+
+    #[test]
+    fn accept_header_plain_navigation_is_html() {
+        // typical browser navigation
+        assert!(accept_header_includes_html(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        ));
+        assert!(accept_header_includes_html("text/html"));
+        assert!(accept_header_includes_html("text/html; charset=utf-8"));
+        assert!(accept_header_includes_html("text/html;q=0.1"));
+    }
+
+    #[test]
+    fn accept_header_explicit_refusal_is_not_html() {
+        // `q=0` means the client explicitly does not want HTML
+        assert!(!accept_header_includes_html(
+            "text/html;q=0, application/json"
+        ));
+        assert!(!accept_header_includes_html("text/html;q=0.0"));
+    }
+
+    #[test]
+    fn accept_header_substring_is_not_html() {
+        // these contain the literal substring "text/html" but are not it
+        assert!(!accept_header_includes_html("application/x-text/html-fake"));
+        assert!(!accept_header_includes_html("application/json"));
+        assert!(!accept_header_includes_html("*/*"));
     }
 }

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -307,6 +307,50 @@ pub fn static_file_path(options: &LeptosOptions, path: &str) -> Option<String> {
     Some(format!("{}/{}.html", options.site_root, path))
 }
 
+/// Writes `contents` to `path` atomically: the file appears with its full
+/// contents or not at all.
+///
+/// The bytes are written to a uniquely-named temp file in the same directory,
+/// which is then renamed over the target. `rename` is atomic on POSIX
+/// filesystems (and replaces the destination on Windows), so a concurrent
+/// reader or a crash never observes a half-written or truncated file. Writing
+/// in place (e.g. `tokio::fs::write`) truncates the target up front, which would
+/// leave an empty file visible (and served with `try_exists == true`) if the
+/// process died mid-write.
+///
+/// Missing parent directories are created first. If the rename fails, the temp
+/// file is removed on a best-effort basis so failures don't leave stray temp
+/// files accumulating in the site root.
+#[cfg(feature = "fs")]
+pub async fn write_file_atomic(
+    path: &std::path::Path,
+    contents: &[u8],
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let tmp_path = {
+        static COUNTER: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut file_name = path
+            .file_name()
+            .map(|name| name.to_os_string())
+            .unwrap_or_default();
+        file_name.push(format!(".tmp.{}.{n}", std::process::id()));
+        path.with_file_name(file_name)
+    };
+
+    tokio::fs::write(&tmp_path, contents).await?;
+    if let Err(err) = tokio::fs::rename(&tmp_path, path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(err);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,5 +422,39 @@ mod tests {
         assert!(!accept_header_includes_html("application/x-text/html-fake"));
         assert!(!accept_header_includes_html("application/json"));
         assert!(!accept_header_includes_html("*/*"));
+    }
+
+    // `write_file_atomic` must create the file (and any missing parents) with
+    // its full contents and leave no temp file behind, so a crash mid-write can
+    // never expose a truncated or empty file to a reader.
+    #[cfg(feature = "fs")]
+    #[tokio::test]
+    async fn write_file_atomic_writes_full_contents_without_leftovers() {
+        let dir = std::env::temp_dir().join(format!(
+            "leptos_integration_utils_atomic_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        // a missing parent directory is created on the way to the target
+        let target = dir.join("nested").join("page.html");
+        let contents = b"<html><body>hello</body></html>";
+        write_file_atomic(&target, contents).await.unwrap();
+
+        // the target was written in full
+        assert_eq!(std::fs::read(&target).unwrap(), contents);
+
+        // no temp file was left behind alongside it
+        let leftovers = std::fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .count();
+        assert_eq!(leftovers, 0);
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

These fixes  are mostly identical to the Axum counterpart.

## Changes

### Panic fixes (worker DoS)
- **`redirect()`** — no longer `expect()`s on `HeaderValue::from_str`. User-influenced redirect targets containing CR/LF/NUL (header injection attempts) returned an `InvalidHeaderValue` that panicked the worker; now logs a warning and skips the redirect.
- **`set_default_content_type()`** — replaces `from_str(..).unwrap()` with a match; an invalid `&str` (e.g. containing a NUL) now skips the header instead of crashing.
- **Unsupported `SsrMode`** — both `LeptosRoutes` impls ended their match with `_ => unreachable!()`. A future enum variant would compile fine then panic at runtime; replaced with a helper that logs and serves `500`.

### Correctness fixes
- **Accept header parsing** — `redirect()` and `handle_server_fns_with_context` used `accept.contains("text/html")`. Now parses media ranges with the `mime` crate, so `text/html;q=0` (explicit refusal) and substring false-positives like `application/x-text/html-fake` are handled correctly.
- **HEAD requests** — registered HEAD handlers returned a bare `200 OK` (wrong status/headers per RFC 9110), and the `ServiceConfig` impl didn't register HEAD at all. HEAD now routes to the GET render handler via `guard::Get().or(guard::Head())`, mirroring GET's real status/headers across both mount paths.

### Static route fixes
- **TOCTOU error leak** — a failed `NamedFile::open` after `try_exists` rendered the raw `io::Error` into the 500 body, disclosing server paths. Now logs server-side and returns a generic 500.
- **Unbounded cache** — `STATIC_HEADERS` (a `HashMap`) grew one entry per distinct path forever. Replaced with an `lru::LruCache` (default 1024, override via `LEPTOS_STATIC_HEADERS_CACHE_SIZE`).
- **Atomic writes** — `tokio::fs::write` truncates then writes; a crash mid-write left empty/partial files that were later served. Now writes to a temp file and atomically `rename`s it over the target.
