### PR TITLE
fix(tachys): Keyed SSR injects spurious whitespace text nodes, causing hydration panics

### DIFF
--- a/tachys/src/view/keyed.rs
+++ b/tachys/src/view/keyed.rs
@@ -301,7 +301,7 @@ where
         }
 
         #[cfg(feature = "ssr")]
-        for item in self.ssr_items {
+        for (_, item) in self.ssr_items {
             if mark_branches && escape {
                 buf.open_branch("item");
             }


### PR DESCRIPTION
The Bug
Server-rendered pages that use <For> components (or any keyed iteration) have invisible whitespace text nodes injected before every child element. When the WASM hydrates the page, it encounters these unexpected text nodes and panics with:

```
panicked at tachys/src/hydration.rs:227:9:
internal error: entered unreachable code
```
This means any Leptos SSR+hydrate app that uses <For> breaks on page load. The panic is unrecoverable — the page never becomes interactive.

Why It Happens
Keyed::to_html_with_buf (the sync SSR rendering path) iterates self.ssr_items as raw (String, V) tuples:

```
for item in self.ssr_items {
    item.to_html_with_buf(...);
}
```
item here is the full tuple (String, V). When the tuple's RenderHtml::to_html_with_buf runs, it renders the String first, then the view V. The string is the item's key. When the islands feature is not enabled, every key is initialized as String::new() (empty). An empty string rendered in SSR escape mode becomes a space character ' ' — this is the whitespace text node.

The async counterpart to_html_async_with_buf already handles this correctly — it destructures for (key, item) and only renders item. The sync method was missed during the refactor that added the ssr_items field in tachys 0.2.12.

```
The Fix
One-line change — match the async method's destructuring:

// Before
for item in self.ssr_items {

// After
for (_, item) in self.ssr_items {
```
Concrete Symptom
With the bug, SSR renders:

```
<div><!> <span>a</span><!> <span>b</span></div>
```
Note the space ( ) after each <!> marker. Without the bug:

```
<div><!><span>a</span><!><span>b</span></div>
```
Any test that hydrates the page will observe the panic immediately.

Verification
Fix verified in an app I have in development (Playwright E2E tests). Before: 2 hydration panics per page load. After: 0 panics, all tests green.

Related
#4780 (closed "not planned" due to needs reproduction — this PR provides the reproduction)