### PR TITLE
fix(axum): don't panic on requests without path-and-query

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -916,7 +916,11 @@ where
             move || {
                 // Need to get the path and query string of the Request
                 // For reasons that escape me, if the incoming URI protocol is https, it provides the absolute URI
-                let path = req.uri().path_and_query().unwrap().as_str();
+                let path = req
+                    .uri()
+                    .path_and_query()
+                    .map(|pq| pq.as_str())
+                    .unwrap_or("/");
 
                 let full_path = format!("http://leptos.dev{path}");
                 let (_, req_parts) = generate_request_and_parts(req);


### PR DESCRIPTION
`handle_response_inner` (and every `render_app_*` helper built on it) is
documented to be used as an Axum `.fallback()`, which means it receives
every unmatched request regardless of method. For requests with an
asterisk-form URI (`OPTIONS *`) or authority-form URI (`CONNECT
host:port`), `req.uri().path_and_query()` returns `None`; calling
`.unwrap()` then panics the Tokio worker and takes down the server.

Fix: fall back to `/` when no path-and-query component is present.