### PR TITLE
Surface failed lazy-route chunk loads to ErrorBoundary instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4659,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_helpers"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0cb6d1008be3c4c5abc31a407bfb8c8449ae14efc8561c1db821f79b9614b0a"
+checksum = "69a727977b2d2e2193e8f85f59069d791d9ce091a4217b8c3d6a6f17f1554498"
 dependencies = [
  "async-once-cell",
  "wasm_split_macros",
@@ -4669,9 +4669,9 @@ dependencies = [
 
 [[package]]
 name = "wasm_split_macros"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a659ffe5c7f4538aa6357c07e3d73221cc61eba03bd9a081e14bc91ed09b8c"
+checksum = "3e653af7ee4a9ef0fce481a9ec6f43cb78de20d0cdb4f4f5862e1dc6e407e6c8"
 dependencies = [
  "base16",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,9 @@ sha2 = { default-features = false, version = "0.11" }
 subsecond = { default-features = false, version = "0.7" }
 dioxus-cli-config = { default-features = false, version = "0.7" }
 dioxus-devtools = { default-features = false, version = "0.7" }
-wasm_split_helpers = { default-features = false, version = "0.2.1" }
+# 0.2.2 adds the `fallible` option that `#[lazy_route]` relies on to surface a
+# failed chunk load to an `<ErrorBoundary>` instead of panicking.
+wasm_split_helpers = { default-features = false, version = "0.2.2" }
 
 [profile.release]
 codegen-units = 1
@@ -187,3 +189,4 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(leptos_debuginfo)',
   'cfg(erase_components)',
 ] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,4 +189,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(leptos_debuginfo)',
   'cfg(erase_components)',
 ] }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,8 +171,6 @@ sha2 = { default-features = false, version = "0.11" }
 subsecond = { default-features = false, version = "0.7" }
 dioxus-cli-config = { default-features = false, version = "0.7" }
 dioxus-devtools = { default-features = false, version = "0.7" }
-# 0.2.2 adds the `fallible` option that `#[lazy_route]` relies on to surface a
-# failed chunk load to an `<ErrorBoundary>` instead of panicking.
 wasm_split_helpers = { default-features = false, version = "0.2.2" }
 
 [profile.release]

--- a/examples/lazy_routes/e2e/features/chunk_failure.feature
+++ b/examples/lazy_routes/e2e/features/chunk_failure.feature
@@ -1,0 +1,26 @@
+@chunk_failure
+Feature: A failed lazy-route chunk load renders the ErrorBoundary fallback
+
+	Scenario: A chunk-fetch failure shows the fallback instead of crashing the app.
+		Given I see the app
+		Then I see the page is View A
+		When wasm chunk requests fail
+		When I select the link C
+		Then I see the chunk error fallback
+
+	# TODO: enable once a cargo-leptos release ships wasm_split_cli_support >= 0.2.2
+	# (leptos-rs/cargo-leptos#662). Older versions cache a rejected chunk load for
+	# the lifetime of the session, so the re-navigation below cannot succeed.
+	#
+	# Scenario: A transient chunk-fetch failure is not cached, so navigating again recovers.
+	#	Given I see the app
+	#	Then I see the page is View A
+	#	When wasm chunk requests fail
+	#	When I select the link C
+	#	Then I see the chunk error fallback
+	#	When wasm chunk requests succeed again
+	#	When I select the link A
+	#	Then I see the page is View A
+	#	When I select the link C
+	#	When I wait for a second
+	#	Then I see the page is View C

--- a/examples/lazy_routes/e2e/features/chunk_failure.feature
+++ b/examples/lazy_routes/e2e/features/chunk_failure.feature
@@ -8,19 +8,15 @@ Feature: A failed lazy-route chunk load renders the ErrorBoundary fallback
 		When I select the link C
 		Then I see the chunk error fallback
 
-	# TODO: enable once a cargo-leptos release ships wasm_split_cli_support >= 0.2.2
-	# (leptos-rs/cargo-leptos#662). Older versions cache a rejected chunk load for
-	# the lifetime of the session, so the re-navigation below cannot succeed.
-	#
-	# Scenario: A transient chunk-fetch failure is not cached, so navigating again recovers.
-	#	Given I see the app
-	#	Then I see the page is View A
-	#	When wasm chunk requests fail
-	#	When I select the link C
-	#	Then I see the chunk error fallback
-	#	When wasm chunk requests succeed again
-	#	When I select the link A
-	#	Then I see the page is View A
-	#	When I select the link C
-	#	When I wait for a second
-	#	Then I see the page is View C
+	Scenario: A transient chunk-fetch failure is not cached, so navigating again recovers.
+		Given I see the app
+		Then I see the page is View A
+		When wasm chunk requests fail
+		When I select the link C
+		Then I see the chunk error fallback
+		When wasm chunk requests succeed again
+		When I select the link A
+		Then I see the page is View A
+		When I select the link C
+		When I wait for a second
+		Then I see the page is View C

--- a/examples/lazy_routes/e2e/tests/fixtures/action.rs
+++ b/examples/lazy_routes/e2e/tests/fixtures/action.rs
@@ -21,3 +21,33 @@ pub async fn click_button(client: &Client, id: &str) -> Result<()> {
     btn.click().await?;
     Ok(())
 }
+
+/// Simulates a network failure for lazily loaded WASM chunks by shimming
+/// `window.fetch` to reject requests for `.wasm` files while blocking is
+/// enabled. The main bundle is unaffected: it has already been loaded by the
+/// time this runs, and everything that isn't a `.wasm` request passes through.
+pub async fn set_wasm_chunks_blocked(client: &Client, blocked: bool) -> Result<()> {
+    client
+        .execute(
+            r#"
+            const [blocked] = arguments;
+            if (!window.__realFetch) {
+                window.__realFetch = window.fetch;
+                window.fetch = function (input, init) {
+                    const url =
+                        typeof input === "string" ? input : input.url || String(input);
+                    if (window.__blockWasmChunks && url.split("?")[0].endsWith(".wasm")) {
+                        return Promise.reject(
+                            new TypeError("simulated network failure: " + url)
+                        );
+                    }
+                    return window.__realFetch.apply(this, arguments);
+                };
+            }
+            window.__blockWasmChunks = blocked;
+            "#,
+            vec![serde_json::Value::Bool(blocked)],
+        )
+        .await?;
+    Ok(())
+}

--- a/examples/lazy_routes/e2e/tests/fixtures/world/action_steps.rs
+++ b/examples/lazy_routes/e2e/tests/fixtures/world/action_steps.rs
@@ -51,6 +51,14 @@ async fn i_select_the_following_links(
     Ok(())
 }
 
+#[when(regex = "^wasm chunk requests (fail|succeed again)$")]
+async fn wasm_chunk_requests(world: &mut AppWorld, mode: String) -> Result<()> {
+    let client = &world.client;
+    action::set_wasm_chunks_blocked(client, mode == "fail").await?;
+
+    Ok(())
+}
+
 #[when("I wait for a second")]
 async fn i_wait_for_a_second(world: &mut AppWorld) -> Result<()> {
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;

--- a/examples/lazy_routes/e2e/tests/fixtures/world/check_steps.rs
+++ b/examples/lazy_routes/e2e/tests/fixtures/world/check_steps.rs
@@ -23,6 +23,13 @@ async fn i_see_the_result_is(world: &mut AppWorld, text: String) -> Result<()> {
     Ok(())
 }
 
+#[then(regex = r"^I see the chunk error fallback$")]
+async fn i_see_the_chunk_error_fallback(world: &mut AppWorld) -> Result<()> {
+    let client = &world.client;
+    check::element_exists(client, "chunk-error").await?;
+    Ok(())
+}
+
 #[then(regex = r"^I see the navbar$")]
 async fn i_see_the_navbar(world: &mut AppWorld) -> Result<()> {
     let client = &world.client;

--- a/examples/lazy_routes/src/app.rs
+++ b/examples/lazy_routes/src/app.rs
@@ -1,4 +1,4 @@
-use leptos::{prelude::*, task::spawn_local};
+use leptos::{prelude::*, task::spawn_local, LazyViewError};
 use leptos_router::{
     components::{Outlet, ParentRoute, Route, Router, Routes},
     lazy_route, Lazy, LazyRoute, StaticSegment,
@@ -171,7 +171,7 @@ pub struct Album {
 // View C: a lazy view, and some data, loaded in parallel when we navigate to /c.
 #[derive(Clone)]
 pub struct ViewC {
-    data: LocalResource<Vec<Album>>,
+    data: LocalResource<Result<Vec<Album>, LazyViewError>>,
 }
 
 // Lazy-loaded routes need to implement the LazyRoute trait. They define a "route data" struct,
@@ -189,10 +189,14 @@ impl LazyRoute for ViewC {
         // the data method itself is synchronous: it typically creates things like Resources,
         // which are created synchronously but spawn an async data-loading task
         // if you want further code-splitting, however, you can create a lazy function to load the data!
-        #[lazy]
-        async fn lazy_data() -> Vec<Album> {
+        // A `fallible` lazy data loader: if its chunk fails to load, the error
+        // flows through the `Resource` and is surfaced to the `<ErrorBoundary>`
+        // (see `view`), instead of panicking. This is what makes navigating to
+        // the route resilient to a transient chunk-fetch failure.
+        #[lazy(fallible)]
+        async fn lazy_data() -> Result<Vec<Album>, LazyViewError> {
             gloo_timers::future::TimeoutFuture::new(250).await;
-            vec![
+            Ok(vec![
                 Album {
                     user_id: 1,
                     id: 1,
@@ -208,7 +212,7 @@ impl LazyRoute for ViewC {
                     id: 3,
                     title: "omnis laborum odio".into(),
                 },
-            ]
+            ])
         }
 
         Self {
@@ -219,17 +223,22 @@ impl LazyRoute for ViewC {
     fn view(this: Self) -> AnyView {
         let albums = move || {
             Suspend::new(async move {
-                this.data
-                    .await
-                    .into_iter()
-                    .map(|album| {
-                        view! {
-                            <li id=format!("{}-{}", album.user_id, album.id)>
-                                {album.title}
-                            </li>
-                        }
-                    })
-                    .collect::<Vec<_>>()
+                // `?` propagates a failed data-chunk load as `Err(LazyViewError)`,
+                // which renders to the nearest `<ErrorBoundary>` instead of
+                // panicking. The failure isn't cached, so a retry can recover.
+                let albums = this.data.await?;
+                Ok::<_, LazyViewError>(
+                    albums
+                        .into_iter()
+                        .map(|album| {
+                            view! {
+                                <li id=format!("{}-{}", album.user_id, album.id)>
+                                    {album.title}
+                                </li>
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
             })
         };
         view! {

--- a/examples/lazy_routes/src/app.rs
+++ b/examples/lazy_routes/src/app.rs
@@ -39,15 +39,22 @@ pub fn App() -> impl IntoView {
             </span>
         </nav>
         <Router set_is_routing>
-            <Routes fallback=|| "Not found.">
-                <Route path=StaticSegment("") view=ViewA/>
-                <Route path=StaticSegment("b") view=ViewB/>
-                <Route path=StaticSegment("c") view={Lazy::<ViewC>::new()}/>
-                // you can nest lazy routes, and there data and views will all load concurrently
-                <ParentRoute path=StaticSegment("d") view={Lazy::<ViewD>::new()}>
-                    <Route path=StaticSegment("") view={Lazy::<ViewE>::new()}/>
-                </ParentRoute>
-            </Routes>
+            // If a lazy route's chunk fails to load, its view renders an `Err`,
+            // which this `<ErrorBoundary>` catches to show a fallback instead of
+            // panicking. The failure isn't cached, so navigating again retries.
+            <ErrorBoundary fallback=|_errors| {
+                view! { <p id="chunk-error">"This page failed to load. Try navigating to it again."</p> }
+            }>
+                <Routes fallback=|| "Not found.">
+                    <Route path=StaticSegment("") view=ViewA/>
+                    <Route path=StaticSegment("b") view=ViewB/>
+                    <Route path=StaticSegment("c") view={Lazy::<ViewC>::new()}/>
+                    // you can nest lazy routes, and there data and views will all load concurrently
+                    <ParentRoute path=StaticSegment("d") view={Lazy::<ViewD>::new()}>
+                        <Route path=StaticSegment("") view={Lazy::<ViewE>::new()}/>
+                    </ParentRoute>
+                </Routes>
+            </ErrorBoundary>
         </Router>
     }
 }

--- a/leptos/src/lazy_view_error.rs
+++ b/leptos/src/lazy_view_error.rs
@@ -7,17 +7,6 @@ use wasm_split_helpers::SplitLoaderError;
 
 /// The error produced when a lazy route's view fails to load its WASM chunk.
 ///
-/// `#[lazy_route]` generates a `fallible` view whose `Err` is rendered by the
-/// nearest [`ErrorBoundary`](crate::error::ErrorBoundary) instead of panicking.
-/// That rendering path requires the error to be `Send + Sync + 'static`, but the
-/// underlying [`SplitLoaderError`] is deliberately allowed to be neither (so it
-/// can, for example, carry a `JsValue` describing the JavaScript failure).
-///
-/// This wrapper bridges the two: it holds the split error in a [`SendWrapper`],
-/// which is `Send + Sync` unconditionally. That is sound here because a lazy
-/// chunk only ever loads — and so this error is only ever constructed and
-/// rendered — on the single WASM thread.
-///
 /// You can match on this type from an `<ErrorBoundary>` fallback (via
 /// `Error::downcast_ref`) to detect a chunk-load failure specifically.
 #[derive(Clone)]

--- a/leptos/src/lazy_view_error.rs
+++ b/leptos/src/lazy_view_error.rs
@@ -1,0 +1,43 @@
+//! Error type bridging a failed lazy-route chunk load into an
+//! [`ErrorBoundary`](crate::error::ErrorBoundary).
+
+use send_wrapper::SendWrapper;
+use std::fmt;
+use wasm_split_helpers::SplitLoaderError;
+
+/// The error produced when a lazy route's view fails to load its WASM chunk.
+///
+/// `#[lazy_route]` generates a `fallible` view whose `Err` is rendered by the
+/// nearest [`ErrorBoundary`](crate::error::ErrorBoundary) instead of panicking.
+/// That rendering path requires the error to be `Send + Sync + 'static`, but the
+/// underlying [`SplitLoaderError`] is deliberately allowed to be neither (so it
+/// can, for example, carry a `JsValue` describing the JavaScript failure).
+///
+/// This wrapper bridges the two: it holds the split error in a [`SendWrapper`],
+/// which is `Send + Sync` unconditionally. That is sound here because a lazy
+/// chunk only ever loads — and so this error is only ever constructed and
+/// rendered — on the single WASM thread.
+///
+/// You can match on this type from an `<ErrorBoundary>` fallback (via
+/// `Error::downcast_ref`) to detect a chunk-load failure specifically.
+pub struct LazyViewError(SendWrapper<SplitLoaderError>);
+
+impl fmt::Debug for LazyViewError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&*self.0, f)
+    }
+}
+
+impl fmt::Display for LazyViewError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl std::error::Error for LazyViewError {}
+
+impl From<SplitLoaderError> for LazyViewError {
+    fn from(err: SplitLoaderError) -> Self {
+        Self(SendWrapper::new(err))
+    }
+}

--- a/leptos/src/lazy_view_error.rs
+++ b/leptos/src/lazy_view_error.rs
@@ -20,8 +20,12 @@ use wasm_split_helpers::SplitLoaderError;
 ///
 /// You can match on this type from an `<ErrorBoundary>` fallback (via
 /// `Error::downcast_ref`) to detect a chunk-load failure specifically.
+#[derive(Clone)]
 pub struct LazyViewError(SendWrapper<SplitLoaderError>);
 
+// Delegate `Debug`/`Display` to the inner error rather than deriving them, so
+// diagnostics show the `SplitLoaderError` itself and not the `SendWrapper`
+// implementation detail.
 impl fmt::Debug for LazyViewError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&*self.0, f)
@@ -34,7 +38,13 @@ impl fmt::Display for LazyViewError {
     }
 }
 
-impl std::error::Error for LazyViewError {}
+impl std::error::Error for LazyViewError {
+    // Preserve the chain to the underlying `SplitLoaderError` so a fallback can
+    // walk `source()` (or downcast it) for the load-failure details.
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.0)
+    }
+}
 
 impl From<SplitLoaderError> for LazyViewError {
     fn from(err: SplitLoaderError) -> Self {

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -164,8 +164,8 @@ pub mod prelude {
     mod export_types {
         pub use crate::{
             callback::*, children::*, component::*, control_flow::*, error::*,
-            form::*, hydration::*, into_view::*, lazy_view_error::*, mount::*,
-            nonce::*, suspense::*, text_prop::*,
+            form::*, hydration::*, into_view::*, mount::*, nonce::*,
+            suspense::*, text_prop::*,
         };
         pub use leptos_config::*;
         pub use leptos_dom::helpers::*;

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -164,8 +164,8 @@ pub mod prelude {
     mod export_types {
         pub use crate::{
             callback::*, children::*, component::*, control_flow::*, error::*,
-            form::*, hydration::*, into_view::*, mount::*, nonce::*,
-            suspense::*, text_prop::*,
+            form::*, hydration::*, into_view::*, lazy_view_error::*, mount::*,
+            nonce::*, suspense::*, text_prop::*,
         };
         pub use leptos_config::*;
         pub use leptos_dom::helpers::*;
@@ -215,6 +215,9 @@ pub mod error {
     pub use crate::error_boundary::*;
     pub use throw_error::*;
 }
+
+mod lazy_view_error;
+pub use lazy_view_error::LazyViewError;
 
 /// Control-flow components like `<Show>`, `<For>`, and `<Await>`.
 pub mod control_flow {

--- a/leptos_macro/src/lazy.rs
+++ b/leptos_macro/src/lazy.rs
@@ -6,8 +6,8 @@ use proc_macro2::Ident;
 use quote::{format_ident, quote};
 use std::mem;
 use syn::{
-    ItemFn, Path, ReturnType, Stmt, parse::Parse, parse_macro_input,
-    parse_quote,
+    ItemFn, Path, ReturnType, Stmt, Token, parse::Parse, parse_macro_input,
+    parse_quote, punctuated::Punctuated,
 };
 
 fn preload_name(ident: &Ident) -> Ident {
@@ -15,11 +15,25 @@ fn preload_name(ident: &Ident) -> Ident {
 }
 
 pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
-    let name = if !args.is_empty() {
-        Some(parse_macro_input!(args as syn::Ident))
-    } else {
-        None
-    };
+    // Optional, comma-separated args: an explicit module name (a bare ident)
+    // and/or the `fallible` flag. `fallible` forwards to
+    // `#[wasm_split(.., fallible)]`, so the annotated function must return
+    // `Result<_, E: From<SplitLoaderError>>` and a failed chunk load is
+    // surfaced as `Err` instead of panicking.
+    let parsed_args = parse_macro_input!(
+        args with Punctuated::<Ident, Token![,]>::parse_terminated
+    );
+    let mut name = None;
+    let mut fallible = false;
+    for ident in parsed_args {
+        if ident == "fallible" {
+            fallible = true;
+        } else if name.is_none() {
+            name = Some(ident);
+        } else {
+            abort!(ident.span(), "unexpected `lazy` argument");
+        }
+    }
 
     let fun = syn::parse::<ItemFn>(s).unwrap_or_else(|e| {
         abort!(e.span(), "`lazy` can only be used on a function")
@@ -77,11 +91,17 @@ pub fn lazy_impl(args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
             });
         }
         let preload_name = preload_name(&fun.sig.ident);
+        let fallible_opt = if fallible {
+            quote! { fallible, }
+        } else {
+            quote! {}
+        };
 
         quote! {
             #[::leptos::wasm_split::wasm_split(
                 #unique_name,
                 wasm_split_path = ::leptos::wasm_split,
+                #fallible_opt
                 preload(#[doc(hidden)] #[allow(non_snake_case)] #preload_name),
                 #return_wrapper
             )]

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -392,7 +392,7 @@ fn lazy_route_impl(
                 &mut fun.block,
                 parse_quote!({
                     // The split view fn is `fallible`, so it returns
-                    // `Result<AnyView, SplitLoaderError>`. Erase it with
+                    // `Result<AnyView, LazyViewError>`. Erase it with
                     // `into_any()`: on `Err`, the `Result` renders to the
                     // nearest `<ErrorBoundary>` instead of panicking.
                     ::leptos::prelude::IntoAny::into_any(
@@ -408,7 +408,7 @@ fn lazy_route_impl(
                     #user_pat: #self_ty,
                 ) -> ::core::result::Result<
                     ::leptos::prelude::AnyView,
-                    ::leptos::wasm_split::SplitLoaderError,
+                    ::leptos::LazyViewError,
                 > {
                     ::core::result::Result::Ok(#body)
                 }

--- a/router_macro/src/lib.rs
+++ b/router_macro/src/lib.rs
@@ -243,6 +243,12 @@ impl ToTokens for Segments {
 /// add a [`lazy`] annotation to the `view` method, which will cause the code for the view
 /// to lazy-load concurrently with the `data` being loaded for the route.
 ///
+/// If the view's WASM chunk fails to load (e.g. a transient network error), the error is
+/// surfaced to the nearest [`ErrorBoundary`](leptos::prelude::ErrorBoundary) instead of
+/// panicking, and the (uncached) failure is retried on the next navigation. Wrap your
+/// `<Routes/>` in an `<ErrorBoundary>` to render a fallback; without one, a failed chunk
+/// renders nothing.
+///
 /// ```rust
 /// use leptos::prelude::*;
 /// use leptos_router::{lazy_route, LazyRoute};
@@ -321,8 +327,12 @@ fn lazy_route_impl(
                     // TODO for 0.9 this is not precise
                     // we don't split routes for wasm32 ssr
                     // but we don't require a `hydrate`/`csr` feature on leptos_router
+                    //
+                    // Best-effort prefetch: discard a load error here (it is not
+                    // cached) so a failed chunk does not panic; `view()` surfaces
+                    // the error on the retry, where an `<ErrorBoundary>` can catch it.
                     #[cfg(target_arch = "wasm32")]
-                    #preload_ident().await;
+                    let _ = #preload_ident().await;
                 }
             }
             .into(),
@@ -380,18 +390,32 @@ fn lazy_route_impl(
 
             let body = std::mem::replace(
                 &mut fun.block,
-                parse_quote!({ #lazy_view_ident(#this_ident).await }),
+                parse_quote!({
+                    // The split view fn is `fallible`, so it returns
+                    // `Result<AnyView, SplitLoaderError>`. Erase it with
+                    // `into_any()`: on `Err`, the `Result` renders to the
+                    // nearest `<ErrorBoundary>` instead of panicking.
+                    ::leptos::prelude::IntoAny::into_any(
+                        #lazy_view_ident(#this_ident).await,
+                    )
+                }),
             );
 
             quote! {
                 #[allow(non_snake_case)]
-                #[::leptos::lazy]
-                fn #lazy_view_ident(#user_pat: #self_ty) -> ::leptos::prelude::AnyView {
-                    #body
+                #[::leptos::lazy(fallible)]
+                fn #lazy_view_ident(
+                    #user_pat: #self_ty,
+                ) -> ::core::result::Result<
+                    ::leptos::prelude::AnyView,
+                    ::leptos::wasm_split::SplitLoaderError,
+                > {
+                    ::core::result::Result::Ok(#body)
                 }
 
                 #im
-            }.into()
+            }
+            .into()
         }
     }
 }


### PR DESCRIPTION
## Problem

A lazy route's view is loaded from a separate WASM chunk (`#[lazy_route]` → `#[lazy]` → `#[wasm_split]`). Today that `#[wasm_split]` is **not** `fallible`, so a single transient chunk-fetch failure — flaky mobile network, a navigation abort, a momentary 5xx — makes the generated wrapper `.expect()` the load and **panic**. On wasm a panic aborts the whole module (`unreachable`), so the app is bricked until a full page reload, and the failure is cached for the session.

(This is the leptos side of WorldSEnder/wasm-split-prototype#35.)

## Change

Make the generated lazy-route view `fallible` and route its error to the nearest `<ErrorBoundary>`, so a failed chunk renders a fallback (and recovers on the next navigation, since the loader no longer caches failures).

- **`leptos_macro` (`lazy.rs`)** — `#[lazy]` accepts an optional `fallible` flag (alongside the optional module-name ident) that forwards to `#[wasm_split(.., fallible)]`. Existing `#[lazy]` / `#[lazy(name)]` uses are byte-identical.
- **`router_macro` (`lazy_route`)** — emit `#[lazy(fallible)]`; give the generated split view fn the type `Result<AnyView, SplitLoaderError>` (`Ok`-wrapping the user's body — their `view` still reads `-> AnyView`); and `into_any()` it so an `Err` renders to the nearest `<ErrorBoundary>` via the existing `impl<T, E> RenderHtml for Result<T, E>`. `preload()` discards the error (best-effort prefetch; the real surfacing happens in `view()` on the uncached retry).
- Bump the `wasm_split_helpers` floor to **0.2.2**, which adds the `fallible` option and re-exports `SplitLoaderError` (`std::error::Error + Send + Sync`, so it already satisfies `Into<throw_error::Error>` — no new error plumbing needed).
- Document the behavior on `#[lazy_route]` and wrap the `lazy_routes` example in an `<ErrorBoundary>` to model the pattern.

## Why it's small and doesn't change any public API

- The **`LazyRoute` trait is untouched** (`view() -> impl Future<Output = AnyView>`, `preload() -> ()`), and **how users write `#[lazy_route]` is unchanged** (`view` still returns `AnyView`).
- Only an internal, `__`-prefixed generated helper's return type changes, and `#[lazy]` gains an optional flag. So this is a non-breaking change.
- One behavioral note (now in the `#[lazy_route]` docs): without an enclosing `<ErrorBoundary>`, a failed chunk renders nothing rather than panicking — still strictly better than aborting, but worth a boundary to show a fallback.

## Validation

Built the official `examples/lazy_routes` against this branch (with the `wasm_split_helpers` 0.2.2 patch) and drove it with Playwright — aborting exactly one fetch of the ViewC view chunk (`split___view_c_view_*.wasm`):

- **before** (stock): nav 1 → `pageerror: unreachable` (panic); route bricked.
- **after** (this PR): nav 1 → the `<ErrorBoundary>` fallback renders, no panic; nav 2 loads the route.

A standalone non-`fallible` `#[lazy]` data fn in the same example (`lazy_data() -> Vec<Album>`) compiles unchanged, confirming backward-compat.

## Status: draft, blocked on a `wasm_split_helpers` release

This depends on the `fallible` option in WorldSEnder/wasm-split-prototype#36, which isn't published yet — so the `wasm_split_helpers = "0.2.2"` floor here won't resolve from crates.io until that lands. Opening as a draft until then; happy to adjust the design to whatever shape that PR settles on.

---

Thank you all for leptos — the lazy-route + `wasm_split` work is what makes mobile-first Leptos apps viable, and building the fix on top of it was a pleasure precisely because the pieces (`RenderHtml for Result`, `ErrorBoundary`, the `#[lazy_route]` codegen) compose so cleanly. Grateful for the care that goes into this project, and happy to revise anything here. cc @gbj (per the ErrorBoundary discussion on the wasm-split PR).