### PR TITLE
fix(tachys): don't render keyed-list key as a text node in SSR

### DIFF
--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -256,7 +256,7 @@ where
 
     fn dry_resolve(&mut self) {
         #[cfg(feature = "ssr")]
-        for view in &mut self.ssr_items {
+        for (_, view) in &mut self.ssr_items {
             view.dry_resolve();
         }
     }
@@ -301,7 +301,7 @@ where
         }
 
         #[cfg(feature = "ssr")]
-        for item in self.ssr_items {
+        for (_, item) in self.ssr_items {
             if mark_branches && escape {
                 buf.open_branch("item");
             }


### PR DESCRIPTION
In `KeyedView::to_html_with_buf`, the SSR sync path iterated `self.ssr_items` (type `Vec<(String, V)>`) and called `to_html_with_buf` on each tuple. Because tuples implement `RenderHtml` for all elements, this rendered both the `String` key and the view `V`, inserting a stray text node for the key on every list item and causing hydration desync.

The async path already destructured correctly with `for (key, item) in self.ssr_items`. This fix mirrors that pattern in the sync path (`for (_, item) in self.ssr_items`) and also fixes `dry_resolve` for consistency.