### PR TITLE
test(integrations): gate static route tests on the `default` feature

### DIFF
--- a/integrations/actix/src/lib.rs
+++ b/integrations/actix/src/lib.rs
@@ -1838,7 +1838,7 @@ where
     .await
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "default"))]
 mod tests {
     // Targeted imports rather than `use super::*`: the crate root glob-imports
     // `actix_web::test`, which would shadow the `#[test]` attribute macro.

--- a/integrations/actix/tests/static_cache_hit_headers.rs
+++ b/integrations/actix/tests/static_cache_hit_headers.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "default")]
+
 #[cfg(test)]
 mod tests {
     use actix_web::{App, test, web::Data};

--- a/integrations/actix/tests/static_race.rs
+++ b/integrations/actix/tests/static_race.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "default")]
+
 #[cfg(test)]
 mod tests {
     use actix_web::{App, test, web::Data};

--- a/integrations/axum/tests/static_cache_hit_headers.rs
+++ b/integrations/axum/tests/static_cache_hit_headers.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "default", not(feature = "wasm")))]
+
 #[cfg(test)]
 mod tests {
     use axum::{Router, body::Body, http::Request};

--- a/integrations/axum/tests/static_race.rs
+++ b/integrations/axum/tests/static_race.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "default", not(feature = "wasm")))]
+
 #[cfg(test)]
 mod tests {
     use axum::{Router, body::Body, http::Request};


### PR DESCRIPTION
Related: https://github.com/leptos-rs/leptos/actions/runs/29874655448/job/88782457685?pr=4522
Related: https://github.com/leptos-rs/leptos/actions/runs/29874655448/job/88782457908?pr=4522

The `leptos_axum` and `leptos_actix` test targets fail when the crates are
built without default features, which the feature-combination CI run does.

- `leptos_axum`: with `default` off, `SsrMode::Static` routes are not
  registered — building the router panics with "Static routes are not
  currently supported on WASM32 server targets.", so every static route test
  fails at setup.
- `leptos_actix`: `default` → `actix-default` → `actix-web/default`, so
  turning it off drops `actix-web/macros`. `#[actix_web::test]` no longer
  resolves and the whole test build fails to compile.