### PR TITLE
fix(reactive_graph): ignore dropped local-resource listener

### DIFF
--- a/reactive_graph/src/computed/async_derived/mod.rs
+++ b/reactive_graph/src/computed/async_derived/mod.rs
@@ -130,7 +130,12 @@ pub mod suspense {
         /// Send the notification. If the inner channel has already been used, this does nothing.
         pub fn notify(&mut self) {
             if let Some(tx) = self.0.lock().or_poisoned().take() {
-                tx.send(()).unwrap();
+                if tx.send(()).is_err() {
+                    crate::log_warning(format_args!(
+                        "A local-resource notification could not be delivered \
+                         because its listener was already dropped."
+                    ));
+                }
             }
         }
     }


### PR DESCRIPTION
We've ran into an unwrap panic under streaming SSR: `LocalResourceNotifier::notify()` unwraps the `oneshot` send, but the receiver isn't guaranteed to still be around.