### PR TITLE
fix(axum): don't panic in redirect() on invalid header values

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -228,12 +228,22 @@ pub fn redirect(path: &str) {
     if let (Some(req), Some(res)) =
         (use_context::<Parts>(), use_context::<ResponseOptions>())
     {
+        let location = match header::HeaderValue::from_str(path) {
+            Ok(v) => v,
+            Err(_) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                #[cfg(not(feature = "tracing"))]
+                eprintln!(
+                    "redirect() ignored: target is not a valid header value"
+                );
+                return;
+            }
+        };
         // insert the Location header in any case
-        res.insert_header(
-            header::LOCATION,
-            header::HeaderValue::from_str(path)
-                .expect("Failed to create HeaderValue"),
-        );
+        res.insert_header(header::LOCATION, location);
 
         let accepts_html = req
             .headers


### PR DESCRIPTION
`redirect()` calls `HeaderValue::from_str(path).expect(...)`. A redirect
target that contains CR, LF, NUL, or other bytes illegal in HTTP headers
causes `from_str` to return an error, which panics the Tokio worker and
takes down the server -- a potential DoS for any app that passes
user-controlled input to `redirect()`.

The identical bug was fixed in the actix integration by #4755; this
applies the same fix to axum: match the result, log a warning, and return
early instead of panicking.