### PR TITLE
perf(any_spawner): outline non-generic spawn dispatch tail

### DIFF
--- a/any_spawner/src/lib.rs
+++ b/any_spawner/src/lib.rs
@@ -71,6 +71,35 @@ fn current_executor_fns() -> Option<ExecutorFns> {
         .or_else(|| EXECUTOR_FNS.get().copied())
 }
 
+// Non-generic dispatch tail shared by every `Executor::spawn` call site.
+// `#[inline(never)]` forces a single shared copy of the lookup + match +
+// indirect call rather than duplicating it into each monomorphization of the
+// generic `spawn`. `#[track_caller]` keeps the original call site flowing
+// through to `handle_uninitialized_spawn` for diagnostics.
+#[inline(never)]
+#[track_caller]
+fn dispatch_spawn(fut: PinnedFuture<()>) {
+    if let Some(fns) = current_executor_fns() {
+        (fns.spawn)(fut)
+    } else {
+        // No executor set for this thread or globally.
+        handle_uninitialized_spawn(fut);
+    }
+}
+
+// Non-generic dispatch tail shared by every `Executor::spawn_local` call site.
+// See `dispatch_spawn`.
+#[inline(never)]
+#[track_caller]
+fn dispatch_spawn_local(fut: PinnedLocalFuture<()>) {
+    if let Some(fns) = current_executor_fns() {
+        (fns.spawn_local)(fut)
+    } else {
+        // No executor set for this thread or globally.
+        handle_uninitialized_spawn_local(fut);
+    }
+}
+
 // No-op functions to use when an executor doesn't support a specific operation.
 #[cfg(any(feature = "tokio", feature = "wasm-bindgen", feature = "glib"))]
 #[cold]
@@ -129,34 +158,27 @@ impl Executor {
     ///
     /// Uses the globally configured executor.
     /// Panics if no global executor has been initialized.
-    #[inline(always)]
+    #[inline]
     #[track_caller]
     pub fn spawn(fut: impl Future<Output = ()> + Send + 'static) {
-        let pinned_fut = Box::pin(fut);
-
-        if let Some(fns) = current_executor_fns() {
-            (fns.spawn)(pinned_fut)
-        } else {
-            // No executor set for this thread or globally.
-            handle_uninitialized_spawn(pinned_fut);
-        }
+        // Only the `Box::pin` coercion to `dyn Future` is generic over the
+        // concrete future type and must be monomorphized per call site; the
+        // executor lookup and dispatch live in the non-generic
+        // `dispatch_spawn`, so a single shared copy of that logic is emitted
+        // instead of one inlined copy per (call site × future type).
+        dispatch_spawn(Box::pin(fut));
     }
 
     /// Spawns a [`Future`] that cannot be sent across threads.
     ///
     /// Uses the globally configured executor.
     /// Panics if no global executor has been initialized.
-    #[inline(always)]
+    #[inline]
     #[track_caller]
     pub fn spawn_local(fut: impl Future<Output = ()> + 'static) {
-        let pinned_fut = Box::pin(fut);
-
-        if let Some(fns) = current_executor_fns() {
-            (fns.spawn_local)(pinned_fut)
-        } else {
-            // No executor set for this thread or globally.
-            handle_uninitialized_spawn_local(pinned_fut);
-        }
+        // See `spawn`: keep the per-type work to just `Box::pin` and route the
+        // shared dispatch through the outlined `dispatch_spawn_local`.
+        dispatch_spawn_local(Box::pin(fut));
     }
 
     /// Waits until the next "tick" of the current async executor.


### PR DESCRIPTION
`Executor::spawn` / `Executor::spawn_local` were `#[inline(always)]` and generic over the future type. Only the `Box::pin(fut)` coercion to `Pin<Box<dyn Future>>` actually needs the concrete type — the executor lookup, the `Option` match, and the indirect call are entirely non-generic, yet they were monomorphized and inlined into **every call site × every distinct future type**.

This change splits each entry point into a thin generic wrapper (`#[inline]`) that does only the `Box::pin`, plus a single shared `#[inline(never)]` `dispatch_spawn` / `dispatch_spawn_local` holding the lookup + dispatch. `#[track_caller]` is propagated so caller-location diagnostics are unchanged.

**Why** — smaller generated code, which is the priority for the size-optimized (`opt-level = "z"`) WASM target. The saving scales with the number of distinct future types, which is large in real apps (≈ one spawn per reactive binding).

**Measured** (isolated binary, `opt-level="z"`, `lto`, `codegen-units=1`; 60 distinct future types each for `spawn`/`spawn_local`):

| metric                           | before    | after     | Δ                     |
| -------------------------------- | --------- | --------- | --------------------- |
| `.text` section                  | 222,904 B | 218,416 B | **−4,488 B (−2.01%)** |
| spawn call-sites + dispatch      | 15,564 B  | 11,016 B  | **−4,548 B (−29%)**   |
| distinct `dispatch_spawn` copies | 60        | **1**     | —                     |

Cost: ~1 ns per spawn (one non-inlined call), negligible against the ~200 ns executor enqueue.