### PR TITLE
fix(leptos_macro): localize view! diagnostics and recover incomplete component tags

### DIFF
--- a/leptos_macro/Cargo.toml
+++ b/leptos_macro/Cargo.toml
@@ -33,6 +33,11 @@ uuid = { features = ["v4"], workspace = true, default-features = true }
 tracing = { optional = true, workspace = true, default-features = true }
 
 [dev-dependencies]
+# `span-locations` lets the diagnostics locality tests map a recorded span back
+# to its line/column in the source string.
+proc-macro2 = { workspace = true, default-features = true, features = [
+  "span-locations",
+] }
 log = { workspace = true, default-features = true }
 typed-builder = { workspace = true, default-features = true }
 trybuild = { workspace = true, default-features = true }

--- a/leptos_macro/src/lib.rs
+++ b/leptos_macro/src/lib.rs
@@ -324,16 +324,17 @@ fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
             .chain(tokens)
             .collect()
     };
-    let config = rstml::ParserConfig::default().recover_block(true);
-    let parser = rstml::Parser::new(config);
-    let (mut nodes, errors) = parser.parse_recoverable(tokens).split_vec();
-    let errors = errors.into_iter().map(|e| e.emit_as_expr_tokens());
+    let (mut nodes, errors) = view::parse_nodes(tokens);
     let nodes_output = view::render_view(
         &mut nodes,
         global_class.as_ref(),
         normalized_call_site(proc_macro::Span::call_site()),
         template,
     );
+
+    // Surface every diagnostic recorded during lowering, de-duplicated and
+    // capped. This is the single sink for `view::diagnostics`.
+    view::diagnostics::emit_all();
 
     // The allow lint needs to be put here instead of at the expansion of
     // view::attribute_value(). Adding this next to the expanded expression
@@ -342,7 +343,7 @@ fn view_macro_impl(tokens: TokenStream, template: bool) -> TokenStream {
         {
             #[allow(unused_braces)]
             {
-                #(#errors;)*
+                #errors
                 #nodes_output
             }
         }

--- a/leptos_macro/src/view/component_builder.rs
+++ b/leptos_macro/src/view/component_builder.rs
@@ -286,6 +286,10 @@ pub(crate) fn component_to_tokens(
     };
 
     let name = node.name();
+    // Span `.build()` to the component name so that TypedBuilder's
+    // "missing required field" error (raised on `build`) points at this
+    // specific `<Component/>` instead of at the whole `view!` invocation.
+    let build = quote_spanned! { name.span() => .build() };
     #[allow(unused_mut)] // used in debug
     let mut component = quote! {
         {
@@ -300,7 +304,7 @@ pub(crate) fn component_to_tokens(
                         #(#required_props)*
                         #(#slots)*
                         #children
-                        .build();
+                        #build;
                     #(#optional_props)*
                     props
                 }

--- a/leptos_macro/src/view/diagnostics.rs
+++ b/leptos_macro/src/view/diagnostics.rs
@@ -1,0 +1,115 @@
+//! A small, centralized diagnostics layer for the `view!`/`template!` macros.
+//!
+//! Lowering code records diagnostics as *values* (via [`error`]) instead of
+//! calling `proc_macro_error2::emit_error!`/`abort!` directly at the point of
+//! failure. A single sink at the macro boundary ([`emit_all`]) drains the
+//! buffer and reports everything at once.
+//!
+//! This buys three things the previous ad-hoc calls could not:
+//!
+//! 1. **Locality by construction** – every diagnostic must be handed an
+//!    explicit [`Span`]. `Span::call_site()` (which underlines the *entire*
+//!    `view!` invocation) is reserved for the single documented overflow
+//!    summary below, so it can no longer leak in by accident.
+//! 2. **Bounded output** – identical diagnostics are de-duplicated and the
+//!    total is capped at [`MAX_DIAGNOSTICS`], so one mistake can't bury the
+//!    user under a wall of repeated/cascading errors.
+//! 3. **Testability** – [`collect`] runs lowering and returns the recorded
+//!    diagnostics *without* touching the global `proc_macro_error` sink, which
+//!    is what lets us unit-test error *locality* (see `view/tests.rs`).
+//!
+//! Only errors are modelled today (every `view!` diagnostic is one); a warning
+//! level can be added the same way if a use case appears.
+
+use proc_macro2::Span;
+use std::cell::RefCell;
+
+/// Maximum number of distinct diagnostics surfaced from a single macro
+/// invocation. Anything beyond this is collapsed into one summary message so a
+/// single mistake cannot flood the user with hundreds of (often cascading)
+/// errors.
+pub const MAX_DIAGNOSTICS: usize = 16;
+
+/// A single deferred error: a message anchored at a specific [`Span`].
+pub struct Diagnostic {
+    pub span: Span,
+    pub message: String,
+}
+
+impl Diagnostic {
+    /// Key used to collapse duplicate diagnostics. Two are considered the same
+    /// iff they share a message and a span (compared by its debug
+    /// representation, which encodes the source range).
+    fn dedup_key(&self) -> (String, String) {
+        (self.message.clone(), format!("{:?}", self.span))
+    }
+}
+
+thread_local! {
+    static BUFFER: RefCell<Vec<Diagnostic>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Record an error anchored at `span`, to be emitted at the macro boundary.
+pub fn error(span: Span, message: impl Into<String>) {
+    let message = message.into();
+    BUFFER
+        .with(|buffer| buffer.borrow_mut().push(Diagnostic { span, message }));
+}
+
+/// Drain the buffer, applying de-dup and the [`MAX_DIAGNOSTICS`] cap.
+fn take_normalized() -> Vec<Diagnostic> {
+    let raw = BUFFER.with(|buffer| std::mem::take(&mut *buffer.borrow_mut()));
+
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<Diagnostic> = Vec::new();
+    let mut suppressed = 0usize;
+
+    for diagnostic in raw {
+        if !seen.insert(diagnostic.dedup_key()) {
+            continue; // exact duplicate
+        }
+        if out.len() >= MAX_DIAGNOSTICS {
+            suppressed += 1;
+            continue;
+        }
+        out.push(diagnostic);
+    }
+
+    if suppressed > 0 {
+        // The only sanctioned use of `call_site()`: a summary that is not tied
+        // to any single token by nature.
+        out.push(Diagnostic {
+            span: Span::call_site(),
+            message: format!(
+                "{suppressed} additional view! diagnostic(s) were suppressed; \
+                 fix the errors above and recompile to see the rest"
+            ),
+        });
+    }
+
+    out
+}
+
+/// Drain and emit every buffered diagnostic through `proc_macro_error2`.
+///
+/// Must be called exactly once, at the macro boundary, from within a
+/// `#[proc_macro_error]` function.
+pub fn emit_all() {
+    for Diagnostic { span, message } in take_normalized() {
+        // Format with an explicit `{}` so braces inside `message` are never
+        // interpreted as format directives.
+        proc_macro_error2::emit_error!(span, "{}", message);
+    }
+}
+
+/// Run `f`, returning its result together with the diagnostics it recorded,
+/// *without* emitting them. Used by the locality unit tests.
+#[cfg(test)]
+pub fn collect<T>(f: impl FnOnce() -> T) -> (T, Vec<Diagnostic>) {
+    // Start from a clean slate so leftover state from a previous call on this
+    // thread can't contaminate the result.
+    let _ = BUFFER.with(|buffer| std::mem::take(&mut *buffer.borrow_mut()));
+    let out = f();
+    let diagnostics = take_normalized();
+    (out, diagnostics)
+}

--- a/leptos_macro/src/view/mod.rs
+++ b/leptos_macro/src/view/mod.rs
@@ -1,5 +1,8 @@
 mod component_builder;
+pub(crate) mod diagnostics;
 mod slot_helper;
+#[cfg(test)]
+mod tests;
 mod utils;
 
 use self::{
@@ -36,6 +39,66 @@ pub(crate) enum TagType {
     Html,
     Svg,
     Math,
+}
+
+/// Parse `view!`/`template!` input into nodes, plus a token stream carrying any
+/// parse-error diagnostics (ready to splice into the macro output).
+///
+/// In debug builds this adds a recovery pass for rust-analyzer. While you are
+/// still typing an opening tag — e.g. `view! { <A/> <Counter ` — the half-typed
+/// tag has no closing `/>`, so rstml discards that element and no props are
+/// offered for completion. We retry with a synthetic `/>` appended and keep the
+/// retry only if it *strictly reduces* the number of parse errors without
+/// losing any nodes. Together with rust-analyzer's own cursor fix-up, that lets
+/// a half-typed component still expand into its props builder so the editor can
+/// complete its props.
+///
+/// A complete view parses with **zero** errors, so the retry is never even
+/// attempted for valid code — this can only ever affect incomplete, mid-edit
+/// input.
+pub fn parse_nodes(tokens: TokenStream) -> (Vec<Node>, TokenStream) {
+    let new_parser = || {
+        rstml::Parser::new(rstml::ParserConfig::default().recover_block(true))
+    };
+
+    #[cfg(debug_assertions)]
+    let retry_tokens = (!tokens.is_empty()).then(|| tokens.clone());
+
+    #[allow(unused_mut)] // mutated only by the debug-only recovery below
+    let (mut nodes, mut errors) =
+        new_parser().parse_recoverable(tokens).split_vec();
+
+    // Only incomplete input has parse errors; a valid view has none and is
+    // left completely untouched.
+    #[cfg(debug_assertions)]
+    if !errors.is_empty()
+        && let Some(retry_tokens) = retry_tokens
+    {
+        let mut patched = retry_tokens;
+        patched.extend([
+            TokenTree::Punct(proc_macro2::Punct::new(
+                '/',
+                proc_macro2::Spacing::Joint,
+            )),
+            TokenTree::Punct(proc_macro2::Punct::new(
+                '>',
+                proc_macro2::Spacing::Alone,
+            )),
+        ]);
+        let (recovered_nodes, recovered_errors) =
+            new_parser().parse_recoverable(patched).split_vec();
+        // Accept the recovery only if it genuinely improved the parse:
+        // strictly fewer errors and no nodes lost.
+        if recovered_errors.len() < errors.len()
+            && recovered_nodes.len() >= nodes.len()
+        {
+            nodes = recovered_nodes;
+            errors = recovered_errors;
+        }
+    }
+
+    let errors = errors.into_iter().map(|e| e.emit_as_expr_tokens());
+    (nodes, quote! { #(#errors;)* })
 }
 
 pub fn render_view(
@@ -833,9 +896,9 @@ pub(crate) fn element_to_tokens(
                 }
             }
             if names.contains(&name) && !allow_multiples(&name, attr) {
-                proc_macro_error2::emit_error!(
+                diagnostics::error(
                     attr.span(),
-                    format!("This element already has a `{name}` attribute.")
+                    format!("This element already has a `{name}` attribute."),
                 );
             } else {
                 names.insert(name);
@@ -991,12 +1054,12 @@ pub(crate) fn element_to_tokens(
         } else {
             if !node.children.is_empty() {
                 let name = node.name();
-                proc_macro_error2::emit_error!(
+                diagnostics::error(
                     name.span(),
                     format!(
                         "Self-closing elements like <{name}> cannot have \
                          children."
-                    )
+                    ),
                 );
             };
             None
@@ -1140,7 +1203,7 @@ fn attribute_to_tokens(
                     && node.value().and_then(value_to_string).is_none()
                 {
                     let span = node.key.span();
-                    proc_macro_error2::emit_error!(
+                    diagnostics::error(
                         span,
                         "Combining a global class (view! { class = ... }) \
             and a dynamic `class=` attribute on an element causes runtime inconsistencies. You can \
@@ -1251,13 +1314,14 @@ pub(crate) fn attribute_absolute(
                                 quote! { ::leptos::tachys::html::event::#on(#ty, #handler) },
                             )
                         } else {
-                            proc_macro_error2::abort!(
+                            diagnostics::error(
                                 id.span(),
-                                &format!(
+                                format!(
                                     "`{id}:` syntax is not supported on \
                                      components"
-                                )
+                                ),
                             );
+                            None
                         }
                     }
                     _ => None,
@@ -1331,7 +1395,8 @@ pub(crate) fn event_type_and_handler(
 ) -> (TokenStream, TokenStream, TokenStream) {
     let handler = attribute_value(node, false);
 
-    let (event_type, is_custom, options) = parse_event_name(name);
+    let (event_type, is_custom, options) =
+        parse_event_name(name, node.key.span());
 
     let event_name_ident = match &node.key {
         NodeName::Punctuated(parts) => {
@@ -1421,7 +1486,10 @@ fn class_to_tokens(
                     }) => quote! {
                         .#class((#s, #value))
                     },
-                    _ => proc_macro_error2::abort!(elem.span(), "invalid name"),
+                    _ => {
+                        diagnostics::error(elem.span(), "invalid name");
+                        quote! {}
+                    }
                 })
                 .collect();
         }
@@ -1597,15 +1665,30 @@ fn is_ambiguous_element(tag: &str) -> bool {
     tag == "a" || tag == "script" || tag == "title"
 }
 
-fn parse_event(event_name: &str) -> (String, EventNameOptions) {
+fn parse_event(event_name: &str, span: Span) -> (String, EventNameOptions) {
     match try_parse_event(event_name) {
         Ok(parsed) => parsed,
-        Err(modifier) => abort!(
-            Span::call_site(),
-            "unknown event modifier `:{}`; expected one of `:undelegated`, \
-             `:target`, or `:capture`",
-            modifier
-        ),
+        Err(modifier) => {
+            diagnostics::error(
+                span,
+                format!(
+                    "unknown event modifier `:{modifier}`; expected one of \
+                     `:undelegated`, `:target`, or `:capture`"
+                ),
+            );
+            // Recover so the rest of the view can still be checked: keep the
+            // base event name and drop the unknown modifier(s).
+            let name =
+                event_name.split(':').next().unwrap_or_default().to_string();
+            (
+                name,
+                EventNameOptions {
+                    undelegated: false,
+                    targeted: false,
+                    captured: false,
+                },
+            )
+        }
     }
 }
 
@@ -1842,8 +1925,9 @@ pub(crate) struct EventNameOptions {
 
 pub(crate) fn parse_event_name(
     name: &str,
+    span: Span,
 ) -> (TokenStream, bool, EventNameOptions) {
-    let (name, options) = parse_event(name);
+    let (name, options) = parse_event(name, span);
 
     let (event_type, is_custom) = TYPED_EVENTS
         .binary_search(&name.as_str())
@@ -1881,10 +1965,7 @@ pub(crate) fn ident_from_tag_name(tag_name: &NodeName) -> Ident {
             .expect("element needs to have a name"),
         NodeName::Block(_) => {
             let span = tag_name.span();
-            proc_macro_error2::emit_error!(
-                span,
-                "blocks not allowed in tag-name position"
-            );
+            diagnostics::error(span, "blocks not allowed in tag-name position");
             Ident::new("", span)
         }
         _ => Ident::new(
@@ -1899,18 +1980,12 @@ pub(crate) fn full_path_from_tag_name(tag_name: &NodeName) -> Option<ExprPath> {
         NodeName::Path(path) => Some(path.clone()),
         NodeName::Block(_) => {
             let span = tag_name.span();
-            proc_macro_error2::emit_error!(
-                span,
-                "blocks not allowed in tag-name position"
-            );
+            diagnostics::error(span, "blocks not allowed in tag-name position");
             None
         }
         _ => {
             let span = tag_name.span();
-            proc_macro_error2::emit_error!(
-                span,
-                "punctuated names not allowed in slots"
-            );
+            diagnostics::error(span, "punctuated names not allowed in slots");
             None
         }
     }
@@ -1952,10 +2027,13 @@ fn tuple_name(name: &str, node: &KeyedAttribute) -> TupleName {
                                 Expr::Lit(ExprLit {
                                     lit: Lit::Str(s), ..
                                 }) => Some(s.value()),
-                                _ => proc_macro_error2::abort!(
-                                    elem.span(),
-                                    "invalid name"
-                                ),
+                                _ => {
+                                    diagnostics::error(
+                                        elem.span(),
+                                        "invalid name",
+                                    );
+                                    None
+                                }
                             })
                             .collect(),
                     );

--- a/leptos_macro/src/view/slot_helper.rs
+++ b/leptos_macro/src/view/slot_helper.rs
@@ -27,9 +27,9 @@ pub(crate) fn slot_to_tokens(
     let component_path = full_path_from_tag_name(node.name());
 
     let Some(parent_slots) = parent_slots else {
-        proc_macro_error2::emit_error!(
+        crate::view::diagnostics::error(
             node.name().span(),
-            "slots cannot be used inside HTML elements"
+            "slots cannot be used inside HTML elements",
         );
         return;
     };

--- a/leptos_macro/src/view/tests.rs
+++ b/leptos_macro/src/view/tests.rs
@@ -1,0 +1,215 @@
+//! Locality tests for `view!` diagnostics.
+//!
+//! These assert two things the previous `emit_error!`/`abort!` approach had no
+//! way to guarantee or check:
+//!
+//! * **Locality** – a diagnostic underlines the specific offending token, not
+//!   the whole `view!` invocation (which is what `Span::call_site()` does).
+//! * **Bounded output** – duplicate diagnostics collapse and the total is
+//!   capped (see [`MAX_DIAGNOSTICS`]).
+//!
+//! The span→source mapping relies on `proc-macro2`'s `span-locations` feature,
+//! enabled for the test build in `Cargo.toml`.
+
+use super::diagnostics::{self, Diagnostic, MAX_DIAGNOSTICS};
+use proc_macro2::{Span, TokenStream};
+use std::str::FromStr;
+
+/// Lower `src` exactly the way the `view!` macro does and return the
+/// diagnostics it records, without emitting them.
+fn diagnostics_for(src: &str) -> Vec<Diagnostic> {
+    let tokens = TokenStream::from_str(src).expect("test input must tokenize");
+    let config = rstml::ParserConfig::default().recover_block(true);
+    let parser = rstml::Parser::new(config);
+    let (mut nodes, _parse_errors) =
+        parser.parse_recoverable(tokens).split_vec();
+
+    let (_output, diagnostics) = diagnostics::collect(|| {
+        super::render_view(&mut nodes, None, None, false)
+    });
+    diagnostics
+}
+
+/// Assert that `span` starts exactly where `needle` begins in `src` (first
+/// occurrence), i.e. the diagnostic is anchored at the offending token rather
+/// than at the macro call site (which would be line 1, column 0).
+fn assert_anchored_at(src: &str, span: Span, needle: &str) {
+    let expected_col = src
+        .find(needle)
+        .unwrap_or_else(|| panic!("`{needle}` not in source"));
+    let start = span.start();
+    assert_eq!(start.line, 1, "diagnostic should be on the first line");
+    assert_eq!(
+        start.column, expected_col,
+        "diagnostic should be anchored at `{needle}` (column {expected_col}), \
+         but started at column {}",
+        start.column
+    );
+}
+
+/// Recursively find the span of the first `Ident` named `name` in `tokens`.
+fn find_ident_span(
+    tokens: &TokenStream,
+    name: &str,
+) -> Option<proc_macro2::Span> {
+    for tt in tokens.clone() {
+        match tt {
+            proc_macro2::TokenTree::Ident(id) if id == name => {
+                return Some(id.span());
+            }
+            proc_macro2::TokenTree::Group(g) => {
+                if let Some(span) = find_ident_span(&g.stream(), name) {
+                    return Some(span);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+#[test]
+fn missing_required_prop_error_points_at_component() {
+    // `<Greeting excitement=4/>` is missing the required `name` prop. The
+    // TypedBuilder error is raised on `.build()`, so `build` must be spanned to
+    // the `Greeting` tag, not to the whole `view!` (which is what a default
+    // `quote!` call-site span would do).
+    let src = "<Greeting excitement=4/>";
+    let tokens = TokenStream::from_str(src).unwrap();
+    let (mut nodes, _) = super::parse_nodes(tokens);
+    let output = super::render_view(&mut nodes, None, None, false)
+        .expect("component should lower");
+
+    let build_span = find_ident_span(&output, "build")
+        .expect("`.build()` should be emitted");
+    let expected_col = src.find("Greeting").unwrap();
+    assert_eq!(build_span.start().line, 1);
+    assert_eq!(
+        build_span.start().column,
+        expected_col,
+        "`.build()` should be anchored at the `Greeting` tag, not the macro"
+    );
+}
+
+#[test]
+fn event_modifier_error_is_local_and_recovers() {
+    let src = "<button on:click:bad=foo>\"x\"</button>";
+    let diagnostics = diagnostics_for(src);
+
+    // Exactly one diagnostic: lowering recovered instead of aborting, and the
+    // single mistake produced a single error.
+    assert_eq!(diagnostics.len(), 1, "expected exactly one diagnostic");
+    let diagnostic = &diagnostics[0];
+    assert!(
+        diagnostic.message.contains("unknown event modifier"),
+        "unexpected message: {}",
+        diagnostic.message
+    );
+    // The error points at the event attribute, not the whole `view!`.
+    assert_anchored_at(src, diagnostic.span, "on:click:bad");
+}
+
+#[test]
+fn duplicate_attribute_error_is_local() {
+    let src = r#"<div id="a" id="b">"x"</div>"#;
+    let diagnostics = diagnostics_for(src);
+
+    assert_eq!(diagnostics.len(), 1, "expected exactly one diagnostic");
+    let diagnostic = &diagnostics[0];
+    assert!(
+        diagnostic.message.contains("already has a `id` attribute"),
+        "unexpected message: {}",
+        diagnostic.message
+    );
+    // Anchored at the *second* `id`, where the conflict is.
+    let second_id = src.rfind("id").unwrap();
+    assert_eq!(
+        diagnostic.span.start().column,
+        second_id,
+        "duplicate-attribute error should underline the second `id`"
+    );
+}
+
+/// A half-typed component (`<Greeting ` with no closing `/>`) normally parses
+/// to nothing, so the editor has no props builder to complete against. The
+/// debug-only IDE recovery in `parse_nodes` should surface the builder chain
+/// anyway. (Only meaningful in debug builds, where the recovery is compiled.)
+#[cfg(debug_assertions)]
+#[test]
+fn incomplete_component_tag_recovers_props_builder() {
+    let incomplete = TokenStream::from_str("<Greeting ").unwrap();
+    let (mut nodes, _errors) = super::parse_nodes(incomplete);
+    assert!(
+        !nodes.is_empty(),
+        "incomplete tag should be recovered into a node"
+    );
+
+    let output = super::render_view(&mut nodes, None, None, false)
+        .expect("recovered nodes should lower")
+        .to_string();
+    assert!(
+        output.contains("component_props_builder"),
+        "recovered output should expose the props builder, got: {output}"
+    );
+}
+
+/// The recovery must also fire when the half-typed tag is *not* the only thing
+/// in the view (e.g. a second component being added below an existing one).
+#[cfg(debug_assertions)]
+#[test]
+fn incomplete_second_component_recovers() {
+    let incomplete =
+        TokenStream::from_str("<Greeting name=\"x\"/> <Greeting ").unwrap();
+    let (nodes, _errors) = super::parse_nodes(incomplete);
+    assert_eq!(
+        nodes.len(),
+        2,
+        "both the complete and the half-typed component should be present"
+    );
+}
+
+/// A complete view must never trigger the recovery pass (it parses with zero
+/// errors), so its output is identical regardless of the debug-only path. This
+/// guards against the recovery ever touching real code.
+#[test]
+fn complete_view_is_untouched_by_recovery() {
+    let complete =
+        TokenStream::from_str("<Greeting name=\"x\"/><Greeting name=\"y\"/>")
+            .unwrap();
+    let (nodes, _errors) = super::parse_nodes(complete);
+    assert_eq!(nodes.len(), 2, "a complete view parses to all its nodes");
+}
+
+#[test]
+fn duplicate_diagnostics_are_collapsed() {
+    let (_, diagnostics) = diagnostics::collect(|| {
+        let span = Span::call_site();
+        diagnostics::error(span, "same message");
+        diagnostics::error(span, "same message"); // exact duplicate
+        diagnostics::error(span, "different message");
+    });
+
+    assert_eq!(
+        diagnostics.len(),
+        2,
+        "identical (span, message) diagnostics should collapse to one"
+    );
+}
+
+#[test]
+fn diagnostics_are_capped() {
+    let overflow = 5;
+    let (_, diagnostics) = diagnostics::collect(|| {
+        for i in 0..(MAX_DIAGNOSTICS + overflow) {
+            // Distinct messages so de-dup doesn't interfere with the cap.
+            diagnostics::error(Span::call_site(), format!("error {i}"));
+        }
+    });
+
+    // `MAX_DIAGNOSTICS` real errors plus one summary.
+    assert_eq!(diagnostics.len(), MAX_DIAGNOSTICS + 1);
+    assert!(
+        diagnostics.last().unwrap().message.contains("suppressed"),
+        "the final diagnostic should summarize the suppressed ones"
+    );
+}


### PR DESCRIPTION
Improves error reporting and editor support for the `view!`/`template!` macros.

### Error locality
|                                                          | Before                                                                          | After                                                                                |
| -------------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| **Unknown event modifier** (`on:click:typo`)             | Reported at `Span::call_site()` → underlines the whole `view!`; aborts the rest | Points at the event attribute; drops the bad modifier and keeps checking the rest    |
| **Missing required prop** (`<Greeting/>` without `name`) | `.build()` had a call-site span → error blamed the whole `view!`                | `.build()` spanned to the component → underlines that specific `<Component/>`        |
| **Multiple errors**                                      | First `abort!` hid the rest; duplicates/cascades unbounded                      | All errors collected, de-duplicated, and capped (one summary line for the remainder) |

### Editor prop completion
**Before:** typing `view! { <Counter ` leaves the tag unclosed, so the parser drops the element and the macro expands to `()` — no props builder, no completions.

**After:** `view::parse_nodes` (debug builds only) retries with a synthetic `/>` and keeps it **only if it strictly reduces parse errors without losing nodes**. A valid view parses with zero errors, so it's never touched; an incomplete one expands into its props builder, letting rust-analyzer complete the component's props — whether the half-typed tag is alone or beside already-written ones.

### Under the hood
- New `view/diagnostics.rs`: errors recorded as spanned values, emitted from a single sink; de-dup + cap; unit-testable.
- Every `emit_error!`/`abort!` site in view lowering migrated to it; `Span::call_site()` now used in exactly one place (the cap summary).
- New tests for locality, output bounding, and recovery; `proc-macro2` `span-locations` enabled for the test build.

### Notes
- Recovery is **debug-only**, so release/wasm output is unchanged.
- Out of scope (follow-up): friendlier "unknown prop" message — currently surfaces as rustc's "no method named `…`" because the `view!` macro can't see a component's prop list at expansion time.

@lpotthast Could you please let me know if this covers #4628 and #4630.