### PR TITLE
fix(server_fn): don't panic in set_server_url if already set

### DIFF
--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -8,8 +8,27 @@ static ROOT_URL: OnceLock<&'static str> = OnceLock::new();
 /// Set the root server URL that all server function paths are relative to for the client.
 ///
 /// If this is not set, it defaults to the origin.
+///
+/// # Panics
+///
+/// Panics if the server URL has already been set. Setting it twice is almost
+/// always a bug: requests would otherwise be silently sent to a different URL
+/// than intended. If you need to handle the already-set case gracefully, use
+/// [`try_set_server_url`] instead.
 pub fn set_server_url(url: &'static str) {
-    let _ = ROOT_URL.set(url);
+    ROOT_URL.set(url).unwrap();
+}
+
+/// Attempts to set the root server URL that all server function paths are
+/// relative to for the client.
+///
+/// Unlike [`set_server_url`], this does not panic if the URL has already been
+/// set. Instead it returns `Err` containing the `url` that could not be set,
+/// leaving the previously set value unchanged.
+///
+/// If this is not set, it defaults to the origin.
+pub fn try_set_server_url(url: &'static str) -> Result<(), &'static str> {
+    ROOT_URL.set(url)
 }
 
 /// Returns the root server URL for all server functions.

--- a/server_fn/src/client.rs
+++ b/server_fn/src/client.rs
@@ -9,7 +9,7 @@ static ROOT_URL: OnceLock<&'static str> = OnceLock::new();
 ///
 /// If this is not set, it defaults to the origin.
 pub fn set_server_url(url: &'static str) {
-    ROOT_URL.set(url).unwrap();
+    let _ = ROOT_URL.set(url);
 }
 
 /// Returns the root server URL for all server functions.


### PR DESCRIPTION
`set_server_url` calls `ROOT_URL.set(url).unwrap()`. `OnceLock::set`
returns `Err` when the lock is already initialised, which causes `.unwrap()`
to panic. In practice this can happen with hot-module reload, in tests that
call `set_server_url` in multiple test cases, or in component libraries that
call it at startup.

The value is idempotent by construction (a `&'static str` set once at
startup), so silently ignoring a duplicate call with `let _ = ...` is safe
and matches how similar one-time initialisers are handled elsewhere.