### PR TITLE
feat(nonce): add `Nonce::from_value` for externally-supplied CSP nonces

### DIFF
--- a/leptos/src/nonce.rs
+++ b/leptos/src/nonce.rs
@@ -176,6 +176,16 @@ impl Nonce {
         rng.fill_bytes(&mut bytes);
         Nonce(NONCE_ENGINE.encode(bytes).into())
     }
+
+    /// Builds a nonce from a caller-supplied value rather than generating
+    /// one — e.g. a nonce minted by a reverse proxy and forwarded to the
+    /// application as a request header. The caller is responsible for the
+    /// value's randomness and for it being a valid CSP nonce. Provide it via
+    /// context before rendering so [`use_nonce`] and the hydration scripts
+    /// pick it up.
+    pub fn from_value(value: impl Into<Arc<str>>) -> Self {
+        Nonce(value.into())
+    }
 }
 
 impl Default for Nonce {


### PR DESCRIPTION
## Motivation

A common reverse-proxy CSP setup has the **edge proxy mint the per-request nonce** and forward it to the app (e.g. nginx `$request_id`/`sub_filter`, or WAF `script_random_nonce`-style features), with the app reflecting that value onto its inline `<script>`/`<style>` tags while the proxy injects the matching `nonce-…` into the enforced `Content-Security-Policy`.

Today `Nonce` can only be produced by `Nonce::new()` (random) - its inner field is `pub(crate)` and there's no public constructor from a value. So an app behind such a proxy cannot make `HydrationScripts` / `leptos_meta`'s `<Script>`/`<Style>` stamp the proxy-supplied nonce: the framework always mints its own, and the two never match, so the browser blocks the scripts.

## Change

Add an additive constructor:

```rust
impl Nonce {
    pub fn from_value(value: impl Into<Arc<str>>) -> Self { Nonce(value.into()) }
}
```

Usage — provide it via context before rendering (overriding the integration's `provide_nonce`), so `use_nonce()` and the hydration scripts pick it up:

```rust
// inside the leptos_*_with_context additional-context closure
if let Some(nonce) = request_header("x-proxy-csp-nonce") {
    provide_context(Nonce::from_value(nonce));
}
```

The caller owns the value's randomness and CSP-validity (documented on the method). No behavior change.

## Notes

- Happy to adjust the name (`from_value` / `from_trusted` / `From<String>`) or add a `From<String>`/`From<&str>` impl alongside if preferred.