### PR TITLE
feat(leptos): always expose use_nonce()

### DIFF
--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -166,12 +166,10 @@ pub mod prelude {
     // In the future, maybe we should remove this blanket export
     // However, it is definitely useful relative to looking up every struct etc.
     mod export_types {
-        #[cfg(feature = "nonce")]
-        pub use crate::nonce::*;
         pub use crate::{
             callback::*, children::*, component::*, control_flow::*, error::*,
-            form::*, hydration::*, into_view::*, mount::*, suspense::*,
-            text_prop::*,
+            form::*, hydration::*, into_view::*, mount::*, nonce::*,
+            suspense::*, text_prop::*,
         };
         pub use leptos_config::*;
         pub use leptos_dom::helpers::*;
@@ -241,7 +239,6 @@ pub mod portal;
 pub mod hydration;
 
 /// Utilities for exporting nonces to be used for a Content Security Policy.
-#[cfg(feature = "nonce")]
 pub mod nonce;
 
 /// Components to load asynchronous data.

--- a/leptos/src/nonce.rs
+++ b/leptos/src/nonce.rs
@@ -1,10 +1,3 @@
-use crate::context::{provide_context, use_context};
-use base64::{
-    alphabet,
-    engine::{self, general_purpose},
-    Engine,
-};
-use rand::{rng, RngCore};
 use std::{fmt::Display, ops::Deref, sync::Arc};
 use tachys::html::attribute::AttributeValue;
 
@@ -49,7 +42,12 @@ use tachys::html::attribute::AttributeValue;
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(feature = "nonce")]
 pub struct Nonce(pub(crate) Arc<str>);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(not(feature = "nonce"))]
+pub struct Nonce(pub(crate) Arc<str>, std::convert::Infallible);
 
 impl Nonce {
     /// Returns a reference to the inner reference-counted string slice representing the nonce.
@@ -127,6 +125,9 @@ impl AttributeValue for Nonce {
 /// server response. This can be added to inline `<script>` and
 /// `<style>` tags for compatibility with a Content Security Policy.
 ///
+/// This function can be called without the `nonce` feature enabled,
+/// in which case it will always return [`None::<Nonce>`].
+///
 /// ```rust,ignore
 /// #[component]
 /// pub fn App() -> impl IntoView {
@@ -156,21 +157,36 @@ impl AttributeValue for Nonce {
 ///     }
 /// }
 /// ```
+#[inline(always)]
 pub fn use_nonce() -> Option<Nonce> {
-    use_context::<Nonce>()
+    #[cfg(feature = "nonce")]
+    return crate::context::use_context::<Nonce>();
+    #[cfg(not(feature = "nonce"))]
+    return None;
 }
 
 /// Generates a nonce and provides it via context.
+#[cfg(feature = "nonce")]
 pub fn provide_nonce() {
-    provide_context(Nonce::new())
+    crate::context::provide_context(Nonce::new())
 }
 
-const NONCE_ENGINE: engine::GeneralPurpose =
-    engine::GeneralPurpose::new(&alphabet::URL_SAFE, general_purpose::NO_PAD);
-
+#[cfg(feature = "nonce")]
 impl Nonce {
     /// Generates a new nonce from 16 bytes (128 bits) of random data.
     pub fn new() -> Self {
+        use base64::{
+            alphabet,
+            engine::{self, general_purpose},
+            Engine as _,
+        };
+        use rand::{rng, RngCore as _};
+        const NONCE_ENGINE: engine::GeneralPurpose =
+            engine::GeneralPurpose::new(
+                &alphabet::URL_SAFE,
+                general_purpose::NO_PAD,
+            );
+
         let mut rng = rng();
         let mut bytes = [0; 16];
         rng.fill_bytes(&mut bytes);
@@ -188,6 +204,7 @@ impl Nonce {
     }
 }
 
+#[cfg(feature = "nonce")]
 impl Default for Nonce {
     fn default() -> Self {
         Self::new()

--- a/leptos/src/nonce.rs
+++ b/leptos/src/nonce.rs
@@ -47,6 +47,7 @@ pub struct Nonce(pub(crate) Arc<str>);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg(not(feature = "nonce"))]
+#[expect(missing_docs)]
 pub struct Nonce(pub(crate) Arc<str>, std::convert::Infallible);
 
 impl Nonce {

--- a/leptos/src/nonce.rs
+++ b/leptos/src/nonce.rs
@@ -1,3 +1,4 @@
+use crate::context::use_context;
 use std::{fmt::Display, ops::Deref, sync::Arc};
 use tachys::html::attribute::AttributeValue;
 
@@ -42,13 +43,12 @@ use tachys::html::attribute::AttributeValue;
 /// }
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg(feature = "nonce")]
-pub struct Nonce(pub(crate) Arc<str>);
+pub struct Nonce(pub(crate) Arc<str>, NonceAppendix);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(feature = "nonce")]
+type NonceAppendix = ();
 #[cfg(not(feature = "nonce"))]
-#[expect(missing_docs)]
-pub struct Nonce(pub(crate) Arc<str>, std::convert::Infallible);
+type NonceAppendix = std::convert::Infallible;
 
 impl Nonce {
     /// Returns a reference to the inner reference-counted string slice representing the nonce.
@@ -160,10 +160,7 @@ impl AttributeValue for Nonce {
 /// ```
 #[inline(always)]
 pub fn use_nonce() -> Option<Nonce> {
-    #[cfg(feature = "nonce")]
-    return crate::context::use_context::<Nonce>();
-    #[cfg(not(feature = "nonce"))]
-    return None;
+    cfg!(feature = "nonce").then(use_context).flatten()
 }
 
 /// Generates a nonce and provides it via context.
@@ -191,7 +188,7 @@ impl Nonce {
         let mut rng = rng();
         let mut bytes = [0; 16];
         rng.fill_bytes(&mut bytes);
-        Nonce(NONCE_ENGINE.encode(bytes).into())
+        Nonce(NONCE_ENGINE.encode(bytes).into(), ())
     }
 
     /// Builds a nonce from a caller-supplied value rather than generating
@@ -201,7 +198,7 @@ impl Nonce {
     /// context before rendering so [`use_nonce`] and the hydration scripts
     /// pick it up.
     pub fn from_value(value: impl Into<Arc<str>>) -> Self {
-        Nonce(value.into())
+        Nonce(value.into(), ())
     }
 }
 

--- a/meta/src/lib.rs
+++ b/meta/src/lib.rs
@@ -47,6 +47,7 @@ use leptos::{
     attr::{any_attribute::AnyAttribute, NextAttribute},
     component,
     logging::debug_warn,
+    nonce::use_nonce,
     oco::Oco,
     reactive::owner::{provide_context, use_context},
     tachys::{
@@ -595,18 +596,9 @@ pub(crate) trait OrDefaultNonce {
 
 impl OrDefaultNonce for Option<Oco<'static, str>> {
     fn or_default_nonce(self) -> Option<Oco<'static, str>> {
-        #[cfg(feature = "nonce")]
-        {
-            use leptos::nonce::use_nonce;
-
-            match self {
-                Some(nonce) => Some(nonce),
-                None => use_nonce().map(|n| Arc::clone(n.as_inner()).into()),
-            }
-        }
-        #[cfg(not(feature = "nonce"))]
-        {
-            self
+        match self {
+            Some(nonce) => Some(nonce),
+            None => use_nonce().map(|n| Arc::clone(n.as_inner()).into()),
         }
     }
 }


### PR DESCRIPTION
I'm building a static site, but during testing I'm using `axum`. The static site does not need nonce, but `leptos_axum` enables it by default. This means that my app (which does not care about nonce) _should_ sometimes include nonce and sometimes not. This creates a small amount of friction for me, but I would imagine it to be more friction if I was developing a library. For the sake of this PR, assume that I'm writing a library.

In the best of worlds, I could guard nonce usage with `#[cfg(feature = "leptos/nonce")]`, but this is not supported by Rust. Alternatively I could add a feature `nonce = ["leptos/nonce"]`, but I don't like this method, because it will never detect that `leptos/nonce` is active, just enforce it if the user enables my library's feature. I did find the `OrDefaultNonce` trait, but it's internal to `meta`, and it's not actually detecting whether leptos has nonce support.

This PR makes it so that `use_nonce` and `Nonce` are available regardless of the `nonce` feature flag, but the `Nonce` struct can only be constructed if the `nonce` feature is enabled, and `use_nonce` always returns `None` if it's disabled. The dependencies of the `nonce` feature are still only enabled if the actual feature is enabled.