### PR TITLE
fix(tachys): decouple child escaping from hydration for raw-text elements

### DIFF
--- a/examples/lazy_routes/src/app.rs
+++ b/examples/lazy_routes/src/app.rs
@@ -62,6 +62,7 @@ pub fn ViewA() -> impl IntoView {
     let result = RwSignal::new("Click a button to see the result".to_string());
 
     view! {
+	<textarea>"hey"</textarea>
         <p id="page">"View A"</p>
         <pre id="result">{result}</pre>
         <button id="First" on:click=move |_| spawn_local(async move { result.set(first_value().await); })>"First"</button>

--- a/examples/lazy_routes/src/app.rs
+++ b/examples/lazy_routes/src/app.rs
@@ -62,7 +62,6 @@ pub fn ViewA() -> impl IntoView {
     let result = RwSignal::new("Click a button to see the result".to_string());
 
     view! {
-	<textarea>"hey"</textarea>
         <p id="page">"View A"</p>
         <pre id="result">{result}</pre>
         <button id="First" on:click=move |_| spawn_local(async move { result.set(first_value().await); })>"First"</button>

--- a/leptos/src/attribute_interceptor.rs
+++ b/leptos/src/attribute_interceptor.rs
@@ -2,7 +2,7 @@ use crate::attr::{
     Attribute, NextAttribute,
     any_attribute::{AnyAttribute, IntoAnyAttribute},
 };
-use leptos::prelude::*;
+use leptos::{prelude::*, tachys::view::RenderFlags};
 
 /// Function stored to build/rebuild the wrapped children when attributes are added.
 type ChildBuilder<T> = dyn Fn(AnyAttribute) -> T + Send + Sync + 'static;
@@ -136,17 +136,10 @@ impl<T: IntoView + 'static, A: Attribute> RenderHtml
         self,
         buf: &mut String,
         position: &mut leptos::tachys::view::Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
-        self.children.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            vec![],
-        )
+        self.children.to_html_with_buf(buf, position, flags, vec![])
     }
 
     fn hydrate<const FROM_SERVER: bool>(

--- a/leptos/src/error_boundary.rs
+++ b/leptos/src/error_boundary.rs
@@ -23,7 +23,7 @@ use tachys::{
     reactive_graph::OwnedView,
     ssr::{StreamBuilder, StreamChunk},
     view::{
-        Mountable, Position, PositionState, Render, RenderHtml,
+        Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
         add_attr::AddAnyAttr,
     },
 };
@@ -326,8 +326,7 @@ where
         mut self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         // first, attempt to serialize the children to HTML, then check for errors
@@ -341,8 +340,7 @@ where
         self.children.to_html_with_buf(
             buf,
             &mut new_pos,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs.clone(),
         );
 
@@ -353,8 +351,7 @@ where
             (self.fallback)(self.errors).to_html_with_buf(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
         }
@@ -366,8 +363,7 @@ where
         mut self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -380,8 +376,7 @@ where
         self.children.to_html_async_with_buf::<OUT_OF_ORDER>(
             &mut new_buf,
             &mut new_pos,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs.clone(),
         );
 
@@ -399,8 +394,7 @@ where
                 (self.fallback)(self.errors).to_html_with_buf(
                     &mut fallback,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
                 buf.push_sync(&fallback);
@@ -445,8 +439,7 @@ where
                     (self.fallback)(self.errors).to_html_with_buf(
                         &mut fallback,
                         &mut position,
-                        escape,
-                        mark_branches,
+                        flags,
                         extra_attrs,
                     );
                     my_chunks.clear();

--- a/leptos/src/into_view.rs
+++ b/leptos/src/into_view.rs
@@ -4,7 +4,7 @@ use tachys::{
     hydration::Cursor,
     ssr::StreamBuilder,
     view::{
-        Position, PositionState, Render, RenderHtml, ToTemplate,
+        Position, PositionState, Render, RenderFlags, RenderHtml, ToTemplate,
         add_attr::AddAnyAttr,
     },
 };
@@ -104,8 +104,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         #[cfg(debug_assertions)]
@@ -120,13 +119,8 @@ impl<T: RenderHtml> RenderHtml for View<T> {
             buf.push_str(&format!("<!--hot-reload|{vm}|open-->"));
         }
 
-        self.inner.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.inner
+            .to_html_with_buf(buf, position, flags, extra_attrs);
 
         #[cfg(debug_assertions)]
         if let Some(vm) = vm.as_ref() {
@@ -138,8 +132,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -159,8 +152,7 @@ impl<T: RenderHtml> RenderHtml for View<T> {
         self.inner.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
 

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -29,7 +29,7 @@ use tachys::{
     reactive_graph::{OwnedView, OwnedViewState},
     ssr::StreamBuilder,
     view::{
-        Mountable, Position, PositionState, Render, RenderHtml,
+        Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
         add_attr::AddAnyAttr,
         either::{EitherKeepAlive, EitherKeepAliveState},
     },
@@ -309,25 +309,18 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        self.fallback.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.fallback
+            .to_html_with_buf(buf, position, flags, extra_attrs);
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         mut self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -496,8 +489,7 @@ where
                     .to_html_async_with_buf::<OUT_OF_ORDER>(
                         buf,
                         position,
-                        escape,
-                        mark_branches,
+                        flags,
                         extra_attrs,
                     );
             }
@@ -506,8 +498,7 @@ where
                     .to_html_async_with_buf::<OUT_OF_ORDER>(
                         buf,
                         position,
-                        escape,
-                        mark_branches,
+                        flags,
                         extra_attrs,
                     );
             }
@@ -521,13 +512,13 @@ where
                     buf.push_fallback(
                         self.fallback,
                         &mut fallback_position,
-                        mark_branches,
+                        flags.mark_branches,
                         extra_attrs.clone(),
                     );
                     buf.push_async_out_of_order_with_nonce(
                         fut,
                         position,
-                        mark_branches,
+                        flags.mark_branches,
                         nonce_or_not(),
                         extra_attrs,
                     );
@@ -548,8 +539,7 @@ where
                             value.to_html_async_with_buf::<OUT_OF_ORDER>(
                                 &mut builder,
                                 &mut position,
-                                escape,
-                                mark_branches,
+                                flags,
                                 extra_attrs,
                             );
                             builder.finish().take_chunks()
@@ -670,25 +660,17 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        (self.0)().to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        (self.0)().to_html_with_buf(buf, position, flags, extra_attrs);
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -696,8 +678,7 @@ where
         (self.0)().to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
     }

--- a/leptos_server/src/lib.rs
+++ b/leptos_server/src/lib.rs
@@ -86,7 +86,8 @@ mod view_implementations {
         reactive_graph::{RenderEffectState, Suspend, SuspendState},
         ssr::StreamBuilder,
         view::{
-            Position, PositionState, Render, RenderHtml, add_attr::AddAnyAttr,
+            Position, PositionState, Render, RenderFlags, RenderHtml,
+            add_attr::AddAnyAttr,
         },
     };
 
@@ -153,15 +154,13 @@ mod view_implementations {
             self,
             buf: &mut String,
             position: &mut Position,
-            escape: bool,
-            mark_branches: bool,
+            flags: RenderFlags,
             extra_attrs: Vec<AnyAttribute>,
         ) {
             (move || Suspend::new(async move { self.await })).to_html_with_buf(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
         }
@@ -170,8 +169,7 @@ mod view_implementations {
             self,
             buf: &mut StreamBuilder,
             position: &mut Position,
-            escape: bool,
-            mark_branches: bool,
+            flags: RenderFlags,
             extra_attrs: Vec<AnyAttribute>,
         ) where
             Self: Sized,
@@ -180,8 +178,7 @@ mod view_implementations {
                 .to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
         }

--- a/meta/src/body.rs
+++ b/meta/src/body.rs
@@ -9,8 +9,8 @@ use leptos::{
         html::attribute::Attribute,
         hydration::Cursor,
         view::{
-            Mountable, Position, PositionState, Render, RenderHtml,
-            add_attr::AddAnyAttr,
+            Mountable, Position, PositionState, Render, RenderFlags,
+            RenderHtml, add_attr::AddAnyAttr,
         },
     },
 };
@@ -121,8 +121,7 @@ where
         self,
         _buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         if let Some(meta) = use_context::<ServerMetaContext>() {

--- a/meta/src/html.rs
+++ b/meta/src/html.rs
@@ -9,8 +9,8 @@ use leptos::{
         html::attribute::Attribute,
         hydration::Cursor,
         view::{
-            Mountable, Position, PositionState, Render, RenderHtml,
-            add_attr::AddAnyAttr,
+            Mountable, Position, PositionState, Render, RenderFlags,
+            RenderHtml, add_attr::AddAnyAttr,
         },
     },
 };
@@ -121,8 +121,7 @@ where
         self,
         _buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         if let Some(meta) = use_context::<ServerMetaContext>() {

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -58,8 +58,8 @@ use leptos::{
         },
         hydration::Cursor,
         view::{
-            Mountable, Position, PositionState, Render, RenderHtml,
-            add_attr::AddAnyAttr,
+            Mountable, Position, PositionState, Render, RenderFlags,
+            RenderHtml, add_attr::AddAnyAttr,
         },
     },
 };
@@ -427,8 +427,7 @@ where
         self,
         _buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         // meta tags are rendered into the buffer stored into the context
@@ -439,8 +438,7 @@ where
             self.el.to_html_with_buf(
                 &mut buf,
                 &mut Position::NextChild,
-                false,
-                false,
+                RenderFlags::new(false, false, false),
                 vec![],
             );
             _ = cx.elements.send(buf); // fails only if the receiver is already dropped
@@ -570,8 +568,7 @@ impl RenderHtml for MetaTagsView {
         self,
         buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         buf.push_str("<!--HEAD-->");

--- a/meta/src/title.rs
+++ b/meta/src/title.rs
@@ -10,8 +10,8 @@ use leptos::{
         dom::document,
         hydration::Cursor,
         view::{
-            Mountable, Position, PositionState, Render, RenderHtml,
-            add_attr::AddAnyAttr,
+            Mountable, Position, PositionState, Render, RenderFlags,
+            RenderHtml, add_attr::AddAnyAttr,
         },
     },
     text_prop::TextProp,
@@ -334,8 +334,7 @@ impl RenderHtml for TitleView {
         self,
         _buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         // meta tags are rendered into the buffer stored into the context

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -25,7 +25,8 @@ use tachys::{
     reactive_graph::OwnedView,
     ssr::StreamBuilder,
     view::{
-        MarkBranch, Mountable, Position, PositionState, Render, RenderHtml,
+        MarkBranch, Mountable, Position, PositionState, Render, RenderFlags,
+        RenderHtml,
         add_attr::AddAnyAttr,
         any_view::{AnyView, AnyViewState, IntoAny},
     },
@@ -416,21 +417,15 @@ impl RenderHtml for MatchedRoute {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        let branch_name = (mark_branches && escape).then(|| self.branch_name());
+        let branch_name =
+            (flags.mark_branches && flags.escape).then(|| self.branch_name());
         if let Some(bn) = &branch_name {
             buf.open_branch(bn);
         }
-        self.1.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.1.to_html_with_buf(buf, position, flags, extra_attrs);
         if let Some(bn) = &branch_name {
             buf.close_branch(bn);
             if *position == Position::NextChildAfterText {
@@ -443,21 +438,20 @@ impl RenderHtml for MatchedRoute {
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
     {
-        let branch_name = (mark_branches && escape).then(|| self.branch_name());
+        let branch_name =
+            (flags.mark_branches && flags.escape).then(|| self.branch_name());
         if let Some(bn) = &branch_name {
             buf.open_branch(bn);
         }
         self.1.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
         if let Some(bn) = &branch_name {
@@ -564,8 +558,7 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         // if this is being run on the server for the first time, generating all possible routes
@@ -613,13 +606,7 @@ where
             RouteList::register(RouteList::from(routes));
         } else {
             let view = self.choose_ssr();
-            view.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
+            view.to_html_with_buf(buf, position, flags, extra_attrs);
         }
     }
 
@@ -627,8 +614,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -637,8 +623,7 @@ where
         view.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -45,7 +45,7 @@ use tachys::{
     reactive_graph::{OwnedView, Suspend},
     ssr::StreamBuilder,
     view::{
-        Mountable, Position, PositionState, Render, RenderHtml,
+        Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
         add_attr::AddAnyAttr,
         any_view::{AnyView, IntoAny},
         either::EitherOf3State,
@@ -303,8 +303,7 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         // if this is being run on the server for the first time, generating all possible routes
@@ -385,13 +384,7 @@ where
                     Either::Right(top_level_outlet(&outlets, &outer_owner))
                 }
             };
-            view.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
+            view.to_html_with_buf(buf, position, flags, extra_attrs);
         }
     }
 
@@ -399,8 +392,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -449,8 +441,7 @@ where
         view.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
     }

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -8,6 +8,7 @@ use crate::{
 use std::fmt::Debug;
 
 macro_rules! html_element_inner {
+    // Single escape literal: hydration follows escaping (the common case).
     (
         #[$meta:meta]
         $tag:ident
@@ -15,6 +16,27 @@ macro_rules! html_element_inner {
         $ty:ident
         [$($attr:ty),*]
         $escape:literal
+    ) => {
+        html_element_inner! {
+            #[$meta]
+            $tag
+            $struct_name
+            $ty
+            [$($attr),*]
+            $escape
+            $escape
+        }
+    };
+    // Explicit escape + hydrate literals: decouples escaping from hydration, for escapable
+    // raw-text elements (`<textarea>`/`<title>`) that are escaped but must not be hydrated.
+    (
+        #[$meta:meta]
+        $tag:ident
+        $struct_name:ident
+        $ty:ident
+        [$($attr:ty),*]
+        $escape:literal
+        $hydrate:literal
     ) => {
         paste::paste! {
             #[$meta]
@@ -79,6 +101,7 @@ macro_rules! html_element_inner {
                 const TAG: &'static str = stringify!($tag);
                 const SELF_CLOSING: bool = false;
                 const ESCAPE_CHILDREN: bool = $escape;
+                const HYDRATES_CHILDREN: bool = $hydrate;
                 const NAMESPACE: Option<&'static str> = None;
 
                 #[inline(always)]
@@ -99,6 +122,7 @@ macro_rules! html_elements {
         $ty:ident
         [$($attr:ty),*]
         $escape:literal
+        $($hydrate:literal)?
       ),*
       $(,)?
     ) => {
@@ -110,6 +134,7 @@ macro_rules! html_elements {
                 $ty
                 [$($attr),*]
                 $escape
+                $($hydrate)?
             })*
         }
     }
@@ -403,7 +428,7 @@ html_elements! {
     /// The `<template>` HTML element is a mechanism for holding HTML that is not to be rendered immediately when a page is loaded but may be instantiated subsequently during runtime using JavaScript.
     template HtmlTemplateElement [] true,
     /// The `<textarea>` HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.
-    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] true,
+    textarea HtmlTextAreaElement [autocomplete, cols, dirname, disabled, form, maxlength, minlength, name, placeholder, readonly, required, rows, wrap] true false,
     /// The `<tfoot>` HTML element defines a set of rows summarizing the columns of the table.
     tfoot HtmlTableSectionElement [] true,
     /// The `<th>` HTML element defines a cell as header of a group of table cells. The exact nature of this group is defined by the scope and headers attributes.
@@ -413,7 +438,7 @@ html_elements! {
     /// The `<time>` HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders.
     time HtmlTimeElement [datetime] true,
     ///	The `<title>` HTML element defines the document's title that is shown in a Browser's title bar or a page's tab. It only contains text; tags within the element are ignored.
-    title HtmlTitleElement [] true,
+    title HtmlTitleElement [] true false,
     /// The `<tr>` HTML element defines a row of cells in a table. The row's cells can then be established using a mix of td (data cell) and th (header cell) elements.
     tr HtmlTableRowElement [] true,
     /// The `<u>` HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a simple solid underline, but may be altered using CSS.
@@ -434,7 +459,9 @@ html_element_inner! {
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
     use crate::{
-        html::element::{ElementChild, textarea},
+        html::element::{
+            ElementChild, noscript, script, style, textarea, title,
+        },
         view::RenderHtml,
     };
 
@@ -450,5 +477,47 @@ mod tests {
             "<textarea>&lt;/textarea&gt;&lt;script&gt;alert('xss')&lt;/script&\
              gt;</textarea>"
         );
+    }
+
+    #[test]
+    fn title_escapes_child_content() {
+        // `<title>` is escapable raw text just like `<textarea>`, so it is
+        // escaped (and, like `<textarea>`, not hydrated).
+        let untrusted = "</title><script>alert('xss')</script>".to_string();
+        let html = title().child(untrusted).to_html();
+        assert_eq!(
+            html,
+            "<title>&lt;/title&gt;&lt;script&gt;alert('xss')&lt;/script&gt;</\
+             title>"
+        );
+    }
+
+    #[test]
+    fn raw_text_elements_render_children_verbatim() {
+        // Raw-text elements emit children verbatim: `<`/`&` are NOT
+        // entity-escaped (escaping would corrupt the embedded JS/CSS). The
+        // content below is breakout-safe (no `</tag` delimiter).
+        assert_eq!(
+            script().child("if (1 < 2 && 3 > 2) load();").to_html(),
+            "<script>if (1 < 2 && 3 > 2) load();</script>"
+        );
+        assert_eq!(
+            style().child("a::before { content: '<'; }").to_html(),
+            "<style>a::before { content: '<'; }</style>"
+        );
+        assert_eq!(
+            noscript().child("<p>enable JS</p>").to_html(),
+            "<noscript><p>enable JS</p></noscript>"
+        );
+    }
+
+    // Raw text cannot be escaped, so the only defense against end-tag breakout
+    // is the debug-only guard, which must fire on untrusted breakout content.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic = "break out of `<script>`"]
+    fn raw_text_breakout_is_caught_in_debug() {
+        let untrusted = "</script><script>alert('xss')</script>".to_string();
+        let _ = script().child(untrusted).to_html();
     }
 }

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -480,6 +480,40 @@ mod tests {
     }
 
     #[test]
+    fn escapable_raw_text_children_have_no_hydration_marker() {
+        // Variable-length child containers (`Vec`/`StaticVec`, used to hold an
+        // element's children in erased/lazy mode) append a trailing `<!>`
+        // hydration marker. `<textarea>`/`<title>` escape their children but are
+        // *not* hydrated, so that marker must not leak into their raw-text content
+        // (it would render as literal text, e.g. `hey<!>`).
+        assert_eq!(
+            textarea().child(vec!["hey"]).to_html(),
+            "<textarea>hey</textarea>"
+        );
+        assert_eq!(title().child(vec!["hey"]).to_html(), "<title>hey</title>");
+        // Escaping still applies to the (marker-free) rendered content.
+        assert_eq!(
+            textarea().child(vec!["a < b"]).to_html(),
+            "<textarea>a &lt; b</textarea>"
+        );
+    }
+
+    #[tokio::test]
+    async fn escapable_raw_text_children_have_no_hydration_marker_streaming() {
+        // The axum/actix integrations render via out-of-order streaming, so the
+        // async path must suppress the marker too.
+        use futures::StreamExt;
+
+        let mut stream =
+            textarea().child(vec!["hey"]).to_html_stream_out_of_order();
+        let mut html = String::new();
+        while let Some(chunk) = stream.next().await {
+            html.push_str(&chunk);
+        }
+        assert_eq!(html, "<textarea>hey</textarea>");
+    }
+
+    #[test]
     fn title_escapes_child_content() {
         // `<title>` is escapable raw text just like `<textarea>`, so it is
         // escaped (and, like `<textarea>`, not hydrated).

--- a/tachys/src/html/element/elements.rs
+++ b/tachys/src/html/element/elements.rs
@@ -529,8 +529,7 @@ mod tests {
     #[test]
     fn raw_text_elements_render_children_verbatim() {
         // Raw-text elements emit children verbatim: `<`/`&` are NOT
-        // entity-escaped (escaping would corrupt the embedded JS/CSS). The
-        // content below is breakout-safe (no `</tag` delimiter).
+        // entity-escaped (escaping would corrupt the embedded JS/CSS).
         assert_eq!(
             script().child("if (1 < 2 && 3 > 2) load();").to_html(),
             "<script>if (1 < 2 && 3 > 2) load();</script>"
@@ -543,15 +542,5 @@ mod tests {
             noscript().child("<p>enable JS</p>").to_html(),
             "<noscript><p>enable JS</p></noscript>"
         );
-    }
-
-    // Raw text cannot be escaped, so the only defense against end-tag breakout
-    // is the debug-only guard, which must fire on untrusted breakout content.
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic = "break out of `<script>`"]
-    fn raw_text_breakout_is_caught_in_debug() {
-        let untrusted = "</script><script>alert('xss')</script>".to_string();
-        let _ = script().child(untrusted).to_html();
     }
 }

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -285,18 +285,6 @@ pub trait ElementType: Send + 'static {
     /// entity escaping.
     const ESCAPE_CHILDREN: bool;
     /// Whether the element's children should be hydrated (walked as DOM nodes on the client).
-    ///
-    /// This is `true` for normal elements, but `false` for raw-text and escapable-raw-text
-    /// elements — `<script>`, `<style>`, `<noscript>`, `<textarea>`, `<title>` — whose textual
-    /// content the HTML parser reconstructs as the element's *value*, not as cursor-walkable child
-    /// nodes. Hydration markers (`<!>` separators, the empty-text space, branch markers) are only
-    /// parsed as nodes in normal "data" context; inside raw-text/escapable-raw-text content they are
-    /// swallowed as literal text, so walking such children desyncs the hydration cursor.
-    ///
-    /// Defaults to [`ESCAPE_CHILDREN`](Self::ESCAPE_CHILDREN). Override it to decouple escaping from
-    /// hydration: e.g. `<textarea>`/`<title>` are escapable raw text, so their children *are*
-    /// HTML-escaped (`ESCAPE_CHILDREN = true`) yet must *not* be hydrated (`HYDRATES_CHILDREN =
-    /// false`).
     const HYDRATES_CHILDREN: bool = Self::ESCAPE_CHILDREN;
     /// The element's namespace, if it is not HTML.
     const NAMESPACE: Option<&'static str>;
@@ -455,10 +443,6 @@ where
             } else if Ch::EXISTS {
                 // children
                 *position = Position::FirstChild;
-                // `ESCAPE_CHILDREN` and `HYDRATES_CHILDREN` are independent: escapable raw-text
-                // elements (`<textarea>`/`<title>`) escape their children but are not hydrated, so
-                // their children must not emit hydration markers (which would surface as literal
-                // text in the raw-text content).
                 self.children.to_html_with_buf(
                     buf,
                     position,

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -284,6 +284,20 @@ pub trait ElementType: Send + 'static {
     /// like `<style>` and `<script>`, which include other languages that should not use HTML
     /// entity escaping.
     const ESCAPE_CHILDREN: bool;
+    /// Whether the element's children should be hydrated (walked as DOM nodes on the client).
+    ///
+    /// This is `true` for normal elements, but `false` for raw-text and escapable-raw-text
+    /// elements — `<script>`, `<style>`, `<noscript>`, `<textarea>`, `<title>` — whose textual
+    /// content the HTML parser reconstructs as the element's *value*, not as cursor-walkable child
+    /// nodes. Hydration markers (`<!>` separators, the empty-text space, branch markers) are only
+    /// parsed as nodes in normal "data" context; inside raw-text/escapable-raw-text content they are
+    /// swallowed as literal text, so walking such children desyncs the hydration cursor.
+    ///
+    /// Defaults to [`ESCAPE_CHILDREN`](Self::ESCAPE_CHILDREN). Override it to decouple escaping from
+    /// hydration: e.g. `<textarea>`/`<title>` are escapable raw text, so their children *are*
+    /// HTML-escaped (`ESCAPE_CHILDREN = true`) yet must *not* be hydrated (`HYDRATES_CHILDREN =
+    /// false`).
+    const HYDRATES_CHILDREN: bool = Self::ESCAPE_CHILDREN;
     /// The element's namespace, if it is not HTML.
     const NAMESPACE: Option<&'static str>;
 
@@ -365,6 +379,57 @@ where
     }
 }
 
+/// Debug-only XSS guard for raw-text elements (`ESCAPE_CHILDREN == false`).
+///
+/// `<script>`, `<style>`, `<noscript>` and other raw-text elements emit their children
+/// **verbatim**: character references are not decoded inside them, so — unlike escapable raw text
+/// (`<textarea>`/`<title>`) — there is no in-band way to escape their content. The only thing that
+/// can terminate such an element is its own end-tag delimiter `</tag`, so untrusted data containing
+/// that delimiter breaks out of the element and can inject live markup (an XSS sink). For `<script>`
+/// the script-data tokenizer state can additionally be perturbed by `<!--` and `<script`.
+///
+/// Because no generic escaping is possible, callers must encode such data in the embedded language
+/// (JS/CSS) before rendering it, exactly like `inner_html`. This check catches accidental breakout
+/// during development and is compiled out of release builds.
+#[cfg(debug_assertions)]
+fn debug_assert_no_raw_text_breakout(tag: &str, children: &str) {
+    fn find_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        if needle.is_empty() || haystack.len() < needle.len() {
+            return None;
+        }
+        (0..=haystack.len() - needle.len()).find(|&i| {
+            haystack[i..i + needle.len()].eq_ignore_ascii_case(needle)
+        })
+    }
+
+    let bytes = children.as_bytes();
+    let end_tag = format!("</{tag}");
+    // An "appropriate end tag" is `</tag` followed by a tag-terminating char (or EOF); requiring the
+    // terminator avoids false positives like `</scripted`.
+    let breaks_out = match find_ignore_ascii_case(bytes, end_tag.as_bytes()) {
+        Some(i) => match bytes.get(i + end_tag.len()) {
+            None => true,
+            Some(c) => {
+                matches!(c, b'>' | b'/' | b' ' | b'\t' | b'\n' | 0x0C | b'\r')
+            }
+        },
+        None => false,
+    };
+    let script_state_change = tag.eq_ignore_ascii_case("script")
+        && (find_ignore_ascii_case(bytes, b"<!--").is_some()
+            || find_ignore_ascii_case(bytes, b"<script").is_some());
+
+    debug_assert!(
+        !(breaks_out || script_state_change),
+        "untrusted content appears to break out of `<{tag}>`: its rendered \
+         children contain the `</{tag}` end-tag delimiter (or, for \
+         `<script>`, a `<!--`/`<script` sequence). Raw-text elements emit \
+         children verbatim with no escaping, so dynamic data must be encoded \
+         in the embedded language (JS/CSS) before being rendered into them, \
+         like `inner_html`."
+    );
+}
+
 impl<E, At, Ch> RenderHtml for HtmlElement<E, At, Ch>
 where
     E: ElementType + Send,
@@ -442,6 +507,8 @@ where
             } else if Ch::EXISTS {
                 // children
                 *position = Position::FirstChild;
+                #[cfg(debug_assertions)]
+                let children_start = buf.len();
                 self.children.to_html_with_buf(
                     buf,
                     position,
@@ -449,6 +516,14 @@ where
                     mark_branches,
                     vec![],
                 );
+                // Raw-text elements emit children verbatim, so guard against end-tag breakout.
+                #[cfg(debug_assertions)]
+                if !E::ESCAPE_CHILDREN {
+                    debug_assert_no_raw_text_breakout(
+                        self.tag.tag(),
+                        &buf[children_start..],
+                    );
+                }
             }
 
             // closing tag
@@ -486,6 +561,8 @@ where
             if !inner_html.is_empty() {
                 buffer.push_sync(&inner_html);
             } else if Ch::EXISTS {
+                #[cfg(debug_assertions)]
+                let children_start = buffer.sync_buf.len();
                 self.children.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buffer,
                     position,
@@ -493,6 +570,15 @@ where
                     mark_branches,
                     vec![],
                 );
+                // Raw-text elements emit children verbatim, so guard against end-tag breakout.
+                // Best-effort on the streaming path: only inspects content still in the sync buffer.
+                #[cfg(debug_assertions)]
+                if !E::ESCAPE_CHILDREN {
+                    debug_assert_no_raw_text_breakout(
+                        self.tag.tag(),
+                        buffer.sync_buf.get(children_start..).unwrap_or(""),
+                    );
+                }
             }
 
             // closing tag
@@ -551,7 +637,7 @@ where
         let attrs = self.attributes.hydrate::<FROM_SERVER>(&el);
 
         // hydrate children
-        let children = if !Ch::EXISTS || !E::ESCAPE_CHILDREN {
+        let children = if !Ch::EXISTS || !E::HYDRATES_CHILDREN {
             None
         } else {
             position.set(Position::FirstChild);
@@ -622,7 +708,7 @@ where
         let attrs = self.attributes.hydrate::<true>(&el);
 
         // hydrate children
-        let children = if !Ch::EXISTS || !E::ESCAPE_CHILDREN {
+        let children = if !Ch::EXISTS || !E::HYDRATES_CHILDREN {
             None
         } else {
             position.set(Position::FirstChild);

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -379,57 +379,6 @@ where
     }
 }
 
-/// Debug-only XSS guard for raw-text elements (`ESCAPE_CHILDREN == false`).
-///
-/// `<script>`, `<style>`, `<noscript>` and other raw-text elements emit their children
-/// **verbatim**: character references are not decoded inside them, so — unlike escapable raw text
-/// (`<textarea>`/`<title>`) — there is no in-band way to escape their content. The only thing that
-/// can terminate such an element is its own end-tag delimiter `</tag`, so untrusted data containing
-/// that delimiter breaks out of the element and can inject live markup (an XSS sink). For `<script>`
-/// the script-data tokenizer state can additionally be perturbed by `<!--` and `<script`.
-///
-/// Because no generic escaping is possible, callers must encode such data in the embedded language
-/// (JS/CSS) before rendering it, exactly like `inner_html`. This check catches accidental breakout
-/// during development and is compiled out of release builds.
-#[cfg(debug_assertions)]
-fn debug_assert_no_raw_text_breakout(tag: &str, children: &str) {
-    fn find_ignore_ascii_case(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-        if needle.is_empty() || haystack.len() < needle.len() {
-            return None;
-        }
-        (0..=haystack.len() - needle.len()).find(|&i| {
-            haystack[i..i + needle.len()].eq_ignore_ascii_case(needle)
-        })
-    }
-
-    let bytes = children.as_bytes();
-    let end_tag = format!("</{tag}");
-    // An "appropriate end tag" is `</tag` followed by a tag-terminating char (or EOF); requiring the
-    // terminator avoids false positives like `</scripted`.
-    let breaks_out = match find_ignore_ascii_case(bytes, end_tag.as_bytes()) {
-        Some(i) => match bytes.get(i + end_tag.len()) {
-            None => true,
-            Some(c) => {
-                matches!(c, b'>' | b'/' | b' ' | b'\t' | b'\n' | 0x0C | b'\r')
-            }
-        },
-        None => false,
-    };
-    let script_state_change = tag.eq_ignore_ascii_case("script")
-        && (find_ignore_ascii_case(bytes, b"<!--").is_some()
-            || find_ignore_ascii_case(bytes, b"<script").is_some());
-
-    debug_assert!(
-        !(breaks_out || script_state_change),
-        "untrusted content appears to break out of `<{tag}>`: its rendered \
-         children contain the `</{tag}` end-tag delimiter (or, for \
-         `<script>`, a `<!--`/`<script` sequence). Raw-text elements emit \
-         children verbatim with no escaping, so dynamic data must be encoded \
-         in the embedded language (JS/CSS) before being rendered into them, \
-         like `inner_html`."
-    );
-}
-
 impl<E, At, Ch> RenderHtml for HtmlElement<E, At, Ch>
 where
     E: ElementType + Send,
@@ -506,8 +455,6 @@ where
             } else if Ch::EXISTS {
                 // children
                 *position = Position::FirstChild;
-                #[cfg(debug_assertions)]
-                let children_start = buf.len();
                 // `ESCAPE_CHILDREN` and `HYDRATES_CHILDREN` are independent: escapable raw-text
                 // elements (`<textarea>`/`<title>`) escape their children but are not hydrated, so
                 // their children must not emit hydration markers (which would surface as literal
@@ -520,14 +467,6 @@ where
                         .with_hydrate(E::HYDRATES_CHILDREN),
                     vec![],
                 );
-                // Raw-text elements emit children verbatim, so guard against end-tag breakout.
-                #[cfg(debug_assertions)]
-                if !E::ESCAPE_CHILDREN {
-                    debug_assert_no_raw_text_breakout(
-                        self.tag.tag(),
-                        &buf[children_start..],
-                    );
-                }
             }
 
             // closing tag
@@ -564,8 +503,6 @@ where
             if !inner_html.is_empty() {
                 buffer.push_sync(&inner_html);
             } else if Ch::EXISTS {
-                #[cfg(debug_assertions)]
-                let children_start = buffer.sync_buf.len();
                 self.children.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buffer,
                     position,
@@ -574,15 +511,6 @@ where
                         .with_hydrate(E::HYDRATES_CHILDREN),
                     vec![],
                 );
-                // Raw-text elements emit children verbatim, so guard against end-tag breakout.
-                // Best-effort on the streaming path: only inspects content still in the sync buffer.
-                #[cfg(debug_assertions)]
-                if !E::ESCAPE_CHILDREN {
-                    debug_assert_no_raw_text_breakout(
-                        self.tag.tag(),
-                        buffer.sync_buf.get(children_start..).unwrap_or(""),
-                    );
-                }
             }
 
             // closing tag

--- a/tachys/src/html/element/mod.rs
+++ b/tachys/src/html/element/mod.rs
@@ -8,8 +8,8 @@ use crate::{
     renderer::{CastFrom, Rndr},
     ssr::StreamBuilder,
     view::{
-        IntoRender, Mountable, Position, PositionState, Render, RenderHtml,
-        ToTemplate, add_attr::AddAnyAttr,
+        IntoRender, Mountable, Position, PositionState, Render, RenderFlags,
+        RenderHtml, ToTemplate, add_attr::AddAnyAttr,
     },
 };
 use const_str_slice_concat::{
@@ -488,8 +488,7 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        _escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attributes: Vec<AnyAttribute>,
     ) {
         // opening tag
@@ -509,11 +508,16 @@ where
                 *position = Position::FirstChild;
                 #[cfg(debug_assertions)]
                 let children_start = buf.len();
+                // `ESCAPE_CHILDREN` and `HYDRATES_CHILDREN` are independent: escapable raw-text
+                // elements (`<textarea>`/`<title>`) escape their children but are not hydrated, so
+                // their children must not emit hydration markers (which would surface as literal
+                // text in the raw-text content).
                 self.children.to_html_with_buf(
                     buf,
                     position,
-                    E::ESCAPE_CHILDREN,
-                    mark_branches,
+                    flags
+                        .with_escape(E::ESCAPE_CHILDREN)
+                        .with_hydrate(E::HYDRATES_CHILDREN),
                     vec![],
                 );
                 // Raw-text elements emit children verbatim, so guard against end-tag breakout.
@@ -538,8 +542,7 @@ where
         self,
         buffer: &mut StreamBuilder,
         position: &mut Position,
-        _escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attributes: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -566,8 +569,9 @@ where
                 self.children.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buffer,
                     position,
-                    E::ESCAPE_CHILDREN,
-                    mark_branches,
+                    flags
+                        .with_escape(E::ESCAPE_CHILDREN)
+                        .with_hydrate(E::HYDRATES_CHILDREN),
                     vec![],
                 );
                 // Raw-text elements emit children verbatim, so guard against end-tag breakout.

--- a/tachys/src/html/islands.rs
+++ b/tachys/src/html/islands.rs
@@ -3,7 +3,7 @@ use crate::{
     hydration::Cursor,
     prelude::{Render, RenderHtml},
     ssr::StreamBuilder,
-    view::{Position, PositionState, add_attr::AddAnyAttr},
+    view::{Position, PositionState, RenderFlags, add_attr::AddAnyAttr},
 };
 
 /// An island of interactivity in an otherwise-inert HTML document.
@@ -151,21 +151,15 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         let has_element = self.has_element_representation;
         if has_element {
             Self::open_tag(self.component, &self.props_json, buf);
         }
-        self.view.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.view
+            .to_html_with_buf(buf, position, flags, extra_attrs);
         if has_element {
             Self::close_tag(buf);
         }
@@ -175,8 +169,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -193,8 +186,7 @@ where
         self.view.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
 
@@ -334,18 +326,12 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         Self::open_tag(buf);
-        self.view.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.view
+            .to_html_with_buf(buf, position, flags, extra_attrs);
         Self::close_tag(buf);
     }
 
@@ -353,8 +339,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -368,8 +353,7 @@ where
         self.view.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
 

--- a/tachys/src/html/mod.rs
+++ b/tachys/src/html/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         CastFrom, Rndr,
         dom::{Element, Node},
     },
-    view::{Position, PositionState, Render, RenderHtml},
+    view::{Position, PositionState, Render, RenderFlags, RenderHtml},
 };
 use attribute::any_attribute::AnyAttribute;
 use std::borrow::Cow;
@@ -83,8 +83,7 @@ impl RenderHtml for Doctype {
         self,
         buf: &mut String,
         _position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         buf.push_str("<!DOCTYPE ");
@@ -194,8 +193,7 @@ impl RenderHtml for InertElement {
         self,
         buf: &mut String,
         position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         buf.push_str(&self.html);

--- a/tachys/src/oco.rs
+++ b/tachys/src/oco.rs
@@ -10,7 +10,9 @@ use crate::{
     no_attrs,
     prelude::{Mountable, Render, RenderHtml},
     renderer::Rndr,
-    view::{Position, PositionState, ToTemplate, strings::StrState},
+    view::{
+        Position, PositionState, RenderFlags, ToTemplate, strings::StrState,
+    },
 };
 use oco_ref::Oco;
 use wasm_bindgen::JsValue;
@@ -56,16 +58,14 @@ impl RenderHtml for Oco<'static, str> {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         <&str as RenderHtml>::to_html_with_buf(
             &self,
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     renderer::Rndr,
     ssr::StreamBuilder,
     view::{
-        Mountable, Position, PositionState, Render, RenderHtml, ToTemplate,
-        add_attr::AddAnyAttr,
+        Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+        ToTemplate, add_attr::AddAnyAttr,
     },
 };
 use reactive_graph::effect::RenderEffect;
@@ -155,26 +155,18 @@ where
         mut self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         let value = self.invoke();
-        value.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        )
+        value.to_html_with_buf(buf, position, flags, extra_attrs)
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         mut self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -183,8 +175,7 @@ where
         value.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
     }
@@ -702,16 +693,14 @@ macro_rules! reactive_impl {
                 self,
                 buf: &mut String,
                 position: &mut Position,
-                escape: bool,
-                mark_branches: bool,
+                flags: $crate::view::RenderFlags,
                 extra_attrs: Vec<AnyAttribute>,
             ) {
                 let value = self.get();
                 value.to_html_with_buf(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 )
             }
@@ -720,8 +709,7 @@ macro_rules! reactive_impl {
                 self,
                 buf: &mut StreamBuilder,
                 position: &mut Position,
-                escape: bool,
-                mark_branches: bool,
+                flags: $crate::view::RenderFlags,
                 extra_attrs: Vec<AnyAttribute>,
             ) where
                 Self: Sized,
@@ -730,8 +718,7 @@ macro_rules! reactive_impl {
                 value.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
             }

--- a/tachys/src/reactive_graph/owned.rs
+++ b/tachys/src/reactive_graph/owned.rs
@@ -3,7 +3,10 @@ use crate::{
     hydration::Cursor,
     prelude::Mountable,
     ssr::StreamBuilder,
-    view::{Position, PositionState, Render, RenderHtml, add_attr::AddAnyAttr},
+    view::{
+        Position, PositionState, Render, RenderFlags, RenderHtml,
+        add_attr::AddAnyAttr,
+    },
 };
 use reactive_graph::{computed::ScopedFuture, owner::Owner};
 use std::mem;
@@ -111,18 +114,12 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         self.owner.with(|| {
-            self.view.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            )
+            self.view
+                .to_html_with_buf(buf, position, flags, extra_attrs)
         });
     }
 
@@ -130,8 +127,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -140,8 +136,7 @@ where
             self.view.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             )
         });

--- a/tachys/src/reactive_graph/suspense.rs
+++ b/tachys/src/reactive_graph/suspense.rs
@@ -3,7 +3,7 @@ use crate::{
     hydration::Cursor,
     ssr::StreamBuilder,
     view::{
-        Mountable, Position, PositionState, Render, RenderHtml,
+        Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
         add_attr::AddAnyAttr, iterators::OptionState,
     },
 };
@@ -297,21 +297,14 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         // TODO wrap this with a Suspense as needed
         // currently this is just used for Routes, which creates a Suspend but never actually needs
         // it (because we don't lazy-load routes on the server)
         if let Some(inner) = self.inner.now_or_never() {
-            inner.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
+            inner.to_html_with_buf(buf, position, flags, extra_attrs);
         }
     }
 
@@ -319,8 +312,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -330,8 +322,7 @@ where
             Some(inner) => inner.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             ),
             None => {
@@ -356,7 +347,7 @@ where
                         buf.push_fallback::<()>(
                             (),
                             &mut fallback_position,
-                            mark_branches,
+                            flags.mark_branches,
                             extra_attrs.clone(),
                         );
 
@@ -368,7 +359,7 @@ where
                         buf.push_async_out_of_order(
                             fut,
                             position,
-                            mark_branches,
+                            flags.mark_branches,
                             extra_attrs,
                         );
                     } else {
@@ -380,8 +371,7 @@ where
                                 value.to_html_async_with_buf::<OUT_OF_ORDER>(
                                     &mut builder,
                                     &mut position,
-                                    escape,
-                                    mark_branches,
+                                    flags,
                                     extra_attrs,
                                 );
                                 builder.finish().take_chunks()

--- a/tachys/src/ssr/mod.rs
+++ b/tachys/src/ssr/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     html::attribute::any_attribute::AnyAttribute,
-    view::{Position, RenderHtml},
+    view::{Position, RenderFlags, RenderHtml},
 };
 use futures::Stream;
 use std::{
@@ -118,8 +118,7 @@ impl StreamBuilder {
         fallback.to_html_with_buf(
             &mut self.sync_buf,
             position,
-            true,
-            mark_branches,
+            RenderFlags::HYDRATE.with_mark_branches(mark_branches),
             extra_attrs,
         );
         self.write_chunk_marker(false);
@@ -216,8 +215,7 @@ impl StreamBuilder {
                 view.to_html_async_with_buf::<true>(
                     &mut subbuilder,
                     &mut position,
-                    true,
-                    mark_branches,
+                    RenderFlags::HYDRATE.with_mark_branches(mark_branches),
                     extra_attrs,
                 );
                 let chunks = subbuilder.finish().take_chunks();

--- a/tachys/src/svg/mod.rs
+++ b/tachys/src/svg/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         CastFrom, Rndr,
         dom::{Element, Node},
     },
-    view::{Position, PositionState, Render, RenderHtml},
+    view::{Position, PositionState, Render, RenderFlags, RenderHtml},
 };
 use std::{borrow::Cow, fmt::Debug};
 
@@ -283,8 +283,7 @@ impl RenderHtml for InertElement {
         self,
         buf: &mut String,
         position: &mut Position,
-        _escape: bool,
-        _mark_branches: bool,
+        _flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         buf.push_str(&self.html);

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -14,6 +14,7 @@ use crate::{
     hydration::Cursor,
     renderer::Rndr,
     ssr::StreamBuilder,
+    view::RenderFlags,
 };
 use futures::future::{join, join_all};
 use std::{any::TypeId, fmt::Debug};
@@ -43,14 +44,13 @@ pub struct AnyView {
     html_len: usize,
     #[cfg(feature = "ssr")]
     to_html:
-        fn(Erased, &mut String, &mut Position, bool, bool, Vec<AnyAttribute>),
+        fn(Erased, &mut String, &mut Position, RenderFlags, Vec<AnyAttribute>),
     #[cfg(feature = "ssr")]
     to_html_async: fn(
         Erased,
         &mut StreamBuilder,
         &mut Position,
-        bool,
-        bool,
+        RenderFlags,
         Vec<AnyAttribute>,
     ),
     #[cfg(feature = "ssr")]
@@ -58,8 +58,7 @@ pub struct AnyView {
         Erased,
         &mut StreamBuilder,
         &mut Position,
-        bool,
-        bool,
+        RenderFlags,
         Vec<AnyAttribute>,
     ),
     #[cfg(feature = "ssr")]
@@ -219,15 +218,13 @@ where
             value: Erased,
             buf: &mut String,
             position: &mut Position,
-            escape: bool,
-            mark_branches: bool,
+            flags: RenderFlags,
             extra_attrs: Vec<AnyAttribute>,
         ) {
             value.into_inner::<T>().to_html_with_buf(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
             if !T::EXISTS {
@@ -240,15 +237,13 @@ where
             value: Erased,
             buf: &mut StreamBuilder,
             position: &mut Position,
-            escape: bool,
-            mark_branches: bool,
+            flags: RenderFlags,
             extra_attrs: Vec<AnyAttribute>,
         ) {
             value.into_inner::<T>().to_html_async_with_buf::<false>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
             if !T::EXISTS {
@@ -261,15 +256,13 @@ where
             value: Erased,
             buf: &mut StreamBuilder,
             position: &mut Position,
-            escape: bool,
-            mark_branches: bool,
+            flags: RenderFlags,
             extra_attrs: Vec<AnyAttribute>,
         ) {
             value.into_inner::<T>().to_html_async_with_buf::<true>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
             if !T::EXISTS {
@@ -452,24 +445,16 @@ impl RenderHtml for AnyView {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         #[cfg(feature = "ssr")]
         {
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.open_branch_fmt(format_args!("{:?}", self.type_id));
             }
-            (self.to_html)(
-                self.value,
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
-            if mark_branches && escape {
+            (self.to_html)(self.value, buf, position, flags, extra_attrs);
+            if flags.mark_branches && flags.escape {
                 buf.close_branch_fmt(format_args!("{:?}", self.type_id));
                 if *position == Position::NextChildAfterText {
                     *position = Position::NextChild;
@@ -478,10 +463,9 @@ impl RenderHtml for AnyView {
         }
         #[cfg(not(feature = "ssr"))]
         {
-            _ = mark_branches;
+            _ = flags;
             _ = buf;
             _ = position;
-            _ = escape;
             _ = extra_attrs;
             panic!(
                 "You are rendering AnyView to HTML without the `ssr` feature \
@@ -494,44 +478,35 @@ impl RenderHtml for AnyView {
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
     {
         #[cfg(feature = "ssr")]
         if OUT_OF_ORDER {
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.open_branch_fmt(format_args!("{:?}", self.type_id));
             }
             (self.to_html_async_ooo)(
                 self.value,
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             );
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.close_branch_fmt(format_args!("{:?}", self.type_id));
                 if *position == Position::NextChildAfterText {
                     *position = Position::NextChild;
                 }
             }
         } else {
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.open_branch_fmt(format_args!("{:?}", self.type_id));
             }
-            (self.to_html_async)(
-                self.value,
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            );
-            if mark_branches && escape {
+            (self.to_html_async)(self.value, buf, position, flags, extra_attrs);
+            if flags.mark_branches && flags.escape {
                 buf.close_branch_fmt(format_args!("{:?}", self.type_id));
                 if *position == Position::NextChildAfterText {
                     *position = Position::NextChild;
@@ -542,8 +517,7 @@ impl RenderHtml for AnyView {
         {
             _ = buf;
             _ = position;
-            _ = escape;
-            _ = mark_branches;
+            _ = flags;
             _ = extra_attrs;
             panic!(
                 "You are rendering AnyView to HTML without the `ssr` feature \
@@ -736,28 +710,21 @@ impl RenderHtml for AnyViewWithAttrs {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         mut extra_attrs: Vec<AnyAttribute>,
     ) {
         // `extra_attrs` will be empty here in most cases, but it will have
         // attributes in it already if this is, itself, receiving additional attrs
         extra_attrs.extend(self.attrs);
-        self.view.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.view
+            .to_html_with_buf(buf, position, flags, extra_attrs);
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         mut extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -766,8 +733,7 @@ impl RenderHtml for AnyViewWithAttrs {
         self.view.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
     }

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -1,6 +1,6 @@
 use super::{
-    MarkBranch, Mountable, Position, PositionState, Render, RenderHtml,
-    add_attr::AddAnyAttr,
+    MarkBranch, Mountable, Position, PositionState, Render, RenderFlags,
+    RenderHtml, add_attr::AddAnyAttr,
 };
 use crate::{
     html::attribute::{
@@ -312,23 +312,16 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         match self {
             Either::Left(left) => {
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.open_branch("0");
                 }
-                left.to_html_with_buf(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                    extra_attrs,
-                );
-                if mark_branches && escape {
+                left.to_html_with_buf(buf, position, flags, extra_attrs);
+                if flags.mark_branches && flags.escape {
                     buf.close_branch("0");
                     if *position == Position::NextChildAfterText {
                         *position = Position::NextChild;
@@ -336,17 +329,11 @@ where
                 }
             }
             Either::Right(right) => {
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.open_branch("1");
                 }
-                right.to_html_with_buf(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                    extra_attrs,
-                );
-                if mark_branches && escape {
+                right.to_html_with_buf(buf, position, flags, extra_attrs);
+                if flags.mark_branches && flags.escape {
                     buf.close_branch("1");
                     if *position == Position::NextChildAfterText {
                         *position = Position::NextChild;
@@ -360,25 +347,23 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
     {
         match self {
             Either::Left(left) => {
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.open_branch("0");
                 }
                 left.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.close_branch("0");
                     if *position == Position::NextChildAfterText {
                         *position = Position::NextChild;
@@ -386,17 +371,16 @@ where
                 }
             }
             Either::Right(right) => {
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.open_branch("1");
                 }
                 right.to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
-                if mark_branches && escape {
+                if flags.mark_branches && flags.escape {
                     buf.close_branch("1");
                     if *position == Position::NextChildAfterText {
                         *position = Position::NextChild;
@@ -583,30 +567,17 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         if self.show_b {
             self.b
                 .expect("rendering B to HTML without filling it")
-                .to_html_with_buf(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                    extra_attrs,
-                );
+                .to_html_with_buf(buf, position, flags, extra_attrs);
         } else {
             self.a
                 .expect("rendering A to HTML without filling it")
-                .to_html_with_buf(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                    extra_attrs,
-                );
+                .to_html_with_buf(buf, position, flags, extra_attrs);
         }
     }
 
@@ -614,8 +585,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -626,8 +596,7 @@ where
                 .to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
         } else {
@@ -636,8 +605,7 @@ where
                 .to_html_async_with_buf::<OUT_OF_ORDER>(
                     buf,
                     position,
-                    escape,
-                    mark_branches,
+                    flags,
                     extra_attrs,
                 );
         }
@@ -908,17 +876,16 @@ macro_rules! tuples {
                     self,
                     buf: &mut String,
                     position: &mut Position,
-                    escape: bool,
-                    mark_branches: bool,
+                    flags: RenderFlags,
                     extra_attrs: Vec<AnyAttribute>
                 ) {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            if mark_branches && escape {
+                            if flags.mark_branches && flags.escape {
                                 buf.open_branch(stringify!($ty));
                             }
-                            this.to_html_with_buf(buf, position, escape, mark_branches, extra_attrs);
-                            if mark_branches && escape {
+                            this.to_html_with_buf(buf, position, flags, extra_attrs);
+                            if flags.mark_branches && flags.escape {
                                 buf.close_branch(stringify!($ty));
                                 if *position == Position::NextChildAfterText {
                                     *position = Position::NextChild;
@@ -932,19 +899,18 @@ macro_rules! tuples {
                     self,
                     buf: &mut StreamBuilder,
                     position: &mut Position,
-                    escape: bool,
-                    mark_branches: bool,
+                    flags: RenderFlags,
                     extra_attrs: Vec<AnyAttribute>
                 ) where
                     Self: Sized,
                 {
                     match self {
                         $([<EitherOf $num>]::$ty(this) => {
-                            if mark_branches && escape {
+                            if flags.mark_branches && flags.escape {
                                 buf.open_branch(stringify!($ty));
                             }
-                            this.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches, extra_attrs);
-                            if mark_branches && escape {
+                            this.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, flags, extra_attrs);
+                            if flags.mark_branches && flags.escape {
                                 buf.close_branch(stringify!($ty));
                                 if *position == Position::NextChildAfterText {
                                     *position = Position::NextChild;

--- a/tachys/src/view/error_boundary.rs
+++ b/tachys/src/view/error_boundary.rs
@@ -1,4 +1,6 @@
-use super::{Position, PositionState, RenderHtml, add_attr::AddAnyAttr};
+use super::{
+    Position, PositionState, RenderFlags, RenderHtml, add_attr::AddAnyAttr,
+};
 use crate::{
     html::attribute::{Attribute, any_attribute::AnyAttribute},
     hydration::Cursor,
@@ -166,19 +168,12 @@ where
         self,
         buf: &mut String,
         position: &mut super::Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         match self {
             Ok(inner) => {
-                inner.to_html_with_buf(
-                    buf,
-                    position,
-                    escape,
-                    mark_branches,
-                    extra_attrs,
-                );
+                inner.to_html_with_buf(buf, position, flags, extra_attrs);
             }
             Err(e) => {
                 buf.push_str("<!>");
@@ -191,8 +186,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -201,8 +195,7 @@ where
             Ok(inner) => inner.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs,
             ),
             Err(e) => {

--- a/tachys/src/view/iterators.rs
+++ b/tachys/src/view/iterators.rs
@@ -1,5 +1,5 @@
 use super::{
-    Mountable, Position, PositionState, Render, RenderHtml,
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
     add_attr::AddAnyAttr,
 };
 use crate::{
@@ -88,29 +88,21 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         match self {
             Some(value) => Either::Left(value),
             None => Either::Right(()),
         }
-        .to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        )
+        .to_html_with_buf(buf, position, flags, extra_attrs)
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -122,8 +114,7 @@ where
         .to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }
@@ -317,31 +308,23 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         let mut children = self.into_iter();
         if let Some(first) = children.next() {
-            first.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs.clone(),
-            );
+            first.to_html_with_buf(buf, position, flags, extra_attrs.clone());
         }
         for child in children {
             child.to_html_with_buf(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 // each child will have the extra attributes applied
                 extra_attrs.clone(),
             );
         }
-        if escape {
+        if flags.hydrate {
             buf.push_str("<!>");
             *position = Position::NextChild;
         }
@@ -351,8 +334,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -362,8 +344,7 @@ where
             first.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs.clone(),
             );
         }
@@ -371,12 +352,11 @@ where
             child.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs.clone(),
             );
         }
-        if escape {
+        if flags.hydrate {
             buf.push_sync("<!>");
             *position = Position::NextChild;
         }
@@ -616,20 +596,13 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         for child in self.0.into_iter() {
-            child.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs.clone(),
-            );
+            child.to_html_with_buf(buf, position, flags, extra_attrs.clone());
         }
-        if escape {
+        if flags.hydrate {
             buf.push_str("<!>");
             *position = Position::NextChild;
         }
@@ -639,8 +612,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -649,12 +621,11 @@ where
             child.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs.clone(),
             );
         }
-        if escape {
+        if flags.hydrate {
             buf.push_sync("<!>");
             *position = Position::NextChild;
         }
@@ -817,18 +788,11 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         for child in self.into_iter() {
-            child.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs.clone(),
-            );
+            child.to_html_with_buf(buf, position, flags, extra_attrs.clone());
         }
     }
 
@@ -836,8 +800,7 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -846,8 +809,7 @@ where
             child.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs.clone(),
             );
         }

--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -1,6 +1,6 @@
 use super::{
-    MarkBranch, Mountable, Position, PositionState, Render, RenderHtml,
-    add_attr::AddAnyAttr,
+    MarkBranch, Mountable, Position, PositionState, Render, RenderFlags,
+    RenderHtml, add_attr::AddAnyAttr,
 };
 use crate::{
     html::attribute::{Attribute, any_attribute::AnyAttribute},
@@ -292,32 +292,25 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        if mark_branches && escape {
+        if flags.mark_branches && flags.escape {
             buf.open_branch("for");
         }
 
         #[cfg(feature = "ssr")]
         for item in self.ssr_items {
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.open_branch("item");
             }
-            item.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs.clone(),
-            );
-            if mark_branches && escape {
+            item.to_html_with_buf(buf, position, flags, extra_attrs.clone());
+            if flags.mark_branches && flags.escape {
                 buf.close_branch("item");
             }
             *position = Position::NextChild;
         }
-        if mark_branches && escape {
+        if flags.mark_branches && flags.escape {
             buf.close_branch("for");
         }
         buf.push_str("<!>");
@@ -328,33 +321,31 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        if mark_branches && escape {
+        if flags.mark_branches && flags.escape {
             buf.open_branch("for");
         }
 
         #[cfg(feature = "ssr")]
         for (key, item) in self.ssr_items {
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.open_branch_fmt(format_args!("item-{key}"));
             }
             item.to_html_async_with_buf::<OUT_OF_ORDER>(
                 buf,
                 position,
-                escape,
-                mark_branches,
+                flags,
                 extra_attrs.clone(),
             );
-            if mark_branches && escape {
+            if flags.mark_branches && flags.escape {
                 buf.close_branch_fmt(format_args!("item-{key}"));
             }
             *position = Position::NextChild;
         }
 
-        if mark_branches && escape {
+        if flags.mark_branches && flags.escape {
             buf.close_branch("for");
         }
         buf.push_sync("<!>");

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -123,22 +123,13 @@ impl MarkBranch for StreamBuilder {
 /// Flags that control how a view is serialized to HTML.
 ///
 /// These are threaded through [`RenderHtml::to_html_with_buf`] and the streaming variants. The
-/// axes are independent on purpose — for example, escapable raw-text elements (`<textarea>`,
-/// `<title>`) escape their children (`escape`) but are *not* hydrated (`hydrate`), so their
-/// content must be escaped without emitting hydration markers that would surface as literal text.
-///
-/// This type is `#[non_exhaustive]`: build it with [`RenderFlags::new`] or the presets and adjust
-/// it with the `with_*` methods, and thread it opaquely through child calls. New rendering axes can
-/// then be added as fields without breaking existing [`RenderHtml`] implementors.
+/// axes are independent on purpose.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct RenderFlags {
     /// Whether text content should be HTML-escaped.
     pub escape: bool,
-    /// Whether hydration position/boundary markers should be emitted: the `<!>` separators between
-    /// adjacent text nodes, the empty-text placeholder space, and the variable-length-list end
-    /// markers. These matter only for content the hydration cursor will walk on the client; content
-    /// that is rendered but never hydrated (raw text, server-only subtrees) must not carry them.
+    /// Whether hydration position/boundary markers should be emitted.
     pub hydrate: bool,
     /// Whether branch markers should be emitted, to support libraries that diff HTML pages against
     /// one another by marking sections of the view that branch to different types.
@@ -336,13 +327,6 @@ where
     }
 
     /// Renders a view to HTML, writing it into the given buffer.
-    ///
-    /// `escape` controls whether text content is HTML-escaped. `hydrate` controls whether
-    /// hydration position/boundary markers (the `<!>` separators, empty-text placeholders, and
-    /// variable-length-list end markers) are emitted; these are only meaningful for content that
-    /// will be walked by the hydration cursor on the client. The two axes are independent: e.g.
-    /// `<textarea>`/`<title>` content is escaped (`escape = true`) but not hydrated
-    /// (`hydrate = false`), so it must not carry markers that would surface as literal text.
     fn to_html_with_buf(
         self,
         buf: &mut String,

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -120,6 +120,75 @@ impl MarkBranch for StreamBuilder {
     }
 }
 
+/// Flags that control how a view is serialized to HTML.
+///
+/// These are threaded through [`RenderHtml::to_html_with_buf`] and the streaming variants. The
+/// axes are independent on purpose — for example, escapable raw-text elements (`<textarea>`,
+/// `<title>`) escape their children (`escape`) but are *not* hydrated (`hydrate`), so their
+/// content must be escaped without emitting hydration markers that would surface as literal text.
+///
+/// This type is `#[non_exhaustive]`: build it with [`RenderFlags::new`] or the presets and adjust
+/// it with the `with_*` methods, and thread it opaquely through child calls. New rendering axes can
+/// then be added as fields without breaking existing [`RenderHtml`] implementors.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct RenderFlags {
+    /// Whether text content should be HTML-escaped.
+    pub escape: bool,
+    /// Whether hydration position/boundary markers should be emitted: the `<!>` separators between
+    /// adjacent text nodes, the empty-text placeholder space, and the variable-length-list end
+    /// markers. These matter only for content the hydration cursor will walk on the client; content
+    /// that is rendered but never hydrated (raw text, server-only subtrees) must not carry them.
+    pub hydrate: bool,
+    /// Whether branch markers should be emitted, to support libraries that diff HTML pages against
+    /// one another by marking sections of the view that branch to different types.
+    pub mark_branches: bool,
+}
+
+impl RenderFlags {
+    /// Standard flags for hydratable server rendering: escape text and emit hydration markers, but
+    /// no branch markers.
+    pub const HYDRATE: Self = Self {
+        escape: true,
+        hydrate: true,
+        mark_branches: false,
+    };
+
+    /// Like [`HYDRATE`](Self::HYDRATE), but also emits branch markers.
+    pub const HYDRATE_BRANCHING: Self = Self {
+        escape: true,
+        hydrate: true,
+        mark_branches: true,
+    };
+
+    /// Creates a new set of flags.
+    pub const fn new(escape: bool, hydrate: bool, mark_branches: bool) -> Self {
+        Self {
+            escape,
+            hydrate,
+            mark_branches,
+        }
+    }
+
+    /// Returns a copy of these flags with `escape` set to the given value.
+    pub const fn with_escape(mut self, escape: bool) -> Self {
+        self.escape = escape;
+        self
+    }
+
+    /// Returns a copy of these flags with `hydrate` set to the given value.
+    pub const fn with_hydrate(mut self, hydrate: bool) -> Self {
+        self.hydrate = hydrate;
+        self
+    }
+
+    /// Returns a copy of these flags with `mark_branches` set to the given value.
+    pub const fn with_mark_branches(mut self, mark_branches: bool) -> Self {
+        self.mark_branches = mark_branches;
+        self
+    }
+}
+
 /// The `RenderHtml` trait allows rendering something to HTML, and transforming
 /// that HTML into an interactive interface.
 ///
@@ -174,8 +243,7 @@ where
         self.to_html_with_buf(
             &mut buf,
             &mut Position::FirstChild,
-            true,
-            false,
+            RenderFlags::HYDRATE,
             vec![],
         );
         buf
@@ -192,8 +260,7 @@ where
         self.to_html_with_buf(
             &mut buf,
             &mut Position::FirstChild,
-            true,
-            true,
+            RenderFlags::HYDRATE_BRANCHING,
             vec![],
         );
         buf
@@ -208,8 +275,7 @@ where
         self.to_html_async_with_buf::<false>(
             &mut builder,
             &mut Position::FirstChild,
-            true,
-            false,
+            RenderFlags::HYDRATE,
             vec![],
         );
         builder.finish()
@@ -226,8 +292,7 @@ where
         self.to_html_async_with_buf::<false>(
             &mut builder,
             &mut Position::FirstChild,
-            true,
-            true,
+            RenderFlags::HYDRATE_BRANCHING,
             vec![],
         );
         builder.finish()
@@ -245,8 +310,7 @@ where
         self.to_html_async_with_buf::<true>(
             &mut builder,
             &mut Position::FirstChild,
-            true,
-            false,
+            RenderFlags::HYDRATE,
             vec![],
         );
         builder.finish()
@@ -265,20 +329,25 @@ where
         self.to_html_async_with_buf::<true>(
             &mut builder,
             &mut Position::FirstChild,
-            true,
-            true,
+            RenderFlags::HYDRATE_BRANCHING,
             vec![],
         );
         builder.finish()
     }
 
     /// Renders a view to HTML, writing it into the given buffer.
+    ///
+    /// `escape` controls whether text content is HTML-escaped. `hydrate` controls whether
+    /// hydration position/boundary markers (the `<!>` separators, empty-text placeholders, and
+    /// variable-length-list end markers) are emitted; these are only meaningful for content that
+    /// will be walked by the hydration cursor on the client. The two axes are independent: e.g.
+    /// `<textarea>`/`<title>` content is escaped (`escape = true`) but not hydrated
+    /// (`hydrate = false`), so it must not carry markers that would surface as literal text.
     fn to_html_with_buf(
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     );
 
@@ -287,20 +356,13 @@ where
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
     {
         buf.with_buf(|buf| {
-            self.to_html_with_buf(
-                buf,
-                position,
-                escape,
-                mark_branches,
-                extra_attrs,
-            )
+            self.to_html_with_buf(buf, position, flags, extra_attrs)
         });
     }
 

--- a/tachys/src/view/primitives.rs
+++ b/tachys/src/view/primitives.rs
@@ -1,4 +1,6 @@
-use super::{Mountable, Position, PositionState, Render, RenderHtml};
+use super::{
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+};
 use crate::{
     html::attribute::any_attribute::AnyAttribute,
     hydration::Cursor,
@@ -80,9 +82,9 @@ macro_rules! render_primitive {
                     self
                 }
 
-				fn to_html_with_buf(self, buf: &mut String, position: &mut Position, escape: bool, _mark_branches: bool, _extra_attrs: Vec<AnyAttribute>) {
+				fn to_html_with_buf(self, buf: &mut String, position: &mut Position, flags: RenderFlags, _extra_attrs: Vec<AnyAttribute>) {
 					// add a comment node to separate from previous sibling, if any
-					if matches!(position, Position::NextChildAfterText) {
+					if flags.hydrate && matches!(position, Position::NextChildAfterText) {
 						buf.push_str("<!>")
 					}
 					// `$escape` is `true` only for types whose `Display` output can
@@ -90,7 +92,7 @@ macro_rules! render_primitive {
 					// primitives emit a syntactic subset of HTML text and are written
 					// directly to avoid an intermediate allocation.
 					if $escape {
-						if escape {
+						if flags.escape {
 							buf.push_str(&html_escape::encode_text(&self.to_string()));
 						} else {
 							_ = write!(buf, "{}", self);
@@ -200,7 +202,7 @@ render_primitive![true; char];
 
 #[cfg(test)]
 mod tests {
-    use crate::view::{Position, RenderHtml};
+    use crate::view::{Position, RenderFlags, RenderHtml};
 
     #[test]
     fn char_escapes_html_special_characters() {
@@ -208,8 +210,7 @@ mod tests {
         '<'.to_html_with_buf(
             &mut buf,
             &mut Position::FirstChild,
-            true,
-            false,
+            RenderFlags::new(true, false, false),
             vec![],
         );
         assert_eq!(buf, "&lt;");
@@ -223,8 +224,7 @@ mod tests {
         '<'.to_html_with_buf(
             &mut buf,
             &mut Position::FirstChild,
-            false,
-            false,
+            RenderFlags::new(false, false, false),
             vec![],
         );
         assert_eq!(buf, "<");
@@ -236,8 +236,7 @@ mod tests {
         42u32.to_html_with_buf(
             &mut buf,
             &mut Position::FirstChild,
-            true,
-            false,
+            RenderFlags::new(true, false, false),
             vec![],
         );
         assert_eq!(buf, "42");

--- a/tachys/src/view/static_types.rs
+++ b/tachys/src/view/static_types.rs
@@ -1,6 +1,6 @@
 use super::{
-    Mountable, Position, PositionState, Render, RenderHtml, ToTemplate,
-    add_attr::AddAnyAttr,
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+    ToTemplate, add_attr::AddAnyAttr,
 };
 use crate::{
     html::attribute::{
@@ -185,17 +185,16 @@ impl<const V: &'static str> RenderHtml for Static<V> {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        _mark_branches: bool,
+        flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         // add a comment node to separate from previous sibling, if any
-        if matches!(position, Position::NextChildAfterText) {
+        if flags.hydrate && matches!(position, Position::NextChildAfterText) {
             buf.push_str("<!>")
         }
-        if V.is_empty() && escape {
+        if V.is_empty() && flags.hydrate {
             buf.push(' ');
-        } else if escape {
+        } else if flags.escape {
             let escaped = html_escape::encode_text(V);
             buf.push_str(&escaped);
         } else {

--- a/tachys/src/view/strings.rs
+++ b/tachys/src/view/strings.rs
@@ -1,5 +1,6 @@
 use super::{
-    Mountable, Position, PositionState, Render, RenderHtml, ToTemplate,
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+    ToTemplate,
 };
 use crate::{
     html::attribute::any_attribute::AnyAttribute,
@@ -57,17 +58,16 @@ impl RenderHtml for &str {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        _mark_branches: bool,
+        flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
         // add a comment node to separate from previous sibling, if any
-        if matches!(position, Position::NextChildAfterText) {
+        if flags.hydrate && matches!(position, Position::NextChildAfterText) {
             buf.push_str("<!>")
         }
-        if self.is_empty() && escape {
+        if self.is_empty() && flags.hydrate {
             buf.push(' ');
-        } else if escape {
+        } else if flags.escape {
             let escaped = html_escape::encode_text(self);
             buf.push_str(&escaped);
         } else {
@@ -193,16 +193,14 @@ impl RenderHtml for String {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         <&str as RenderHtml>::to_html_with_buf(
             self.as_str(),
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }
@@ -399,16 +397,14 @@ impl RenderHtml for Arc<str> {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         <&str as RenderHtml>::to_html_with_buf(
             &self,
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }
@@ -510,16 +506,14 @@ impl RenderHtml for Cow<'_, str> {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
         <&str as RenderHtml>::to_html_with_buf(
             &self,
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         )
     }

--- a/tachys/src/view/template.rs
+++ b/tachys/src/view/template.rs
@@ -1,6 +1,6 @@
 use super::{
-    Mountable, Position, PositionState, Render, RenderHtml, ToTemplate,
-    add_attr::AddAnyAttr,
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+    ToTemplate, add_attr::AddAnyAttr,
 };
 use crate::{
     html::attribute::{Attribute, any_attribute::AnyAttribute},
@@ -81,17 +81,11 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        self.view.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        )
+        self.view
+            .to_html_with_buf(buf, position, flags, extra_attrs)
     }
 
     fn hydrate<const FROM_SERVER: bool>(

--- a/tachys/src/view/tuples.rs
+++ b/tachys/src/view/tuples.rs
@@ -1,5 +1,6 @@
 use super::{
-    Mountable, Position, PositionState, Render, RenderHtml, ToTemplate,
+    Mountable, Position, PositionState, Render, RenderFlags, RenderHtml,
+    ToTemplate,
 };
 use crate::{
     html::attribute::{Attribute, any_attribute::AnyAttribute},
@@ -32,11 +33,10 @@ impl RenderHtml for () {
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        _mark_branches: bool,
+        flags: RenderFlags,
         _extra_attrs: Vec<AnyAttribute>,
     ) {
-        if escape {
+        if flags.hydrate {
             buf.push_str("<!>");
             *position = Position::NextChild;
         }
@@ -144,25 +144,17 @@ where
         self,
         buf: &mut String,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) {
-        self.0.to_html_with_buf(
-            buf,
-            position,
-            escape,
-            mark_branches,
-            extra_attrs,
-        );
+        self.0.to_html_with_buf(buf, position, flags, extra_attrs);
     }
 
     fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
         self,
         buf: &mut StreamBuilder,
         position: &mut Position,
-        escape: bool,
-        mark_branches: bool,
+        flags: RenderFlags,
         extra_attrs: Vec<AnyAttribute>,
     ) where
         Self: Sized,
@@ -170,8 +162,7 @@ where
         self.0.to_html_async_with_buf::<OUT_OF_ORDER>(
             buf,
             position,
-            escape,
-            mark_branches,
+            flags,
             extra_attrs,
         );
     }
@@ -289,30 +280,28 @@ macro_rules! impl_view_for_tuples {
                 self,
                 buf: &mut String,
                 position: &mut Position,
-                escape: bool,
-                mark_branches: bool,
+                flags: RenderFlags,
                 extra_attrs: Vec<AnyAttribute>
             ) {
                 #[allow(non_snake_case)]
                 let ($first, $($ty,)* ) = self;
-                $first.to_html_with_buf(buf, position, escape, mark_branches, extra_attrs.clone());
-                $($ty.to_html_with_buf(buf, position, escape, mark_branches, extra_attrs.clone()));*
+                $first.to_html_with_buf(buf, position, flags, extra_attrs.clone());
+                $($ty.to_html_with_buf(buf, position, flags, extra_attrs.clone()));*
 			}
 
 			fn to_html_async_with_buf<const OUT_OF_ORDER: bool>(
 				self,
 				buf: &mut StreamBuilder,
                 position: &mut Position,
-                escape: bool,
-                mark_branches: bool,
+                flags: RenderFlags,
                 extra_attrs: Vec<AnyAttribute>
             ) where
 				Self: Sized,
 			{
                 #[allow(non_snake_case)]
                 let ($first, $($ty,)* ) = self;
-                $first.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches, extra_attrs.clone());
-                $($ty.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, escape, mark_branches, extra_attrs.clone()));*
+                $first.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, flags, extra_attrs.clone());
+                $($ty.to_html_async_with_buf::<OUT_OF_ORDER>(buf, position, flags, extra_attrs.clone()));*
 			}
 
 			fn hydrate<const FROM_SERVER: bool>(self, cursor: &Cursor, position: &PositionState) -> Self::State {


### PR DESCRIPTION
Follow-up: #4819, #4730

`ElementType::ESCAPE_CHILDREN` conflated two independent concerns: whether child text is HTML-escaped during SSR, and whether children are hydrated on the client. Raw-text elements (`<script>`, `<style>`, `<noscript>`) and escapable-raw-text elements (`<textarea>`, `<title>`) all shared `false`, so escaping a `<textarea>` to close the `</textarea>` breakout XSS necessarily turned its hydration on too — and walking a textarea's raw value as cursor-walkable child nodes desyncs the hydration cursor (hydration markers are swallowed as literal text inside RCDATA/RAWTEXT), causing hydration errors.

Split the axis by HTML content model, uniformly (no per-tag special cases in the engine):

- Add `ElementType::HYDRATES_CHILDREN`, defaulted to `ESCAPE_CHILDREN` so svg/mathml/custom/external impls are unchanged, and gate hydration on it.
- `<textarea>`/`<title>` are escapable raw text -> escaped but not hydrated; `<script>`/`<style>`/`<noscript>` are raw text -> verbatim and not hydrated.
- Raw text cannot be HTML-escaped (entities are not decoded), so add a general, tag-parameterized debug-only guard that catches `</tag` end-tag breakout (plus `<!--`/`<script` for `<script>`). Release builds are unaffected.

This fixes the `<textarea>` XSS without the hydration regression and closes the same latent issue on `<title>`, while giving the raw-text elements the only general, spec-honest defense a serializer can offer.