### PR TITLE
fix(reactive_stores): untrack parent in AtIndex::writer to avoid spurious notifications

### DIFF
--- a/reactive_stores/src/iter.rs
+++ b/reactive_stores/src/iter.rs
@@ -71,7 +71,7 @@ where
     type Value = Prev::Output;
     type Reader = MappedMutArc<Inner::Reader, Prev::Output>;
     type Writer =
-        MappedMutArc<WriteGuard<ArcTrigger, Inner::Writer>, Prev::Output>;
+        MappedMutArc<WriteGuard<Vec<ArcTrigger>, Inner::Writer>, Prev::Output>;
 
     fn path(&self) -> impl IntoIterator<Item = StorePathSegment> {
         self.inner
@@ -106,8 +106,10 @@ where
     }
 
     fn writer(&self) -> Option<Self::Writer> {
-        let trigger = self.get_trigger(self.path().into_iter().collect());
-        let inner = WriteGuard::new(trigger.children, self.inner.writer()?);
+        let mut parent = self.inner.writer()?;
+        parent.untrack();
+        let triggers = self.triggers_for_current_path();
+        let inner = WriteGuard::new(triggers, parent);
         let index = self.index;
         Some(MappedMutArc::new(
             inner,

--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -1399,6 +1399,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn writing_unkeyed_element_does_not_notify_sibling() {
+        _ = any_spawner::Executor::init_tokio();
+
+        let element0_count = Arc::new(AtomicUsize::new(0));
+        let element1_count = Arc::new(AtomicUsize::new(0));
+
+        let store = Store::new(data());
+
+        Effect::new_sync({
+            let element0_count = Arc::clone(&element0_count);
+            move |_| {
+                store.todos().at_unkeyed(0).track();
+                element0_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+        Effect::new_sync({
+            let element1_count = Arc::clone(&element1_count);
+            move |_| {
+                store.todos().at_unkeyed(1).track();
+                element1_count.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+
+        tick().await;
+        assert_eq!(element0_count.load(Ordering::Relaxed), 1);
+        assert_eq!(element1_count.load(Ordering::Relaxed), 1);
+
+        // writing element 0 should notify element 0's observer but NOT element 1's
+        *store.todos().at_unkeyed(0).write() = Todo::new("changed");
+        tick().await;
+        assert_eq!(element0_count.load(Ordering::Relaxed), 2);
+        assert_eq!(element1_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
     async fn untracked_write_on_subfield_shouldnt_notify() {
         _ = any_spawner::Executor::init_tokio();
 

--- a/tachys/src/reactive_graph/owned.rs
+++ b/tachys/src/reactive_graph/owned.rs
@@ -33,8 +33,12 @@ pub struct OwnedViewState<T>
 where
     T: Mountable,
 {
-    owner: Owner,
+    // note: the drop order of the fields matters here
+    // dropping `state` before `owner` ensures that cleanups happen
+    // from the bottom up: i.e., the child state is dropped before
+    // any other cleanups attached to this owner are fired
     state: T,
+    owner: Owner,
 }
 
 impl<T> OwnedViewState<T>

--- a/tachys/src/reactive_graph/owned.rs
+++ b/tachys/src/reactive_graph/owned.rs
@@ -6,6 +6,7 @@ use crate::{
     view::{add_attr::AddAnyAttr, Position, PositionState, Render, RenderHtml},
 };
 use reactive_graph::{computed::ScopedFuture, owner::Owner};
+use std::mem;
 
 /// A view wrapper that sets the reactive [`Owner`] to a particular owner whenever it is rendered.
 #[derive(Debug, Clone)]
@@ -65,7 +66,13 @@ where
     fn rebuild(self, state: &mut Self::State) {
         let OwnedView { owner, view, .. } = self;
         owner.with(|| view.rebuild(&mut state.state));
-        state.owner = owner;
+        // Defer dropping the previous owner until after effects have run:
+        // render effects that do things like reading from context it provides
+        // may have already been triggered and queued to run. `spawn_local` will
+        // defer the drop to the end of the queue, while still deterministically
+        // cleaning up the memory to prevent leaks.
+        let old_owner = mem::replace(&mut state.owner, owner);
+        reactive_graph::spawn_local(async move { drop(old_owner) });
     }
 }
 


### PR DESCRIPTION
AtIndex::writer was not calling parent.untrack() before constructing its WriteGuard. This caused the parent collection's notification chain to fire when writing a single element, so effects tracking the whole collection re-ran on every element write. Subfield::writer and KeyedSubfield::writer both call untrack() and use triggers_for_current_path(); AtIndex::writer was inconsistent. Fix: call parent.untrack() and use triggers_for_current_path() so only the element's own trigger chain propagates. Added a regression test.