### PR TITLE
Fix `any_spawner` correctness bugs

### DIFF
--- a/any_spawner/Cargo.toml
+++ b/any_spawner/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { default-features = false, features = [
 ] , workspace = true }
 wasm-bindgen-test = { workspace = true, default-features = true }
 serial_test = { workspace = true, default-features = true }
+tracing = { workspace = true, default-features = true }
 
 [features]
 async-executor = ["dep:async-executor"]

--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -420,6 +420,16 @@ impl Executor {
             > = const { OnceLock::new() };
         };
 
+        // Reject re-initialization up front, before allocating the box or
+        // touching the instance slot. `LOCAL_EXECUTOR_FNS` is the authoritative
+        // per-thread "already configured" flag and is the *last* slot written
+        // on the success path, so checking it here guarantees we never leave the
+        // instance slot populated while reporting failure. The rejected executor
+        // is dropped when this function returns.
+        if LOCAL_EXECUTOR_FNS.with(|local| local.get().is_some()) {
+            return Err(ExecutorError::AlreadySet);
+        }
+
         CUSTOM_EXECUTOR_INSTANCE.with(|this| {
             this.set(Box::new(custom_executor))
                 .map_err(|_| ExecutorError::AlreadySet)

--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -372,31 +372,42 @@ impl Executor {
             Box<dyn CustomExecutor + Send + Sync>,
         > = OnceLock::new();
 
-        CUSTOM_EXECUTOR_INSTANCE
-            .set(Box::new(custom_executor))
-            .map_err(|_| ExecutorError::AlreadySet)?;
-
-        // Now set the ExecutorFns using the stored instance
         let executor_impl = ExecutorFns {
-            spawn: |fut| {
-                // Unwrap is safe because we just set it successfully or returned Err.
-                CUSTOM_EXECUTOR_INSTANCE.get().unwrap().spawn(fut);
+            spawn: |fut| match CUSTOM_EXECUTOR_INSTANCE.get() {
+                Some(executor) => executor.spawn(fut),
+                // Only reachable in the tiny window between winning the global
+                // slot and storing the instance below; treat it the same as
+                // spawning before any executor was initialized.
+                None => handle_uninitialized_spawn(fut),
             },
-            spawn_local: |fut| {
-                CUSTOM_EXECUTOR_INSTANCE.get().unwrap().spawn_local(fut);
+            spawn_local: |fut| match CUSTOM_EXECUTOR_INSTANCE.get() {
+                Some(executor) => executor.spawn_local(fut),
+                None => handle_uninitialized_spawn_local(fut),
             },
             poll_local: || {
-                CUSTOM_EXECUTOR_INSTANCE.get().unwrap().poll_local();
+                if let Some(executor) = CUSTOM_EXECUTOR_INSTANCE.get() {
+                    executor.poll_local();
+                }
             },
         };
 
+        // Claim the global slot *first*. If another initializer wins the race
+        // (or one already ran), we return here without ever storing
+        // `custom_executor`, so it is dropped on return instead of being leaked
+        // into static memory for the life of the process.
         EXECUTOR_FNS
             .set(executor_impl)
-            .map_err(|_| ExecutorError::AlreadySet)
-        // If setting EXECUTOR_FNS fails (extremely unlikely race if called *concurrently*
-        // with another init_* after CUSTOM_EXECUTOR_INSTANCE was set), we technically
-        // leave CUSTOM_EXECUTOR_INSTANCE set but EXECUTOR_FNS not. This is an edge case,
-        // but the primary race condition is solved.
+            .map_err(|_| ExecutorError::AlreadySet)?;
+
+        // We are the unique winner of the global slot, so the instance slot is
+        // guaranteed to be empty; this store cannot fail.
+        let _ = CUSTOM_EXECUTOR_INSTANCE.set(Box::new(custom_executor));
+        debug_assert!(
+            CUSTOM_EXECUTOR_INSTANCE.get().is_some(),
+            "custom executor instance must be stored after winning \
+             EXECUTOR_FNS"
+        );
+        Ok(())
     }
 
     /// Sets a custom executor *for the current thread only*.

--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -169,7 +169,19 @@ impl Executor {
             _ = tx.send(());
         });
 
-        _ = rx.await;
+        if rx.await.is_err() {
+            // The task spawned to signal the next tick was dropped before it
+            // ran, so the executor never advanced. Returning here would make the
+            // caller believe a tick elapsed when none did; surface it instead of
+            // silently synchronizing on nothing.
+            panic!(
+                "Executor::tick() could not synchronize with the executor: \
+                 the task spawned to signal the next tick was dropped before \
+                 it ran. Either no global executor was initialized, or the \
+                 configured executor drops spawned futures instead of running \
+                 them."
+            );
+        }
     }
 
     /// Polls the global async executor.

--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -77,7 +77,11 @@ fn current_executor_fns() -> Option<ExecutorFns> {
 #[inline(never)]
 fn no_op_poll() {}
 
-#[cfg(all(not(feature = "wasm-bindgen"), not(debug_assertions)))]
+#[cfg(all(
+    not(feature = "wasm-bindgen"),
+    not(debug_assertions),
+    not(feature = "tracing")
+))]
 #[cold]
 #[inline(never)]
 fn no_op_spawn(_: PinnedFuture<()>) {
@@ -99,7 +103,7 @@ fn no_op_spawn(_: PinnedFuture<()>) {
     );
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(all(not(debug_assertions), not(feature = "tracing")))]
 #[cold]
 #[inline(never)]
 fn no_op_spawn_local(_: PinnedLocalFuture<()>) {
@@ -514,26 +518,31 @@ fn test_object_safety(_: Box<dyn CustomExecutor + Send + Sync>) {} // Added Send
 #[inline(never)]
 #[track_caller]
 fn handle_uninitialized_spawn(_fut: PinnedFuture<()>) {
-    let caller = std::panic::Location::caller();
-    #[cfg(all(debug_assertions, feature = "tracing"))]
+    // When tracing is enabled, emit a diagnostic and drop the task. This now
+    // fires in release builds too, where the log was previously cfg-gated out
+    // and the task was dropped with no diagnostic at all.
+    #[cfg(feature = "tracing")]
     {
+        let caller = std::panic::Location::caller();
         tracing::error!(
             target: "any_spawner",
-            spawn_caller=%caller,
-            "Executor::spawn called before a global executor was initialized. Task dropped."
+            spawn_caller = %caller,
+            "Executor::spawn called before a global executor was initialized. \
+             Task dropped."
         );
-        // Drop the future implicitly after logging
         drop(_fut);
     }
-    #[cfg(all(debug_assertions, not(feature = "tracing")))]
+    // Without tracing, fail loudly in debug builds.
+    #[cfg(all(not(feature = "tracing"), debug_assertions))]
     {
+        let caller = std::panic::Location::caller();
         panic!(
             "At {caller}, tried to spawn a Future with Executor::spawn() \
              before a global executor was initialized."
         );
     }
-    // In release builds (without tracing), call the specific no-op function.
-    #[cfg(not(debug_assertions))]
+    // Without tracing in release builds, fall back to the no-op function.
+    #[cfg(all(not(feature = "tracing"), not(debug_assertions)))]
     {
         no_op_spawn(_fut);
     }
@@ -544,26 +553,31 @@ fn handle_uninitialized_spawn(_fut: PinnedFuture<()>) {
 #[inline(never)]
 #[track_caller]
 fn handle_uninitialized_spawn_local(_fut: PinnedLocalFuture<()>) {
-    let caller = std::panic::Location::caller();
-    #[cfg(all(debug_assertions, feature = "tracing"))]
+    // When tracing is enabled, emit a diagnostic and drop the task. This now
+    // fires in release builds too, where the log was previously cfg-gated out.
+    #[cfg(feature = "tracing")]
     {
+        let caller = std::panic::Location::caller();
         tracing::error!(
             target: "any_spawner",
-            spawn_caller=%caller,
-            "Executor::spawn_local called before a global executor was initialized. \
-            Task likely dropped or panicked."
+            spawn_caller = %caller,
+            "Executor::spawn_local called before a global executor was \
+             initialized. Task dropped."
         );
-        // Fall through to panic or no-op depending on build/target
+        drop(_fut);
     }
-    #[cfg(all(debug_assertions, not(feature = "tracing")))]
+    // Without tracing, fail loudly in debug builds.
+    #[cfg(all(not(feature = "tracing"), debug_assertions))]
     {
+        let caller = std::panic::Location::caller();
         panic!(
             "At {caller}, tried to spawn a Future with \
              Executor::spawn_local() before a global executor was initialized."
         );
     }
-    // In release builds (without tracing), call the specific no-op function (which usually panics).
-    #[cfg(not(debug_assertions))]
+    // Without tracing in release builds, fall back to the no-op function
+    // (which panics).
+    #[cfg(all(not(feature = "tracing"), not(debug_assertions)))]
     {
         no_op_spawn_local(_fut);
     }

--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -53,6 +53,24 @@ struct ExecutorFns {
 // Use a single OnceLock to ensure atomic initialization of all functions.
 static EXECUTOR_FNS: OnceLock<ExecutorFns> = OnceLock::new();
 
+thread_local! {
+    // Per-thread executor override installed by
+    // `Executor::init_local_custom_executor`. When set, it takes precedence
+    // over the global `EXECUTOR_FNS` for spawns made *on this thread only*,
+    // leaving other threads and the global state untouched.
+    static LOCAL_EXECUTOR_FNS: OnceLock<ExecutorFns> = const { OnceLock::new() };
+}
+
+// Resolves the executor functions to use for the current thread: a thread-local
+// executor installed via `init_local_custom_executor` takes precedence;
+// otherwise the global executor is used. Returns `None` if neither is set.
+#[inline]
+fn current_executor_fns() -> Option<ExecutorFns> {
+    LOCAL_EXECUTOR_FNS
+        .with(|local| local.get().copied())
+        .or_else(|| EXECUTOR_FNS.get().copied())
+}
+
 // No-op functions to use when an executor doesn't support a specific operation.
 #[cfg(any(feature = "tokio", feature = "wasm-bindgen", feature = "glib"))]
 #[cold]
@@ -112,10 +130,10 @@ impl Executor {
     pub fn spawn(fut: impl Future<Output = ()> + Send + 'static) {
         let pinned_fut = Box::pin(fut);
 
-        if let Some(fns) = EXECUTOR_FNS.get() {
+        if let Some(fns) = current_executor_fns() {
             (fns.spawn)(pinned_fut)
         } else {
-            // No global executor set.
+            // No executor set for this thread or globally.
             handle_uninitialized_spawn(pinned_fut);
         }
     }
@@ -129,10 +147,10 @@ impl Executor {
     pub fn spawn_local(fut: impl Future<Output = ()> + 'static) {
         let pinned_fut = Box::pin(fut);
 
-        if let Some(fns) = EXECUTOR_FNS.get() {
+        if let Some(fns) = current_executor_fns() {
             (fns.spawn_local)(pinned_fut)
         } else {
-            // No global executor set.
+            // No executor set for this thread or globally.
             handle_uninitialized_spawn_local(pinned_fut);
         }
     }
@@ -160,7 +178,7 @@ impl Executor {
     /// Does nothing if the global executor does not support polling.
     #[inline(always)]
     pub fn poll_local() {
-        if let Some(fns) = EXECUTOR_FNS.get() {
+        if let Some(fns) = current_executor_fns() {
             (fns.poll_local)()
         }
         // If not initialized or doesn't support polling, do nothing gracefully.
@@ -399,7 +417,7 @@ impl Executor {
         thread_local! {
             static CUSTOM_EXECUTOR_INSTANCE: OnceLock<
                 Box<dyn CustomExecutor>,
-            > = OnceLock::new();
+            > = const { OnceLock::new() };
         };
 
         CUSTOM_EXECUTOR_INSTANCE.with(|this| {
@@ -410,7 +428,9 @@ impl Executor {
         // Now set the ExecutorFns using the stored instance
         let executor_impl = ExecutorFns {
             spawn: |fut| {
-                // Unwrap is safe because we just set it successfully or returned Err.
+                // Unwrap is safe: the dispatch table below is only installed
+                // after the thread-local instance has been set, and these
+                // function pointers read the instance on the same thread.
                 CUSTOM_EXECUTOR_INSTANCE
                     .with(|this| this.get().unwrap().spawn(fut));
             },
@@ -424,8 +444,11 @@ impl Executor {
             },
         };
 
-        EXECUTOR_FNS
-            .set(executor_impl)
+        // Install the dispatch table for *this thread only*. The global
+        // `EXECUTOR_FNS` is intentionally left untouched so that other threads
+        // continue to use the global executor and `init_*` remains available.
+        LOCAL_EXECUTOR_FNS
+            .with(|local| local.set(executor_impl))
             .map_err(|_| ExecutorError::AlreadySet)
     }
 }

--- a/any_spawner/tests/already_set_error.rs
+++ b/any_spawner/tests/already_set_error.rs
@@ -18,7 +18,14 @@ fn test_already_set_error() {
     let result = Executor::init_custom_executor(SimpleExecutor);
     assert!(matches!(result, Err(ExecutorError::AlreadySet)));
 
-    // First local initialization should fail
+    // A thread-local override is independent of the global executor, so the
+    // first local initialization on this thread succeeds even though a global
+    // executor has already been set.
+    let result = Executor::init_local_custom_executor(SimpleExecutor);
+    assert!(result.is_ok());
+
+    // A second local initialization on the same thread fails, since a local
+    // executor has already been set for this thread.
     let result = Executor::init_local_custom_executor(SimpleExecutor);
     assert!(matches!(result, Err(ExecutorError::AlreadySet)));
 }

--- a/any_spawner/tests/custom_executor_conflict_no_leak.rs
+++ b/any_spawner/tests/custom_executor_conflict_no_leak.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "tokio")]
+
+use any_spawner::{
+    CustomExecutor, Executor, ExecutorError, PinnedFuture, PinnedLocalFuture,
+};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+// Flips a flag when dropped, so we can detect whether the executor it is
+// embedded in was dropped or leaked into static memory.
+struct DropProbe(Arc<AtomicBool>);
+
+impl Drop for DropProbe {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+struct ProbeExecutor(#[allow(dead_code)] DropProbe);
+
+impl CustomExecutor for ProbeExecutor {
+    fn spawn(&self, _: PinnedFuture<()>) {}
+    fn spawn_local(&self, _: PinnedLocalFuture<()>) {}
+    fn poll_local(&self) {}
+}
+
+// When the global executor slot is already claimed (here by tokio, which does
+// not touch the custom-executor instance slot), `init_custom_executor` must
+// fail *without* storing the rejected executor in the static instance slot —
+// otherwise that executor is leaked for the life of the process.
+#[test]
+fn rejected_custom_executor_is_not_leaked() {
+    Executor::init_tokio().expect("init tokio");
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    let result = Executor::init_custom_executor(ProbeExecutor(DropProbe(
+        dropped.clone(),
+    )));
+
+    assert!(matches!(result, Err(ExecutorError::AlreadySet)));
+    assert!(
+        dropped.load(Ordering::SeqCst),
+        "rejected custom executor must be dropped, not leaked into static \
+         memory"
+    );
+}

--- a/any_spawner/tests/executor_tick_dropped.rs
+++ b/any_spawner/tests/executor_tick_dropped.rs
@@ -1,0 +1,20 @@
+use any_spawner::{CustomExecutor, Executor, PinnedFuture, PinnedLocalFuture};
+
+// An executor that drops every future it is handed instead of running it.
+struct DropAll;
+
+impl CustomExecutor for DropAll {
+    fn spawn(&self, _fut: PinnedFuture<()>) {}
+    fn spawn_local(&self, _fut: PinnedLocalFuture<()>) {}
+    fn poll_local(&self) {}
+}
+
+// If the executor drops spawned futures, the tick-synchronization task never
+// runs and `tick()` can never observe an executor cycle. It must surface this
+// loudly instead of returning as though a tick had elapsed.
+#[test]
+#[should_panic(expected = "could not synchronize with the executor")]
+fn tick_panics_when_sync_task_is_dropped() {
+    Executor::init_custom_executor(DropAll).expect("init");
+    futures::executor::block_on(Executor::tick());
+}

--- a/any_spawner/tests/local_custom_executor.rs
+++ b/any_spawner/tests/local_custom_executor.rs
@@ -1,54 +1,72 @@
-use any_spawner::Executor;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use any_spawner::{CustomExecutor, Executor, PinnedFuture, PinnedLocalFuture};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    thread,
 };
 
+// A custom executor that counts how many futures it is handed and runs them to
+// completion. The same type is used both as the global executor and as a
+// thread-local override so we can observe which one a spawn was routed to.
+struct CountingExecutor {
+    count: Arc<AtomicUsize>,
+}
+
+impl CustomExecutor for CountingExecutor {
+    fn spawn(&self, fut: PinnedFuture<()>) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        futures::executor::block_on(fut);
+    }
+
+    fn spawn_local(&self, fut: PinnedLocalFuture<()>) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        futures::executor::block_on(fut);
+    }
+
+    fn poll_local(&self) {}
+}
+
+// Exercises the documented contract of `init_local_custom_executor`: it
+// overrides the executor for spawns made *on the current thread only*, without
+// affecting other threads or the global executor.
 #[test]
-fn test_local_custom_executor() {
-    // Define a thread-local custom executor
-    struct LocalTestExecutor {
-        spawn_called: Arc<AtomicBool>,
-        spawn_local_called: Arc<AtomicBool>,
-    }
+fn local_executor_overrides_global_only_on_its_thread() {
+    let global_count = Arc::new(AtomicUsize::new(0));
+    let local_count = Arc::new(AtomicUsize::new(0));
 
-    impl any_spawner::CustomExecutor for LocalTestExecutor {
-        fn spawn(&self, fut: any_spawner::PinnedFuture<()>) {
-            self.spawn_called.store(true, Ordering::SeqCst);
-            futures::executor::block_on(fut);
-        }
+    // Global executor used by every thread that has no local override.
+    Executor::init_custom_executor(CountingExecutor {
+        count: global_count.clone(),
+    })
+    .expect("global executor should initialize");
 
-        fn spawn_local(&self, fut: any_spawner::PinnedLocalFuture<()>) {
-            self.spawn_local_called.store(true, Ordering::SeqCst);
-            futures::executor::block_on(fut);
-        }
+    // Thread-local override for the current thread only. This must succeed even
+    // though a global executor is already set, because the two are independent.
+    Executor::init_local_custom_executor(CountingExecutor {
+        count: local_count.clone(),
+    })
+    .expect("local override should initialize");
 
-        fn poll_local(&self) {
-            // No-op for this test
-        }
-    }
+    // On this thread, both spawn and spawn_local route to the LOCAL executor.
+    Executor::spawn(async {});
+    Executor::spawn_local(async {});
+    assert_eq!(local_count.load(Ordering::SeqCst), 2);
+    assert_eq!(global_count.load(Ordering::SeqCst), 0);
 
-    let local_spawn_called = Arc::new(AtomicBool::new(false));
-    let local_spawn_local_called = Arc::new(AtomicBool::new(false));
+    // On another thread (no local override) a spawn must fall through to the
+    // GLOBAL executor and must NOT panic. Before the thread-local dispatch fix,
+    // the global table pointed at an unset thread-local instance and this
+    // panicked with `Option::unwrap()` on `None`.
+    let global_count_thread = global_count.clone();
+    thread::spawn(move || {
+        Executor::spawn(async {});
+        assert_eq!(global_count_thread.load(Ordering::SeqCst), 1);
+    })
+    .join()
+    .expect("spawn on a different thread must not panic");
 
-    let local_executor = LocalTestExecutor {
-        spawn_called: local_spawn_called.clone(),
-        spawn_local_called: local_spawn_local_called.clone(),
-    };
-
-    // Initialize a thread-local executor
-    Executor::init_local_custom_executor(local_executor)
-        .expect("Failed to initialize local custom executor");
-
-    // Test spawn - should use the thread-local executor
-    Executor::spawn(async {
-        // Simple task
-    });
-    assert!(local_spawn_called.load(Ordering::SeqCst));
-
-    // Test spawn_local - should use the thread-local executor
-    Executor::spawn_local(async {
-        // Simple local task
-    });
-    assert!(local_spawn_local_called.load(Ordering::SeqCst));
+    // The other thread never touched the local executor.
+    assert_eq!(local_count.load(Ordering::SeqCst), 2);
 }

--- a/any_spawner/tests/local_custom_executor_reinit.rs
+++ b/any_spawner/tests/local_custom_executor_reinit.rs
@@ -1,0 +1,50 @@
+use any_spawner::{
+    CustomExecutor, Executor, ExecutorError, PinnedFuture, PinnedLocalFuture,
+};
+use std::{cell::Cell, rc::Rc};
+
+// Tracks whether the executor it is embedded in has been dropped.
+struct DropProbe(Rc<Cell<bool>>);
+
+impl Drop for DropProbe {
+    fn drop(&mut self) {
+        self.0.set(true);
+    }
+}
+
+struct ProbeExecutor(#[allow(dead_code)] DropProbe);
+
+impl CustomExecutor for ProbeExecutor {
+    fn spawn(&self, _: PinnedFuture<()>) {}
+    fn spawn_local(&self, _: PinnedLocalFuture<()>) {}
+    fn poll_local(&self) {}
+}
+
+// A second `init_local_custom_executor` on the same thread must be rejected
+// with `AlreadySet`, and the rejected executor must be dropped rather than
+// pinned in thread-local state (which would leak it and leave the API
+// permanently unusable on the thread).
+#[test]
+fn reinitializing_local_executor_is_rejected_without_residue() {
+    struct Noop;
+    impl CustomExecutor for Noop {
+        fn spawn(&self, _: PinnedFuture<()>) {}
+        fn spawn_local(&self, _: PinnedLocalFuture<()>) {}
+        fn poll_local(&self) {}
+    }
+
+    Executor::init_local_custom_executor(Noop)
+        .expect("first local initialization should succeed");
+
+    let dropped = Rc::new(Cell::new(false));
+    let result = Executor::init_local_custom_executor(ProbeExecutor(
+        DropProbe(dropped.clone()),
+    ));
+
+    assert!(matches!(result, Err(ExecutorError::AlreadySet)));
+    assert!(
+        dropped.get(),
+        "the rejected executor must be dropped, not pinned in thread-local \
+         state"
+    );
+}

--- a/any_spawner/tests/uninitialized_spawn_tracing.rs
+++ b/any_spawner/tests/uninitialized_spawn_tracing.rs
@@ -1,0 +1,63 @@
+#![cfg(feature = "tracing")]
+
+use any_spawner::Executor;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use tracing::{
+    Event, Level, Metadata, Subscriber,
+    span::{Attributes, Id, Record},
+};
+
+// Minimal subscriber that counts ERROR-level events emitted with the
+// `any_spawner` target.
+struct CountingSubscriber(Arc<AtomicUsize>);
+
+impl Subscriber for CountingSubscriber {
+    fn enabled(&self, _: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _: &Id, _: &Record<'_>) {}
+
+    fn record_follows_from(&self, _: &Id, _: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let meta = event.metadata();
+        if meta.target() == "any_spawner" && *meta.level() == Level::ERROR {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn enter(&self, _: &Id) {}
+
+    fn exit(&self, _: &Id) {}
+}
+
+// With the `tracing` feature enabled, spawning before any executor is
+// initialized must emit an ERROR diagnostic and drop the task instead of
+// panicking. Crucially this must hold in release builds, where the diagnostic
+// was previously cfg-gated behind `debug_assertions` and never emitted.
+#[test]
+fn uninitialized_spawn_emits_tracing_diagnostic() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let subscriber = CountingSubscriber(count.clone());
+
+    tracing::subscriber::with_default(subscriber, || {
+        // No executor is initialized in this test binary.
+        Executor::spawn(async {});
+        Executor::spawn_local(async {});
+    });
+
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        2,
+        "spawn and spawn_local must each emit an ERROR diagnostic when no \
+         executor is initialized"
+    );
+}


### PR DESCRIPTION
Aggregating changes to save review and CI time. Every change has its own commit with dedicated commit's message/explanation.

## Changes

**Make `init_local_custom_executor` truly thread-local**
It was documented as a per-thread override but stored its dispatch table in the *global* `EXECUTOR_FNS` while its function pointers read a thread-local instance. This panicked on any spawn from another thread (`unwrap()` on `None`) and locked out every other `init_*`. Added a per-thread `LOCAL_EXECUTOR_FNS` table with a `current_executor_fns()` resolver that prefers the thread-local executor and falls back to the global one; the global table is now left untouched.

**Reject local re-init without residue**
`init_local_custom_executor` could return `AlreadySet` while leaving the thread-local instance populated, permanently pinning the executor and breaking retries. It now checks the per-thread "already configured" flag up front and rejects before allocating, dropping the rejected executor.

**Claim the global slot before storing a custom executor**
`init_custom_executor` stored the executor in a `'static` slot *before* claiming `EXECUTOR_FNS`; losing the race left the executor leaked in static memory forever. It now claims the global slot first and only stores the instance on success, so a rejected executor is dropped.

**Surface a dropped `tick()` instead of returning silently**
`Executor::tick()` discarded the channel result, so if the executor dropped the synchronization task it returned as though a cycle had elapsed. It now panics with a clear message when the task is dropped. Real executors are unaffected; the signature is unchanged.

**Emit the uninitialized-spawn diagnostic in release builds**
The `tracing::error!` for spawning before initialization was gated on `all(debug_assertions, feature = "tracing")`, so it never fired in release builds — `spawn` dropped silently and `spawn_local` panicked, both with no log. The diagnostic now fires in debug and release; non-tracing paths are unchanged. Also removes the unused-`caller` release warning.
