### PR TITLE
feat: Add the `#[prop(marker)]` option

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1000,20 +1000,23 @@ impl ToTokens for UnknownAttrs {
 #[derive(Clone, Debug, FromAttr)]
 #[attribute(ident = prop)]
 struct PropOpt {
-    #[attribute(conflicts = [optional_no_strip, strip_option])]
+    #[attribute(conflicts = [optional_no_strip, strip_option, marker])]
     optional: bool,
-    #[attribute(conflicts = [optional, strip_option])]
+    #[attribute(conflicts = [optional, strip_option, marker])]
     optional_no_strip: bool,
-    #[attribute(conflicts = [optional, optional_no_strip])]
+    #[attribute(conflicts = [optional, optional_no_strip, marker])]
     strip_option: bool,
     #[attribute(example = "5 * 10")]
     default: Option<syn::Expr>,
     into: bool,
     attrs: bool,
     name: Option<String>,
+    #[attribute(conflicts = [optional, optional_no_strip, strip_option, default, into, attrs, name])]
+    marker: bool,
 }
 
 struct TypedBuilderOpts<'a> {
+    marker: bool,
     default: bool,
     default_with_value: Option<syn::Expr>,
     strip_option: bool,
@@ -1024,6 +1027,7 @@ struct TypedBuilderOpts<'a> {
 impl<'a> TypedBuilderOpts<'a> {
     fn from_opts(opts: &PropOpt, ty: &'a Type) -> Self {
         Self {
+            marker: opts.marker,
             default: opts.optional || opts.optional_no_strip || opts.attrs,
             default_with_value: opts.default.clone(),
             strip_option: opts.strip_option || opts.optional && is_option(ty),
@@ -1054,6 +1058,13 @@ impl TypedBuilderOpts<'_> {
 
 impl ToTokens for TypedBuilderOpts<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+        if self.marker {
+            tokens.append_all(quote! {
+                #[builder(default, setter(skip))]
+            });
+            return;
+        }
+
         let default = if let Some(v) = &self.default_with_value {
             let v = v.to_token_stream().to_string();
             quote! { default_code=#v, }
@@ -1121,31 +1132,33 @@ fn prop_builder_fields(
                 ty,
             } = prop;
 
+            let PatIdent { ident, by_ref, .. } = &name;
+
             let builder_attrs = TypedBuilderOpts::from_opts(prop_opts, ty);
 
             let builder_docs = prop_to_doc(prop, PropDocStyle::Inline);
 
-            // Children won't need documentation in many cases
-            let allow_missing_docs = if name.ident == "children" {
+            // Children and markers won't need documentation in many cases
+            let allow_missing_docs = if prop_opts.marker || ident == "children"
+            {
                 quote!(#[allow(missing_docs)])
             } else {
                 quote!()
             };
-            let skip_children_serde =
-                if is_island_with_other_props && name.ident == "children" {
-                    quote!(#[serde(skip)])
-                } else {
-                    quote!()
-                };
-
-            let PatIdent { ident, by_ref, .. } = &name;
+            let serde_skip = if is_island_with_other_props
+                && (prop_opts.marker || ident == "children")
+            {
+                quote!(#[serde(skip)])
+            } else {
+                quote!()
+            };
 
             quote! {
                 #docs
                 #builder_docs
                 #builder_attrs
                 #allow_missing_docs
-                #skip_children_serde
+                #serde_skip
                 #vis #by_ref #ident: #ty,
             }
         })
@@ -1201,6 +1214,7 @@ fn generate_component_fn_prop_docs(props: &[Prop]) -> TokenStream {
                 || prop_opts.optional_no_strip
                 || prop_opts.default.is_some())
         })
+        .filter(|prop| !prop.prop_opts.marker)
         .map(|p| prop_to_doc(p, PropDocStyle::List))
         .collect::<TokenStream>();
 
@@ -1211,6 +1225,7 @@ fn generate_component_fn_prop_docs(props: &[Prop]) -> TokenStream {
                 || prop_opts.optional_no_strip
                 || prop_opts.default.is_some()
         })
+        .filter(|prop| !prop.prop_opts.marker)
         .map(|p| prop_to_doc(p, PropDocStyle::List))
         .collect::<TokenStream>();
 

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -519,6 +519,10 @@ pub fn include_view(tokens: TokenStream) -> TokenStream {
 ///   property is not specified.
 /// * `#[prop(name = "new_name")]`: Specifiy a different name for the property. Can be used to destructure
 ///   fields in component function parameters (see example below).
+/// * `#[prop(marker)]`: Specifiy that prop to be some kind of marker. This removes the prop
+///   from the docs and the builder (no setter is created).
+///   It is usefull when you want a generic component where no props actually use that generic,
+///   you can then use `#[prop(marker)] _marker: PhantomData<T>`.
 ///
 /// ```rust
 /// # use leptos::prelude::*;


### PR DESCRIPTION
Add the `#[prop(marker)]` option, this is intended for marker props such as `PhantomData`, it is incompatible with any other prop option:

- skip displaying the prop in the component doc
- set `#[doc(hidden)]` on the builder
- skip the setter method (`#[builder(default, setter(skip))]`)
- set `#[serde(skip)]` 

## Motivations

This code will compile fine:

```rust
trait Foo {
    fn bar() -> impl IntoView;
}

fn Test<T: Foo>() -> impl IntoView {
    T::bar()
}
```

but adding `#[component]` to `Test` will cause a compilation error, because now the underlying builder as an unused type parameter:

```
error[E0392]: type parameter `T` is never used                                                                                                                                                                                                                                 
  --> src\app.rs:89:9
   |
89 | fn Test<T: Foo>() -> impl IntoView {
   |         ^ unused type parameter
   |
   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`

error[E0282]: type annotations needed                                                                                                                                                                                                                                          
  --> src\app.rs:89:4
   |
89 | fn Test<T: Foo>() -> impl IntoView {
   |    ^^^^ cannot infer type of the type parameter `T` declared on the function `__component_test`
   |
help: consider specifying the generic argument
   |
89 | fn Test::<_><T: Foo>() -> impl IntoView {
   |        +++++
```


The solution is to have an optional prop:

```rust
#[component]
fn Test<T: Foo>(#[prop(optional)] _marker: PhantomData<T>) -> impl IntoView {
    T::bar()
}
```

Works great, but now `_marker` appears in docs, is serialized in islands, has a setter on the builder, or appears in the builder doc.

This PR add a way to remove those by simply marking the prop with `#[prop(marker)]`.

## Alternatives

One other way that could be done is to have an attribute on the type parameter itself:

```rust
#[component]
fn Test<#[prop(marker)] T: Foo>() -> impl IntoView {
    T::bar()
}
```
> placeholder name for now, any suggestion is welcome

This would aggregate all the marked generics on the builder with a single `__marker: PhantomData<(...T)>` and skip the doc/setter/serde. Or also might allow to skip the generic from the builder entirely and thus allow component with no props to stay without props, and thus stay a `fn() -> impl IntoView`.
This would, in my opinion, be the better option, but would not be as straightforward as the currently proposed solution, but I would be happy to implement it if decided better.
(I actually just thought about it while writing this PR)
