### PR TITLE
fix: don't panic in the wasm-split prefetch machinery when its lock is unavailable

### DIFF
--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -62,38 +62,57 @@ pub trait ExtendResponse: Sized {
                 pending.await;
             }
 
-            if !prefetches.0.read_value().is_empty() {
-                use leptos::prelude::*;
+            // try_read_value, not read_value: the prefetch set's lock can be
+            // unavailable here — a late/OOO-streamed component may hold the
+            // write lock via prefetch_lazy_fn_on_server, and an aborted
+            // response can leave it poisoned. read_value() would panic the
+            // server worker with a spurious "already disposed" message. The
+            // prefetch hints are best-effort <link rel=preload> tags, so
+            // skipping them beats crashing the response task.
+            //
+            // Scoped block: the ReadGuards must drop before the await below.
+            {
+                let prefetch_keys = prefetches.0.try_read_value();
+                if prefetch_keys.as_ref().is_some_and(|p| !p.is_empty()) {
+                    use leptos::prelude::*;
 
-                let nonce =
-                    use_nonce().map(|n| n.to_string()).unwrap_or_default();
-                if let Some(manifest) = use_context::<WasmSplitManifest>() {
-                    let (pkg_path, manifest, wasm_split_file) =
-                        &*manifest.0.read_value();
-                    let prefetches = prefetches.0.read_value();
+                    let prefetches =
+                        prefetch_keys.expect("checked is_some above");
+                    let nonce =
+                        use_nonce().map(|n| n.to_string()).unwrap_or_default();
+                    // The ReadGuard holds its own Arc to the value, so it can
+                    // outlive the context handle it was read from.
+                    if let Some(manifest_read) =
+                        use_context::<WasmSplitManifest>()
+                            .and_then(|m| m.0.try_read_value())
+                    {
+                        let (pkg_path, manifest, wasm_split_file) =
+                            &*manifest_read;
 
-                    let all_prefetches = prefetches.iter().flat_map(|key| {
-                        manifest.get(*key).into_iter().flatten()
-                    });
+                        let all_prefetches =
+                            prefetches.iter().flat_map(|key| {
+                                manifest.get(*key).into_iter().flatten()
+                            });
 
-                    for module in all_prefetches {
-                        // to_html() on leptos_meta components registers them with the meta context,
-                        // rather than returning HTML directly
-                        _ = view! {
-                            <Link
-                                rel="preload"
-                                href=format!("{pkg_path}/{module}.wasm")
-                                as_="fetch"
-                                type_="application/wasm"
-                                crossorigin=nonce.clone()
-                            />
+                        for module in all_prefetches {
+                            // to_html() on leptos_meta components registers them with the meta context,
+                            // rather than returning HTML directly
+                            _ = view! {
+                                <Link
+                                    rel="preload"
+                                    href=format!("{pkg_path}/{module}.wasm")
+                                    as_="fetch"
+                                    type_="application/wasm"
+                                    crossorigin=nonce.clone()
+                                />
+                            }
+                            .to_html();
                         }
-                        .to_html();
-                    }
-                    _ = view! {
+                        _ = view! {
                         <Link rel="modulepreload" href=format!("{pkg_path}/{wasm_split_file}") crossorigin=nonce/>
                     }
                     .to_html();
+                    }
                 }
             }
 

--- a/integrations/utils/src/lib.rs
+++ b/integrations/utils/src/lib.rs
@@ -62,57 +62,40 @@ pub trait ExtendResponse: Sized {
                 pending.await;
             }
 
-            // try_read_value, not read_value: the prefetch set's lock can be
-            // unavailable here — a late/OOO-streamed component may hold the
-            // write lock via prefetch_lazy_fn_on_server, and an aborted
-            // response can leave it poisoned. read_value() would panic the
-            // server worker with a spurious "already disposed" message. The
-            // prefetch hints are best-effort <link rel=preload> tags, so
-            // skipping them beats crashing the response task.
-            //
-            // Scoped block: the ReadGuards must drop before the await below.
+            if let Some(prefetches) =
+                prefetches.0.try_read_value().filter(|p| !p.is_empty())
             {
-                let prefetch_keys = prefetches.0.try_read_value();
-                if prefetch_keys.as_ref().is_some_and(|p| !p.is_empty()) {
-                    use leptos::prelude::*;
+                use leptos::prelude::*;
 
-                    let prefetches =
-                        prefetch_keys.expect("checked is_some above");
-                    let nonce =
-                        use_nonce().map(|n| n.to_string()).unwrap_or_default();
-                    // The ReadGuard holds its own Arc to the value, so it can
-                    // outlive the context handle it was read from.
-                    if let Some(manifest_read) =
-                        use_context::<WasmSplitManifest>()
-                            .and_then(|m| m.0.try_read_value())
-                    {
-                        let (pkg_path, manifest, wasm_split_file) =
-                            &*manifest_read;
+                let nonce =
+                    use_nonce().map(|n| n.to_string()).unwrap_or_default();
+                if let Some(manifest_read) = use_context::<WasmSplitManifest>()
+                    .and_then(|m| m.0.try_read_value())
+                {
+                    let (pkg_path, manifest, wasm_split_file) = &*manifest_read;
 
-                        let all_prefetches =
-                            prefetches.iter().flat_map(|key| {
-                                manifest.get(*key).into_iter().flatten()
-                            });
+                    let all_prefetches = prefetches.iter().flat_map(|key| {
+                        manifest.get(*key).into_iter().flatten()
+                    });
 
-                        for module in all_prefetches {
-                            // to_html() on leptos_meta components registers them with the meta context,
-                            // rather than returning HTML directly
-                            _ = view! {
-                                <Link
-                                    rel="preload"
-                                    href=format!("{pkg_path}/{module}.wasm")
-                                    as_="fetch"
-                                    type_="application/wasm"
-                                    crossorigin=nonce.clone()
-                                />
-                            }
-                            .to_html();
-                        }
+                    for module in all_prefetches {
+                        // to_html() on leptos_meta components registers them with the meta context,
+                        // rather than returning HTML directly
                         _ = view! {
+                            <Link
+                                rel="preload"
+                                href=format!("{pkg_path}/{module}.wasm")
+                                as_="fetch"
+                                type_="application/wasm"
+                                crossorigin=nonce.clone()
+                            />
+                        }
+                        .to_html();
+                    }
+                    _ = view! {
                         <Link rel="modulepreload" href=format!("{pkg_path}/{wasm_split_file}") crossorigin=nonce/>
                     }
                     .to_html();
-                    }
                 }
             }
 

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -407,7 +407,14 @@ pub fn prefetch_lazy_fn_on_server(id: &'static str) {
     use reactive_graph::traits::WriteValue;
 
     if let Some(prefetches) = use_context::<PrefetchLazyFn>() {
-        prefetches.0.write_value().insert(id);
+        // try_write_value, not write_value: a lazy component can render after
+        // the client aborted the response, when the set's lock is no longer
+        // writable — write_value() would panic the server worker with a
+        // spurious "already been disposed" message. The prefetch hint is
+        // best-effort; dropping it for a dead response is correct.
+        if let Some(mut set) = prefetches.0.try_write_value() {
+            set.insert(id);
+        }
     }
 }
 

--- a/leptos/src/lib.rs
+++ b/leptos/src/lib.rs
@@ -407,11 +407,6 @@ pub fn prefetch_lazy_fn_on_server(id: &'static str) {
     use reactive_graph::traits::WriteValue;
 
     if let Some(prefetches) = use_context::<PrefetchLazyFn>() {
-        // try_write_value, not write_value: a lazy component can render after
-        // the client aborted the response, when the set's lock is no longer
-        // writable — write_value() would panic the server worker with a
-        // spurious "already been disposed" message. The prefetch hint is
-        // best-effort; dropping it for a dead response is correct.
         if let Some(mut set) = prefetches.0.try_write_value() {
             set.insert(id);
         }


### PR DESCRIPTION
Fixes #4829.

The `PrefetchLazyFn` set and `WasmSplitManifest` are `ArcStoredValue`s whose `read_value()`/`write_value()` panic (with a misleading "already been disposed" message) whenever the inner lock's `try_read`/`try_write` fails. Both the prefetch epilogue in `leptos_integration_utils::ExtendResponse::from_app` (reader) and `leptos::prefetch_lazy_fn_on_server` (writer) hit this on the server when a client aborts an in-flight SSR stream — the panic runs on the response task and takes the worker's request down with it. Evidence and repro details in the issue (12 identical panics captured in a 12-minute e2e run; zero after this change).

This converts the three reads and one write to their `try_` variants and skips the best-effort `<link rel=preload>` hint emission when the lock isn't available — the affected response is already dead, so nothing is lost. Read guards are scoped so they drop before the subsequent `.await`.

Happy to also target this at `leptos_0.9` and/or a 0.8.x patch release — the identical change based on the `v0.8.19` tag is on `JohnHarrison:prefetch-disposed-read-0.8` (we're carrying it via `[patch.crates-io]` in production meanwhile).