### PR TITLE
fix(router): decode query params exactly once

### DIFF
--- a/router/src/location/history.rs
+++ b/router/src/location/history.rs
@@ -276,19 +276,18 @@ impl LocationProvider for BrowserUrl {
 fn search_params_from_web_url(
     params: &web_sys::UrlSearchParams,
 ) -> Result<ParamsMap, JsValue> {
-    try_iter(params)?
-        .into_iter()
-        .flatten()
-        .map(|pair| {
-            pair.and_then(|pair| {
-                let row = pair.dyn_into::<Array>()?;
-                Ok((
-                    String::from(row.get(0).dyn_into::<JsString>()?),
-                    String::from(row.get(1).dyn_into::<JsString>()?),
-                ))
-            })
-        })
-        .collect()
+    // `web_sys::UrlSearchParams` already returns percent-decoded keys and values,
+    // so use `insert_raw` to avoid a second decode that would corrupt values
+    // containing a literal `%` (e.g. `?x=%2525` should yield `%25`, not `%`).
+    let mut map = ParamsMap::new();
+    for pair in try_iter(params)?.into_iter().flatten() {
+        let pair = pair?;
+        let row = pair.dyn_into::<Array>()?;
+        let key = String::from(row.get(0).dyn_into::<JsString>()?);
+        let value = String::from(row.get(1).dyn_into::<JsString>()?);
+        map.insert_raw(key, value);
+    }
+    Ok(map)
 }
 
 /// Resolves a redirect location to an (absolute) URL.

--- a/router/src/location/server.rs
+++ b/router/src/location/server.rs
@@ -33,10 +33,12 @@ impl RequestUrl {
         let base = url::Url::parse(base)?;
         let url = url::Url::options().base_url(Some(&base)).parse(&self.0)?;
 
-        let search_params = url
-            .query_pairs()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect::<ParamsMap>();
+        // `url::Url::query_pairs()` already percent-decodes keys and values, so
+        // we must not decode them a second time via `ParamsMap::insert`.
+        let mut search_params = ParamsMap::new();
+        for (k, v) in url.query_pairs() {
+            search_params.insert_raw(k.into_owned(), v.into_owned());
+        }
 
         Ok(Url {
             origin: url.origin().unicode_serialization(),
@@ -71,5 +73,28 @@ mod tests {
             .unwrap();
         assert_eq!(url.origin(), "https://www.example.com");
         assert_eq!(url.path(), "/foo/bar");
+    }
+
+    #[test]
+    pub fn query_param_with_literal_percent_is_decoded_exactly_once() {
+        // `%2525` in the raw query string is `%25` percent-encoded, so after one
+        // decode it should be `%25`, not `%` (which would be a second decode).
+        let url = RequestUrl::new("/page?x=%2525").parse().unwrap();
+        assert_eq!(
+            url.search_params().get("x").as_deref(),
+            Some("%25"),
+            "expected a single decode: %2525 -> %25"
+        );
+    }
+
+    #[test]
+    pub fn query_param_with_regular_encoding_is_decoded() {
+        // A plain percent-encoded value like `hello%20world` should still decode
+        // to `hello world`.
+        let url = RequestUrl::new("/page?msg=hello%20world").parse().unwrap();
+        assert_eq!(
+            url.search_params().get("msg").as_deref(),
+            Some("hello world")
+        );
     }
 }

--- a/router/src/params.rs
+++ b/router/src/params.rs
@@ -25,9 +25,31 @@ impl ParamsMap {
     ///
     /// If a value with that key already exists, the new value will be added to it.
     /// To replace the value instead, see [`replace`](Self::replace).
+    ///
+    /// The value is percent-decoded before storage. Use [`insert_raw`](Self::insert_raw)
+    /// when the value is already decoded (e.g. from `url::Url::query_pairs()` or
+    /// `web_sys::UrlSearchParams`).
     pub fn insert(&mut self, key: impl Into<Cow<'static, str>>, value: String) {
         let value = Url::unescape(&value);
 
+        let key = key.into();
+        if let Some(prev) = self.0.iter_mut().find(|(k, _)| k == &key) {
+            prev.1.push(value);
+        } else {
+            self.0.push((key, vec![value]));
+        }
+    }
+
+    /// Inserts an already-decoded value into the map without percent-decoding it again.
+    ///
+    /// Use this when the source (e.g. `url::Url::query_pairs()` or
+    /// `web_sys::UrlSearchParams`) already returns decoded values, to avoid
+    /// a second decode that would corrupt values containing a literal `%`.
+    pub(crate) fn insert_raw(
+        &mut self,
+        key: impl Into<Cow<'static, str>>,
+        value: String,
+    ) {
         let key = key.into();
         if let Some(prev) = self.0.iter_mut().find(|(k, _)| k == &key) {
             prev.1.push(value);


### PR DESCRIPTION
`url::Url::query_pairs()` (SSR) and `web_sys::UrlSearchParams` (browser) both return already percent-decoded key/value pairs. `ParamsMap::insert()` then called `Url::unescape()` on them again, so any value containing a literal `%` was decoded twice and corrupted — e.g. `?x=%2525` yielded `%` instead of `%25`.

**Fix:** add `ParamsMap::insert_raw()` (no decode) and use it in both query-param collection sites (`server.rs` and `history.rs`). Path params continue to use `insert()`, as they are extracted raw from the path string and need exactly one decode.

Two regression tests added in `location/server.rs` (SSR, `#[cfg(feature = "ssr")]`).