### PR TITLE
fix: include submit input value in FormData when submitting Form

### DIFF
--- a/leptos/src/form.rs
+++ b/leptos/src/form.rs
@@ -291,7 +291,8 @@ where
     }
 }
 
-fn form_data_from_event(
+/// Retrieves the `FormData` of a form given the `submit` event
+pub fn form_data_from_event(
     ev: &SubmitEvent,
 ) -> Result<FormData, FromFormDataError> {
     let submitter = ev.submitter();

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -112,14 +112,14 @@ where
                     ..Default::default()
                 };
 
-                let Some((form, method, action, enctype)) =
+                let Some((method, action, enctype)) =
                     extract_form_attributes(&ev)
                 else {
                     return;
                 };
 
                 let form_data =
-                    web_sys::FormData::new_with_form(&form).unwrap_throw();
+                    leptos::form::form_data_from_event(&ev).unwrap_throw();
                 if let Some(on_form_data) = on_form_data.clone() {
                     on_form_data(&form_data);
                 }
@@ -347,14 +347,13 @@ fn current_window_origin() -> String {
 }
 
 fn extract_form_attributes(
-    ev: &web_sys::Event,
-) -> Option<(web_sys::HtmlFormElement, String, String, String)> {
-    let submitter = ev.unchecked_ref::<web_sys::SubmitEvent>().submitter();
+    ev: &web_sys::SubmitEvent,
+) -> Option<(String, String, String)> {
+    let submitter = ev.submitter();
     match &submitter {
         Some(el) => {
             if let Some(form) = el.dyn_ref::<web_sys::HtmlFormElement>() {
                 Some((
-                    form.clone(),
                     form.get_attribute("method")
                         .unwrap_or_else(|| "get".to_string())
                         .to_lowercase(),
@@ -375,7 +374,6 @@ fn extract_form_attributes(
                     .unwrap()
                     .unchecked_into::<web_sys::HtmlFormElement>();
                 Some((
-                    form.clone(),
                     input.get_attribute("method").unwrap_or_else(|| {
                         form.get_attribute("method")
                             .unwrap_or_else(|| "get".to_string())
@@ -402,7 +400,6 @@ fn extract_form_attributes(
                     .unwrap()
                     .unchecked_into::<web_sys::HtmlFormElement>();
                 Some((
-                    form.clone(),
                     button.get_attribute("method").unwrap_or_else(|| {
                         form.get_attribute("method")
                             .unwrap_or_else(|| "get".to_string())
@@ -439,7 +436,6 @@ fn extract_form_attributes(
             Some(form) => {
                 let form = form.unchecked_into::<web_sys::HtmlFormElement>();
                 Some((
-                    form.clone(),
                     form.get_attribute("method")
                         .unwrap_or_else(|| "get".to_string()),
                     form.get_attribute("action").unwrap_or_default(),


### PR DESCRIPTION
This fixes the same issue as https://github.com/leptos-rs/leptos/pull/2268 but for regular `Form`s instead of `ActionForm`s.

This uses the same `form_data_from_event` function as the other PR. Since that function is located in the leptos crate and the `Form` component is in the router crate I needed to make that function public. I think this is a good change as this is a useful utility function that people might want to use outside of the context of `ActionForm`s, just like the `FromFormData` trait.  
Alternatively, it would be possible to reimplement the logic of that function in the router crate and keep it private.

I tested the change working with this change to the router example, seeing the expected `submit_name: "submit_value"` as part of the request in the browser tools:  
https://github.com/dav-wolff/leptos/commit/555602ac7580ce6d588f823e945c4aa5fc4bdbef