### PR TITLE
fix(server_fn): use StreamingText content-type in IntoReq and IntoRes

### DIFF
--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -217,7 +217,7 @@ where
         Request::try_new_post_streaming(
             path,
             accepts,
-            Streaming::CONTENT_TYPE,
+            StreamingText::CONTENT_TYPE,
             data.0.map(|chunk| chunk.unwrap_or_default().into()),
         )
     }
@@ -253,7 +253,7 @@ where
 {
     async fn into_res(self) -> Result<Response, E> {
         Response::try_from_stream(
-            Streaming::CONTENT_TYPE,
+            StreamingText::CONTENT_TYPE,
             self.into_inner()
                 .map(|stream| stream.map(Into::into).map_err(|e| e.ser())),
         )


### PR DESCRIPTION
`IntoReq<StreamingText>` and `IntoRes<StreamingText>` both passed `Streaming::CONTENT_TYPE` (`"application/octet-stream"`) instead of `StreamingText::CONTENT_TYPE` (`"text/plain"`).

This means any server function using `TextStream` as its output type would send a `Content-Type: application/octet-stream` header instead of `Content-Type: text/plain`, and the client request would also carry the wrong content-type. Middleware or proxies that inspect Content-Type, as well as clients performing content-type validation, would see the wrong type.