### PR TITLE
fix(leptos_macro): drop by_ref from generated Props struct fields

### DIFF
--- a/leptos_macro/src/component.rs
+++ b/leptos_macro/src/component.rs
@@ -1138,7 +1138,7 @@ fn prop_builder_fields(
                     quote!()
                 };
 
-            let PatIdent { ident, by_ref, .. } = &name;
+            let PatIdent { ident, .. } = &name;
 
             quote! {
                 #docs
@@ -1146,7 +1146,7 @@ fn prop_builder_fields(
                 #builder_attrs
                 #allow_missing_docs
                 #skip_children_serde
-                #vis #by_ref #ident: #ty,
+                #vis #ident: #ty,
             }
         })
         .collect()
@@ -1169,12 +1169,12 @@ fn prop_serializer_fields(vis: &Visibility, props: &[Prop]) -> TokenStream {
                 let builder_attrs = TypedBuilderOpts::from_opts(prop_opts, ty);
                 let serde_attrs = builder_attrs.to_serde_tokens();
 
-                let PatIdent { ident, by_ref, .. } = &name;
+                let PatIdent { ident, .. } = &name;
 
                 Some(quote! {
                     #docs
                     #serde_attrs
-                    #vis #by_ref #ident: #ty,
+                    #vis #ident: #ty,
                 })
             }
         })


### PR DESCRIPTION
A component prop declared with a `ref` binding pattern (e.g. `fn Foo(ref x: String)`) causes the macro to emit `pub ref x: String` inside the generated `Props` struct. `ref` is valid in function argument position but not in struct field position, so this produces a confusing compile error in macro-generated code.

The fix removes `by_ref` from the destructuring and the `quote!` output in both `prop_builder_fields` and `prop_serializer_fields`.

```rust
// before (emits invalid `pub ref x: String` in Props struct)
let PatIdent { ident, by_ref, .. } = &name;
quote! { #vis #by_ref #ident: #ty, }

// after
let PatIdent { ident, .. } = &name;
quote! { #vis #ident: #ty, }
```