### PR TITLE
feat(config): decouple public pkg URL from on-disk pkg dir

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -29,7 +29,7 @@ use leptos::{
 };
 use leptos_integration_utils::{
     BoxedFnOnce, ExtendResponse, PinnedFuture, PinnedStream,
-    accept_header_includes_html, build_request_url,
+    accept_header_includes_html, build_request_url, resolve_static_dir,
 };
 use leptos_meta::ServerMetaContext;
 use leptos_router::{
@@ -725,6 +725,89 @@ where
     )
 }
 
+/// Returns an Actix [struct@Route](actix_web::Route) that serves static files
+/// and renders your application as the `404 Not Found` page for any request that
+/// does not match a file.
+///
+/// This mirrors `leptos_axum`'s `file_and_error_handler`. Register it as the
+/// app's `default_service` so requests that are neither a routed page nor a
+/// static file render your app's not-found view.
+///
+/// Static files are served relative to `LEPTOS_SITE_ROOT`, except when
+/// `LEPTOS_SITE_PKG_DIR` is set to an *absolute* path: the compiled JS/WASM
+/// assets live there instead, and requests under that pkg URL prefix are served
+/// from it. This requires [`LeptosOptions`] to be supplied as application data
+/// (e.g. via [`web::Data`]), as the other render handlers also expect.
+///
+/// `shell` receives the [`LeptosOptions`] from application data, mirroring the
+/// `shell` argument of the routed render handlers.
+#[cfg_attr(
+    feature = "tracing",
+    tracing::instrument(level = "trace", fields(error), skip_all)
+)]
+pub fn file_and_error_handler<IV>(
+    shell: impl Fn(LeptosOptions) -> IV + Clone + Send + 'static,
+) -> Route
+where
+    IV: IntoView + 'static,
+{
+    let handler = move |req: HttpRequest, options: Data<LeptosOptions>| {
+        let shell = shell.clone();
+        async move {
+            let options = options.into_inner();
+            // Own the request path so the request can be moved into the
+            // renderer on the fallback path below.
+            let req_path = req.uri().path().to_owned();
+
+            // Serve the backing static file if there is one, honoring an
+            // absolute `LEPTOS_SITE_PKG_DIR` (whose assets live outside
+            // `site_root`) and rejecting path traversal.
+            if let Some((dir, rel)) = resolve_static_dir(&options, &req_path) {
+                let file_path =
+                    Path::new(dir.as_ref()).join(rel.trim_start_matches('/'));
+                if let Ok(file) = NamedFile::open_async(&file_path).await {
+                    return file.into_response(&req);
+                }
+            }
+
+            // Otherwise render the application as the 404 page.
+            let shell_options = (*options).clone();
+            let app_fn = move || shell(shell_options.clone());
+            let mut res = render_app_response(
+                req,
+                || {},
+                app_fn,
+                |app, chunks, supports_ooo| {
+                    Box::pin(async move {
+                        let app = if cfg!(feature = "islands-router") {
+                            if supports_ooo {
+                                app.to_html_stream_out_of_order_branching()
+                            } else {
+                                app.to_html_stream_in_order_branching()
+                            }
+                        } else if supports_ooo {
+                            app.to_html_stream_out_of_order()
+                        } else {
+                            app.to_html_stream_in_order()
+                        };
+                        Box::pin(app.chain(chunks())) as PinnedStream<String>
+                    })
+                },
+            )
+            .await;
+
+            // Don't clobber a status the app set itself (e.g. a redirect).
+            if res.status() == StatusCode::OK {
+                *res.status_mut() = StatusCode::NOT_FOUND;
+            }
+            res
+        }
+    };
+    web::route()
+        .guard(guard::Any(guard::Get()).or(guard::Head()))
+        .to(handler)
+}
+
 /// Returns an Actix [struct@Route](actix_web::Route) that listens for a `GET` request and tries
 /// to route it using [leptos_router], serving an in-order HTML stream of your application.
 ///
@@ -844,6 +927,56 @@ fn request_url(req: &HttpRequest) -> RequestUrl {
     RequestUrl::new(&url)
 }
 
+/// Renders the app to an [`HttpResponse`] for a single request, providing the
+/// standard Leptos contexts (and the islands-router navigation marker when
+/// applicable). Shared by the routed render handlers and the static-file
+/// fallback so they render identically.
+#[allow(clippy::type_complexity)]
+async fn render_app_response<IV>(
+    req: HttpRequest,
+    additional_context: impl Fn() + 'static + Clone + Send,
+    app_fn: impl Fn() -> IV + Clone + Send + 'static,
+    stream_builder: fn(
+        IV,
+        BoxedFnOnce<PinnedStream<String>>,
+        bool,
+    ) -> PinnedFuture<PinnedStream<String>>,
+) -> HttpResponse
+where
+    IV: IntoView + 'static,
+{
+    let is_island_router_navigation = cfg!(feature = "islands-router")
+        && req.headers().get("Islands-Router").is_some();
+
+    let res_options = ResponseOptions::default();
+    let (meta_context, meta_output) = ServerMetaContext::new();
+
+    let additional_context = {
+        let meta_context = meta_context.clone();
+        let res_options = res_options.clone();
+        let req = Request::new(&req);
+        move || {
+            provide_contexts(req, &meta_context, &res_options);
+            additional_context();
+
+            if is_island_router_navigation {
+                provide_context(IslandsRouterNavigation);
+            }
+        }
+    };
+
+    ActixResponse::from_app(
+        app_fn,
+        meta_output,
+        additional_context,
+        res_options,
+        stream_builder,
+        !is_island_router_navigation,
+    )
+    .await
+    .0
+}
+
 #[allow(clippy::type_complexity)]
 fn handle_response<IV>(
     method: Method,
@@ -863,37 +996,7 @@ where
         let add_context = additional_context.clone();
 
         async move {
-            let is_island_router_navigation = cfg!(feature = "islands-router")
-                && req.headers().get("Islands-Router").is_some();
-
-            let res_options = ResponseOptions::default();
-            let (meta_context, meta_output) = ServerMetaContext::new();
-
-            let additional_context = {
-                let meta_context = meta_context.clone();
-                let res_options = res_options.clone();
-                let req = Request::new(&req);
-                move || {
-                    provide_contexts(req, &meta_context, &res_options);
-                    add_context();
-
-                    if is_island_router_navigation {
-                        provide_context(IslandsRouterNavigation);
-                    }
-                }
-            };
-
-            let res = ActixResponse::from_app(
-                app_fn,
-                meta_output,
-                additional_context,
-                res_options,
-                stream_builder,
-                !is_island_router_navigation,
-            )
-            .await;
-
-            res.0
+            render_app_response(req, add_context, app_fn, stream_builder).await
         }
     };
     match method {

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -2617,8 +2617,7 @@ where
             let shell = shell.clone();
             async move {
                 let options = LeptosOptions::from_ref(&state);
-                let res =
-                    get_static_file(uri, &options.site_root, req.headers());
+                let res = get_static_file(uri, &options, req.headers());
                 // `get_static_file` returns `Err` if the underlying `ServeDir`
                 // fails. This handler is the documented "reasonable default"
                 // fallback, so it must not panic: log and serve a generic 500.
@@ -2707,12 +2706,21 @@ where
 #[cfg(feature = "default")]
 async fn get_static_file(
     uri: Uri,
-    root: &str,
+    options: &LeptosOptions,
     headers: &HeaderMap<HeaderValue>,
 ) -> Result<Response<Body>, (StatusCode, String)> {
     use axum::http::header::ACCEPT_ENCODING;
 
-    let req = Request::builder().uri(uri);
+    // Resolve the directory to serve from and the path within it. This honors
+    // an absolute `LEPTOS_SITE_PKG_DIR` (whose assets live outside `site_root`)
+    // and rejects path traversal.
+    let Some((dir, path)) =
+        leptos_integration_utils::resolve_static_dir(options, uri.path())
+    else {
+        return Ok(StatusCode::NOT_FOUND.into_response());
+    };
+
+    let req = Request::builder().uri(path.as_ref());
 
     let req = match headers.get(ACCEPT_ENCODING) {
         Some(value) => req.header(ACCEPT_ENCODING, value),
@@ -2733,8 +2741,7 @@ async fn get_static_file(
         }
     };
     // `ServeDir` implements `tower::Service` so we can call it with `tower::ServiceExt::oneshot`
-    // This path is relative to the cargo root
-    match ServeDir::new(root)
+    match ServeDir::new(dir.as_ref())
         .precompressed_gzip()
         .precompressed_br()
         .oneshot(req)

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -11,7 +11,7 @@ use leptos::{
 };
 use leptos_config::LeptosOptions;
 use leptos_meta::{Link, ServerMetaContextOutput};
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
 
 pub type PinnedStream<T> = Pin<Box<dyn Stream<Item = T> + Send>>;
 pub type PinnedFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
@@ -377,6 +377,52 @@ pub fn static_file_path(options: &LeptosOptions, path: &str) -> Option<String> {
     Some(format!("{}/{}.html", options.site_root, path))
 }
 
+/// Resolves the on-disk directory a static-asset request should be served from,
+/// together with the request path relative to that directory. Returns `None`
+/// when the request would escape that directory via path traversal; callers
+/// must treat `None` as a rejected request (respond `404`).
+///
+/// The pkg assets are served to the client under
+/// [`pkg_url_path`](LeptosOptions::pkg_url_path) (default `pkg`), independent of
+/// where they live on disk: requests under that URL prefix are mapped to the
+/// pkg directory ([`site_pkg_dir`](LeptosOptions::site_pkg_dir) resolved against
+/// `site_root`, so an absolute `site_pkg_dir` is used as-is) with the prefix
+/// stripped. Every other request is served from `site_root` unchanged. Both
+/// server integrations share this logic.
+pub fn resolve_static_dir<'a>(
+    options: &'a LeptosOptions,
+    request_path: &'a str,
+) -> Option<(Cow<'a, str>, Cow<'a, str>)> {
+    if is_path_traversal(request_path) {
+        return None;
+    }
+    let url_prefix = options.pkg_url_path();
+    if !url_prefix.is_empty() {
+        let after_root = request_path.strip_prefix('/').unwrap_or(request_path);
+        if let Some(rel) = after_root
+            .strip_prefix(url_prefix)
+            .filter(|rest| rest.is_empty() || rest.starts_with('/'))
+        {
+            let rel = if rel.is_empty() { "/" } else { rel };
+            let pkg_dir = &*options.site_pkg_dir;
+            let dir = if pkg_dir.starts_with('/') {
+                Cow::Borrowed(pkg_dir.trim_end_matches('/'))
+            } else {
+                Cow::Owned(format!(
+                    "{}/{}",
+                    options.site_root.trim_end_matches('/'),
+                    pkg_dir.trim_matches('/')
+                ))
+            };
+            return Some((dir, Cow::Borrowed(rel)));
+        }
+    }
+    Some((
+        Cow::Borrowed(&*options.site_root),
+        Cow::Borrowed(request_path),
+    ))
+}
+
 /// Writes `contents` to `path` atomically: the file appears with its full
 /// contents or not at all.
 ///
@@ -464,6 +510,95 @@ mod tests {
             static_file_path(&options, "/a/./b"),
             Some("/var/www/site/static/a/./b.html".into())
         );
+    }
+
+    fn opts_with_pkg(pkg_dir: &str) -> LeptosOptions {
+        LeptosOptions::builder()
+            .output_name("ignored")
+            .site_root("/var/www/site/static")
+            .site_pkg_dir(pkg_dir.to_string())
+            .build()
+    }
+
+    fn opts_with_pkg_url(pkg_dir: &str, pkg_url: &str) -> LeptosOptions {
+        LeptosOptions::builder()
+            .output_name("ignored")
+            .site_root("/var/www/site/static")
+            .site_pkg_dir(pkg_dir.to_string())
+            .site_pkg_url(pkg_url.to_string())
+            .build()
+    }
+
+    #[test]
+    fn resolve_static_dir_relative_pkg_serves_from_pkg_subdir() {
+        let options = opts_with_pkg("pkg");
+        // pkg assets come from `site_root/pkg`, with the url prefix stripped
+        assert_eq!(
+            resolve_static_dir(&options, "/pkg/app.js"),
+            Some(("/var/www/site/static/pkg".into(), "/app.js".into()))
+        );
+        // non-pkg assets come from site_root unchanged
+        assert_eq!(
+            resolve_static_dir(&options, "/favicon.ico"),
+            Some(("/var/www/site/static".into(), "/favicon.ico".into()))
+        );
+        // a path that only shares a textual prefix is not treated as pkg
+        assert_eq!(
+            resolve_static_dir(&options, "/pkgX/app.js"),
+            Some(("/var/www/site/static".into(), "/pkgX/app.js".into()))
+        );
+    }
+
+    #[test]
+    fn resolve_static_dir_absolute_pkg_serves_from_that_dir() {
+        let options = opts_with_pkg("/tmp/testsplit/");
+        // the client requests under the public `/pkg/` prefix; serve those from
+        // the absolute directory with the prefix stripped
+        assert_eq!(
+            resolve_static_dir(&options, "/pkg/app.js"),
+            Some(("/tmp/testsplit".into(), "/app.js".into()))
+        );
+        // the absolute path is never a client URL, so it is not special-cased
+        assert_eq!(
+            resolve_static_dir(&options, "/tmp/testsplit/app.js"),
+            Some((
+                "/var/www/site/static".into(),
+                "/tmp/testsplit/app.js".into()
+            ))
+        );
+        // everything else still comes from site_root
+        assert_eq!(
+            resolve_static_dir(&options, "/favicon.ico"),
+            Some(("/var/www/site/static".into(), "/favicon.ico".into()))
+        );
+    }
+
+    #[test]
+    fn resolve_static_dir_uses_configurable_pkg_url() {
+        // a custom `site_pkg_url` decouples the public path from the on-disk
+        // dir, for both relative and absolute `site_pkg_dir`
+        let rel = opts_with_pkg_url("pkg", "assets");
+        assert_eq!(
+            resolve_static_dir(&rel, "/assets/app.js"),
+            Some(("/var/www/site/static/pkg".into(), "/app.js".into()))
+        );
+        let abs = opts_with_pkg_url("/tmp/testsplit/", "assets");
+        assert_eq!(
+            resolve_static_dir(&abs, "/assets/app.js"),
+            Some(("/tmp/testsplit".into(), "/app.js".into()))
+        );
+        // the default `/pkg/` is not special once a custom url is configured
+        assert_eq!(
+            resolve_static_dir(&abs, "/pkg/app.js"),
+            Some(("/var/www/site/static".into(), "/pkg/app.js".into()))
+        );
+    }
+
+    #[test]
+    fn resolve_static_dir_rejects_traversal() {
+        let options = opts_with_pkg("/tmp/testsplit/");
+        assert_eq!(resolve_static_dir(&options, "/../../etc/passwd"), None);
+        assert_eq!(resolve_static_dir(&options, "/pkg/..%2f..%2fetc"), None);
     }
 
     #[test]

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -134,7 +134,11 @@ pub fn HydrationScripts(
         let file = std::fs::read_to_string(path).ok()?;
 
         let manifest = WasmSplitManifest(ArcStoredValue::new((
-            format!("{root}/{pkg_dir}"),
+            format!(
+                "{}/{}",
+                root.trim_end_matches('/'),
+                options.pkg_url_path()
+            ),
             serde_json::from_str(&file).expect("could not read manifest file"),
             wasm_split_js,
         )));
@@ -193,7 +197,10 @@ pub fn HydrationScripts(
         })
         .clone();
 
-    let pkg_path = &options.site_pkg_dir;
+    // The URL path the client loads assets from. An absolute `site_pkg_dir` is
+    // a server-side filesystem location, so this resolves to the default `pkg`
+    // path rather than leaking it; the server integrations map it back to disk.
+    let pkg_path = options.pkg_url_path();
     #[cfg(feature = "nonce")]
     let nonce = crate::nonce::use_nonce();
     #[cfg(not(feature = "nonce"))]
@@ -212,6 +219,8 @@ pub fn HydrationScripts(
         .unwrap_or_default();
 
     let root = root.unwrap_or_default();
+    // Trim a trailing slash so the base URL joins cleanly with `pkg_path`.
+    let root = root.trim_end_matches('/');
     view! {
         <link rel="modulepreload" href=format!("{root}/{pkg_path}/{js_file_name}.js") crossorigin=nonce.clone()/>
         <link

--- a/leptos_config/src/lib.rs
+++ b/leptos_config/src/lib.rs
@@ -51,6 +51,19 @@ pub struct LeptosOptions {
     #[builder(setter(into), default=default_site_pkg_dir())]
     #[serde(default = "default_site_pkg_dir")]
     pub site_pkg_dir: Arc<str>,
+    /// The URL path under which the pkg assets (JS/WASM/CSS) are served to the
+    /// client.
+    ///
+    /// This is the public URL counterpart of [`site_pkg_dir`](Self::site_pkg_dir)
+    /// (the on-disk location). Keeping them separate means an absolute
+    /// `site_pkg_dir` — a server-side filesystem location that must not be
+    /// exposed to the client — is still served under a clean URL, with the
+    /// server integrations mapping this path back to the directory on disk.
+    ///
+    /// Defaults to `pkg`.
+    #[builder(setter(into), default=default_site_pkg_url())]
+    #[serde(default = "default_site_pkg_url")]
+    pub site_pkg_url: Arc<str>,
     /// Used to configure the running environment of Leptos.
     /// Can be used to load dev constants and keys v prod,
     /// or change things based on the deployment environment.
@@ -182,17 +195,30 @@ impl LeptosOptions {
         path
     }
 
-    /// Returns the base route to the `site_pkg_dir` with a leading and trailing slash added as necessary.
+    /// Returns the URL path segment under which the pkg assets (JS/WASM/CSS) are
+    /// served to the client.
+    ///
+    /// This is [`site_pkg_url`](Self::site_pkg_url) (default `pkg`), the public
+    /// URL counterpart of the on-disk [`site_pkg_dir`](Self::site_pkg_dir). It is
+    /// used for both relative and absolute `site_pkg_dir` values, so the absolute
+    /// on-disk path is never exposed to the client.
+    pub fn pkg_url_path(&self) -> &str {
+        self.site_pkg_url.trim_matches('/')
+    }
+
+    /// Returns the base route to the pkg assets with a leading and trailing slash.
+    ///
+    /// This uses [`pkg_url_path`](Self::pkg_url_path), so an absolute
+    /// `site_pkg_dir` is never exposed in the route.
     pub fn site_pkg_dir_route_base(&self) -> String {
-        let mut path = String::new();
-        // While it shouldn't start with a '/', but check anyway.
-        if !self.site_pkg_dir.starts_with('/') {
-            path.push('/');
+        let pkg = self.pkg_url_path();
+        if pkg.is_empty() {
+            return "/".to_string();
         }
-        path.push_str(&self.site_pkg_dir);
-        if !path.ends_with('/') {
-            path.push('/');
-        }
+        let mut path = String::with_capacity(pkg.len() + 2);
+        path.push('/');
+        path.push_str(pkg);
+        path.push('/');
         path
     }
 
@@ -216,6 +242,7 @@ impl LeptosOptions {
             output_name: output_name.into(),
             site_root: env_w_default("LEPTOS_SITE_ROOT", "target/site")?.into(),
             site_pkg_dir: env_w_default("LEPTOS_SITE_PKG_DIR", "pkg")?.into(),
+            site_pkg_url: env_w_default("LEPTOS_SITE_PKG_URL", "pkg")?.into(),
             env: env_from_str(env_w_default("LEPTOS_ENV", "DEV")?.as_str())?,
             site_addr: env_w_default("LEPTOS_SITE_ADDR", "127.0.0.1:3000")?
                 .parse()?,
@@ -248,6 +275,10 @@ fn default_site_root() -> Arc<str> {
 }
 
 fn default_site_pkg_dir() -> Arc<str> {
+    "pkg".into()
+}
+
+fn default_site_pkg_url() -> Arc<str> {
     "pkg".into()
 }
 

--- a/leptos_config/src/tests.rs
+++ b/leptos_config/src/tests.rs
@@ -146,7 +146,7 @@ fn leptos_options_css_path() {
 
     let options = LeptosOptions::builder()
         .output_name("test.css")
-        .site_pkg_dir("my/pkg")
+        .site_pkg_url("my/pkg")
         .build();
     assert_eq!(options.css_path(), "/my/pkg/test.css.css");
 
@@ -158,7 +158,7 @@ fn leptos_options_css_path() {
 
     let options = LeptosOptions::builder()
         .output_name("test")
-        .site_pkg_dir("")
+        .site_pkg_url("")
         .build();
     assert_eq!(options.css_path(), "/test.css");
 }

--- a/meta/src/stylesheet.rs
+++ b/meta/src/stylesheet.rs
@@ -77,8 +77,12 @@ pub fn HashedStylesheet(
         }
     }
     css_file_name.push_str(".css");
-    let pkg_path = &options.site_pkg_dir;
+    // An absolute `site_pkg_dir` is a server-side filesystem location, so use
+    // the client-facing pkg URL path (never the absolute path) and join it
+    // cleanly with the base URL.
+    let pkg_path = options.pkg_url_path();
     let root = root.unwrap_or_default();
+    let root = root.trim_end_matches('/');
 
     link()
         .id(id)


### PR DESCRIPTION
Paired with: https://github.com/leptos-rs/cargo-leptos/pull/660

Introduce `site_pkg_url` (env `LEPTOS_SITE_PKG_URL`, default `pkg`) as the public URL path under which the pkg assets (JS/WASM/CSS) are served, kept separate from `site_pkg_dir` (the on-disk location). An absolute `site_pkg_dir` is a server-side filesystem path and is no longer leaked into client-facing URLs; the server integrations map the public path back to the directory on disk.

- Add `LeptosOptions::pkg_url_path()` and route `site_pkg_dir_route_base()` through it so both relative and absolute `site_pkg_dir` resolve to the public URL path.
- Add a shared `resolve_static_dir()` in the integration utils that maps a request under the pkg URL prefix to the pkg directory (relative resolved against `site_root`, absolute used as-is) and rejects path traversal.
- axum `file_and_error_handler` serves static files via `resolve_static_dir`.
- Add an actix `file_and_error_handler` mirroring axum, and factor the shared per-request rendering into `render_app_response`.
- Use `pkg_url_path()` in `HydrationScripts` and `HashedStylesheet`, joining cleanly with the base URL.