### PR TITLE
Assorted islands-router fixes

### DIFF
--- a/examples/islands_router/e2e/tests/navigation.spec.ts
+++ b/examples/islands_router/e2e/tests/navigation.spec.ts
@@ -13,7 +13,7 @@ function collectErrors(page: Page): string[] {
   return errors;
 }
 
-test("navigates from Home to About", async ({ page }) => {
+test("navigates from Home to About, increments Counter", async ({ page }) => {
   const errors = collectErrors(page);
 
   await page.goto("/");
@@ -25,6 +25,37 @@ test("navigates from Home to About", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
   await expect(page).toHaveTitle("About | My Contacts");
   await expect(page.locator("input[type=search]")).not.toBeAttached();
+
+  await expect(page.getByText("Enter a search to begin viewing contacts.")).not.toBeVisible();
+  await expect(page.locator("button[class=counter]")).toHaveText("Click Me: 0");
+  await page.click('button[class=counter]');
+  await expect(page.locator("button[class=counter]")).toHaveText("Click Me: 1");
+
+  expect(errors).toEqual([]);
+});
+
+test("navigates from Home to About (redundantly), increments Counter", async ({ page }) => {
+  const errors = collectErrors(page);
+
+  await page.goto("/");
+  await expect(page).toHaveTitle("Home | My Contacts");
+  await expect(page.locator("input[type=search]")).toBeVisible();
+
+  await page.click('nav a[href="/about"]');
+  await expect(page).toHaveURL(/\/about$/);
+  await expect(page.getByRole("heading", { name: "About" })).toBeVisible();
+  await expect(page).toHaveTitle("About | My Contacts");
+  await expect(page.locator("input[type=search]")).not.toBeAttached();
+
+  await page.click('nav a[href="/about"]'); // 2
+  await page.click('nav a[href="/about"]'); // 3
+  await page.click('nav a[href="/about"]'); // 4
+
+  await expect(page.locator("button[class=counter]")).toBeAttached();
+  await expect(page.getByText("Enter a search to begin viewing contacts.")).not.toBeVisible();
+  await expect(page.locator("button[class=counter]")).toHaveText("Click Me: 0");
+  await page.click('button[class=counter]');
+  await expect(page.locator("button[class=counter]")).toHaveText("Click Me: 1");
 
   expect(errors).toEqual([]);
 });

--- a/examples/islands_router/src/app.rs
+++ b/examples/islands_router/src/app.rs
@@ -211,6 +211,6 @@ pub fn About() -> impl IntoView {
 pub fn Counter() -> impl IntoView {
     let count = RwSignal::new(0);
     view! {
-        <button class="counter" on:click=move |_| *count.write() += 1>{count}</button>
+        <button class="counter" on:click=move |_| *count.write() += 1>"Click Me: "{count}</button>
     }
 }

--- a/leptos/src/hydration/islands_routing.js
+++ b/leptos/src/hydration/islands_routing.js
@@ -357,16 +357,19 @@ function replaceBranch(oldDocWalker, newDocWalker, oldNode, newNode) {
 	seekBranchClose(oldDocWalker);
 	seekBranchClose(newDocWalker);
 
+	const oldClose = oldDocWalker.currentNode;
+	const newClose = newDocWalker.currentNode;
+
 	try {
 		oldRange.setStartAfter(oldNode);
-		oldRange.setEndBefore(oldDocWalker.currentNode);
+		oldRange.setEndBefore(oldClose);
 		newRange.setStartAfter(newNode);
-		newRange.setEndAfter(newDocWalker.currentNode);
+		newRange.setEndBefore(newClose);
 		const newContents = newRange.extractContents();
 		oldRange.deleteContents();
 		oldRange.insertNode(newContents);
-		oldNode.replaceWith(newNode);
-		oldDocWalker.currentNode.replaceWith(newDocWalker.currentNode);
+		oldNode.textContent = newNode.textContent;
+		oldClose.textContent = newClose.textContent;
 	} catch (e) {
 		console.error(e);
 	}

--- a/leptos/src/hydration/islands_routing.js
+++ b/leptos/src/hydration/islands_routing.js
@@ -259,7 +259,9 @@ function replaceFor(oldDocument, oldDocWalker, newDocument, newDocWalker, oldNod
 				oldKeys[k].close = c;
 			}
 		}
-		oldDocWalker.nextNode();
+		if(!oldDocWalker.nextNode()) {
+			break;
+		}
 	}
 	while(newBranches > 0) {
 		const c = newDocWalker.currentNode;
@@ -278,7 +280,9 @@ function replaceFor(oldDocument, oldDocWalker, newDocument, newDocWalker, oldNod
 				newKeys[k].close = c;
 			}
 		}
-		newDocWalker.nextNode();
+		if(!newDocWalker.nextNode()) {
+			break;
+		}
 	}
 
 	for(const key in oldKeys) {

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -366,7 +366,7 @@ pub(crate) struct MatchedRoute(pub String, pub AnyView);
 
 impl MatchedRoute {
     fn branch_name(&self) -> String {
-        format!("{:?}", self.1.as_type_id())
+        format!("{}|{:?}", self.0, self.1.as_type_id())
     }
 }
 

--- a/tachys/src/view/any_view.rs
+++ b/tachys/src/view/any_view.rs
@@ -575,7 +575,10 @@ impl RenderHtml for AnyView {
         #[cfg(feature = "hydrate")]
         {
             if FROM_SERVER {
-                (self.hydrate_from_server)(self.value, cursor, position)
+                let state =
+                    (self.hydrate_from_server)(self.value, cursor, position);
+                super::close_branch_marker(position);
+                state
             } else {
                 panic!(
                     "hydrating AnyView from inside a ViewTemplate is not \
@@ -603,6 +606,7 @@ impl RenderHtml for AnyView {
         {
             let state =
                 (self.hydrate_async)(self.value, cursor, position).await;
+            super::close_branch_marker(position);
             state
         }
         #[cfg(not(feature = "hydrate"))]

--- a/tachys/src/view/either.rs
+++ b/tachys/src/view/either.rs
@@ -411,14 +411,16 @@ where
         cursor: &Cursor,
         position: &PositionState,
     ) -> Self::State {
-        match self {
+        let state = match self {
             Either::Left(left) => {
                 Either::Left(left.hydrate::<FROM_SERVER>(cursor, position))
             }
             Either::Right(right) => {
                 Either::Right(right.hydrate::<FROM_SERVER>(cursor, position))
             }
-        }
+        };
+        super::close_branch_marker(position);
+        state
     }
 
     async fn hydrate_async(
@@ -426,14 +428,16 @@ where
         cursor: &Cursor,
         position: &PositionState,
     ) -> Self::State {
-        match self {
+        let state = match self {
             Either::Left(left) => {
                 Either::Left(left.hydrate_async(cursor, position).await)
             }
             Either::Right(right) => {
                 Either::Right(right.hydrate_async(cursor, position).await)
             }
-        }
+        };
+        super::close_branch_marker(position);
+        state
     }
 
     fn into_owned(self) -> Self::Owned {
@@ -964,6 +968,7 @@ macro_rules! tuples {
                             [<EitherOf $num>]::$ty(this.hydrate::<FROM_SERVER>(cursor, position))
                         })*
                     };
+                    $crate::view::close_branch_marker(position);
 
                     Self::State { state }
                 }
@@ -978,6 +983,7 @@ macro_rules! tuples {
                             [<EitherOf $num>]::$ty(this.hydrate_async(cursor, position).await)
                         })*
                     };
+                    $crate::view::close_branch_marker(position);
 
                     Self::State { state }
                 }

--- a/tachys/src/view/mod.rs
+++ b/tachys/src/view/mod.rs
@@ -86,6 +86,19 @@ impl MarkBranch for StreamBuilder {
     }
 }
 
+#[doc(hidden)]
+#[inline]
+pub fn close_branch_marker(position: &PositionState) {
+    #[cfg(feature = "mark_branches")]
+    if position.get() == Position::NextChildAfterText {
+        position.set(Position::NextChild);
+    }
+    #[cfg(not(feature = "mark_branches"))]
+    {
+        _ = position;
+    }
+}
+
 /// The `RenderHtml` trait allows rendering something to HTML, and transforming
 /// that HTML into an interactive interface.
 ///


### PR DESCRIPTION
These address the issues described in #4854, introduced by b20902aa and 61571ed2, without regressions to #4378.

- Use the route path as part of the branch marker for routes, rather than only the inner view type ID (which can be erased to being identical with component erasure turned on). Ensures that navigations actually replace the previous route fully.
- Leave old branch marker nodes in place (but update their text) to avoid breaking the DOM walk by moving them mid-walk
- Fix hydration after text nodes related to branches