### PR TITLE
fix(server_fn): return an error instead of panicking on missing multipart boundary

### DIFF
--- a/server_fn/src/codec/multipart.rs
+++ b/server_fn/src/codec/multipart.rs
@@ -1,6 +1,6 @@
 use super::{Encoding, FromReq};
 use crate::{
-    error::{FromServerFnError, ServerFnErrorWrapper},
+    error::{FromServerFnError, IntoAppError, ServerFnErrorErr, ServerFnErrorWrapper},
     request::{browser::BrowserFormData, ClientReq, Req},
     ContentType, IntoReq,
 };
@@ -85,7 +85,13 @@ where
         let boundary = req
             .to_content_type()
             .and_then(|ct| multer::parse_boundary(ct).ok())
-            .expect("couldn't parse boundary");
+            .ok_or_else(|| {
+                ServerFnErrorErr::Deserialization(
+                    "couldn't parse multipart boundary from Content-Type header"
+                        .to_string(),
+                )
+                .into_app_error()
+            })?;
         let stream = req.try_into_stream()?;
         let data = multer::Multipart::new(
             stream.map(|data| data.map_err(|e| ServerFnErrorWrapper(E::de(e)))),


### PR DESCRIPTION
## Summary

FromReq for MultipartFormData called .expect() when the request had a missing or invalid Content-Type header. This panics the server instead of returning a proper error to the caller.

The fix replaces .expect() with .ok_or_else()? using ServerFnErrorErr::Deserialization, consistent with how other codecs in this crate handle malformed input.

## Changes

- server_fn/src/codec/multipart.rs: replace .expect() with ok_or_else + ?, import IntoAppError and ServerFnErrorErr