### PR TITLE
Performance optimizations for the server integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "anyhow",
  "axum",
  "futures",
+ "http-body-util",
  "hydration_context",
  "leptos",
  "leptos_integration_utils",

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -376,10 +376,10 @@ pub fn handle_server_fns_with_context(
     additional_context: impl Fn() + 'static + Clone + Send,
 ) -> Route {
     web::to(move |req: HttpRequest, payload: Payload| {
+        // the handler is `Fn`, so it clones the context closure for the
+        // `async move` block below, which owns that clone from then on
         let additional_context = additional_context.clone();
         async move {
-            let additional_context = additional_context.clone();
-
             let path = req.path();
             let method = req.method();
             if let Some(mut service) =

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1441,13 +1441,6 @@ where
                     return HttpResponse::NotFound().finish();
                 };
                 let path = Path::new(&file_path);
-                // Open the file directly instead of probing with `try_exists`
-                // first: a `NotFound` error is the signal that the route still
-                // needs to be generated. This saves a `stat` on every cached
-                // request, closes the TOCTOU window between check and open,
-                // and `open_async` keeps the open/stat syscalls off the
-                // reactor thread (the synchronous `NamedFile::open` would
-                // stall the worker on slow storage).
                 let opened = NamedFile::open_async(path).await;
 
                 match opened {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -834,14 +834,28 @@ fn request_url(req: &HttpRequest) -> RequestUrl {
     // `connection_info` resolves the scheme and host, honoring reverse-proxy
     // forwarding headers.
     let conn = req.connection_info();
-    let origin = format!("{}://{}", conn.scheme(), conn.host());
+    let scheme = conn.scheme();
+    let host = conn.host();
     let path = req.path();
     let query = req.query_string();
-    if query.is_empty() {
-        RequestUrl::new(&format!("{origin}{path}"))
-    } else {
-        RequestUrl::new(&format!("{origin}{path}?{query}"))
+    // assemble once in a pre-sized buffer; `RequestUrl::new` then makes the
+    // one unavoidable copy into its `Arc<str>`
+    let mut url = String::with_capacity(
+        scheme.len()
+            + "://".len()
+            + host.len()
+            + path.len()
+            + if query.is_empty() { 0 } else { 1 + query.len() },
+    );
+    url.push_str(scheme);
+    url.push_str("://");
+    url.push_str(host);
+    url.push_str(path);
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
     }
+    RequestUrl::new(&url)
 }
 
 #[allow(clippy::type_complexity)]

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1328,7 +1328,7 @@ const STATIC_HEADERS_DEFAULT_CAPACITY: NonZeroUsize =
 /// A missing, unparseable, or zero value falls back to the default.
 const STATIC_HEADERS_CAPACITY_ENV: &str = "LEPTOS_STATIC_HEADERS_CACHE_SIZE";
 
-static STATIC_HEADERS: LazyLock<RwLock<LruCache<String, ResponseOptions>>> =
+static STATIC_HEADERS: LazyLock<RwLock<LruCache<String, ResponseParts>>> =
     LazyLock::new(|| {
         let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
             .ok()
@@ -1337,6 +1337,23 @@ static STATIC_HEADERS: LazyLock<RwLock<LruCache<String, ResponseOptions>>> =
             .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
         RwLock::new(LruCache::new(capacity))
     });
+
+/// Apply a cached [`ResponseParts`] snapshot to a response.
+///
+/// `STATIC_HEADERS` caches the headers and status captured when a route was
+/// generated. Unlike [`ExtendResponse::extend_response`], which drains its
+/// `ResponseOptions` with `std::mem::take` (fine for a single-use,
+/// request-scoped value), this clones the cached headers so the same snapshot
+/// can be re-applied to every cache hit without emptying the entry.
+fn apply_response_parts(res: &mut HttpResponse, parts: &ResponseParts) {
+    let headers = res.headers_mut();
+    for (key, value) in &parts.headers {
+        headers.append(key.clone(), value.clone());
+    }
+    if let Some(status) = parts.status {
+        *res.status_mut() = status;
+    }
+}
 
 fn was_404(owner: &Owner) -> bool {
     let resp = owner.with(|| expect_context::<ResponseOptions>());
@@ -1379,10 +1396,15 @@ async fn write_static_route(
     };
 
     if let Some(options) = response_options {
+        // Cache an immutable snapshot of the headers/status captured during this
+        // render, not the live request's `Arc<RwLock<..>>`. The generating
+        // request still owns and drains its own `ResponseOptions` when it serves
+        // the page; the cache keeps a private copy so repeated hits can re-apply
+        // it.
         STATIC_HEADERS
             .write()
             .or_poisoned()
-            .put(path.to_string(), options);
+            .put(path.to_string(), options.0.read().or_poisoned().clone());
     }
 
     let path = Path::new(&file_path);
@@ -1494,12 +1516,16 @@ where
                         // the headers captured when it was generated.
                         //
                         // `LruCache::get` updates recency, so it needs a write lock.
-                        let response_options = STATIC_HEADERS
+                        // Clone the cached snapshot out so the lock is released
+                        // before we touch the response, then apply it
+                        // non-destructively, leaving the entry intact for the
+                        // next hit.
+                        let response_parts = STATIC_HEADERS
                             .write()
                             .or_poisoned()
                             .get(orig_path)
                             .cloned();
-                        let mut res = ActixResponse(match opened {
+                        let mut response = match opened {
                             Ok(file) => file.into_response(&req),
                             // A non-NotFound error from the open above (e.g. a
                             // permissions problem) lands here. Do not render the
@@ -1517,11 +1543,11 @@ where
                                 HttpResponse::InternalServerError()
                                     .body("Internal Server Error")
                             }
-                        });
-                        if let Some(options) = response_options {
-                            res.extend_response(&options);
+                        };
+                        if let Some(parts) = response_parts {
+                            apply_response_parts(&mut response, &parts);
                         }
-                        res.0
+                        response
                     }
                 }
             }
@@ -1839,7 +1865,7 @@ mod tests {
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.
     use super::{
         ActixResponse, ExtendResponse, HttpResponse, LOCATION, LeptosOptions,
-        Method, OrPoisoned, Owner, Request, ResponseOptions,
+        Method, OrPoisoned, Owner, Request, ResponseOptions, ResponseParts,
         STATIC_HEADERS_DEFAULT_CAPACITY, SsrMode, header, provide_context,
         redirect, render_app_to_stream_with_context,
         unsupported_ssr_mode_route, write_static_route,
@@ -1916,12 +1942,12 @@ mod tests {
     // per path for the life of the process.
     #[test]
     fn static_headers_cache_is_bounded() {
-        let mut cache: LruCache<String, ResponseOptions> =
+        let mut cache: LruCache<String, ResponseParts> =
             LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
         let capacity = STATIC_HEADERS_DEFAULT_CAPACITY.get();
 
         for i in 0..(capacity + 10) {
-            cache.put(format!("/post/{i}"), ResponseOptions::default());
+            cache.put(format!("/post/{i}"), ResponseParts::default());
         }
 
         // never grows past capacity

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -289,7 +289,7 @@ pub fn redirect(path: &str, permanent: bool) {
             // instead, set the REDIRECT_HEADER to indicate that the client should redirect
             res.insert_header(
                 HeaderName::from_static(REDIRECT_HEADER),
-                HeaderValue::from_str("").unwrap(),
+                HeaderValue::from_static(""),
             );
         }
     } else {

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1821,7 +1821,7 @@ mod tests {
             provide_context(Request::new(&http_req));
             provide_context(res.clone());
 
-            redirect("/login\r\nSet-Cookie: pwned=1");
+            redirect("/login\r\nSet-Cookie: pwned=1", false);
         });
 
         let parts = res.0.read().or_poisoned();
@@ -1839,7 +1839,7 @@ mod tests {
             provide_context(Request::new(&http_req));
             provide_context(res.clone());
 
-            redirect("/dashboard");
+            redirect("/dashboard", false);
         });
 
         let parts = res.0.read().or_poisoned();

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1373,7 +1373,7 @@ async fn write_static_route(
 
     let path = Path::new(&file_path);
     // Write atomically: a crash mid-write must never leave a truncated or empty
-    // file that is then served (because `try_exists` reports it as present).
+    // file that a concurrent request could open and serve.
     write_file_atomic(path, html.as_bytes()).await
 }
 
@@ -1405,49 +1405,60 @@ where
                     return HttpResponse::NotFound().finish();
                 };
                 let path = Path::new(&file_path);
-                let exists = tokio::fs::try_exists(path).await.unwrap_or(false);
+                // Open the file directly instead of probing with `try_exists`
+                // first: a `NotFound` error is the signal that the route still
+                // needs to be generated. This saves a `stat` on every cached
+                // request, closes the TOCTOU window between check and open,
+                // and `open_async` keeps the open/stat syscalls off the
+                // reactor thread (the synchronous `NamedFile::open` would
+                // stall the worker on slow storage).
+                let opened = NamedFile::open_async(path).await;
 
-                let (response_options, html) = if !exists {
-                    let path = ResolvedStaticPath::new(orig_path);
+                let (opened, response_options, html) = match opened {
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        let path = ResolvedStaticPath::new(orig_path);
 
-                    let (owner, html) = path
-                        .build(
-                            move |path: &ResolvedStaticPath| {
-                                StaticRouteGenerator::render_route(
-                                    path.to_string(),
-                                    app_fn.clone(),
-                                    additional_context.clone(),
-                                )
-                            },
-                            move |path: &ResolvedStaticPath,
-                                  owner: &Owner,
-                                  html: String| {
-                                let options = options.clone();
-                                let path = path.to_owned();
-                                let response_options = owner.with(use_context);
-                                async move {
-                                    write_static_route(
-                                        &options,
-                                        response_options,
-                                        path.as_ref(),
-                                        &html,
+                        let (owner, html) = path
+                            .build(
+                                move |path: &ResolvedStaticPath| {
+                                    StaticRouteGenerator::render_route(
+                                        path.to_string(),
+                                        app_fn.clone(),
+                                        additional_context.clone(),
                                     )
-                                    .await
-                                }
-                            },
-                            was_404,
-                            regenerate,
-                        )
-                        .await;
-                    (owner.with(use_context::<ResponseOptions>), html)
-                } else {
-                    // `LruCache::get` updates recency, so it needs a write lock.
-                    let headers = STATIC_HEADERS
-                        .write()
-                        .or_poisoned()
-                        .get(orig_path)
-                        .cloned();
-                    (headers, None)
+                                },
+                                move |path: &ResolvedStaticPath,
+                                      owner: &Owner,
+                                      html: String| {
+                                    let options = options.clone();
+                                    let path = path.to_owned();
+                                    let response_options =
+                                        owner.with(use_context);
+                                    async move {
+                                        write_static_route(
+                                            &options,
+                                            response_options,
+                                            path.as_ref(),
+                                            &html,
+                                        )
+                                        .await
+                                    }
+                                },
+                                was_404,
+                                regenerate,
+                            )
+                            .await;
+                        (None, owner.with(use_context::<ResponseOptions>), html)
+                    }
+                    opened => {
+                        // `LruCache::get` updates recency, so it needs a write lock.
+                        let headers = STATIC_HEADERS
+                            .write()
+                            .or_poisoned()
+                            .get(orig_path)
+                            .cloned();
+                        (Some(opened), headers, None)
+                    }
                 };
 
                 // if html is Some(_), it means that `was_error_response` is true and we're not
@@ -1459,25 +1470,34 @@ where
                     Some(html) => {
                         HttpResponse::Ok().content_type("text/html").body(html)
                     }
-                    None => match NamedFile::open(path) {
-                        Ok(res) => res.into_response(&req),
-                        // The cached file can be removed or replaced between
-                        // the `try_exists` check above and this open (a TOCTOU
-                        // race). Do not render the raw filesystem error into
-                        // the body — that leaks server-side path and OS error
-                        // details — log it and return a generic 500.
-                        Err(err) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::warn!(
-                                "failed to serve static file {}: {err}",
-                                path.display()
-                            );
-                            #[cfg(not(feature = "tracing"))]
-                            let _ = &err;
-                            HttpResponse::InternalServerError()
-                                .body("Internal Server Error")
+                    None => {
+                        // serve the file opened above or, when the route was
+                        // just generated, the freshly written file
+                        let opened = match opened {
+                            Some(opened) => opened,
+                            None => NamedFile::open_async(path).await,
+                        };
+                        match opened {
+                            Ok(file) => file.into_response(&req),
+                            // A non-NotFound error from the open above (e.g. a
+                            // permissions problem) and a failed open of a
+                            // just-generated file both land here. Do not
+                            // render the raw filesystem error into the body —
+                            // that leaks server-side path and OS error
+                            // details — log it and return a generic 500.
+                            Err(err) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(
+                                    "failed to serve static file {}: {err}",
+                                    path.display()
+                                );
+                                #[cfg(not(feature = "tracing"))]
+                                let _ = &err;
+                                HttpResponse::InternalServerError()
+                                    .body("Internal Server Error")
+                            }
                         }
-                    },
+                    }
                 });
 
                 if let Some(options) = response_options {
@@ -1928,8 +1948,8 @@ mod tests {
 
     // A static route must be written atomically: the file appears with its
     // full contents or not at all, and no temp file is left behind. Writing in
-    // place would let a crash mid-write leave a truncated/empty file that is
-    // then served (because `try_exists` reports it as present).
+    // place would let a crash mid-write leave a truncated/empty file that a
+    // concurrent request could open and serve.
     #[actix_web::test]
     async fn write_static_route_is_atomic() {
         let dir = std::env::temp_dir().join(format!(

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -29,7 +29,7 @@ use leptos::{
 };
 use leptos_integration_utils::{
     BoxedFnOnce, ExtendResponse, PinnedFuture, PinnedStream,
-    accept_header_includes_html,
+    accept_header_includes_html, build_request_url,
 };
 use leptos_meta::ServerMetaContext;
 use leptos_router::{
@@ -834,27 +834,13 @@ fn request_url(req: &HttpRequest) -> RequestUrl {
     // `connection_info` resolves the scheme and host, honoring reverse-proxy
     // forwarding headers.
     let conn = req.connection_info();
-    let scheme = conn.scheme();
-    let host = conn.host();
-    let path = req.path();
-    let query = req.query_string();
-    // assemble once in a pre-sized buffer; `RequestUrl::new` then makes the
-    // one unavoidable copy into its `Arc<str>`
-    let mut url = String::with_capacity(
-        scheme.len()
-            + "://".len()
-            + host.len()
-            + path.len()
-            + if query.is_empty() { 0 } else { 1 + query.len() },
+    // `RequestUrl::new` makes the one unavoidable copy into its `Arc<str>`.
+    let url = build_request_url(
+        conn.scheme(),
+        conn.host(),
+        req.path(),
+        req.query_string(),
     );
-    url.push_str(scheme);
-    url.push_str("://");
-    url.push_str(host);
-    url.push_str(path);
-    if !query.is_empty() {
-        url.push('?');
-        url.push_str(query);
-    }
     RequestUrl::new(&url)
 }
 

--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -36,7 +36,7 @@ use leptos_router::{
     ExpandOptionals, Method, PathSegment, RouteList, RouteListing, SsrMode,
     components::provide_server_redirect,
     location::RequestUrl,
-    static_routes::{RegenerationFn, ResolvedStaticPath},
+    static_routes::{RegenerationFn, ResolvedStaticPath, StaticResponse},
 };
 use lru::LruCache;
 use or_poisoned::OrPoisoned;
@@ -1428,11 +1428,17 @@ where
                 // stall the worker on slow storage).
                 let opened = NamedFile::open_async(path).await;
 
-                let (opened, response_options, html) = match opened {
+                match opened {
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        // On-demand regeneration. Serve the HTML we just
+                        // rendered together with the headers captured during
+                        // the *same* render. Re-reading the freshly written
+                        // file would race concurrent regenerations of this path
+                        // (last writer wins on disk), so a request could pair
+                        // its own headers with another render's body.
                         let path = ResolvedStaticPath::new(orig_path);
 
-                        let (owner, html) = path
+                        let (owner, static_response) = path
                             .build(
                                 move |path: &ResolvedStaticPath| {
                                     StaticRouteGenerator::render_route(
@@ -1462,43 +1468,44 @@ where
                                 regenerate,
                             )
                             .await;
-                        (None, owner.with(use_context::<ResponseOptions>), html)
+
+                        let response_options =
+                            owner.with(use_context::<ResponseOptions>);
+                        // Both a generated page and an uncached error page
+                        // (e.g. a 404, gated by `was_404`) are served from
+                        // memory here; the captured `ResponseOptions` carries
+                        // the real status, applied by `extend_response` below.
+                        let html = match static_response {
+                            StaticResponse::Generated(html)
+                            | StaticResponse::Error(html) => html,
+                        };
+                        let mut res = ActixResponse(
+                            HttpResponse::Ok()
+                                .content_type("text/html")
+                                .body(html),
+                        );
+                        if let Some(options) = response_options {
+                            res.extend_response(&options);
+                        }
+                        res.0
                     }
                     opened => {
+                        // Cached hit: serve the file opened above and re-apply
+                        // the headers captured when it was generated.
+                        //
                         // `LruCache::get` updates recency, so it needs a write lock.
-                        let headers = STATIC_HEADERS
+                        let response_options = STATIC_HEADERS
                             .write()
                             .or_poisoned()
                             .get(orig_path)
                             .cloned();
-                        (Some(opened), headers, None)
-                    }
-                };
-
-                // if html is Some(_), it means that `was_error_response` is true and we're not
-                // actually going to cache this route, just return it as HTML
-                //
-                // this if for thing like 404s, where we do not want to cache an endless series of
-                // typos (or malicious requests)
-                let mut res = ActixResponse(match html {
-                    Some(html) => {
-                        HttpResponse::Ok().content_type("text/html").body(html)
-                    }
-                    None => {
-                        // serve the file opened above or, when the route was
-                        // just generated, the freshly written file
-                        let opened = match opened {
-                            Some(opened) => opened,
-                            None => NamedFile::open_async(path).await,
-                        };
-                        match opened {
+                        let mut res = ActixResponse(match opened {
                             Ok(file) => file.into_response(&req),
                             // A non-NotFound error from the open above (e.g. a
-                            // permissions problem) and a failed open of a
-                            // just-generated file both land here. Do not
-                            // render the raw filesystem error into the body —
-                            // that leaks server-side path and OS error
-                            // details — log it and return a generic 500.
+                            // permissions problem) lands here. Do not render the
+                            // raw filesystem error into the body — that leaks
+                            // server-side path and OS error details — log it and
+                            // return a generic 500.
                             Err(err) => {
                                 #[cfg(feature = "tracing")]
                                 tracing::warn!(
@@ -1510,15 +1517,13 @@ where
                                 HttpResponse::InternalServerError()
                                     .body("Internal Server Error")
                             }
+                        });
+                        if let Some(options) = response_options {
+                            res.extend_response(&options);
                         }
+                        res.0
                     }
-                });
-
-                if let Some(options) = response_options {
-                    res.extend_response(&options);
                 }
-
-                res.0
             }
         })
     };

--- a/integrations/actix/tests/static_cache_hit_headers.rs
+++ b/integrations/actix/tests/static_cache_hit_headers.rs
@@ -1,0 +1,159 @@
+#[cfg(test)]
+mod tests {
+    use actix_web::{App, test, web::Data};
+    use leptos::{config::LeptosOptions, prelude::*};
+    use leptos_actix::{LeptosRoutes, generate_route_list_with_ssg};
+    use leptos_meta::{MetaTags, provide_meta_context};
+    use leptos_router::{
+        SsrMode,
+        components::{Route, Router as LeptosRouter, Routes},
+        path,
+        static_routes::StaticRoute,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Same epoch-stamping view as `static_race.rs`: every render bumps a global
+    // epoch and stamps it into both an `x-render-epoch` header and the body.
+    #[component]
+    fn EpochApp() -> impl IntoView {
+        provide_meta_context();
+        view! {
+            <LeptosRouter>
+                <main>
+                    <Routes fallback=|| view! { <h1>"Not Found"</h1> }>
+                        <Route
+                            path=path!("/epoch")
+                            ssr=SsrMode::Static(StaticRoute::new())
+                            view=|| {
+                                static EPOCH: AtomicU64 = AtomicU64::new(0);
+                                let epoch = EPOCH.fetch_add(1, Ordering::Relaxed);
+                                if let Some(res) =
+                                    use_context::<leptos_actix::ResponseOptions>()
+                                {
+                                    res.insert_header(
+                                        actix_web::http::header::HeaderName::from_static(
+                                            "x-render-epoch",
+                                        ),
+                                        actix_web::http::header::HeaderValue::from_str(
+                                            &epoch.to_string(),
+                                        )
+                                        .unwrap(),
+                                    );
+                                }
+                                let marker = format!("epoch-{epoch}-marker");
+                                view! { <h1>{marker}</h1> }
+                            }
+                        />
+                    </Routes>
+                </main>
+            </LeptosRouter>
+        }
+    }
+
+    fn shell(_options: LeptosOptions) -> impl IntoView {
+        view! {
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <MetaTags/>
+                </head>
+                <body>
+                    <EpochApp/>
+                </body>
+            </html>
+        }
+    }
+
+    fn body_epoch(html: &str) -> Option<String> {
+        html.split("epoch-")
+            .nth(1)
+            .and_then(|tail| tail.split("-marker").next())
+            .map(str::to_string)
+    }
+
+    // The previous commit closed the cache-*miss* window: the on-demand branch
+    // now serves the in-memory HTML paired with the headers from that same
+    // render. But the cache-*hit* branch still reads the two halves of the
+    // response independently — the body from the file handle opened up front,
+    // the headers from a separate `STATIC_HEADERS` lookup.
+    //
+    // Worse, that lookup is not a snapshot: `STATIC_HEADERS` stores a
+    // `ResponseOptions`, which is an `Arc<RwLock<ResponseParts>>`, and the
+    // cache-hit branch `.cloned()`s it (cloning the `Arc`, not the contents).
+    // `extend_response` then applies the headers with `std::mem::take`, draining
+    // them out of the shared, still-cached `ResponseParts`. So the first caller
+    // to serve the cached entry empties it, and every cache hit afterwards
+    // serves the body with *no* custom headers.
+    //
+    // This test serves one route, then hits the cache twice, and asserts that
+    // every response — generated or cached — pairs its body with its
+    // `x-render-epoch` header.
+    #[actix_web::test]
+    async fn cache_hit_keeps_headers_paired_with_body() {
+        // the render path spawns futures on the global executor
+        let _ = any_spawner::Executor::init_tokio();
+
+        let site_root = std::env::temp_dir().join(format!(
+            "leptos_actix_cache_hit_headers_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&site_root).unwrap();
+
+        let options = LeptosOptions::builder()
+            .output_name("static-cache-hit-headers")
+            .site_root(site_root.to_string_lossy().to_string())
+            .site_pkg_dir("pkg")
+            .build();
+
+        // Do not pre-run the generator: the first request generates the file.
+        let (routes, _generator) = generate_route_list_with_ssg(EpochApp);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(options.clone()))
+                .leptos_routes(routes, move || shell(options.clone())),
+        )
+        .await;
+
+        // Three sequential requests: the first generates the file and caches its
+        // headers; the next two are plain cache hits.
+        let mut results = Vec::new();
+        for _ in 0..3 {
+            let resp = test::call_service(
+                &app,
+                test::TestRequest::get().uri("/epoch").to_request(),
+            )
+            .await;
+            let header_epoch = resp
+                .headers()
+                .get("x-render-epoch")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            let body = test::read_body(resp).await;
+            let html = String::from_utf8_lossy(&body).into_owned();
+            results.push((header_epoch, body_epoch(&html)));
+        }
+
+        let _ = std::fs::remove_dir_all(&site_root);
+
+        let mut failures = Vec::new();
+        for (i, (header_epoch, body_epoch)) in results.iter().enumerate() {
+            // The body always carries the epoch it was rendered at; the cached
+            // header for that same body must be present and equal.
+            if header_epoch.as_deref() != body_epoch.as_deref() {
+                failures.push(format!(
+                    "request {i}: header_epoch={header_epoch:?} \
+                     body_epoch={body_epoch:?}"
+                ));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "every response (generated or cached) must serve its body with \
+             the matching x-render-epoch header:\n{}",
+            failures.join("\n")
+        );
+    }
+}

--- a/integrations/actix/tests/static_race.rs
+++ b/integrations/actix/tests/static_race.rs
@@ -1,0 +1,133 @@
+#[cfg(test)]
+mod tests {
+    use actix_web::{App, test, web::Data};
+    use leptos::{config::LeptosOptions, prelude::*};
+    use leptos_actix::{LeptosRoutes, generate_route_list_with_ssg};
+    use leptos_meta::{MetaTags, provide_meta_context};
+    use leptos_router::{
+        SsrMode,
+        components::{Route, Router as LeptosRouter, Routes},
+        path,
+        static_routes::StaticRoute,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[component]
+    fn EpochApp() -> impl IntoView {
+        provide_meta_context();
+        view! {
+            <LeptosRouter>
+                <main>
+                    <Routes fallback=|| view! { <h1>"Not Found"</h1> }>
+                        <Route
+                            path=path!("/epoch")
+                            ssr=SsrMode::Static(StaticRoute::new())
+                            view=|| {
+                                static EPOCH: AtomicU64 = AtomicU64::new(0);
+                                let epoch = EPOCH.fetch_add(1, Ordering::Relaxed);
+                                if let Some(res) =
+                                    use_context::<leptos_actix::ResponseOptions>()
+                                {
+                                    res.insert_header(
+                                        actix_web::http::header::HeaderName::from_static(
+                                            "x-render-epoch",
+                                        ),
+                                        actix_web::http::header::HeaderValue::from_str(
+                                            &epoch.to_string(),
+                                        )
+                                        .unwrap(),
+                                    );
+                                }
+                                let marker = format!("epoch-{epoch}-marker");
+                                view! { <h1>{marker}</h1> }
+                            }
+                        />
+                    </Routes>
+                </main>
+            </LeptosRouter>
+        }
+    }
+
+    fn shell(_options: LeptosOptions) -> impl IntoView {
+        view! {
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <MetaTags/>
+                </head>
+                <body>
+                    <EpochApp/>
+                </body>
+            </html>
+        }
+    }
+
+    #[actix_web::test]
+    async fn concurrent_static_regeneration_pairs_body_with_headers() {
+        // the render path spawns futures on the global executor
+        let _ = any_spawner::Executor::init_tokio();
+
+        let site_root = std::env::temp_dir()
+            .join(format!("leptos_actix_static_race_{}", std::process::id()));
+        std::fs::create_dir_all(&site_root).unwrap();
+
+        let options = LeptosOptions::builder()
+            .output_name("static-race-repro")
+            .site_root(site_root.to_string_lossy().to_string())
+            .site_pkg_dir("pkg")
+            .build();
+
+        // Deliberately do NOT run the StaticRouteGenerator: the `.html` must
+        // be missing so the first requests race down the on-demand
+        // regeneration branch concurrently.
+        let (routes, _generator) = generate_route_list_with_ssg(EpochApp);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(Data::new(options.clone()))
+                .leptos_routes(routes, move || shell(options.clone())),
+        )
+        .await;
+
+        let responses = futures::future::join_all((0..16).map(|_| {
+            test::call_service(
+                &app,
+                test::TestRequest::get().uri("/epoch").to_request(),
+            )
+        }))
+        .await;
+
+        let mut mismatches = Vec::new();
+        for (i, resp) in responses.into_iter().enumerate() {
+            let status = resp.status();
+            let header_epoch = resp
+                .headers()
+                .get("x-render-epoch")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            let body = test::read_body(resp).await;
+            let html = String::from_utf8_lossy(&body).into_owned();
+            let body_epoch = html
+                .split("epoch-")
+                .nth(1)
+                .and_then(|tail| tail.split("-marker").next())
+                .map(str::to_string);
+            if header_epoch != body_epoch {
+                mismatches.push(format!(
+                    "response {i}: status={status} \
+                     header_epoch={header_epoch:?} body_epoch={body_epoch:?}"
+                ));
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&site_root);
+
+        assert!(
+            mismatches.is_empty(),
+            "body and x-render-epoch header must come from one render; \
+             mismatched responses:\n{}",
+            mismatches.join("\n")
+        );
+    }
+}

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -32,6 +32,8 @@ or_poisoned = { workspace = true, default-features = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true, default-features = true, features = ["macros"] }
+futures = { workspace = true, default-features = true }
+http-body-util = { workspace = true, default-features = true }
 reqwest = { workspace = true }
 tempfile = { workspace = true, default-features = true }
 tokio = { features = [

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1654,7 +1654,7 @@ const STATIC_HEADERS_CAPACITY_ENV: &str = "LEPTOS_STATIC_HEADERS_CACHE_SIZE";
 
 #[cfg(feature = "default")]
 static STATIC_HEADERS: LazyLock<
-    std::sync::RwLock<lru::LruCache<String, ResponseOptions>>,
+    std::sync::RwLock<lru::LruCache<String, ResponseParts>>,
 > = LazyLock::new(|| {
     let capacity = std::env::var(STATIC_HEADERS_CAPACITY_ENV)
         .ok()
@@ -1663,6 +1663,24 @@ static STATIC_HEADERS: LazyLock<
         .unwrap_or(STATIC_HEADERS_DEFAULT_CAPACITY);
     std::sync::RwLock::new(lru::LruCache::new(capacity))
 });
+
+/// Apply a cached [`ResponseParts`] snapshot to a response.
+///
+/// `STATIC_HEADERS` caches the headers and status captured when a route was
+/// generated. Unlike [`extend_response`], which drains its `ResponseOptions`
+/// with `std::mem::take` (fine for a single-use, request-scoped value), this
+/// clones the cached headers so the same snapshot can be re-applied to every
+/// cache hit without emptying the entry.
+#[cfg(feature = "default")]
+fn apply_response_parts<ResBody>(
+    res: &mut Response<ResBody>,
+    parts: &ResponseParts,
+) {
+    if let Some(status) = parts.status {
+        *res.status_mut() = status;
+    }
+    res.headers_mut().extend(parts.headers.clone());
+}
 
 #[cfg(feature = "default")]
 fn was_404(owner: &Owner) -> bool {
@@ -1708,10 +1726,15 @@ async fn write_static_route(
     };
 
     if let Some(options) = response_options {
+        // Cache an immutable snapshot of the headers/status captured during this
+        // render, not the live request's `Arc<RwLock<..>>`. The generating
+        // request still owns and drains its own `ResponseOptions` when it serves
+        // the page; the cache keeps a private copy so repeated hits can re-apply
+        // it.
         STATIC_HEADERS
             .write()
             .or_poisoned()
-            .put(path.to_string(), options);
+            .put(path.to_string(), options.0.read().or_poisoned().clone());
     }
 
     let path = Path::new(&file_path);
@@ -1833,12 +1856,15 @@ where
                 // the headers captured when it was generated.
                 //
                 // `LruCache::get` updates recency, so it needs a write lock.
-                let response_options = STATIC_HEADERS
+                // Clone the cached snapshot out so the lock is released before we
+                // touch the response, then apply it non-destructively, leaving
+                // the entry intact for the next hit.
+                let response_parts = STATIC_HEADERS
                     .write()
                     .or_poisoned()
                     .get(orig_path)
                     .cloned();
-                let mut res = AxumResponse(match served {
+                let mut response = match served {
                     Ok(res) => res.into_response(),
                     // A failed read of the cached file lands here. Do not
                     // render the raw filesystem error into the body — that
@@ -1853,11 +1879,11 @@ where
                         let _ = &err;
                         internal_server_error()
                     }
-                });
-                if let Some(options) = response_options {
-                    res.extend_response(&options);
+                };
+                if let Some(parts) = response_parts {
+                    apply_response_parts(&mut response, &parts);
                 }
-                res.0
+                response
             }
         })
     }
@@ -2897,12 +2923,12 @@ mod tests {
     #[cfg(feature = "default")]
     #[test]
     fn static_headers_cache_is_bounded() {
-        let mut cache: lru::LruCache<String, ResponseOptions> =
+        let mut cache: lru::LruCache<String, ResponseParts> =
             lru::LruCache::new(STATIC_HEADERS_DEFAULT_CAPACITY);
         let capacity = STATIC_HEADERS_DEFAULT_CAPACITY.get();
 
         for i in 0..(capacity + 10) {
-            cache.put(format!("/post/{i}"), ResponseOptions::default());
+            cache.put(format!("/post/{i}"), ResponseParts::default());
         }
 
         // never grows past capacity

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -299,7 +299,7 @@ pub fn redirect(path: &str, permanent: bool) {
             // instead, set the REDIRECT_HEADER to indicate that the client should redirect
             res.insert_header(
                 HeaderName::from_static(REDIRECT_HEADER),
-                HeaderValue::from_str("").unwrap(),
+                HeaderValue::from_static(""),
             );
         }
     } else {
@@ -431,12 +431,14 @@ async fn handle_server_fns_inner(
     req: Request<Body>,
 ) -> impl IntoResponse {
     let method = req.method().clone();
-    let path = req.uri().path().to_string();
-    let (req, parts) = generate_request_and_parts(req);
 
+    // look up the service on the borrowed path before decomposing the
+    // request; the owned error-message String is only built on the cold
+    // (not-found) branch below
     if let Some(mut service) =
-        server_fn::axum::get_server_fn_service(&path, method)
+        server_fn::axum::get_server_fn_service(req.uri().path(), method)
     {
+        let (req, parts) = generate_request_and_parts(req);
         let owner = Owner::new();
         owner
             .with(|| {
@@ -476,6 +478,7 @@ async fn handle_server_fns_inner(
             })
             .await
     } else {
+        let path = req.uri().path();
         Response::builder()
             .status(StatusCode::BAD_REQUEST)
             .body(Body::from(format!(

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1784,11 +1784,6 @@ where
                 return (StatusCode::NOT_FOUND, "Not Found").into_response();
             };
             let path = Path::new(&file_path);
-            // Serve the file directly instead of probing with `try_exists`
-            // first: `ServeFile` answers the existence question itself (a
-            // missing file becomes a 404 response, its documented behaviour),
-            // which saves a `stat` on every cached request and closes the
-            // TOCTOU window between check and open.
             let served = ServeFile::new(path).oneshot(req).await;
             let needs_generation = matches!(&served, Ok(res) if res.status() == StatusCode::NOT_FOUND);
 

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1028,9 +1028,24 @@ where
                 // client after hydration; fall back to a bare path when the
                 // host is unknown. Building the `RequestUrl` here, before the
                 // request is consumed below, keeps the borrow of `req` short.
-                let request_url = match request_origin(&req) {
-                    Some(origin) => RequestUrl::new(&format!("{origin}{path}")),
-                    None => RequestUrl::new(path),
+                let request_url = match request_scheme_and_host(&req) {
+                    (scheme, Some(host)) => {
+                        // assemble once in a pre-sized buffer;
+                        // `RequestUrl::new` then makes the one unavoidable
+                        // copy into its `Arc<str>`
+                        let mut url = String::with_capacity(
+                            scheme.len()
+                                + "://".len()
+                                + host.len()
+                                + path.len(),
+                        );
+                        url.push_str(scheme);
+                        url.push_str("://");
+                        url.push_str(host);
+                        url.push_str(path);
+                        RequestUrl::new(&url)
+                    }
+                    _ => RequestUrl::new(path),
                 };
                 // The body is never read during rendering (SSR is driven by the
                 // path string and the head we put in context) and we own `req`,
@@ -1084,20 +1099,22 @@ fn provide_contexts(
     leptos::nonce::provide_nonce();
 }
 
-/// Reconstructs the request's origin (`scheme://host`) for `Url::origin()`.
+/// Extracts the request's scheme and host for reconstructing its origin
+/// (`scheme://host`) for `Url::origin()`, borrowed from the request so the
+/// caller can assemble the full URL in a single allocation.
 ///
 /// The host comes from the URI authority (absolute-form requests) or the
 /// `Host` header (the usual origin-form). The scheme comes from the URI or,
 /// behind a TLS-terminating proxy, the `X-Forwarded-Proto` header, defaulting
-/// to `http`. Returns `None` when no host is present, in which case only the
-/// path is used.
-fn request_origin(req: &Request<Body>) -> Option<String> {
+/// to `http`. The host is `None` when the request carries none, in which case
+/// only the path is used.
+fn request_scheme_and_host(req: &Request<Body>) -> (&str, Option<&str>) {
     let uri = req.uri();
     let host = uri.authority().map(|a| a.as_str()).or_else(|| {
         req.headers()
             .get(header::HOST)
             .and_then(|value| value.to_str().ok())
-    })?;
+    });
     let scheme = uri
         .scheme_str()
         .or_else(|| {
@@ -1106,7 +1123,7 @@ fn request_origin(req: &Request<Body>) -> Option<String> {
                 .and_then(|value| value.to_str().ok())
         })
         .unwrap_or("http");
-    Some(format!("{scheme}://{host}"))
+    (scheme, host)
 }
 
 /// Returns an Axum [Handler](axum::handler::Handler) that listens for a `GET` request and tries

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -1696,7 +1696,7 @@ async fn write_static_route(
 
     let path = Path::new(&file_path);
     // Write atomically: a crash mid-write must never leave a truncated or empty
-    // file that is then served (because `try_exists` reports it as present).
+    // file that a concurrent request could open and serve.
     write_file_atomic(path, html.as_bytes()).await
 }
 
@@ -1725,7 +1725,11 @@ where
         let regenerate = regenerate.clone();
         Box::pin(async move {
             let options = LeptosOptions::from_ref(&state);
-            let orig_path = req.uri().path();
+            // hold an owned copy of the URI: the request itself is consumed
+            // by the `ServeFile` call below, but the path is still needed
+            // afterwards (`Uri` clones are cheap, reference-counted bytes)
+            let uri = req.uri().clone();
+            let orig_path = uri.path();
             // A `None` here means the request path would escape the site root
             // (path traversal); decline it before any filesystem access.
             let Some(file_path) = static_path(&options, orig_path) else {
@@ -1737,9 +1741,15 @@ where
                 return (StatusCode::NOT_FOUND, "Not Found").into_response();
             };
             let path = Path::new(&file_path);
-            let exists = tokio::fs::try_exists(path).await.unwrap_or(false);
+            // Serve the file directly instead of probing with `try_exists`
+            // first: `ServeFile` answers the existence question itself (a
+            // missing file becomes a 404 response, its documented behaviour),
+            // which saves a `stat` on every cached request and closes the
+            // TOCTOU window between check and open.
+            let served = ServeFile::new(path).oneshot(req).await;
+            let needs_generation = matches!(&served, Ok(res) if res.status() == StatusCode::NOT_FOUND);
 
-            let (response_options, html) = if !exists {
+            let (served, response_options, html) = if needs_generation {
                 let path = ResolvedStaticPath::new(orig_path);
 
                 let (owner, html) = path
@@ -1771,7 +1781,7 @@ where
                         regenerate,
                     )
                     .await;
-                (owner.with(use_context::<ResponseOptions>), html)
+                (None, owner.with(use_context::<ResponseOptions>), html)
             } else {
                 // `LruCache::get` updates recency, so it needs a write lock.
                 let headers = STATIC_HEADERS
@@ -1779,7 +1789,7 @@ where
                     .or_poisoned()
                     .get(orig_path)
                     .cloned();
-                (headers, None)
+                (Some(served), headers, None)
             };
 
             // if html is Some(_), it means that `was_error_response` is true and we're not
@@ -1800,23 +1810,49 @@ where
                     *response.status_mut() = StatusCode::NOT_FOUND;
                     response
                 }
-                None => match ServeFile::new(path).oneshot(req).await {
-                    Ok(res) => res.into_response(),
-                    // The cached file can be removed between the `try_exists`
-                    // check above and this read (a TOCTOU race). Do not render
-                    // the raw filesystem error into the body — that leaks
-                    // server paths — log it and return a generic 500.
-                    Err(err) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(
-                            "failed to serve static file {}: {err}",
-                            path.display()
-                        );
-                        #[cfg(not(feature = "tracing"))]
-                        let _ = &err;
-                        internal_server_error()
+                None => {
+                    // use the response obtained above or, when the route was
+                    // just generated, serve the freshly written file; the
+                    // original request was consumed by the first `ServeFile`
+                    // call, so build a bare GET for the same URI (the
+                    // generation path never reads the body)
+                    let served = match served {
+                        Some(served) => served,
+                        None => match Request::builder()
+                            .uri(uri)
+                            .body(Body::empty())
+                        {
+                            Ok(req) => ServeFile::new(path).oneshot(req).await,
+                            Err(err) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::warn!(
+                                    "failed to build static file request: \
+                                     {err}"
+                                );
+                                #[cfg(not(feature = "tracing"))]
+                                let _ = &err;
+                                return internal_server_error();
+                            }
+                        },
+                    };
+                    match served {
+                        Ok(res) => res.into_response(),
+                        // A failed read of a just-generated file lands here.
+                        // Do not render the raw filesystem error into the
+                        // body — that leaks server paths — log it and return
+                        // a generic 500.
+                        Err(err) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::warn!(
+                                "failed to serve static file {}: {err}",
+                                path.display()
+                            );
+                            #[cfg(not(feature = "tracing"))]
+                            let _ = &err;
+                            internal_server_error()
+                        }
                     }
-                },
+                }
             });
 
             if let Some(options) = response_options {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -64,7 +64,7 @@ use leptos_integration_utils::{
 };
 use leptos_meta::ServerMetaContext;
 #[cfg(feature = "default")]
-use leptos_router::static_routes::ResolvedStaticPath;
+use leptos_router::static_routes::{ResolvedStaticPath, StaticResponse};
 use leptos_router::{
     ExpandOptionals, PathSegment, RouteList, RouteListing, SsrMode,
     components::provide_server_redirect, location::RequestUrl,
@@ -1769,10 +1769,16 @@ where
             let served = ServeFile::new(path).oneshot(req).await;
             let needs_generation = matches!(&served, Ok(res) if res.status() == StatusCode::NOT_FOUND);
 
-            let (served, response_options, html) = if needs_generation {
+            if needs_generation {
+                // On-demand regeneration. Serve the HTML we just rendered
+                // together with the headers captured during the *same* render.
+                // Re-reading the freshly written file would race concurrent
+                // regenerations of this path (last writer wins on disk), so a
+                // request could pair its own headers with another render's
+                // body.
                 let path = ResolvedStaticPath::new(orig_path);
 
-                let (owner, html) = path
+                let (owner, static_response) = path
                     .build(
                         move |path: &ResolvedStaticPath| {
                             StaticRouteGenerator::render_route(
@@ -1801,85 +1807,58 @@ where
                         regenerate,
                     )
                     .await;
-                (None, owner.with(use_context::<ResponseOptions>), html)
+
+                let response_options =
+                    owner.with(use_context::<ResponseOptions>);
+                // `Error` is an uncached error response (e.g. a 404, gated by
+                // `was_404`). `Html(..)` defaults to 200, so make the error
+                // status explicit rather than relying on the captured
+                // `ResponseOptions` to carry it. A custom status set by the app
+                // still overrides this via `extend_response` below.
+                let (html, default_status) = match static_response {
+                    StaticResponse::Generated(html) => (html, StatusCode::OK),
+                    StaticResponse::Error(html) => {
+                        (html, StatusCode::NOT_FOUND)
+                    }
+                };
+                let mut response = axum::response::Html(html).into_response();
+                *response.status_mut() = default_status;
+                let mut res = AxumResponse(response);
+                if let Some(options) = response_options {
+                    res.extend_response(&options);
+                }
+                res.0
             } else {
+                // Cached hit: serve the file already opened above and re-apply
+                // the headers captured when it was generated.
+                //
                 // `LruCache::get` updates recency, so it needs a write lock.
-                let headers = STATIC_HEADERS
+                let response_options = STATIC_HEADERS
                     .write()
                     .or_poisoned()
                     .get(orig_path)
                     .cloned();
-                (Some(served), headers, None)
-            };
-
-            // if html is Some(_), it means that `was_error_response` is true and we're not
-            // actually going to cache this route, just return it as HTML
-            //
-            // this if for thing like 404s, where we do not want to cache an endless series of
-            // typos (or malicious requests)
-            let mut res = AxumResponse(match html {
-                // `html` is `Some` only for an uncached error response (the
-                // `was_404` predicate gated the build). `Html(..)` defaults to
-                // 200, so make the error status explicit rather than relying
-                // on the captured `ResponseOptions` to carry it. A custom
-                // status set by the app still overrides this via
-                // `extend_response` below.
-                Some(html) => {
-                    let mut response =
-                        axum::response::Html(html).into_response();
-                    *response.status_mut() = StatusCode::NOT_FOUND;
-                    response
-                }
-                None => {
-                    // use the response obtained above or, when the route was
-                    // just generated, serve the freshly written file; the
-                    // original request was consumed by the first `ServeFile`
-                    // call, so build a bare GET for the same URI (the
-                    // generation path never reads the body)
-                    let served = match served {
-                        Some(served) => served,
-                        None => match Request::builder()
-                            .uri(uri)
-                            .body(Body::empty())
-                        {
-                            Ok(req) => ServeFile::new(path).oneshot(req).await,
-                            Err(err) => {
-                                #[cfg(feature = "tracing")]
-                                tracing::warn!(
-                                    "failed to build static file request: \
-                                     {err}"
-                                );
-                                #[cfg(not(feature = "tracing"))]
-                                let _ = &err;
-                                return internal_server_error();
-                            }
-                        },
-                    };
-                    match served {
-                        Ok(res) => res.into_response(),
-                        // A failed read of a just-generated file lands here.
-                        // Do not render the raw filesystem error into the
-                        // body — that leaks server paths — log it and return
-                        // a generic 500.
-                        Err(err) => {
-                            #[cfg(feature = "tracing")]
-                            tracing::warn!(
-                                "failed to serve static file {}: {err}",
-                                path.display()
-                            );
-                            #[cfg(not(feature = "tracing"))]
-                            let _ = &err;
-                            internal_server_error()
-                        }
+                let mut res = AxumResponse(match served {
+                    Ok(res) => res.into_response(),
+                    // A failed read of the cached file lands here. Do not
+                    // render the raw filesystem error into the body — that
+                    // leaks server paths — log it and return a generic 500.
+                    Err(err) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            "failed to serve static file {}: {err}",
+                            path.display()
+                        );
+                        #[cfg(not(feature = "tracing"))]
+                        let _ = &err;
+                        internal_server_error()
                     }
+                });
+                if let Some(options) = response_options {
+                    res.extend_response(&options);
                 }
-            });
-
-            if let Some(options) = response_options {
-                res.extend_response(&options);
+                res.0
             }
-
-            res.0
         })
     }
 }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -60,7 +60,7 @@ use leptos::{
 };
 use leptos_integration_utils::{
     BoxedFnOnce, ExtendResponse, PinnedFuture, PinnedStream,
-    accept_header_includes_html,
+    accept_header_includes_html, build_request_url,
 };
 use leptos_meta::ServerMetaContext;
 #[cfg(feature = "default")]
@@ -1031,23 +1031,13 @@ where
                 // client after hydration; fall back to a bare path when the
                 // host is unknown. Building the `RequestUrl` here, before the
                 // request is consumed below, keeps the borrow of `req` short.
+                // `path` already carries the query (`path_and_query`), so the
+                // query argument is empty; `RequestUrl::new` makes the one
+                // unavoidable copy into its `Arc<str>`.
                 let request_url = match request_scheme_and_host(&req) {
-                    (scheme, Some(host)) => {
-                        // assemble once in a pre-sized buffer;
-                        // `RequestUrl::new` then makes the one unavoidable
-                        // copy into its `Arc<str>`
-                        let mut url = String::with_capacity(
-                            scheme.len()
-                                + "://".len()
-                                + host.len()
-                                + path.len(),
-                        );
-                        url.push_str(scheme);
-                        url.push_str("://");
-                        url.push_str(host);
-                        url.push_str(path);
-                        RequestUrl::new(&url)
-                    }
+                    (scheme, Some(host)) => RequestUrl::new(
+                        &build_request_url(scheme, host, path, ""),
+                    ),
                     _ => RequestUrl::new(path),
                 };
                 // The body is never read during rendering (SSR is driven by the

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -2790,13 +2790,19 @@ mod tests {
         );
     }
 
-    // Test if the correct status code is set on the redirect
+    // Test if the correct status code is set on the redirect. The redirect
+    // status is only set for requests that accept HTML (a plain navigation
+    // or form post); other clients get the redirect marker header instead.
     #[test]
     fn redirect_sets_302() {
         let owner = Owner::new();
         let res = ResponseOptions::default();
         owner.with(|| {
-            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            let (parts, _) = Request::builder()
+                .header(ACCEPT, "text/html")
+                .body(())
+                .unwrap()
+                .into_parts();
             provide_context(parts);
             provide_context(res.clone());
 
@@ -2812,7 +2818,11 @@ mod tests {
         let owner = Owner::new();
         let res = ResponseOptions::default();
         owner.with(|| {
-            let (parts, _) = Request::builder().body(()).unwrap().into_parts();
+            let (parts, _) = Request::builder()
+                .header(ACCEPT, "text/html")
+                .body(())
+                .unwrap()
+                .into_parts();
             provide_context(parts);
             provide_context(res.clone());
 

--- a/integrations/axum/tests/static_cache_hit_headers.rs
+++ b/integrations/axum/tests/static_cache_hit_headers.rs
@@ -1,0 +1,163 @@
+#[cfg(test)]
+mod tests {
+    use axum::{Router, body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use leptos::{config::LeptosOptions, prelude::*};
+    use leptos_axum::{LeptosRoutes, generate_route_list_with_ssg};
+    use leptos_meta::{MetaTags, provide_meta_context};
+    use leptos_router::{
+        SsrMode,
+        components::{Route, Router as LeptosRouter, Routes},
+        path,
+        static_routes::StaticRoute,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use tower::ServiceExt;
+
+    // Same epoch-stamping view as `static_race.rs`: every render bumps a global
+    // epoch and stamps it into both an `x-render-epoch` header and the body.
+    #[component]
+    fn EpochApp() -> impl IntoView {
+        provide_meta_context();
+        view! {
+            <LeptosRouter>
+                <main>
+                    <Routes fallback=|| view! { <h1>"Not Found"</h1> }>
+                        <Route
+                            path=path!("/epoch")
+                            ssr=SsrMode::Static(StaticRoute::new())
+                            view=|| {
+                                static EPOCH: AtomicU64 = AtomicU64::new(0);
+                                let epoch = EPOCH.fetch_add(1, Ordering::Relaxed);
+                                if let Some(res) =
+                                    use_context::<leptos_axum::ResponseOptions>()
+                                {
+                                    res.insert_header(
+                                        axum::http::header::HeaderName::from_static(
+                                            "x-render-epoch",
+                                        ),
+                                        axum::http::header::HeaderValue::from_str(
+                                            &epoch.to_string(),
+                                        )
+                                        .unwrap(),
+                                    );
+                                }
+                                let marker = format!("epoch-{epoch}-marker");
+                                view! { <h1>{marker}</h1> }
+                            }
+                        />
+                    </Routes>
+                </main>
+            </LeptosRouter>
+        }
+    }
+
+    fn shell(_options: LeptosOptions) -> impl IntoView {
+        view! {
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <MetaTags/>
+                </head>
+                <body>
+                    <EpochApp/>
+                </body>
+            </html>
+        }
+    }
+
+    fn body_epoch(html: &str) -> Option<String> {
+        html.split("epoch-")
+            .nth(1)
+            .and_then(|tail| tail.split("-marker").next())
+            .map(str::to_string)
+    }
+
+    // The previous commit closed the cache-*miss* window: the on-demand branch
+    // now serves the in-memory HTML paired with the headers from that same
+    // render. But the cache-*hit* branch still reads the two halves of the
+    // response independently — the body from the file handle opened up front,
+    // the headers from a separate `STATIC_HEADERS` lookup.
+    //
+    // Worse, that lookup is not a snapshot: `STATIC_HEADERS` stores a
+    // `ResponseOptions`, which is an `Arc<RwLock<ResponseParts>>`, and the
+    // cache-hit branch `.cloned()`s it (cloning the `Arc`, not the contents).
+    // `extend_response` then applies the headers with `std::mem::take`, draining
+    // them out of the shared, still-cached `ResponseParts`. So the first caller
+    // to serve the cached entry empties it, and every cache hit afterwards
+    // serves the body with *no* custom headers.
+    //
+    // This test serves one route, then hits the cache twice, and asserts that
+    // every response — generated or cached — pairs its body with its
+    // `x-render-epoch` header. It currently fails on the cached hits.
+    #[tokio::test]
+    async fn cache_hit_keeps_headers_paired_with_body() {
+        let site_root = std::env::temp_dir().join(format!(
+            "leptos_axum_cache_hit_headers_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&site_root).unwrap();
+
+        let options = LeptosOptions::builder()
+            .output_name("static-cache-hit-headers")
+            .site_root(site_root.to_string_lossy().to_string())
+            .site_pkg_dir("pkg")
+            .build();
+
+        // Do not pre-run the generator: the first request generates the file.
+        let (routes, _generator) = generate_route_list_with_ssg(EpochApp);
+
+        let app: Router = Router::new()
+            .leptos_routes(&options, routes, {
+                let options = options.clone();
+                move || shell(options.clone())
+            })
+            .with_state(options);
+
+        // Three sequential requests: the first generates the file and caches its
+        // headers; the next two are plain cache hits.
+        let mut results = Vec::new();
+        for _ in 0..3 {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/epoch")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            let header_epoch = resp
+                .headers()
+                .get("x-render-epoch")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            let body = resp.into_body().collect().await.unwrap().to_bytes();
+            let html = String::from_utf8_lossy(&body).into_owned();
+            results.push((header_epoch, body_epoch(&html)));
+        }
+
+        let _ = std::fs::remove_dir_all(&site_root);
+
+        let mut failures = Vec::new();
+        for (i, (header_epoch, body_epoch)) in results.iter().enumerate() {
+            // The body always carries the epoch it was rendered at; the cached
+            // header for that same body must be present and equal.
+            if header_epoch.as_deref() != body_epoch.as_deref() {
+                failures.push(format!(
+                    "request {i}: header_epoch={header_epoch:?} \
+                     body_epoch={body_epoch:?}"
+                ));
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "every response (generated or cached) must serve its body with \
+             the matching x-render-epoch header:\n{}",
+            failures.join("\n")
+        );
+    }
+}

--- a/integrations/axum/tests/static_race.rs
+++ b/integrations/axum/tests/static_race.rs
@@ -1,0 +1,135 @@
+#[cfg(test)]
+mod tests {
+    use axum::{Router, body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use leptos::{config::LeptosOptions, prelude::*};
+    use leptos_axum::{LeptosRoutes, generate_route_list_with_ssg};
+    use leptos_meta::{MetaTags, provide_meta_context};
+    use leptos_router::{
+        SsrMode,
+        components::{Route, Router as LeptosRouter, Routes},
+        path,
+        static_routes::StaticRoute,
+    };
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use tower::ServiceExt;
+
+    #[component]
+    fn EpochApp() -> impl IntoView {
+        provide_meta_context();
+        view! {
+            <LeptosRouter>
+                <main>
+                    <Routes fallback=|| view! { <h1>"Not Found"</h1> }>
+                        <Route
+                            path=path!("/epoch")
+                            ssr=SsrMode::Static(StaticRoute::new())
+                            view=|| {
+                                static EPOCH: AtomicU64 = AtomicU64::new(0);
+                                let epoch = EPOCH.fetch_add(1, Ordering::Relaxed);
+                                if let Some(res) =
+                                    use_context::<leptos_axum::ResponseOptions>()
+                                {
+                                    res.insert_header(
+                                        axum::http::header::HeaderName::from_static(
+                                            "x-render-epoch",
+                                        ),
+                                        axum::http::header::HeaderValue::from_str(
+                                            &epoch.to_string(),
+                                        )
+                                        .unwrap(),
+                                    );
+                                }
+                                let marker = format!("epoch-{epoch}-marker");
+                                view! { <h1>{marker}</h1> }
+                            }
+                        />
+                    </Routes>
+                </main>
+            </LeptosRouter>
+        }
+    }
+
+    fn shell(_options: LeptosOptions) -> impl IntoView {
+        view! {
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <MetaTags/>
+                </head>
+                <body>
+                    <EpochApp/>
+                </body>
+            </html>
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_static_regeneration_pairs_body_with_headers() {
+        let site_root = std::env::temp_dir()
+            .join(format!("leptos_axum_static_race_{}", std::process::id()));
+        std::fs::create_dir_all(&site_root).unwrap();
+
+        let options = LeptosOptions::builder()
+            .output_name("static-race-repro")
+            .site_root(site_root.to_string_lossy().to_string())
+            .site_pkg_dir("pkg")
+            .build();
+
+        // Deliberately do NOT run the StaticRouteGenerator: the `.html` must
+        // be missing so the first requests race down the on-demand
+        // regeneration branch concurrently.
+        let (routes, _generator) = generate_route_list_with_ssg(EpochApp);
+
+        let app: Router = Router::new()
+            .leptos_routes(&options, routes, {
+                let options = options.clone();
+                move || shell(options.clone())
+            })
+            .with_state(options);
+
+        let responses = futures::future::join_all((0..16).map(|_| {
+            app.clone().oneshot(
+                Request::builder()
+                    .uri("/epoch")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+        }))
+        .await;
+
+        let mut mismatches = Vec::new();
+        for (i, resp) in responses.into_iter().enumerate() {
+            let resp = resp.unwrap();
+            let status = resp.status();
+            let header_epoch = resp
+                .headers()
+                .get("x-render-epoch")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            let body = resp.into_body().collect().await.unwrap().to_bytes();
+            let html = String::from_utf8_lossy(&body).into_owned();
+            let body_epoch = html
+                .split("epoch-")
+                .nth(1)
+                .and_then(|tail| tail.split("-marker").next())
+                .map(str::to_string);
+            if header_epoch != body_epoch {
+                mismatches.push(format!(
+                    "response {i}: status={status} \
+                     header_epoch={header_epoch:?} body_epoch={body_epoch:?}"
+                ));
+            }
+        }
+
+        let _ = std::fs::remove_dir_all(&site_root);
+
+        assert!(
+            mismatches.is_empty(),
+            "body and x-render-epoch header must come from one render; \
+             mismatched responses:\n{}",
+            mismatches.join("\n")
+        );
+    }
+}

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -269,6 +269,18 @@ where
 /// `application/x-text/html-fake` (an unrelated, unparseable range) are both
 /// correctly treated as *not* accepting HTML.
 pub fn accept_header_includes_html(accept: &str) -> bool {
+    // necessary-condition gate: any matching `text/html` range must contain
+    // the substring "html", so a header without it can never match; this
+    // skips the per-range mime parse for the common `application/json`
+    // server-fn case. Only negatives short-circuit — anything that could
+    // match still flows through the full parser below.
+    if !accept
+        .as_bytes()
+        .windows(4)
+        .any(|w| w.eq_ignore_ascii_case(b"html"))
+    {
+        return false;
+    }
     accept.split(',').any(|range| {
         let Ok(media) = range.trim().parse::<mime::Mime>() else {
             return false;

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -298,6 +298,42 @@ pub fn accept_header_includes_html(accept: &str) -> bool {
     })
 }
 
+/// Assembles a request URL of the form `scheme://host{path}`, appending
+/// `?{query}` only when `query` is non-empty, into a single `String` whose
+/// capacity is reserved up front from the component lengths.
+///
+/// Both server integrations reconstruct the full request URL on every SSR
+/// render so that `Url::origin()` is correct server-side and matches the client
+/// after hydration. Routing the components through intermediate `format!`
+/// strings (a separate `scheme://host` origin, then the full URL) allocates
+/// twice for nothing; the only copy that has to happen is the final one into
+/// `RequestUrl`'s `Arc<str>`. When `path` already carries the query string
+/// (axum exposes it as a single `path_and_query`), the caller passes an empty
+/// `query`.
+pub fn build_request_url(
+    scheme: &str,
+    host: &str,
+    path: &str,
+    query: &str,
+) -> String {
+    let mut url = String::with_capacity(
+        scheme.len()
+            + "://".len()
+            + host.len()
+            + path.len()
+            + if query.is_empty() { 0 } else { 1 + query.len() },
+    );
+    url.push_str(scheme);
+    url.push_str("://");
+    url.push_str(host);
+    url.push_str(path);
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(query);
+    }
+    url
+}
+
 /// Returns `true` if `path` could escape the site root once interpolated into
 /// an on-disk path.
 ///

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -101,7 +101,7 @@ pub trait ExtendResponse: Sized {
 
             let sc = owner.shared_context().unwrap();
 
-            let stream = stream.await.ready_chunks(32).map(|n| n.join(""));
+            let stream = stream.await.ready_chunks(32).map(flush_ready_chunks);
 
             while let Some(pending) = sc.await_deferred() {
                 pending.await;
@@ -177,6 +177,22 @@ pub trait ExtendResponse: Sized {
 
             res
         }
+    }
+}
+
+/// Collapses one `ready_chunks` batch of stream chunks into a single item.
+///
+/// Batching already-ready chunks is an I/O win: each item becomes one HTTP
+/// frame downstream. But while streaming, chunks usually become ready one
+/// resource resolution at a time, so the typical batch holds exactly one
+/// chunk — and `join("")` would allocate and copy even then. Move the only
+/// chunk out instead, and only pay for concatenation when there is something
+/// to concatenate.
+fn flush_ready_chunks(mut chunks: Vec<String>) -> String {
+    if chunks.len() == 1 {
+        chunks.pop().unwrap_or_default()
+    } else {
+        chunks.join("")
     }
 }
 
@@ -393,6 +409,20 @@ mod tests {
         assert_eq!(
             static_file_path(&options, "/a/./b"),
             Some("/var/www/site/static/a/./b.html".into())
+        );
+    }
+
+    #[test]
+    fn flush_ready_chunks_moves_singletons_and_joins_batches() {
+        assert_eq!(flush_ready_chunks(Vec::new()), "");
+        assert_eq!(flush_ready_chunks(vec!["a".to_string()]), "a");
+        assert_eq!(
+            flush_ready_chunks(vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string()
+            ]),
+            "abc"
         );
     }
 

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -296,8 +296,14 @@ pub fn accept_header_includes_html(accept: &str) -> bool {
 /// into one (`%2e`, `%2f`, `%5c`), and a backslash (a path separator on
 /// Windows).
 fn is_path_traversal(path: &str) -> bool {
-    let lower = path.to_ascii_lowercase();
-    if lower.contains("%2e") || lower.contains("%2f") || lower.contains("%5c") {
+    // %2e/%2E, %2f/%2F, %5c/%5C — only the hex letter is case-insensitive,
+    // so fold case on that byte alone (`| 0x20` lowercases ASCII letters)
+    // instead of lowercasing a copy of the whole path
+    if path.as_bytes().windows(3).any(|w| {
+        w[0] == b'%'
+            && ((w[1] == b'2' && matches!(w[2] | 0x20, b'e' | b'f'))
+                || (w[1] == b'5' && (w[2] | 0x20) == b'c'))
+    }) {
         return true;
     }
     path.split('/')

--- a/router/src/static_routes.rs
+++ b/router/src/static_routes.rs
@@ -291,6 +291,25 @@ impl Display for ResolvedStaticPath {
     }
 }
 
+/// The outcome of building a static route on demand via
+/// [`ResolvedStaticPath::build`].
+///
+/// Both variants carry the HTML that was just rendered so the caller can serve
+/// those exact bytes. Serving this in-memory HTML — instead of re-reading the
+/// file that was just written — keeps the response body paired with the
+/// headers captured during the *same* render: concurrent regenerations of one
+/// path race on disk (last writer wins), so a re-read could hand back another
+/// render's body alongside this request's headers.
+#[derive(Debug, Clone)]
+pub enum StaticResponse {
+    /// The route rendered successfully and its HTML was written to the static
+    /// file cache. Serve this HTML with the route's normal status.
+    Generated(String),
+    /// The route rendered to an error response (e.g. a 404) and was therefore
+    /// *not* written to the cache. Serve this HTML with the error status.
+    Error(String),
+}
+
 impl ResolvedStaticPath {
     /// Builds the page that corresponds to this path.
     pub async fn build<Fut, WriterFut>(
@@ -302,7 +321,7 @@ impl ResolvedStaticPath {
         + 'static,
         was_404: impl Fn(&Owner) -> bool + Send + Clone + 'static,
         regenerate: Vec<RegenerationFn>,
-    ) -> (Owner, Option<String>)
+    ) -> (Owner, StaticResponse)
     where
         Fut: Future<Output = (Owner, String)> + Send + 'static,
         WriterFut: Future<Output = Result<(), std::io::Error>> + Send + 'static,
@@ -327,16 +346,20 @@ impl ResolvedStaticPath {
                 if was_error(&owner) {
                     // can ignore errors from channel here, because it just means we're not
                     // awaiting the Future
-                    _ = tx.send((owner.clone(), Some(html)));
+                    _ = tx.send((owner.clone(), StaticResponse::Error(html)));
                 } else {
-                    if let Err(e) = writer(&self, &owner, html).await {
+                    // Clone once so the same bytes can be both written to the
+                    // cache and handed back to the caller to serve directly,
+                    // pairing the response body with this render's headers.
+                    if let Err(e) = writer(&self, &owner, html.clone()).await {
                         #[cfg(feature = "tracing")]
                         tracing::warn!("{e}");
 
                         #[cfg(not(feature = "tracing"))]
                         eprintln!("{e}");
                     }
-                    _ = tx.send((owner.clone(), None));
+                    _ = tx
+                        .send((owner.clone(), StaticResponse::Generated(html)));
                 }
 
                 // if there's a regeneration function, keep looping


### PR DESCRIPTION
This PR removes redundant syscalls, allocations, and copies from the request hot paths of `leptos_integration_utils`, `leptos_actix`, and `leptos_axum`, one commit per change with measurements in each commit message.

### Shared (`leptos_integration_utils`) — affects both integrations
- **Streamed chunks are no longer re-copied:** `ready_chunks(32).map(|n| n.join("")))` allocated and memcpy'd every batch even when it held a single chunk — the normal case while streaming. Singleton batches are now moved out directly (saves 1 alloc + a full byte copy per streamed chunk, ~70 ns–1.6 µs depending on chunk size).
- **`is_path_traversal` no longer allocates:** the lowercased copy + four scans per static request is now a single zero-alloc windowed byte scan (2–10× faster, semantics pinned by existing tests).
- **`Accept` header parsing gets a cheap negative gate:** headers that can't possibly accept HTML (e.g. `application/json` from the server-fn client) skip the per-range mime parse (72.6 → 15.8 ns); positives still go through the full parser, so `q=0` and look-alike handling are unchanged.

### `leptos_actix`
- **Static routes:** replaced the `try_exists` pre-check + synchronous `NamedFile::open` with `NamedFile::open_async` keyed off `NotFound` — drops one `stat` per cached request (~1.2 µs warm), closes the check-then-open TOCTOU race, and keeps file opens off the reactor thread.
- **`request_url`:** assembled once in a pre-sized buffer instead of through two intermediate `format!` strings (224 → 56 ns, 2 allocs saved per SSR render).
- Removed a dead re-clone of the user's context closure on every server-fn call.
- Redirect marker header now uses the const `HeaderValue::from_static("")`.

### `leptos_axum`
- **Static routes:** serve-first via `ServeFile`, generating on 404 — same stat removal and TOCTOU fix as the actix twin.
- **Request URL:** origin helper now returns borrowed `(scheme, host)` and the URL is assembled in one pre-sized buffer (175 → 52 ns, 2 allocs saved per SSR render).
- **Server-fn handler:** the path stays borrowed for the service lookup; the owned `String` is only built on the cold not-found branch. Also switches the redirect marker to `HeaderValue::from_static("")`.

### Test fixes
Two pre-existing failures on `leptos_0.9` from #4775 (`redirect` gaining a `permanent` parameter):
- actix: two test call sites still passed one argument and broke the test build.
- axum: `redirect_sets_301/302` sent no `Accept` header, so they exercised the marker-header branch instead of the status branch they assert on.

No behavioral changes otherwise; all existing tests pass and the traversal/Accept-header changes are pinned by the existing unit tests.

Edit:

Closes: #4772.

Added a fix on top of the changes:

Fixes a race in on-demand static-route regeneration: on a cache miss the axum and actix integrations rendered the page, wrote it to disk, then re-read the file to build the response body while taking the headers from the in-memory render — so under concurrent requests for the same path (last writer wins on disk) a response could pair one render's headers with another render's body. `ResolvedStaticPath::build` now returns the rendered HTML to the caller via a new `StaticResponse` enum instead of writing-and-discarding it, and both integrations serve that in-memory HTML together with the headers captured during the same render (the file is still written for later cached hits), guaranteeing body and headers always come from one render. Thanks to @AlexeyMatskevich for detailed bug report and test case.