### PR TITLE
feat(router): allow permanent redirects (301)

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -215,8 +215,9 @@ impl ExtendResponse for ActixResponse {
 ///
 /// If the route or server function in which this is called is being accessed
 /// by an ordinary `GET` request or an HTML `<form>` without any enhancement, it also sets a
-/// status code of `302` for a temporary redirect. (This is determined by whether the `Accept`
-/// header contains `text/html` as it does for an ordinary navigation.)
+/// status code of `302` for a temporary redirect if `permanent` is false
+/// or a `301` for a permanent redirect if `permanent` is true.
+/// (This is determined by whether the `Accept` header contains `text/html` as it does for an ordinary navigation.)
 ///
 /// Otherwise, it sets a custom header that indicates to the client that it should redirect,
 /// without actually setting the status code. This means that the client will not follow the
@@ -226,7 +227,7 @@ impl ExtendResponse for ActixResponse {
     feature = "tracing",
     tracing::instrument(level = "trace", fields(error), skip_all)
 )]
-pub fn redirect(path: &str) {
+pub fn redirect(path: &str, permanent: bool) {
     if let (Some(req), Some(res)) =
         (use_context::<Request>(), use_context::<ResponseOptions>())
     {
@@ -245,8 +246,15 @@ pub fn redirect(path: &str) {
             .unwrap_or(false);
         if accepts_html {
             // if the request accepts text/html, it's a plain form request and needs
-            // to have the 302 code set
-            res.set_status(StatusCode::FOUND);
+            // to have the redirect status code set
+            let status_code = if permanent {
+                // `301` permanent redirect
+                StatusCode::MOVED_PERMANENTLY
+            } else {
+                // `302` temporary redirect
+                StatusCode::FOUND
+            };
+            res.set_status(status_code);
         } else {
             // otherwise, we sent it from the server fn client and actually don't want
             // to set a real redirect, as this will break the ability to return data

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -268,14 +268,15 @@ impl ExtendResponse for AxumResponse {
 ///
 /// If the route or server function in which this is called is being accessed
 /// by an ordinary `GET` request or an HTML `<form>` without any enhancement, it also sets a
-/// status code of `302` for a temporary redirect. (This is determined by whether the `Accept`
-/// header contains `text/html` as it does for an ordinary navigation.)
+/// status code of `302` for a temporary redirect if `permanent` is false
+/// or a `301` for a permanent redirect if `permanent` is true.
+/// (This is determined by whether the `Accept` header contains `text/html` as it does for an ordinary navigation.)
 ///
 /// Otherwise, it sets a custom header that indicates to the client that it should redirect,
 /// without actually setting the status code. This means that the client will not follow the
 /// redirect, and can therefore return the value of the server function and then handle
 /// the redirect with client-side routing.
-pub fn redirect(path: &str) {
+pub fn redirect(path: &str, permanent: bool) {
     if let (Some(req), Some(res)) =
         (use_context::<Parts>(), use_context::<ResponseOptions>())
     {
@@ -309,8 +310,15 @@ pub fn redirect(path: &str) {
             .unwrap_or(false);
         if accepts_html {
             // if the request accepts text/html, it's a plain form request and needs
-            // to have the 302 code set
-            res.set_status(StatusCode::FOUND);
+            // to have the redirect status code set
+            let status_code = if permanent {
+                // `301` permanent redirect
+                StatusCode::MOVED_PERMANENTLY
+            } else {
+                // `302` temporary redirect
+                StatusCode::FOUND
+            };
+            res.set_status(status_code);
         } else {
             // otherwise, we sent it from the server fn client and actually don't want
             // to set a real redirect, as this will break the ability to return data
@@ -2781,7 +2789,7 @@ mod tests {
             provide_context(parts);
             provide_context(res.clone());
 
-            redirect("/login\r\nSet-Cookie: pwned=1");
+            redirect("/login\r\nSet-Cookie: pwned=1", false);
         });
 
         let parts = res.0.read().or_poisoned();
@@ -2799,7 +2807,7 @@ mod tests {
             provide_context(parts);
             provide_context(res.clone());
 
-            redirect("/dashboard");
+            redirect("/dashboard", false);
         });
 
         let parts = res.0.read().or_poisoned();
@@ -2807,6 +2815,39 @@ mod tests {
             parts.headers.get(LOCATION).map(|v| v.as_bytes()),
             Some(&b"/dashboard"[..])
         );
+    }
+
+    // Test if the correct status code is set on the redirect
+    #[test]
+    fn redirect_sets_302() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            provide_context(parts);
+            provide_context(res.clone());
+
+            redirect("/dashboard", false);
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert_eq!(parts.status, Some(StatusCode::FOUND));
+    }
+
+    #[test]
+    fn redirect_sets_301() {
+        let owner = Owner::new();
+        let res = ResponseOptions::default();
+        owner.with(|| {
+            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            provide_context(parts);
+            provide_context(res.clone());
+
+            redirect("/dashboard", true);
+        });
+
+        let parts = res.0.read().or_poisoned();
+        assert_eq!(parts.status, Some(StatusCode::MOVED_PERMANENTLY));
     }
 
     // When the render_route handler is mounted such that Axum's `MatchedPath`

--- a/router/src/components.rs
+++ b/router/src/components.rs
@@ -548,8 +548,8 @@ define_protected_parent_route!(crate::any_nested_route::AnyNestedRoute);
 define_protected_parent_route!(NestedRoute<Segments, Children, (), impl Fn() -> AnyView + Send + Clone>);
 
 /// Redirects the user to a new URL, whether on the client side or on the server
-/// side. If rendered on the server, this sets a `302` status code and sets a `Location`
-/// header. If rendered in the browser, it uses client-side navigation to redirect.
+/// side. If rendered on the server, this sets a `302` status code if `permanent` is false or a `301` if `permanent` is true,
+/// and sets a `Location` header. If rendered in the browser, it uses client-side navigation to redirect.
 /// In either case, it resolves the route relative to the current route. (To use
 /// an absolute path, prefix it with `/`).
 ///
@@ -568,6 +568,13 @@ pub fn Redirect<P>(
     #[prop(optional)]
     #[allow(unused)]
     options: Option<NavigateOptions>,
+    /// Permanent redirect
+    ///
+    /// Only used on the server side to set a `301` if `permanent` is true
+    /// or a `302` if `permanent` is false (`false` by default)
+    #[prop(optional)]
+    #[allow(unused)]
+    permanent: bool,
 ) where
     P: core::fmt::Display + 'static,
 {
@@ -576,11 +583,10 @@ pub fn Redirect<P>(
 
     // redirect on the server
     if let Some(redirect_fn) = use_context::<ServerRedirectFunction>() {
-        (redirect_fn.f)(&resolve_path(
-            "",
-            &path,
-            Some(&use_matched().get_untracked()),
-        ));
+        (redirect_fn.f)(
+            &resolve_path("", &path, Some(&use_matched().get_untracked())),
+            permanent,
+        );
     }
     // redirect on the client
     else {
@@ -603,12 +609,13 @@ pub fn Redirect<P>(
     }
 }
 
+type ServerRedirectDynFunction = dyn Fn(&str, bool) + Send + Sync;
 /// Wrapping type for a function provided as context to allow for
 /// server-side redirects. See [`provide_server_redirect`]
 /// and [`Redirect`].
 #[derive(Clone)]
 pub struct ServerRedirectFunction {
-    f: Arc<dyn Fn(&str) + Send + Sync>,
+    f: Arc<ServerRedirectDynFunction>,
 }
 
 impl core::fmt::Debug for ServerRedirectFunction {
@@ -617,10 +624,16 @@ impl core::fmt::Debug for ServerRedirectFunction {
     }
 }
 
-/// Provides a function that can be used to redirect the user to another
-/// absolute path, on the server. This should set a `302` status code and an
-/// appropriate `Location` header.
-pub fn provide_server_redirect(handler: impl Fn(&str) + Send + Sync + 'static) {
+/// Provides a function that can be used to redirect the user to another absolute path, on the server.
+/// The passed function takes 2 arguments:
+/// - `path` (`&str`): the path to redirect the client to
+/// - `permanent` (`bool`): indicate if this is a permanent redirect
+///
+/// The passed function should set a `302` status code if `permanent` is false, or a `301` status code if `permanent` is true,
+/// and set an appropriate `Location` header.
+pub fn provide_server_redirect(
+    handler: impl Fn(&str, bool) + Send + Sync + 'static,
+) {
     provide_context(ServerRedirectFunction {
         f: Arc::new(handler),
     })


### PR DESCRIPTION
Add a `permanent` flag to the integrations redirect functions and  the `permanent` prop to the `<Redirect />` component to allow a permanent redirect (301).

`permanent` default to `false` for the `<Redirect />` component