### PR TITLE
Revert "fix(tachys): escape `<textarea>` children to prevent XSS"

### DIFF
--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -403,7 +403,7 @@ html_elements! {
     /// The `<template>` HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript.
     template HtmlTemplateElement [] true,
     /// The `<textarea>` HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
-    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] true,
+    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] false,
     /// The `<tfoot>` HTML element defines a set of rows summarizing the columns of the table.
     tfoot HtmlTableSectionElement [] true,
     /// The `<th>` HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.
@@ -429,26 +429,4 @@ html_elements! {
 html_element_inner! {
     /// The `<option>` HTML element is used to define an item contained in a `<select>`, an` <optgroup>`, or a `<datalist>` element. As such, `<option>` can represent menu items in popups and other lists of items in an HTML document.
     option Option_ HtmlOptionElement [disabled, label, selected, value] true
-}
-
-#[cfg(all(test, feature = "ssr"))]
-mod tests {
-    use crate::{
-        html::element::{textarea, ElementChild},
-        view::RenderHtml,
-    };
-
-    #[test]
-    fn textarea_escapes_child_content() {
-        // `<textarea>` content is escapable raw text per the HTML spec, so a
-        // child string containing `</textarea>` or `<script>` must be escaped
-        // rather than written verbatim.
-        let untrusted = "</textarea><script>alert('xss')</script>".to_string();
-        let html = textarea().child(untrusted).to_html();
-        assert_eq!(
-            html,
-            "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;/script&\
-             gt;</textarea>"
-        );
-    }
 }


### PR DESCRIPTION
`<textarea>`, like `<style>`, `<script>`, and a few other tags, has previously been treated as a special element with raw children that are neither escaped nor hydrated. 

Commit 9417ed441e56a0c3216f8c62e0bfce78e274748e toggles `<textarea>` children to be escaped like other elements. However, `<textarea>` children do not actually behave like other elements. For example, HTML comments that appear inside textareas appear as raw text, not as HTML.

This commit therefore breaks textareas, causing hydration errors.

While it's true that it does close a XSS injection opportunity (if untrusted/unescaped text is rendered directly into the textarea) the same thing is actually true for the other unescaped elements and this commit does not change or fix any of those. Perhaps a better solution would involve fixing that for all unescaped elements rather than toggling textarea to be escaped, which breaks.