### PR TITLE
fix(tachys): stop wrapping inert SVG children in a spurious <g>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/tachys/Cargo.toml
+++ b/tachys/Cargo.toml
@@ -169,6 +169,7 @@ tokio = { features = [
   "rt",
   "macros",
 ], workspace = true, default-features = true }
+wasm-bindgen-test = { workspace = true, default-features = true }
 
 [build-dependencies]
 rustc_version = { workspace = true, default-features = true }

--- a/tachys/Makefile.toml
+++ b/tachys/Makefile.toml
@@ -1,1 +1,4 @@
-extend = { path = "../cargo-make/main.toml" }
+extend = [
+  { path = "../cargo-make/main.toml" },
+  { path = "../cargo-make/wasm-test.toml" },
+]

--- a/tachys/src/renderer/dom.rs
+++ b/tachys/src/renderer/dom.rs
@@ -584,14 +584,7 @@ impl Dom {
                         Self::intern("svg"),
                     )
                     .unwrap();
-                let g = document()
-                    .create_element_ns(
-                        Some(Self::intern("http://www.w3.org/2000/svg")),
-                        Self::intern("g"),
-                    )
-                    .unwrap();
-                g.set_inner_html(&html);
-                svg.append_child(&g).unwrap();
+                svg.set_inner_html(&html);
                 tpl.unchecked_ref::<TemplateElement>()
                     .content()
                     .append_child(&svg)
@@ -603,6 +596,10 @@ impl Dom {
         });
 
         let svg = tpl.first_element_child().unwrap();
+        // The `<svg>` is only a parsing context that gives the fragment the SVG
+        // namespace; the element we actually want is its first child. Returning
+        // the `<svg>` itself would wrap every inert SVG child in a spurious
+        // `<svg>`.
         svg.first_element_child().unwrap_or(svg)
     }
 }

--- a/tachys/tests/svg_inert.rs
+++ b/tachys/tests/svg_inert.rs
@@ -1,0 +1,81 @@
+//! Browser tests for the inert (static) SVG fast path.
+//!
+//! Static SVG children of `<svg>` take the inert HTML path and are
+//! reconstructed on the client by `Dom::create_svg_element_from_html`, which
+//! parses the fragment inside an SVG-namespaced scaffold so the markup inherits
+//! the SVG namespace. These tests pin down two properties of that
+//! reconstruction:
+//!
+//! 1. The mounted node is the authored element itself, not a spurious wrapper
+//!    (the original bug mounted every inert SVG child inside an extra `<g>`).
+//! 2. The element and its descendants are in the SVG namespace, so they
+//!    actually render as SVG rather than as inert HTML-namespaced elements.
+//!
+//! Run in a browser: `wasm-pack test --headless --chrome -p tachys`.
+#![cfg(target_family = "wasm")]
+
+use tachys::{
+    prelude::{Mountable, Render},
+    svg::InertElement,
+};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const SVG_NS: &str = "http://www.w3.org/2000/svg";
+
+/// The reproducible example from the bug report: a nested SVG child must mount
+/// as `<text><tspan>…</tspan></text>`, not `<g><text>…</text></g>`.
+#[wasm_bindgen_test]
+fn inert_svg_child_is_not_wrapped_in_a_scaffold() {
+    let html = r#"<text x="18" y="32"><tspan>Just an example</tspan></text>"#;
+    let elements = InertElement::new(html).build().elements();
+
+    assert_eq!(
+        elements.len(),
+        1,
+        "InertElement should mount exactly one element"
+    );
+    let el = &elements[0];
+
+    // The mounted element is the authored <text>, not a <g>/<svg> scaffold.
+    // (For SVG-namespaced elements `tagName` preserves the authored lowercase;
+    // an HTML-namespaced parse would yield "TEXT" instead.)
+    assert_eq!(
+        el.tag_name(),
+        "text",
+        "expected the authored <text> element, found <{}>",
+        el.tag_name()
+    );
+    assert_eq!(
+        el.namespace_uri().as_deref(),
+        Some(SVG_NS),
+        "mounted element must be in the SVG namespace"
+    );
+
+    // The child is preserved and is itself SVG-namespaced.
+    let child = el
+        .first_element_child()
+        .expect("<text> should have a <tspan> child");
+    assert_eq!(child.tag_name(), "tspan");
+    assert_eq!(child.namespace_uri().as_deref(), Some(SVG_NS));
+    assert_eq!(child.text_content().as_deref(), Some("Just an example"));
+}
+
+/// A self-closing single element exercises the same path with no inner
+/// children, ensuring the scaffold is still stripped and the namespace applied.
+#[wasm_bindgen_test]
+fn inert_self_closing_svg_element_keeps_namespace_without_wrapper() {
+    let html = r#"<circle cx="5" cy="5" r="4"></circle>"#;
+    let elements = InertElement::new(html).build().elements();
+
+    assert_eq!(elements.len(), 1);
+    let el = &elements[0];
+
+    assert_eq!(el.tag_name(), "circle");
+    assert_eq!(el.namespace_uri().as_deref(), Some(SVG_NS));
+    assert!(
+        el.first_element_child().is_none(),
+        "a <circle> should mount with no element children"
+    );
+}


### PR DESCRIPTION
Closes: #4556.

Static SVG children of `<svg>` take the inert HTML fast path and are rebuilt on the client by `Dom::create_svg_element_from_html`. That function parsed the fragment inside a temporary `<g>` (to confer the SVG namespace) but returned the `<g>` itself, so every inert SVG child mounted wrapped in an extra `<g>`:

```
mounted:  <g><text x="18" y="32"><tspan>Just an example</tspan></text></g>
expected: <text x="18" y="32"><tspan>Just an example</tspan></text>
```

Dynamic children were unaffected (they skip the inert path), and SSR was already correct (it emits raw markup with no scaffold).

**Fix:** Drop the inner `<g>` and set `inner_html` directly on the SVG-namespaced `<svg>`. The fragment parser keys the namespace off the context element's *namespace*, not its tag, so an `<svg>` context namespaces the children exactly as the `<g>` did. Return `svg.first_element_child()` (with a safe fallback), which is now the authored element itself, mirroring the non-SVG `create_element_from_html`.