### PR TITLE
fix(leptos): nonce incorrectly generated for wasm preload

### DIFF
--- a/integrations/utils/Cargo.toml
+++ b/integrations/utils/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 futures = { workspace = true, default-features = true }
 hydration_context = { workspace = true }
-leptos = { workspace = true, features = ["nonce"] }
+leptos = { workspace = true }
 leptos_meta = { workspace = true, features = ["ssr"] }
 leptos_router = { workspace = true, features = ["ssr"] }
 leptos_config = { workspace = true }

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -176,7 +176,10 @@ pub fn HydrationScripts(
             href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
             r#as="fetch"
             r#type="application/wasm"
-            crossorigin=nonce.clone()
+            crossorigin=nonce
+                .as_ref()
+                .map(|n| Oco::Counted(n.as_inner().clone()))
+                .unwrap_or(Oco::Borrowed(""))
         />
         <script type="module" nonce=nonce>
             {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?});{islands_router}")}

--- a/leptos/src/hydration/mod.rs
+++ b/leptos/src/hydration/mod.rs
@@ -17,10 +17,7 @@ pub fn AutoReload(
     options: LeptosOptions,
 ) -> impl IntoView {
     (!disable_watch && std::env::var("LEPTOS_WATCH").is_ok()).then(|| {
-        #[cfg(feature = "nonce")]
         let nonce = crate::nonce::use_nonce();
-        #[cfg(not(feature = "nonce"))]
-        let nonce = None::<()>;
 
         let reload_port = match options.reload_external_port {
             Some(val) => val,
@@ -157,10 +154,7 @@ pub fn HydrationScripts(
     }
 
     let pkg_path = &options.site_pkg_dir;
-    #[cfg(feature = "nonce")]
     let nonce = crate::nonce::use_nonce();
-    #[cfg(not(feature = "nonce"))]
-    let nonce = None::<String>;
     let script = if islands {
         if let Some(sc) = Owner::current_shared_context() {
             sc.set_is_hydrating(false);
@@ -182,7 +176,7 @@ pub fn HydrationScripts(
             href=format!("{root}/{pkg_path}/{wasm_file_name}.wasm")
             r#as="fetch"
             r#type="application/wasm"
-            crossorigin=nonce.clone().unwrap_or_default()
+            crossorigin=nonce.clone()
         />
         <script type="module" nonce=nonce>
             {format!("{script}({root:?}, {pkg_path:?}, {js_file_name:?}, {wasm_file_name:?});{islands_router}")}


### PR DESCRIPTION
`HydrationScripts` incorrectly adds a nonce to the wasm preload if `leptos_integration_utils` is included as a dependency. This PR removes this nonce (and cleans up some conditional compilation).