### PR TITLE
fix+perf: server `Url::origin()` returns the real request origin

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -784,9 +784,7 @@ fn provide_contexts(
     meta_context: &ServerMetaContext,
     res_options: &ResponseOptions,
 ) {
-    let path = leptos_corrected_path(&req);
-
-    provide_context(RequestUrl::new(&path));
+    provide_context(request_url(&req));
     provide_context(meta_context.clone());
     provide_context(res_options.clone());
     provide_context(req);
@@ -794,13 +792,19 @@ fn provide_contexts(
     leptos::nonce::provide_nonce();
 }
 
-fn leptos_corrected_path(req: &HttpRequest) -> String {
+fn request_url(req: &HttpRequest) -> RequestUrl {
+    // Prefix the real request origin (scheme://host) so that `Url::origin()`
+    // is correct server-side and matches the client after hydration.
+    // `connection_info` resolves the scheme and host, honoring reverse-proxy
+    // forwarding headers.
+    let conn = req.connection_info();
+    let origin = format!("{}://{}", conn.scheme(), conn.host());
     let path = req.path();
     let query = req.query_string();
     if query.is_empty() {
-        "http://leptos".to_string() + path
+        RequestUrl::new(&format!("{origin}{path}"))
     } else {
-        "http://leptos".to_string() + path + "?" + query
+        RequestUrl::new(&format!("{origin}{path}?{query}"))
     }
 }
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1030,10 +1030,18 @@ where
                     .map(|p| p.as_str())
                     .unwrap_or("/");
 
-                let full_path = format!("http://leptos.dev{path}");
+                // Prefix the real request origin (scheme://host) so that
+                // `Url::origin()` is correct server-side and matches the
+                // client after hydration; fall back to a bare path when the
+                // host is unknown. Building the `RequestUrl` here, before the
+                // request is consumed below, keeps the borrow of `req` short.
+                let request_url = match request_origin(&req) {
+                    Some(origin) => RequestUrl::new(&format!("{origin}{path}")),
+                    None => RequestUrl::new(path),
+                };
                 let (_, req_parts) = generate_request_and_parts(req);
                 provide_contexts(
-                    &full_path,
+                    request_url,
                     &meta_context,
                     req_parts,
                     res_options.clone(),
@@ -1065,17 +1073,42 @@ where
     tracing::instrument(level = "trace", fields(error), skip_all)
 )]
 fn provide_contexts(
-    path: &str,
+    request_url: RequestUrl,
     meta_context: &ServerMetaContext,
     parts: Parts,
     default_res_options: ResponseOptions,
 ) {
-    provide_context(RequestUrl::new(path));
+    provide_context(request_url);
     provide_context(meta_context.clone());
     provide_context(parts);
     provide_context(default_res_options);
     provide_server_redirect(redirect);
     leptos::nonce::provide_nonce();
+}
+
+/// Reconstructs the request's origin (`scheme://host`) for `Url::origin()`.
+///
+/// The host comes from the URI authority (absolute-form requests) or the
+/// `Host` header (the usual origin-form). The scheme comes from the URI or,
+/// behind a TLS-terminating proxy, the `X-Forwarded-Proto` header, defaulting
+/// to `http`. Returns `None` when no host is present, in which case only the
+/// path is used.
+fn request_origin(req: &Request<Body>) -> Option<String> {
+    let uri = req.uri();
+    let host = uri.authority().map(|a| a.as_str()).or_else(|| {
+        req.headers()
+            .get(header::HOST)
+            .and_then(|value| value.to_str().ok())
+    })?;
+    let scheme = uri
+        .scheme_str()
+        .or_else(|| {
+            req.headers()
+                .get("x-forwarded-proto")
+                .and_then(|value| value.to_str().ok())
+        })
+        .unwrap_or("http");
+    Some(format!("{scheme}://{host}"))
 }
 
 /// Returns an Axum [Handler](axum::handler::Handler) that listens for a `GET` request and tries
@@ -1390,7 +1423,12 @@ where
             provide_context(RequestUrl::new(""));
             let (mock_parts, _) = Request::new(Body::from("")).into_parts();
             let (mock_meta, _) = ServerMetaContext::new();
-            provide_contexts("", &mock_meta, mock_parts, Default::default());
+            provide_contexts(
+                RequestUrl::new(""),
+                &mock_meta,
+                mock_parts,
+                Default::default(),
+            );
             additional_context();
             RouteList::generate(&app_fn)
         })
@@ -1459,7 +1497,6 @@ impl StaticRouteGenerator {
         let additional_context = {
             let add_context = additional_context.clone();
             move || {
-                let full_path = format!("http://leptos.dev{path}");
                 let mock_req = Request::builder()
                     .method(Method::GET)
                     .header("Accept", "text/html")
@@ -1467,8 +1504,9 @@ impl StaticRouteGenerator {
                     .unwrap();
                 let (mock_parts, _) = mock_req.into_parts();
                 let res_options = ResponseOptions::default();
+                // `mock_parts.uri` is `/`; pass the route path explicitly.
                 provide_contexts(
-                    &full_path,
+                    RequestUrl::new(&path),
                     &meta_context,
                     mock_parts,
                     res_options,

--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -22,8 +22,6 @@ use crate::params::ParamsMap;
 pub use history::*;
 pub use server::*;
 
-pub(crate) const BASE: &str = "https://leptos.dev";
-
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Url {
     origin: String,
@@ -251,9 +249,7 @@ pub trait LocationProvider: Clone + 'static {
     /// Update the browser's history to reflect a new location.
     fn complete_navigation(&self, loc: &LocationChange);
 
-    fn parse(url: &str) -> Result<Url, Self::Error> {
-        Self::parse_with_base(url, BASE)
-    }
+    fn parse(url: &str) -> Result<Url, Self::Error>;
 
     fn parse_with_base(url: &str, base: &str) -> Result<Url, Self::Error>;
 

--- a/router/src/location/server.rs
+++ b/router/src/location/server.rs
@@ -1,4 +1,4 @@
-use super::{BASE, Url};
+use super::Url;
 use crate::params::ParamsMap;
 use std::sync::Arc;
 
@@ -25,14 +25,25 @@ impl Default for RequestUrl {
 }
 
 impl RequestUrl {
+    /// Parses the request URL into its components.
+    ///
+    /// A server-side request URL is normally a relative reference such as
+    /// `/foo?bar`, with no scheme or authority. `url::Url` is an *absolute*-URL
+    /// type and cannot decompose a relative reference without a base, so the
+    /// path and query are parsed by hand here — no base and no synthetic
+    /// authority are required. Inputs that already carry a scheme (a full
+    /// absolute URL, which some proxies forward) are delegated to `url::Url`.
     pub fn parse(&self) -> Result<Url, url::ParseError> {
-        self.parse_with_base(BASE)
+        match url::Url::parse(&self.0) {
+            Ok(url) => Ok(Self::from_absolute(url)),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                Ok(self.parse_relative())
+            }
+            Err(e) => Err(e),
+        }
     }
 
-    pub fn parse_with_base(&self, base: &str) -> Result<Url, url::ParseError> {
-        let base = url::Url::parse(base)?;
-        let url = url::Url::options().base_url(Some(&base)).parse(&self.0)?;
-
+    fn from_absolute(url: url::Url) -> Url {
         // `query_pairs()` already percent-decodes the values, so insert them
         // as-is. Going through `ParamsMap::insert`/`FromIterator` would decode
         // a second time and corrupt any literal `%xx` sequence.
@@ -41,13 +52,50 @@ impl RequestUrl {
             search_params.insert_decoded(k.into_owned(), v.into_owned());
         }
 
-        Ok(Url {
+        Url {
             origin: url.origin().unicode_serialization(),
             path: url.path().to_string(),
             search: url.query().unwrap_or_default().to_string(),
             search_params,
             hash: Default::default(),
-        })
+        }
+    }
+
+    fn parse_relative(&self) -> Url {
+        let (path, query) = match self.0.split_once('?') {
+            Some((path, query)) => (path, query),
+            None => (&*self.0, ""),
+        };
+
+        // Normalize a missing leading slash, matching the previous `url::Url`
+        // behavior where `foo/bar` became `/foo/bar` and an empty path `/`. A
+        // leading `//` is kept literally in the path rather than reinterpreted
+        // as a protocol-relative authority, so injected input cannot reach
+        // `origin`.
+        let path = if path.is_empty() {
+            String::from("/")
+        } else if path.starts_with('/') {
+            path.to_string()
+        } else {
+            format!("/{path}")
+        };
+
+        // Decode each query pair exactly once, mirroring the previous
+        // `url::Url::query_pairs` behavior (application/x-www-form-urlencoded:
+        // `+` -> space, then percent-decode). `insert_decoded` stores the
+        // already-decoded values as-is to avoid a second decode.
+        let mut search_params = ParamsMap::new();
+        for (k, v) in url::form_urlencoded::parse(query.as_bytes()) {
+            search_params.insert_decoded(k.into_owned(), v.into_owned());
+        }
+
+        Url {
+            origin: String::new(),
+            path,
+            search: query.to_string(),
+            search_params,
+            hash: Default::default(),
+        }
     }
 }
 
@@ -90,5 +138,66 @@ mod tests {
         // Base64 padding carried in a signature must not be truncated.
         let url = RequestUrl::new("/?sig=YWJj%253D%253D").parse().unwrap();
         assert_eq!(url.search_params().get("sig").unwrap(), "YWJj%3D%3D");
+    }
+
+    #[test]
+    pub fn should_keep_protocol_relative_path_literal() {
+        // A leading `//` must stay in the path and must NOT be reinterpreted as
+        // a protocol-relative authority, which would otherwise let injected
+        // input set `origin` (e.g. host `evil.com`).
+        let url = RequestUrl::new("//evil.com/foo").parse().unwrap();
+        assert_eq!(url.path(), "//evil.com/foo");
+        assert_eq!(url.origin(), "");
+    }
+
+    #[test]
+    pub fn should_default_empty_path_to_root() {
+        let url = RequestUrl::new("").parse().unwrap();
+        assert_eq!(url.path(), "/");
+    }
+
+    #[test]
+    pub fn should_leave_relative_origin_empty() {
+        let url = RequestUrl::new("/foo?bar=baz").parse().unwrap();
+        assert_eq!(url.origin(), "");
+        assert_eq!(url.path(), "/foo");
+        assert_eq!(url.search(), "bar=baz");
+    }
+
+    #[test]
+    pub fn should_decode_plus_as_space_in_query() {
+        // `application/x-www-form-urlencoded` decodes `+` to a space, matching
+        // the previous `url::Url::query_pairs` behavior. The raw `search`
+        // string is preserved verbatim.
+        let url = RequestUrl::new("/?q=a+b").parse().unwrap();
+        assert_eq!(url.search_params().get("q").unwrap(), "a b");
+        assert_eq!(url.search(), "q=a+b");
+    }
+
+    #[test]
+    pub fn should_extract_real_origin_from_absolute_request_url() {
+        // The integrations prefix the real origin, e.g. `{scheme}://{host}{path}`,
+        // so `origin()` reflects the actual request host (and matches the
+        // client after hydration), with path/query decomposed as before.
+        let url = RequestUrl::new("http://127.0.0.1:3000/foo/bar?q=1&r=2")
+            .parse()
+            .unwrap();
+        assert_eq!(url.origin(), "http://127.0.0.1:3000");
+        assert_eq!(url.path(), "/foo/bar");
+        assert_eq!(url.search(), "q=1&r=2");
+        assert_eq!(url.search_params().get("q").unwrap(), "1");
+        assert_eq!(url.search_params().get("r").unwrap(), "2");
+    }
+
+    #[test]
+    pub fn absolute_request_url_keeps_real_origin_for_protocol_relative_path() {
+        // A `//`-prefixed path carried after the real origin must stay in the
+        // path and must NOT override the authority, so injected input cannot
+        // change `origin`.
+        let url = RequestUrl::new("http://127.0.0.1:3000//evil.com/foo")
+            .parse()
+            .unwrap();
+        assert_eq!(url.origin(), "http://127.0.0.1:3000");
+        assert_eq!(url.path(), "//evil.com/foo");
     }
 }


### PR DESCRIPTION
Server-side request URLs were parsed by resolving the path against a hardcoded `BASE = "https://leptos.dev"` (a constant that `url::Url` needs because it can't decompose a relative reference without a base). That dummy host leaked into `Url::origin()`, so `use_url().origin()` returned a fake constant server-side — never the real host — and mismatched the client after hydration. This makes the server derive the **real** origin from the request and removes the hardcoded base.

### Bug fix
- `Url::origin()` (via `use_url()`) now returns the actual request origin server-side (e.g. `http://127.0.0.1:3000`) instead of the hardcoded dummy (`https://leptos.dev` on axum, `http://leptos` on actix).
- Server origin now **matches the client** origin after hydration, fixing a latent SSR/client mismatch.
- Origin is sourced correctly per integration: axum from the URI authority / `Host` header with `X-Forwarded-Proto` (defaults to `http`); actix from `connection_info` (honors reverse-proxy forwarding headers).
- A leading `//` stays literal in the path instead of being reinterpreted as a protocol-relative authority, so injected input can't override `origin`.

### Performance / cleanup
- Drops the per-request `url::Url::parse(BASE)` that ran on every render (the base was reparsed each call); a live request now does a single `url::Url` parse.
- Host-less contexts (static-site generation, route discovery) are parsed base-free — split on the first `?`, with query pairs decoded exactly once via `url::form_urlencoded::parse` (same engine as `url::Url::query_pairs`).
- Removes the now-dead `BASE` constant and the unreachable `LocationProvider::parse` default (`BrowserUrl` already overrides it with the real `window` origin); `parse` becomes a required trait method.

### Compatibility
`path` / `search` / `search_params` are unchanged for normal inputs. `origin()` changes value server-side (fake dummy → real host); like every web framework it reflects the `Host` header.

This may close #4153.