### PR TITLE
fix(leptos_server): print serialization errors when tracing is disabled

### DIFF
--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -175,10 +175,14 @@ where
                         match value.as_ref() {
                             Some(value) => match Ser::encode(value) {
                                 Ok(encoded) => encoded.into_encoded_string(),
-                                #[allow(unused)]
                                 Err(e) => {
                                     #[cfg(feature = "tracing")]
                                     tracing::error!(
+                                        "error serializing resource for \
+                                         hydration: {e:?}"
+                                    );
+                                    #[cfg(not(feature = "tracing"))]
+                                    eprintln!(
                                         "error serializing resource for \
                                          hydration: {e:?}"
                                     );
@@ -191,6 +195,11 @@ where
                             None => {
                                 #[cfg(feature = "tracing")]
                                 tracing::error!(
+                                    "resource value missing while serializing \
+                                     for hydration"
+                                );
+                                #[cfg(not(feature = "tracing"))]
+                                eprintln!(
                                     "resource value missing while serializing \
                                      for hydration"
                                 );

--- a/leptos_server/src/resource.rs
+++ b/leptos_server/src/resource.rs
@@ -360,10 +360,14 @@ where
                         value.with_untracked(|data| match &data {
                             Some(val) => match Ser::encode(val) {
                                 Ok(encoded) => encoded.into_encoded_string(),
-                                #[allow(unused)]
                                 Err(e) => {
                                     #[cfg(feature = "tracing")]
                                     tracing::error!(
+                                        "error serializing resource for \
+                                         hydration: {e:?}"
+                                    );
+                                    #[cfg(not(feature = "tracing"))]
+                                    eprintln!(
                                         "error serializing resource for \
                                          hydration: {e:?}"
                                     );
@@ -377,6 +381,11 @@ where
                             None => {
                                 #[cfg(feature = "tracing")]
                                 tracing::error!(
+                                    "resource value missing while serializing \
+                                     for hydration"
+                                );
+                                #[cfg(not(feature = "tracing"))]
+                                eprintln!(
                                     "resource value missing while serializing \
                                      for hydration"
                                 );


### PR DESCRIPTION
Follow-up: #4753

The SSR resource serialization path only logged encode failures and missing values under the tracing feature, silently swallowing them otherwise. Fall back to eprintln! when tracing is not enabled so these server-side errors remain visible.