### PR TITLE
fix(router): reject over-long static segment instead of partial-matching

### DIFF
--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -94,7 +94,7 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
                 }
                 break;
             } else if n.is_none() {
-                break;
+                return None;
             }
             // if the next character in the path matches the
             // next character in the segment, add it to the match
@@ -312,5 +312,11 @@ mod tests {
         assert!(def.test("/test/abc/").is_none());
         assert!(def.test("/tests/ab").is_none());
         assert!(def.test("/tests/ab/").is_none());
+    }
+
+    #[test]
+    fn no_partial_match_on_overlong_path() {
+        let def = StaticSegment("fo");
+        assert!(def.test("/foobar").is_none());
     }
 }


### PR DESCRIPTION
## Summary

`StaticSegment::test` was using `break` when the pattern iterator was
exhausted but the URL path still had non-slash characters remaining.
This caused a false partial match: `StaticSegment(fo).test(/foobar)`
returned `Some(...)` with `bar` as remaining instead of `None`.

The fix changes the `break` to `return None` so the segment only matches
when the URL characters are fully consumed along with the pattern.

A regression test (`no_partial_match_on_overlong_path`) is added to
`static_segment.rs` to cover this case.