### PR TITLE
fix: bump wasm-streams for Cloudflare Workers compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3606,7 +3606,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.6.0",
  "web-sys",
  "xxhash-rust",
 ]
@@ -4671,6 +4671,19 @@ name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d3be8814f5ba5f074491a469eed3d73c273ffad955f25ed1635efac4b0d269"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ multer = { default-features = false, version = "3.1" }
 leptos-spin-macro = { default-features = false, version = "0.2" }
 sledgehammer_utils = { default-features = false, version = "0.3" }
 sledgehammer_bindgen = { default-features = false, version = "0.6" }
-wasm-streams = { default-features = false, version = "0.5" }
+wasm-streams = { default-features = false, version = "0.6" }
 rkyv = { default-features = false, version = "0.8" }
 temp-env = { default-features = false, version = "0.3" }
 uuid = { default-features = false, version = "1.20" }


### PR DESCRIPTION
This bumps `wasm-streams` to [0.6.0](https://github.com/MattiasBuelens/wasm-streams/releases/tag/v0.6.0).
I do not believe this will cause any changes to users, unless it's the first dependency for some users to require the 2024 edition.

Cloudflare workers depends on 0.6.0 and this does not seem to be compatible with 0.5.0.

To compile the latest template you also need to remove `strip = true` from `Cargo.toml`.

Error when using 0.5.0:
```
PS C:\Users\sushi\privat\rust\editoffice\web-app>  worker-build --release --features ssr
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
   Compiling web-app v0.1.0 (C:\Users\sushi\privat\rust\editoffice\web-app)
warning: Linking globals named '__wbg_intounderlyingbytesource_free': symbol multiply defined!

error: failed to load bitcode of module "wasm_streams-dc159e6efc4d8fe5.wasm_streams.5fa0d6c7df9a5116-cgu.0.rcgu.o":

warning: `web-app` (lib) generated 1 warning
error: could not compile `web-app` (lib) due to 1 previous error; 1 warning emitted
Error: Compiling your crate to WebAssembly failed

Caused by:
    failed to execute `cargo build`: exited with exit code: 101
      full command: "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown" "--features" "ssr"
```