### PR TITLE
fix(router): propagate error instead of unwrapping in anchor click handler

### DIFF
--- a/router/src/location/mod.rs
+++ b/router/src/location/mod.rs
@@ -347,7 +347,7 @@ where
                 return Ok(());
             }
 
-            let url = parse_with_base(href.as_str(), &origin).unwrap();
+            let url = parse_with_base(href.as_str(), &origin)?;
             let path_name = Url::unescape_minimal(&url.path);
 
             // let browser handle this event if it leaves our domain


### PR DESCRIPTION
The anchor click handler in `router/src/location/mod.rs` calls
`parse_with_base(href.as_str(), &origin).unwrap()`, which panics
(aborts in WASM) when an href cannot be parsed as a URL.

The enclosing closure returns `Result<(), JsValue>` and
`parse_with_base` returns `Result<Url, JsValue>`, so replacing
`.unwrap()` with `?` propagates the error cleanly to the caller.