### PR TITLE
fix(reactive_graph): don't drop mark_dirty during ArcAsyncDerived notify window

### DIFF
--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -451,10 +451,14 @@ impl<T: 'static> ArcAsyncDerived<T> {
             waker.wake();
         }
 
-        // if this was marked dirty before notifications began, this means it
-        // had been notified while loading; marking it clean will cause it not to
-        // run on the next tick of the async loop, so here it should be left dirty
-        inner.write().or_poisoned().state = prev_state;
+        // Restore the state that existed before we entered the Notifying window.
+        // However, if a source was dirtied *during* the window (mark_dirty now
+        // always sets Dirty), we must keep Dirty so the async loop re-runs for
+        // that change rather than silently dropping it.
+        let mut guard = inner.write().or_poisoned();
+        if guard.state != AsyncDerivedState::Dirty {
+            guard.state = prev_state;
+        }
     }
 }
 

--- a/reactive_graph/src/computed/async_derived/inner.rs
+++ b/reactive_graph/src/computed/async_derived/inner.rs
@@ -36,15 +36,18 @@ pub(crate) enum AsyncDerivedState {
 impl ReactiveNode for RwLock<ArcAsyncDerivedInner> {
     fn mark_dirty(&self) {
         let mut lock = self.write().or_poisoned();
-        if lock.state != AsyncDerivedState::Notifying {
-            lock.state = AsyncDerivedState::Dirty;
-            lock.notifier.notify();
-        }
+        // Always set Dirty and notify, even if we are in the Notifying window.
+        // notify_subs temporarily sets state=Notifying and restores it afterward;
+        // if a source changes during that window we must not silently drop the
+        // update.  notify_subs will preserve Dirty when it restores state.
+        lock.state = AsyncDerivedState::Dirty;
+        lock.notifier.notify();
     }
 
     fn mark_check(&self) {
         let mut lock = self.write().or_poisoned();
-        if lock.state != AsyncDerivedState::Notifying {
+        // Same reasoning as mark_dirty: do not suppress during the Notifying window.
+        if lock.state != AsyncDerivedState::Dirty {
             lock.notifier.notify();
         }
     }

--- a/reactive_graph/tests/async_derived.rs
+++ b/reactive_graph/tests/async_derived.rs
@@ -1,11 +1,54 @@
 use any_spawner::Executor;
+use reactive_graph::traits::IsDisposed;
 use reactive_graph::{
     computed::{ArcAsyncDerived, AsyncDerived},
+    graph::{AnySource, AnySubscriber, ReactiveNode, Source, Subscriber},
     owner::Owner,
+    signal::ArcRwSignal,
     signal::RwSignal,
     traits::{Get, Read, Set, With, WithUntracked},
 };
-use std::future::pending;
+use std::{
+    future::pending,
+    sync::{Arc, Weak},
+};
+
+struct SignalSetOnDirty {
+    signal: ArcRwSignal<i32>,
+    value: i32,
+    fired: std::sync::atomic::AtomicBool,
+}
+
+impl IsDisposed for SignalSetOnDirty {
+    fn is_disposed(&self) -> bool {
+        false
+    }
+}
+
+impl ReactiveNode for SignalSetOnDirty {
+    fn mark_dirty(&self) {
+        if !self.fired.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            self.signal.set(self.value);
+        }
+    }
+    fn mark_check(&self) {}
+    fn mark_subscribers_check(&self) {}
+    fn update_if_necessary(&self) -> bool {
+        false
+    }
+}
+
+impl Subscriber for SignalSetOnDirty {
+    fn add_source(&self, _: AnySource) {}
+    fn clear_sources(&self, _: &AnySubscriber) {}
+}
+
+fn make_any_subscriber(sub: Arc<SignalSetOnDirty>) -> AnySubscriber {
+    AnySubscriber(
+        Arc::as_ptr(&sub) as usize,
+        Arc::downgrade(&sub) as Weak<dyn Subscriber + Send + Sync>,
+    )
+}
 
 #[tokio::test]
 async fn arc_async_derived_calculates_eagerly() {
@@ -136,4 +179,53 @@ async fn async_derived_with_initial() {
     // setting multiple dependencies will hold until the latest change is ready
     signal2.set(1);
     assert_eq!(derived.await, 2);
+}
+
+/// Demonstrates that a source change arriving during the notify_subs window
+/// (while ArcAsyncDerived temporarily holds state=Notifying) is not silently
+/// dropped.  Before the fix, mark_dirty skipped both setting Dirty and calling
+/// the channel notifier when it observed Notifying, and notify_subs then
+/// restored the previous Clean state, leaving the derived permanently stale.
+#[tokio::test]
+async fn arc_async_derived_notify_window_not_dropped() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let signal = ArcRwSignal::new(1_i32);
+
+    // derived just reads the signal
+    let signal_c = signal.clone();
+    let derived: ArcAsyncDerived<i32> = ArcAsyncDerived::new(move || {
+        let s = signal_c.clone();
+        async move { s.get() }
+    });
+
+    // wait for the initial computation (signal == 1)
+    assert_eq!(derived.clone().await, 1);
+
+    // Register a downstream subscriber that, when notified, fires signal.set(3).
+    // This simulates a source change arriving during the notify_subs window:
+    // notify_subs sets state=Notifying, calls sub.mark_dirty() on our probe,
+    // the probe calls signal.set(3) which calls mark_dirty on the derived while
+    // state is still Notifying.  Without the fix that mark_dirty is a no-op and
+    // the derived stays stale at 2 forever.
+    let probe = Arc::new(SignalSetOnDirty {
+        signal: signal.clone(),
+        value: 3,
+        fired: std::sync::atomic::AtomicBool::new(false),
+    });
+    derived.add_subscriber(make_any_subscriber(probe.clone()));
+
+    // Trigger a recomputation: signal -> 2.
+    signal.set(2);
+    Executor::tick().await;
+    Executor::tick().await;
+
+    // The derived must have re-run for signal==3.  Before the fix it returned 2.
+    assert_eq!(
+        derived.clone().await,
+        3,
+        "derived did not re-run after a source changed during the notify window"
+    );
 }


### PR DESCRIPTION
## Summary

`notify_subs` temporarily sets `state = Notifying` while iterating downstream subscribers. `mark_dirty` (called when an upstream source changes) skipped both the `Dirty` assignment and the channel `notify()` call whenever it observed `Notifying`. If a source changed during this window, the update was silently lost: `notify_subs` then restored `prev_state` (Clean), and the derived never re-ran.

- `mark_dirty` now always sets `Dirty` and calls `notifier.notify()`, regardless of `Notifying`.
- `notify_subs` now preserves `Dirty` at the end of the window instead of blindly restoring the pre-window state.

The bug is single-threaded: a downstream subscriber whose `mark_dirty` mutates an upstream signal re-enters `mark_dirty` on the derived while `state == Notifying`. The regression test demonstrates this deterministically — it fails on unpatched code (derived stays at 2) and passes after the fix (derived re-runs to 3).

## Test plan

- [ ] `cargo test -p reactive_graph` passes (all 8 `async_derived` integration tests + 64 doc tests)
- [ ] New test `arc_async_derived_notify_window_not_dropped` fails on unpatched code, passes after fix