### PR TITLE
Fix two concurrency issues with Suspense

### DIFF
--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -16,8 +16,7 @@ use reactive_graph::{
     owner::{provide_context, use_context, ArcStoredValue, Owner},
     signal::ArcRwSignal,
     traits::{
-        Dispose, Get, Read, ReadUntracked, Track, With, WithUntracked,
-        WriteValue,
+        Dispose, Get, ReadUntracked, Track, With, WithUntracked, WriteValue,
     },
 };
 use slotmap::{DefaultKey, SlotMap};
@@ -354,12 +353,31 @@ where
             let children = Arc::clone(&children);
             let notify_error_boundary = notify_error_boundary.clone();
             move |double_checking: Option<bool>| {
-                // on the first run, always track the tasks
-                if double_checking.is_none() {
+                // Subscribe to `tasks` before reading on every run, unless the notification
+                // has already been sent via `tasks_tx`
+                //
+                // Because dependencies are dynamic, the signal<>effect set of links is cleared
+                // on every run, it's possible for a run that reads first and subscribes second to lose
+                // a notification that fires in between on another thread. It reads a non-empty task
+                // set, the last task finishes and notifies its subscribers, but this run has not
+                // subscribed yet. This run then subscribes... but the signal won't be updated again.
+                //
+                // This is the primary source of the hangs described in a few issues
+                // - https://github.com/leptos-rs/leptos/issues/4851
+                // - https://github.com/leptos-rs/leptos/issues/4673
+                // - https://github.com/leptos-rs/leptos/pull/4698
+                //
+                // It's important not to *over*-run this effect though; `dry_resolve` walks the view tree
+                // and re-runs child closures, which can have side effects (like creating new Resources, etc.)
+                //
+                // Tracking only if the notification has not already been sent should block those spurious reruns.
+                if tasks_tx.is_some() {
                     tasks.track();
                 }
 
-                if let Some(curr_tasks) = tasks.try_read_untracked() {
+                let curr_tasks = tasks.try_read_untracked();
+
+                if let Some(curr_tasks) = curr_tasks {
                     if curr_tasks.is_empty() {
                         if double_checking == Some(true) {
                             // we have finished loading, and checking the children again told us there are
@@ -387,7 +405,7 @@ where
                             }
 
                             if tasks
-                                .try_read()
+                                .try_read_untracked()
                                 .map(|n| n.is_empty())
                                 .unwrap_or(false)
                             {
@@ -407,8 +425,6 @@ where
                             // tell ourselves that we're just double-checking
                             return true;
                         }
-                    } else {
-                        tasks.track();
                     }
                 }
                 false

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -125,8 +125,14 @@ where
             reactive_graph::spawn(async move {
                 let loaded = fut.await;
                 *value.write().or_poisoned() = Some(loaded);
-                loading.store(false, Ordering::Relaxed);
-                for waker in mem::take(&mut *wakers.write().or_poisoned()) {
+                // clear `loading` and take the workers under one lock, to prevent polling
+                // from registering a waker that's never woken
+                let pending_wakers = {
+                    let mut wakers = wakers.write().or_poisoned();
+                    loading.store(false, Ordering::Relaxed);
+                    mem::take(&mut *wakers)
+                };
+                for waker in pending_wakers {
                     waker.wake();
                 }
                 trigger.notify();
@@ -322,8 +328,10 @@ where
             self.suspenses.write().or_poisoned().push(suspense_context);
         }
 
+        // hold the `wakers` lock across the change in `loading`
+        let mut wakers = self.wakers.write().or_poisoned();
         if self.loading.load(Ordering::Relaxed) {
-            self.wakers.write().or_poisoned().push(waker.clone());
+            wakers.push(waker.clone());
             Poll::Pending
         } else {
             Poll::Ready(

--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -425,7 +425,13 @@ impl<T: 'static> ArcAsyncDerived<T> {
         loading: &Arc<AtomicBool>,
         ready_tx: Option<oneshot::Sender<()>>,
     ) {
-        loading.store(false, Ordering::Relaxed);
+        // clear `loading` and take the workers under one lock, to prevent polling
+        // from registering a waker that's never woken
+        let pending_wakers = {
+            let mut wakers = wakers.write().or_poisoned();
+            loading.store(false, Ordering::Relaxed);
+            mem::take(&mut *wakers)
+        };
 
         let prev_state = mem::replace(
             &mut inner.write().or_poisoned().state,
@@ -447,7 +453,7 @@ impl<T: 'static> ArcAsyncDerived<T> {
         }
 
         // notify async .awaiters
-        for waker in mem::take(&mut *wakers.write().or_poisoned()) {
+        for waker in pending_wakers {
             waker.wake();
         }
 

--- a/reactive_graph/src/computed/async_derived/future_impls.rs
+++ b/reactive_graph/src/computed/async_derived/future_impls.rs
@@ -59,8 +59,10 @@ impl Future for AsyncDerivedReadyFuture {
         let _guard = SpecialNonReactiveZone::enter();
         let waker = cx.waker();
         self.source.track();
+        // hold the `wakers` lock across the change in `loading`
+        let mut wakers = self.wakers.write().or_poisoned();
         if self.loading.load(Ordering::Relaxed) {
-            self.wakers.write().or_poisoned().push(waker.clone());
+            wakers.push(waker.clone());
             Poll::Pending
         } else {
             Poll::Ready(())
@@ -137,9 +139,10 @@ where
         }
 
         pin_mut!(value);
+        let mut wakers = self.wakers.write().or_poisoned();
         match (self.loading.load(Ordering::Relaxed), value.poll(cx)) {
             (true, _) => {
-                self.wakers.write().or_poisoned().push(waker.clone());
+                wakers.push(waker.clone());
                 Poll::Pending
             }
             (_, Poll::Pending) => Poll::Pending,
@@ -203,9 +206,10 @@ where
         self.source.track();
         let value = self.value.read_arc();
         pin_mut!(value);
+        let mut wakers = self.wakers.write().or_poisoned();
         match (self.loading.load(Ordering::Relaxed), value.poll(cx)) {
             (true, _) => {
-                self.wakers.write().or_poisoned().push(waker.clone());
+                wakers.push(waker.clone());
                 Poll::Pending
             }
             (_, Poll::Pending) => Poll::Pending,


### PR DESCRIPTION
This should address two different kinds of issues with parallelism that are (probably) the causes of the issues described in https://github.com/leptos-rs/leptos/issues/4851 https://github.com/leptos-rs/leptos/issues/4673 and https://github.com/leptos-rs/leptos/pull/4698

1. Fixes a synchronization issue between "loading" and "wakers" on resources
2. Fixes a timing issue between reading from and tracking the sets of active tasks in Suspense

See comments on the commits.