### PR TITLE
fix(leptos_server): log serialization error instead of panic in resource SSR

### DIFF
--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -164,10 +164,13 @@ where
                             .map(|e| e.into_encoded_string())
                         {
                             Ok(s) => s,
-                            #[allow(unused_variables)]
                             Err(e) => {
                                 #[cfg(feature = "tracing")]
                                 tracing::error!(
+                                    "couldn't serialize resource: {e:?}"
+                                );
+                                #[cfg(not(feature = "tracing"))]
+                                eprintln!(
                                     "couldn't serialize resource: {e:?}"
                                 );
                                 String::new()

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -160,7 +160,19 @@ where
                         ready_fut.await;
                         let value = value.read().or_poisoned();
                         let value = value.as_ref().unwrap();
-                        Ser::encode(value).unwrap().into_encoded_string()
+                        match Ser::encode(value)
+                            .map(|e| e.into_encoded_string())
+                        {
+                            Ok(s) => s,
+                            #[allow(unused_variables)]
+                            Err(e) => {
+                                #[cfg(feature = "tracing")]
+                                tracing::error!(
+                                    "couldn't serialize resource: {e:?}"
+                                );
+                                String::new()
+                            }
+                        }
                     }),
                 );
             }

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -170,9 +170,7 @@ where
                                     "couldn't serialize resource: {e:?}"
                                 );
                                 #[cfg(not(feature = "tracing"))]
-                                eprintln!(
-                                    "couldn't serialize resource: {e:?}"
-                                );
+                                eprintln!("couldn't serialize resource: {e:?}");
                                 String::new()
                             }
                         }

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -350,10 +350,13 @@ where
                                 .map(|e| e.into_encoded_string())
                             {
                                 Ok(s) => s,
-                                #[allow(unused_variables)]
                                 Err(e) => {
                                     #[cfg(feature = "tracing")]
                                     tracing::error!(
+                                        "couldn't serialize resource: {e:?}"
+                                    );
+                                    #[cfg(not(feature = "tracing"))]
+                                    eprintln!(
                                         "couldn't serialize resource: {e:?}"
                                     );
                                     String::new()

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -346,10 +346,19 @@ where
                     Box::pin(async move {
                         ready_fut.await;
                         value.with_untracked(|data| match &data {
-                            // TODO handle serialization errors
-                            Some(val) => {
-                                Ser::encode(val).unwrap().into_encoded_string()
-                            }
+                            Some(val) => match Ser::encode(val)
+                                .map(|e| e.into_encoded_string())
+                            {
+                                Ok(s) => s,
+                                #[allow(unused_variables)]
+                                Err(e) => {
+                                    #[cfg(feature = "tracing")]
+                                    tracing::error!(
+                                        "couldn't serialize resource: {e:?}"
+                                    );
+                                    String::new()
+                                }
+                            },
                             _ => unreachable!(),
                         })
                     }),


### PR DESCRIPTION
`resource.rs` and `once_resource.rs` call `Ser::encode(...).unwrap()` to
serialize resource values for hydration. The `Ser` codec is generic and its
`Error` type is only required to implement `Debug`, not `Infallible`, so
`encode` can fail legitimately (e.g. a value that is not serializable by the
chosen codec). Unwrapping panics the SSR task.

A `// TODO handle serialization errors` comment in `resource.rs` already
acknowledged this. `shared.rs` already handles the same call correctly with
a `match` that logs the error. Apply the same pattern to both files.