### PR TITLE
Revert "chore: don't rely on unstable wasm bindgen apis (#4741)"

### DIFF
--- a/tachys/src/html/event.rs
+++ b/tachys/src/html/event.rs
@@ -15,6 +15,7 @@ use std::{
     ops::{Deref, DerefMut},
     rc::Rc,
 };
+use wasm_bindgen::convert::FromWasmAbi;
 
 /// A cloneable event callback.
 pub type SharedEventCallback<E> = Rc<RefCell<dyn FnMut(E)>>;
@@ -395,7 +396,7 @@ impl<E, F> ToTemplate for On<E, F> {
 /// A trait for converting types into [web_sys events](web_sys).
 pub trait EventDescriptor: Clone {
     /// The [`web_sys`] event type, such as [`web_sys::MouseEvent`].
-    type EventType;
+    type EventType: FromWasmAbi;
 
     /// Indicates if this event bubbles. For example, `click` bubbles,
     /// but `focus` does not.
@@ -449,13 +450,13 @@ impl<E: EventDescriptor> EventDescriptor for Capture<E> {
 
 /// A custom event.
 #[derive(Debug)]
-pub struct Custom<E = web_sys::Event> {
+pub struct Custom<E: FromWasmAbi = web_sys::Event> {
     name: Cow<'static, str>,
     options: Option<SendWrapper<web_sys::AddEventListenerOptions>>,
     _event_type: PhantomData<fn() -> E>,
 }
 
-impl<E> Clone for Custom<E> {
+impl<E: FromWasmAbi> Clone for Custom<E> {
     fn clone(&self) -> Self {
         Self {
             name: self.name.clone(),
@@ -465,7 +466,7 @@ impl<E> Clone for Custom<E> {
     }
 }
 
-impl<E> EventDescriptor for Custom<E> {
+impl<E: FromWasmAbi> EventDescriptor for Custom<E> {
     type EventType = E;
 
     fn name(&self) -> Cow<'static, str> {
@@ -484,7 +485,7 @@ impl<E> EventDescriptor for Custom<E> {
     }
 }
 
-impl<E> Custom<E> {
+impl<E: FromWasmAbi> Custom<E> {
     /// Creates a custom event type that can be used within
     /// [`OnAttribute::on`](crate::prelude::OnAttribute::on), for events
     /// which are not covered in the [`ev`](crate::html::event) module.


### PR DESCRIPTION
This reverts commit 00a388a0216c1d399ec81ea252d4ff0cc4faeab6 (PR #4815)

#4815 removes a trait bound on `EventType` that is completely unused in `tachys` or in any other `leptos` crate. However, this causes a compile error in at least one downstream user of the crate (`leptos-use`), which uses `EventDescriptor` as a trait bound and relies on behavior that is (apparently?) gated by `FromWasmAbi`.

```
error[E0277]: the trait bound `<Ev as EventDescriptor>::EventType: FromWasmAbi` is not satisfied
   --> .../leptos-use-0.19.0/src/use_event_listener.rs:134:40
    |
134 |           let closure_js = Closure::wrap(Box::new(move |e| {
    |  __________________________-------------_^
    | |                          |
    | |                          required by a bound introduced by this call
135 | |             #[cfg(debug_assertions)]
136 | |             let _z = leptos::reactive::diagnostics::SpecialNonReactiveZone::enter();
...   |
139 | |         }) as Box<dyn FnMut(_)>)
    | |_______________________________^ the trait `FromWasmAbi` is not implemented for `<Ev as EventDescriptor>::EventType`
    |
    = note: required for `dyn FnMut(<Ev as EventDescriptor>::EventType)` to implement `wasm_bindgen::closure::WasmClosure`
    = note: required for `dyn FnMut(<Ev as EventDescriptor>::EventType)` to implement `IntoWasmClosure<dyn FnMut(...)>`
note: required by a bound in `ScopedClosure::<'static, T>::wrap`
```

I still think removing this in a future version is the right change, and this issue can be fixed on the `leptos-use` side by adding `FromWasmAbi` to the bounds of `Ev` if it's needed there, but for now *removing* this bound turned out to be a breaking change in a patch release, so I'm going to revert it for now to un-break this.