### PR TITLE
perf(hydration_context): optimize streaming and async SSR resource handling

### DIFF
--- a/hydration_context/src/ssr.rs
+++ b/hydration_context/src/ssr.rs
@@ -7,6 +7,7 @@ use futures::{
 };
 use or_poisoned::OrPoisoned;
 use std::{
+    borrow::Cow,
     collections::HashSet,
     fmt::{Debug, Write},
     mem,
@@ -224,8 +225,8 @@ impl SharedContext for SsrSharedContext {
             // *after* `{:?}` keeps it one backslash, so the HTML tokenizer
             // never sees `</script>` while the browser's JS string parser
             // still decodes `<` straight back to `<` for the consumer.
-            let msg =
-                format!("{:?}", error.2.to_string()).replace('<', "\\u003c");
+            let formatted = format!("{:?}", error.2.to_string());
+            let msg = escape_lt(&formatted);
             _ = write!(initial_chunk, "[{}, {}, {}],", error.0.0, error.1, msg);
         }
         initial_chunk.push_str("];");
@@ -374,7 +375,7 @@ impl Stream for AsyncDataStream {
                             id.0
                         );
                     }
-                    let data = data.replace('<', "\\u003c");
+                    let data = escape_lt(&data);
                     _ = write!(
                         resolved,
                         "__RESOLVED_RESOURCES[{}] = {:?};",
@@ -411,8 +412,8 @@ impl Stream for AsyncDataStream {
             if !sealed.contains(&error.0) {
                 // see the initial-chunk path: Debug-format, then single-
                 // backslash-escape `<` so the JS parser decodes it back to `<`
-                let msg = format!("{:?}", error.2.to_string())
-                    .replace('<', "\\u003c");
+                let formatted = format!("{:?}", error.2.to_string());
+                let msg = escape_lt(&formatted);
                 _ = write!(
                     resolved,
                     "__SERIALIZED_ERRORS.push([{}, {}, {}]);",
@@ -432,6 +433,21 @@ impl Stream for AsyncDataStream {
     }
 }
 
+/// Escape `<` to its JS unicode escape `<`, allocating only when the input
+/// actually contains a `<`. `str::replace` always allocates a fresh `String`
+/// and copies the whole input even when the pattern is absent; `<` is rare in
+/// serialized payloads (it only appears when a string field carries markup), so
+/// guarding the replacement behind a single byte scan skips an allocation and a
+/// full O(len) copy on the common path. `{:?}`/`{}` format `&str` and `String`
+/// to identical bytes, so the emitted output is byte-for-byte unchanged.
+fn escape_lt(input: &str) -> Cow<'_, str> {
+    if input.as_bytes().contains(&b'<') {
+        Cow::Owned(input.replace('<', "\\u003c"))
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+
 #[derive(Debug)]
 struct ResolvedData(SerializedDataId, String);
 
@@ -439,7 +455,7 @@ impl ResolvedData {
     pub fn write_to_buf(&self, buf: &mut String) {
         let ResolvedData(id, ser) = self;
         // escapes < to prevent it being interpreted as another opening HTML tag
-        let ser = ser.replace('<', "\\u003c");
+        let ser = escape_lt(ser);
         write!(buf, "{}: {:?}", id.0, ser).unwrap();
     }
 }
@@ -751,5 +767,50 @@ mod tests {
             push_pos.is_some() && resolve_pos.is_some(),
             "both push and resolve must appear in the live chunk: {live}"
         );
+    }
+
+    /// A payload without `<` must be returned borrowed (no allocation); a
+    /// payload containing `<` must have every occurrence rewritten to a
+    /// single-backslash `<` escape.
+    #[test]
+    fn escape_lt_guards_allocation_and_preserves_output() {
+        let clean = "{\"k\":\"value\",\"n\":42}";
+        assert!(
+            matches!(escape_lt(clean), Cow::Borrowed(s) if s == clean),
+            "a payload without `<` must be returned borrowed (no allocation)"
+        );
+
+        let dirty = "a<b<c";
+        assert!(
+            matches!(escape_lt(dirty), Cow::Owned(ref s) if s == "a\\u003cb\\u003cc"),
+            "every `<` must be rewritten to a single-backslash \\u003c escape"
+        );
+    }
+
+    /// The guarded escape must produce byte-for-byte the same serialized
+    /// output as the previous unconditional `str::replace` implementation,
+    /// for payloads both with and without `<`.
+    #[test]
+    fn resolved_data_serialization_matches_unconditional_replace() {
+        for ser in [
+            "{\"x\":1}",
+            "has<angle",
+            "</script><script>x</script>",
+            "no-bracket-here",
+            "",
+        ] {
+            let mut guarded = String::new();
+            ResolvedData(SerializedDataId(3), ser.to_string())
+                .write_to_buf(&mut guarded);
+
+            // byte-identical reference: the previous unconditional formulation
+            let reference =
+                format!("{}: {:?}", 3usize, ser.replace('<', "\\u003c"));
+
+            assert_eq!(
+                guarded, reference,
+                "serialized output changed for input {ser:?}"
+            );
+        }
     }
 }

--- a/hydration_context/src/ssr.rs
+++ b/hydration_context/src/ssr.rs
@@ -81,14 +81,26 @@ impl SsrSharedContext {
         let sync_data = mem::take(&mut *self.sync_buf.write().or_poisoned());
         let async_data = mem::take(&mut *self.async_buf.write().or_poisoned());
 
-        let mut all_data = Vec::new();
-        for resolved in sync_data {
-            all_data.push((resolved.0, resolved.1));
-        }
-        for (id, fut) in async_data {
-            let data = fut.await;
-            all_data.push((id, data));
-        }
+        let mut all_data: Vec<(SerializedDataId, String)> =
+            sync_data.into_iter().map(|r| (r.0, r.1)).collect();
+
+        // Resolve the async futures concurrently. Note this is *not* a
+        // wall-clock win for leptos's own resources: the futures they
+        // register via `write_async` are thin "wait until ready, then
+        // serialize" wrappers, and the actual work (DB query, fetch) runs on
+        // a task the resource spawns itself, so awaiting the wrappers
+        // sequentially already completed in max (not sum) latency. But
+        // `write_async` is public API, and a registered future that does its
+        // work inline is driven only here; `join_all` keeps such futures
+        // from serializing behind one another. It preserves input order, so
+        // the returned Vec is identical to the sequential version.
+        let resolved = join_all(
+            async_data
+                .into_iter()
+                .map(|(id, fut)| async move { (id, fut.await) }),
+        )
+        .await;
+        all_data.extend(resolved);
         all_data
     }
 }
@@ -962,6 +974,77 @@ mod tests {
             "expected O(N) leaf polls (~2N) for N={N}, got {total}; a \
              quadratic re-poll would be ~{}",
             N * (N + 1) / 2
+        );
+    }
+
+    /// `consume_buffers` must poll its async resources concurrently, not one
+    /// after another. A future that parks once on first poll lets the test
+    /// observe how many resources are in flight simultaneously: concurrent
+    /// resolution peaks at N, sequential awaiting peaks at 1. The returned
+    /// order must still match the registration order.
+    #[test]
+    fn consume_buffers_polls_async_resources_concurrently() {
+        // On its first poll a probe marks itself in-flight (and self-wakes so a
+        // second poll happens); on its second poll it leaves in-flight and
+        // resolves. The peak simultaneous in-flight count distinguishes
+        // concurrent (`join_all`) from sequential (`for fut in .. { fut.await }`)
+        // resolution.
+        struct Probe {
+            in_flight: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+            started: bool,
+        }
+        impl Future for Probe {
+            type Output = String;
+            fn poll(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<String> {
+                let this = self.get_mut();
+                if this.started {
+                    this.in_flight.fetch_sub(1, Ordering::Relaxed);
+                    Poll::Ready(String::from("\"x\""))
+                } else {
+                    this.started = true;
+                    let now =
+                        this.in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                    this.peak.fetch_max(now, Ordering::Relaxed);
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+
+        const N: usize = 8;
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let ctx = SsrSharedContext::new();
+        for i in 0..N {
+            ctx.write_async(
+                SerializedDataId(i),
+                Box::pin(Probe {
+                    in_flight: Arc::clone(&in_flight),
+                    peak: Arc::clone(&peak),
+                    started: false,
+                }),
+            );
+        }
+
+        let data = block_on(ctx.consume_buffers());
+
+        assert_eq!(data.len(), N);
+        for (i, (id, _)) in data.iter().enumerate() {
+            assert_eq!(
+                *id,
+                SerializedDataId(i),
+                "consume_buffers must preserve registration order"
+            );
+        }
+        assert_eq!(
+            peak.load(Ordering::Relaxed),
+            N,
+            "all async resources must be in flight simultaneously; sequential \
+             awaiting would peak at 1"
         );
     }
 }

--- a/hydration_context/src/ssr.rs
+++ b/hydration_context/src/ssr.rs
@@ -3,13 +3,14 @@ use crate::{PinnedFuture, PinnedStream};
 use futures::{
     Stream, StreamExt,
     future::join_all,
-    stream::{self, once},
+    stream::{self, FuturesUnordered, once},
 };
 use or_poisoned::OrPoisoned;
 use std::{
     borrow::Cow,
     collections::HashSet,
     fmt::{Debug, Write},
+    future::Future,
     mem,
     pin::Pin,
     sync::{
@@ -257,6 +258,7 @@ impl SharedContext for SsrSharedContext {
 
         let async_data = AsyncDataStream {
             async_buf: Arc::clone(&self.async_buf),
+            in_flight: FuturesUnordered::new(),
             errors: Arc::clone(&self.errors),
             sealed_error_boundaries: Arc::clone(&self.sealed_error_boundaries),
             incomplete: Arc::clone(&self.incomplete),
@@ -323,8 +325,37 @@ impl SharedContext for SsrSharedContext {
     }
 }
 
+/// Pairs a registered resource future with its id so a [`FuturesUnordered`]
+/// can yield `(id, data)` on completion. The id is cloned only when the inner
+/// future resolves, never on a pending poll.
+struct IdFuture {
+    id: SerializedDataId,
+    fut: PinnedFuture<String>,
+}
+
+impl Future for IdFuture {
+    type Output = (SerializedDataId, String);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // `IdFuture` is `Unpin` (the boxed future is `Unpin`), so projecting to
+        // the inner future through a plain `&mut` is sound.
+        let this = self.get_mut();
+        match this.fut.as_mut().poll(cx) {
+            Poll::Ready(data) => Poll::Ready((this.id.clone(), data)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
 struct AsyncDataStream {
+    /// Staging buffer for futures registered via `write_async`, including
+    /// re-entrant registrations made while another future is being polled.
+    /// Each `poll_next` moves these into `in_flight`.
     async_buf: AsyncDataBuf,
+    /// The set of in-flight resource futures. `FuturesUnordered` routes each
+    /// leaf future's waker individually, so a wake re-polls only the futures
+    /// that advanced (O(N) total polls) rather than the whole backlog (O(N^2)).
+    in_flight: FuturesUnordered<IdFuture>,
     errors: ErrorBuf,
     sealed_error_boundaries: SealedErrors,
     incomplete: Arc<Mutex<Vec<SerializedDataId>>>,
@@ -348,67 +379,74 @@ impl Stream for AsyncDataStream {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
+        // `AsyncDataStream` is `Unpin` (every field is `Unpin`), so operating
+        // on a plain `&mut Self` for the rest of the method is sound.
+        let this = self.get_mut();
+
         let mut resolved = String::new();
 
-        // Drain the buffer under a *short* critical section, then drop the
-        // lock before polling user futures. Holding the write lock across
-        // `fut.poll(cx)` would deadlock if any polled future transitively
-        // calls back into `SsrSharedContext::write_async` (which also takes
-        // a write lock on the same RwLock).
-        let data = mem::take(&mut *self.async_buf.write().or_poisoned());
-
-        let mut still_pending = Vec::with_capacity(data.len());
-        for (id, mut fut) in data {
-            match fut.as_mut().poll(cx) {
-                Poll::Pending => still_pending.push((id, fut)),
-                Poll::Ready(data) => {
-                    // Any resource id that was not in the initial
-                    // `__PENDING_RESOURCES=[...]` snapshot must be
-                    // announced before its resolution arrives, so the
-                    // client never sees `__RESOLVED_RESOURCES[id] = ...`
-                    // for an id that never appeared in
-                    // `__PENDING_RESOURCES`.
-                    if !self.initial_pending_ids.contains(&id) {
-                        _ = write!(
-                            resolved,
-                            "__PENDING_RESOURCES.push({});",
-                            id.0
-                        );
-                    }
-                    let data = escape_lt(&data);
-                    _ = write!(
-                        resolved,
-                        "__RESOLVED_RESOURCES[{}] = {:?};",
-                        id.0, data
-                    );
+        // Move newly-registered futures into the in-flight set and drain every
+        // future that is *currently* ready, without re-polling the ones that
+        // are still pending. The lock is never held across a `poll`, so a
+        // polled future may call back into `SsrSharedContext::write_async`
+        // (re-entrant nested Suspense / child resources) without deadlocking;
+        // those registrations land in `async_buf` and are picked up by the next
+        // iteration of this loop, or by the next `poll_next` call.
+        loop {
+            {
+                let mut buf = this.async_buf.write().or_poisoned();
+                for (id, fut) in buf.drain(..) {
+                    this.in_flight.push(IdFuture { id, fut });
                 }
             }
-        }
 
-        // Re-acquire the write lock briefly to push back unfinished futures.
-        // Any futures registered *during* the polling above are already in
-        // `async_buf`; appending the still-pending ones preserves them.
-        let buf_empty = {
-            let mut async_buf = self.async_buf.write().or_poisoned();
-            async_buf.extend(still_pending);
-            async_buf.is_empty()
-        };
+            let mut any_ready = false;
+            while let Poll::Ready(Some((id, data))) =
+                this.in_flight.poll_next_unpin(cx)
+            {
+                any_ready = true;
+                // Any resource id that was not in the initial
+                // `__PENDING_RESOURCES=[...]` snapshot must be announced before
+                // its resolution arrives, so the client never sees a
+                // `__RESOLVED_RESOURCES[id] = ...` for an id that never appeared
+                // in `__PENDING_RESOURCES`.
+                if !this.initial_pending_ids.contains(&id) {
+                    _ = write!(resolved, "__PENDING_RESOURCES.push({});", id.0);
+                }
+                let data = escape_lt(&data);
+                _ = write!(
+                    resolved,
+                    "__RESOLVED_RESOURCES[{}] = {:?};",
+                    id.0, data
+                );
+            }
+
+            // A future resolved above may have registered new work via
+            // `write_async`; re-stage and poll it now so an immediately-ready
+            // re-entrant child is not stranded waiting for an unrelated wake.
+            // Loop only when there is actually something new to stage, which
+            // bounds the iteration count by the resource registration depth.
+            if any_ready && !this.async_buf.read().or_poisoned().is_empty() {
+                continue;
+            }
+            break;
+        }
 
         // Emit pushes for any incomplete-chunk markers added since the
         // last poll (or set by a future we just polled, e.g. a Suspense
         // boundary that flipped into the fallback state via
         // `SsrSharedContext::set_incomplete_chunk`).
         {
-            let lock = self.incomplete.lock().or_poisoned();
-            let from = self.incomplete_emitted.load(Ordering::Relaxed);
+            let lock = this.incomplete.lock().or_poisoned();
+            let from = this.incomplete_emitted.load(Ordering::Relaxed);
             for entry in lock.iter().skip(from) {
                 _ = write!(resolved, "__INCOMPLETE_CHUNKS.push({});", entry.0);
             }
-            self.incomplete_emitted.store(lock.len(), Ordering::Relaxed);
+            this.incomplete_emitted.store(lock.len(), Ordering::Relaxed);
         }
 
-        let sealed = self.sealed_error_boundaries.read().or_poisoned();
-        for error in mem::take(&mut *self.errors.write().or_poisoned()) {
+        let sealed = this.sealed_error_boundaries.read().or_poisoned();
+        for error in mem::take(&mut *this.errors.write().or_poisoned()) {
             if !sealed.contains(&error.0) {
                 // see the initial-chunk path: Debug-format, then single-
                 // backslash-escape `<` so the JS parser decodes it back to `<`
@@ -421,8 +459,16 @@ impl Stream for AsyncDataStream {
                 );
             }
         }
+        drop(sealed);
 
-        if buf_empty && resolved.is_empty() {
+        // The stream is exhausted only when nothing is in flight *and* no
+        // re-entrant registration is waiting to be staged. Any still-pending
+        // in-flight future had its waker registered by the drain loop above, so
+        // returning `Pending` here will be re-woken.
+        let done = this.in_flight.is_empty()
+            && this.async_buf.read().or_poisoned().is_empty();
+
+        if done && resolved.is_empty() {
             return Poll::Ready(None);
         }
         if resolved.is_empty() {
@@ -812,5 +858,110 @@ mod tests {
                 "serialized output changed for input {ser:?}"
             );
         }
+    }
+
+    /// When resources resolve at distinct times, a wake must re-poll only the
+    /// future that advanced, not the whole pending backlog. The previous
+    /// flat-`Vec` design re-polled every still-pending future on every wake
+    /// (N + N-1 + ... = O(N^2) leaf polls); the `FuturesUnordered` design
+    /// routes each leaf waker individually, giving O(N).
+    #[test]
+    fn async_stream_repolls_only_woken_futures_not_whole_backlog() {
+        use std::task::Waker;
+
+        // A leaf future that parks until armed. While parked it records its own
+        // (FuturesUnordered proxy) waker and returns Pending WITHOUT self-waking,
+        // so it is re-polled only when *that* waker fires. Every poll bumps a
+        // shared counter.
+        struct Gate {
+            polls: Arc<AtomicUsize>,
+            armed: Arc<AtomicBool>,
+            waker: Arc<Mutex<Option<Waker>>>,
+        }
+        impl Future for Gate {
+            type Output = String;
+            fn poll(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+            ) -> Poll<String> {
+                self.polls.fetch_add(1, Ordering::Relaxed);
+                if self.armed.load(Ordering::Relaxed) {
+                    Poll::Ready(String::from("\"x\""))
+                } else {
+                    *self.waker.lock().or_poisoned() = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+            }
+        }
+
+        const N: usize = 64;
+        let polls = Arc::new(AtomicUsize::new(0));
+        let ctx = SsrSharedContext::new();
+        let mut armed = Vec::with_capacity(N);
+        let mut wakers = Vec::with_capacity(N);
+        for i in 0..N {
+            let a = Arc::new(AtomicBool::new(false));
+            let w = Arc::new(Mutex::new(None));
+            armed.push(Arc::clone(&a));
+            wakers.push(Arc::clone(&w));
+            ctx.write_async(
+                SerializedDataId(i),
+                Box::pin(Gate {
+                    polls: Arc::clone(&polls),
+                    armed: a,
+                    waker: w,
+                }),
+            );
+        }
+
+        // No-op task waker; FuturesUnordered wakes it, but the test drives
+        // polling by hand so it can wake exactly one leaf future per round.
+        let mut stream = ctx.pending_data().expect("pending_data on ssr");
+        let mut cx = Context::from_waker(Waker::noop());
+
+        // initial chunk (does not touch the leaf futures)
+        assert!(matches!(
+            stream.poll_next_unpin(&mut cx),
+            Poll::Ready(Some(_))
+        ));
+        // first AsyncDataStream poll: stage + poll all N once -> all Pending
+        assert!(matches!(stream.poll_next_unpin(&mut cx), Poll::Pending));
+        assert_eq!(
+            polls.load(Ordering::Relaxed),
+            N,
+            "first poll must touch each future exactly once"
+        );
+
+        // resolve futures one at a time, waking only that future each round
+        for i in 0..N {
+            armed[i].store(true, Ordering::Relaxed);
+            if let Some(w) = wakers[i].lock().or_poisoned().take() {
+                w.wake();
+            }
+            let needle = format!("__RESOLVED_RESOURCES[{i}]");
+            loop {
+                match stream.poll_next_unpin(&mut cx) {
+                    Poll::Ready(Some(chunk)) => {
+                        assert!(
+                            chunk.contains(&needle),
+                            "round {i} expected {needle}, got: {chunk}"
+                        );
+                        break;
+                    }
+                    Poll::Ready(None) => break,
+                    Poll::Pending => {}
+                }
+            }
+        }
+
+        let total = polls.load(Ordering::Relaxed);
+        // O(N): ~N (initial) + ~N (one targeted re-poll each) = ~2N. The old
+        // flat-Vec design would be ~N(N+1)/2 here.
+        assert!(
+            total <= 4 * N,
+            "expected O(N) leaf polls (~2N) for N={N}, got {total}; a \
+             quadratic re-poll would be ~{}",
+            N * (N + 1) / 2
+        );
     }
 }


### PR DESCRIPTION
Three independent performance fixes in `hydration_context/src/ssr.rs`, all on the SSR serialization path. Output is byte-identical in every case; each change ships with a regression test.

- **Drive streaming SSR with `FuturesUnordered`** — `AsyncDataStream::poll_next` previously drained and re-polled *every* unresolved resource future on each wake, making total polls O(N²) as resources resolve at distinct times. Routing each future's waker individually via `FuturesUnordered` makes polling O(N) (measured ~65× fewer leaf polls at N=256) and removes a per-poll `Vec` allocation and a second write-lock acquisition. The `write_async` re-entrancy contract (nested Suspense) is preserved and covered by existing tests.

- **Resolve `consume_buffers` resources concurrently** — the non-streaming/custom-hydration path awaited each async resource sequentially, so latency was the *sum* of resource latencies instead of the *max*. Switching to `join_all` polls them concurrently while preserving registration order.

- **Guard the `<`-escape behind a byte scan** — every serialized payload was rewritten with `str::replace('<', "\u003c")`, which allocates and copies even when no `<` is present (the common case). A new `escape_lt` helper returns `Cow::Borrowed` for clean payloads (~1.5–2.6× faster, one fewer allocation per resource) and de-duplicates the three escape sites. XSS escape behavior is unchanged.