### PR TITLE
fix(router): return early in Form submit handler instead of panic

### DIFF
--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -112,8 +112,11 @@ where
                     ..Default::default()
                 };
 
-                let (form, method, action, enctype) =
-                    extract_form_attributes(&ev);
+                let Some((form, method, action, enctype)) =
+                    extract_form_attributes(&ev)
+                else {
+                    return;
+                };
 
                 let form_data =
                     web_sys::FormData::new_with_form(&form).unwrap_throw();
@@ -345,12 +348,12 @@ fn current_window_origin() -> String {
 
 fn extract_form_attributes(
     ev: &web_sys::Event,
-) -> (web_sys::HtmlFormElement, String, String, String) {
+) -> Option<(web_sys::HtmlFormElement, String, String, String)> {
     let submitter = ev.unchecked_ref::<web_sys::SubmitEvent>().submitter();
     match &submitter {
         Some(el) => {
             if let Some(form) = el.dyn_ref::<web_sys::HtmlFormElement>() {
-                (
+                Some((
                     form.clone(),
                     form.get_attribute("method")
                         .unwrap_or_else(|| "get".to_string())
@@ -363,7 +366,7 @@ fn extract_form_attributes(
                             "application/x-www-form-urlencoded".to_string()
                         })
                         .to_lowercase(),
-                )
+                ))
             } else if let Some(input) =
                 el.dyn_ref::<web_sys::HtmlInputElement>()
             {
@@ -371,7 +374,7 @@ fn extract_form_attributes(
                     .target()
                     .unwrap()
                     .unchecked_into::<web_sys::HtmlFormElement>();
-                (
+                Some((
                     form.clone(),
                     input.get_attribute("method").unwrap_or_else(|| {
                         form.get_attribute("method")
@@ -390,7 +393,7 @@ fn extract_form_attributes(
                             })
                             .to_lowercase()
                     }),
-                )
+                ))
             } else if let Some(button) =
                 el.dyn_ref::<web_sys::HtmlButtonElement>()
             {
@@ -398,7 +401,7 @@ fn extract_form_attributes(
                     .target()
                     .unwrap()
                     .unchecked_into::<web_sys::HtmlFormElement>();
-                (
+                Some((
                     form.clone(),
                     button.get_attribute("method").unwrap_or_else(|| {
                         form.get_attribute("method")
@@ -417,13 +420,13 @@ fn extract_form_attributes(
                             })
                             .to_lowercase()
                     }),
-                )
+                ))
             } else {
                 leptos::logging::debug_warn!(
                     "<Form/> cannot be submitted from a tag other than \
                      <form>, <input>, or <button>"
                 );
-                panic!()
+                None
             }
         }
         None => match ev.target() {
@@ -431,11 +434,11 @@ fn extract_form_attributes(
                 leptos::logging::debug_warn!(
                     "<Form/> SubmitEvent fired without a target."
                 );
-                panic!()
+                None
             }
             Some(form) => {
                 let form = form.unchecked_into::<web_sys::HtmlFormElement>();
-                (
+                Some((
                     form.clone(),
                     form.get_attribute("method")
                         .unwrap_or_else(|| "get".to_string()),
@@ -443,7 +446,7 @@ fn extract_form_attributes(
                     form.get_attribute("enctype").unwrap_or_else(|| {
                         "application/x-www-form-urlencoded".to_string()
                     }),
-                )
+                ))
             }
         },
     }


### PR DESCRIPTION
extract_form_attributes calls `panic!()` in two recoverable situations:
when the `SubmitEvent` submitter is an unrecognised element type, and when
the event has no target at all. In both cases a `debug_warn!` is already
emitted before the panic, making the panic redundant and harmful -- it
crashes the WASM runtime instead of silently aborting the submission.

Change the return type to `Option<...>`, return `None` for the two error
paths, and have the caller return early when `None` is received.