### PR TITLE
fix(router): keep `""` and `"/"` static segments as pass-through parents

### DIFF
--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -365,7 +365,9 @@ mod tests {
     #[test]
     fn empty_segment_is_passthrough_parent() {
         let def = StaticSegment("");
-        let m = def.test("/lang").expect("empty segment should pass through");
+        let m = def
+            .test("/lang")
+            .expect("empty segment should pass through");
         assert_eq!(m.matched(), "");
         assert_eq!(m.remaining(), "/lang");
 

--- a/router/src/matching/horizontal/static_segment.rs
+++ b/router/src/matching/horizontal/static_segment.rs
@@ -104,7 +104,13 @@ impl<T: AsPath> PossibleRouteMatch for StaticSegment<T> {
             } else if expected.is_none() {
                 // segment is exhausted but the path continues with a
                 // non-`/` byte: an overlong path must not match a shorter
-                // static segment (e.g. `/foobar` must not match `fo`)
+                // static segment (e.g. `/foobar` must not match `fo`).
+                // `""` and `"/"` are the exceptions: they are pass-through
+                // parents (e.g. nested wrapper routes) that consume nothing
+                // and leave the rest of the path to their children.
+                if segment.is_empty() || segment == "/" {
+                    break;
+                }
                 return None;
             }
             // if the next byte in the path matches the
@@ -354,5 +360,18 @@ mod tests {
     fn no_partial_match_on_overlong_path() {
         let def = StaticSegment("fo");
         assert!(def.test("/foobar").is_none());
+    }
+
+    #[test]
+    fn empty_segment_is_passthrough_parent() {
+        let def = StaticSegment("");
+        let m = def.test("/lang").expect("empty segment should pass through");
+        assert_eq!(m.matched(), "");
+        assert_eq!(m.remaining(), "/lang");
+
+        let def = StaticSegment("/");
+        let m = def.test("/lang").expect("root segment should pass through");
+        assert_eq!(m.matched(), "/");
+        assert_eq!(m.remaining(), "/lang");
     }
 }


### PR DESCRIPTION
123eec61 made StaticSegment::test return None when the segment is exhausted but the path continues with a non-slash byte, so an overlong path no longer matches a shorter segment ("/foobar" vs "fo"). But the check also rejected the `""` and `"/"` wrapper segments that nested parent routes use, so every route behind such a parent stopped matching and fell through to the fallback:

    // parent wrapper, as produced by nested route trees
    assert!(StaticSegment("").test("/lang").is_some());  // was None
    assert!(StaticSegment("/").test("/about").is_some()); // was None

Restrict the overlong check to other segments; `""` and `"/"` are already treated as trivially matching when initializing has_matched.

Fixes matches_nested_route, chooses_between_nested_routes and arbitrary_nested_routes, which fail on the parent branch.