### PR TITLE
fix: check for resource reads inside Signal/Memo used as attribute values (see #4856)

### DIFF
--- a/tachys/src/reactive_graph/class.rs
+++ b/tachys/src/reactive_graph/class.rs
@@ -524,7 +524,7 @@ where
 */
 
 macro_rules!  tuple_class_reactive {
-    ($name:ident, <$($impl_gen:ident),*>, <$($gen:ident),*> , $( $where_clause:tt )*) =>
+    ($name:ident, <$($impl_gen:ident),*>, <$($gen:ident),*>, $dry_resolve:literal, $( $where_clause:tt )*) =>
     {
         #[allow(deprecated)]
         impl<$($impl_gen),*>  IntoClass for (&'static str, $name<$($gen),*>)
@@ -580,7 +580,11 @@ macro_rules!  tuple_class_reactive {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.1.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -610,7 +614,7 @@ macro_rules!  tuple_class_reactive {
 }
 
 macro_rules!  class_reactive {
-    ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+    ($name:ident, <$($gen:ident),*>, $v:ty, $dry_resolve:literal, $( $where_clause:tt )*) =>
     {
         #[allow(deprecated)]
         impl<$($gen),*> IntoClass for $name<$($gen),*>
@@ -659,7 +663,11 @@ macro_rules!  class_reactive {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -699,6 +707,7 @@ mod stable {
         RwSignal,
         <V, S>,
         V,
+        false,
         RwSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -707,6 +716,7 @@ mod stable {
         ReadSignal,
         <V, S>,
         V,
+        false,
         ReadSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -715,6 +725,7 @@ mod stable {
         Memo,
         <V, S>,
         V,
+        true,
         Memo<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -723,6 +734,7 @@ mod stable {
         Signal,
         <V, S>,
         V,
+        true,
         Signal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -731,19 +743,21 @@ mod stable {
         MaybeSignal,
         <V, S>,
         V,
+        true,
         MaybeSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    class_reactive!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
-    class_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
-    class_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
-    class_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+    class_reactive!(ArcRwSignal, <V>, V, false, ArcRwSignal<V>: Get<Value = V>);
+    class_reactive!(ArcReadSignal, <V>, V, false, ArcReadSignal<V>: Get<Value = V>);
+    class_reactive!(ArcMemo, <V>, V, true, ArcMemo<V>: Get<Value = V>);
+    class_reactive!(ArcSignal, <V>, V, true, ArcSignal<V>: Get<Value = V>);
 
     tuple_class_reactive!(
         RwSignal,
         <S>,
         <bool, S>,
+        false,
         RwSignal<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send  + 'static,
@@ -752,6 +766,7 @@ mod stable {
         ReadSignal,
         <S>,
         <bool, S>,
+        false,
         ReadSignal<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send + 'static,
@@ -760,6 +775,7 @@ mod stable {
         Memo,
         <S>,
         <bool, S>,
+        true,
         Memo<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send + 'static,
@@ -768,6 +784,7 @@ mod stable {
         Signal,
         <S>,
         <bool, S>,
+        true,
         Signal<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send + 'static,
@@ -776,14 +793,15 @@ mod stable {
         MaybeSignal,
         <S>,
         <bool, S>,
+        true,
         MaybeSignal<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send + 'static,
     );
-    tuple_class_reactive!(ArcRwSignal,<>, <bool>, ArcRwSignal<bool>: Get<Value = bool>);
-    tuple_class_reactive!(ArcReadSignal,<>, <bool>, ArcReadSignal<bool>: Get<Value = bool>);
-    tuple_class_reactive!(ArcMemo,<>, <bool>, ArcMemo<bool>: Get<Value = bool>);
-    tuple_class_reactive!(ArcSignal,<>, <bool>, ArcSignal<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcRwSignal,<>, <bool>, false, ArcRwSignal<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcReadSignal,<>, <bool>, false, ArcReadSignal<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcMemo,<>, <bool>, true, ArcMemo<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcSignal,<>, <bool>, true, ArcSignal<bool>: Get<Value = bool>);
 }
 
 #[cfg(feature = "reactive_stores")]
@@ -802,6 +820,7 @@ mod reactive_stores {
         Subfield,
         <Inner, Prev, V>,
         V,
+        false,
         Subfield<Inner, Prev, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -811,6 +830,7 @@ mod reactive_stores {
         AtKeyed,
         <Inner, Prev, K, V>,
         V,
+        false,
         AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -822,6 +842,7 @@ mod reactive_stores {
         KeyedSubfield,
         <Inner, Prev, K, V>,
         V,
+        false,
         KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -833,6 +854,7 @@ mod reactive_stores {
         DerefedField,
         <S>,
         <S::Value as Deref>::Target,
+        false,
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
@@ -841,6 +863,7 @@ mod reactive_stores {
         AtIndex,
         <Inner, Prev>,
         <Prev as Index<usize>>::Output,
+        false,
         AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
         Prev: Send + Sync + IndexMut<usize> + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -849,6 +872,7 @@ mod reactive_stores {
         Store,
         <V, S>,
         V,
+        false,
         Store<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -857,17 +881,19 @@ mod reactive_stores {
         Field,
         <V, S>,
         V,
+        false,
         Field<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    class_reactive!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
-    class_reactive!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
+    class_reactive!(ArcStore, <V>, V, false, ArcStore<V>: Get<Value = V>);
+    class_reactive!(ArcField, <V>, V, false, ArcField<V>: Get<Value = V>);
 
     tuple_class_reactive!(
         Subfield,
         <Inner, Prev>,
         <Inner, Prev, bool>,
+        false,
         Subfield<Inner, Prev, bool>: Get<Value = bool>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -877,6 +903,7 @@ mod reactive_stores {
         AtKeyed,
         <Inner, Prev, K>,
         <Inner, Prev, K, bool>,
+        false,
         AtKeyed<Inner, Prev, K, bool>: Get<Value = bool>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -888,6 +915,7 @@ mod reactive_stores {
         KeyedSubfield,
         <Inner, Prev, K>,
         <Inner, Prev, K, bool>,
+        false,
         KeyedSubfield<Inner, Prev, K, bool>: Get<Value = bool>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -899,6 +927,7 @@ mod reactive_stores {
         DerefedField,
         <S>,
         <S>,
+        false,
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref<Target = bool> + DerefMut
     );
@@ -907,6 +936,7 @@ mod reactive_stores {
         AtIndex,
         <Inner, Prev>,
         <Inner, Prev>,
+        false,
         AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
         Prev: Send + Sync + IndexMut<usize,Output = bool> + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -915,6 +945,7 @@ mod reactive_stores {
         Store,
         <S>,
         <bool, S>,
+        false,
         Store<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send  + 'static,
@@ -923,12 +954,13 @@ mod reactive_stores {
         Field,
         <S>,
         <bool, S>,
+        false,
         Field<bool, S>: Get<Value = bool>,
         S: Storage<bool>,
         S: Send  + 'static,
     );
-    tuple_class_reactive!(ArcStore,<>, <bool>, ArcStore<bool>: Get<Value = bool>);
-    tuple_class_reactive!(ArcField,<>, <bool>, ArcField<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcStore,<>, <bool>, false, ArcStore<bool>: Get<Value = bool>);
+    tuple_class_reactive!(ArcField,<>, <bool>, false, ArcField<bool>: Get<Value = bool>);
 }
 
 /*

--- a/tachys/src/reactive_graph/inner_html.rs
+++ b/tachys/src/reactive_graph/inner_html.rs
@@ -87,7 +87,7 @@ where
 }
 
 macro_rules! inner_html_reactive {
-    ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+    ($name:ident, <$($gen:ident),*>, $v:ty, $dry_resolve:literal, $( $where_clause:tt )*) =>
     {
         #[allow(deprecated)]
         impl<$($gen),*> InnerHtmlValue for $name<$($gen),*>
@@ -138,7 +138,11 @@ macro_rules! inner_html_reactive {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -165,6 +169,7 @@ mod stable {
         RwSignal,
         <V, S>,
         V,
+        false,
         RwSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -173,6 +178,7 @@ mod stable {
         ReadSignal,
         <V, S>,
         V,
+        false,
         ReadSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -181,6 +187,7 @@ mod stable {
         Memo,
         <V, S>,
         V,
+        true,
         Memo<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -189,6 +196,7 @@ mod stable {
         Signal,
         <V, S>,
         V,
+        true,
         Signal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -197,14 +205,15 @@ mod stable {
         MaybeSignal,
         <V, S>,
         V,
+        true,
         MaybeSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    inner_html_reactive!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
-    inner_html_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
-    inner_html_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
-    inner_html_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+    inner_html_reactive!(ArcRwSignal, <V>, V, false, ArcRwSignal<V>: Get<Value = V>);
+    inner_html_reactive!(ArcReadSignal, <V>, V, false, ArcReadSignal<V>: Get<Value = V>);
+    inner_html_reactive!(ArcMemo, <V>, V, true, ArcMemo<V>: Get<Value = V>);
+    inner_html_reactive!(ArcSignal, <V>, V, true, ArcSignal<V>: Get<Value = V>);
 }
 
 #[cfg(feature = "reactive_stores")]
@@ -222,6 +231,7 @@ mod reactive_stores {
         Subfield,
         <Inner, Prev, V>,
         V,
+        false,
         Subfield<Inner, Prev, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -231,6 +241,7 @@ mod reactive_stores {
         AtKeyed,
         <Inner, Prev, K, V>,
         V,
+        false,
         AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -242,6 +253,7 @@ mod reactive_stores {
         KeyedSubfield,
         <Inner, Prev, K, V>,
         V,
+        false,
         KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -253,6 +265,7 @@ mod reactive_stores {
         DerefedField,
         <S>,
         <S::Value as Deref>::Target,
+        false,
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
@@ -261,6 +274,7 @@ mod reactive_stores {
         AtIndex,
         <Inner, Prev>,
         <Prev as Index<usize>>::Output,
+        false,
         AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
         Prev: Send + Sync + IndexMut<usize> + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -269,6 +283,7 @@ mod reactive_stores {
         Store,
         <V, S>,
         V,
+        false,
         Store<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -277,10 +292,11 @@ mod reactive_stores {
         Field,
         <V, S>,
         V,
+        false,
         Field<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    inner_html_reactive!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
-    inner_html_reactive!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
+    inner_html_reactive!(ArcStore, <V>, V, false, ArcStore<V>: Get<Value = V>);
+    inner_html_reactive!(ArcField, <V>, V, false, ArcField<V>: Get<Value = V>);
 }

--- a/tachys/src/reactive_graph/mod.rs
+++ b/tachys/src/reactive_graph/mod.rs
@@ -801,7 +801,11 @@ macro_rules! reactive_impl {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -891,7 +895,7 @@ mod stable {
     );
     reactive_impl!(ArcRwSignal, <V>, V, false, ArcRwSignal<V>: Get<Value = V>);
     reactive_impl!(ArcReadSignal, <V>, V, false, ArcReadSignal<V>: Get<Value = V>);
-    reactive_impl!(ArcMemo, <V>, V, false, ArcMemo<V>: Get<Value = V>);
+    reactive_impl!(ArcMemo, <V>, V, true, ArcMemo<V>: Get<Value = V>);
     reactive_impl!(ArcSignal, <V>, V, true, ArcSignal<V>: Get<Value = V>);
 }
 

--- a/tachys/src/reactive_graph/style.rs
+++ b/tachys/src/reactive_graph/style.rs
@@ -207,7 +207,7 @@ where
 }
 
 macro_rules! style_reactive {
-    ($name:ident, <$($gen:ident),*>, $v:ty, $( $where_clause:tt )*) =>
+    ($name:ident, <$($gen:ident),*>, $v:ty, $dry_resolve:literal, $( $where_clause:tt )*) =>
     {
         #[allow(deprecated)]
         impl<$($gen),*> IntoStyle for $name<$($gen),*>
@@ -252,7 +252,11 @@ macro_rules! style_reactive {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -326,7 +330,11 @@ macro_rules! style_reactive {
                 self
             }
 
-            fn dry_resolve(&mut self) {}
+            fn dry_resolve(&mut self) {
+                if $dry_resolve {
+                    _ = self.get();
+                }
+            }
 
             async fn resolve(self) -> Self::AsyncOutput {
                 self
@@ -354,6 +362,7 @@ mod stable {
         RwSignal,
         <V, S>,
         V,
+        false,
         RwSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -362,6 +371,7 @@ mod stable {
         ReadSignal,
         <V, S>,
         V,
+        false,
         ReadSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -370,6 +380,7 @@ mod stable {
         Memo,
         <V, S>,
         V,
+        true,
         Memo<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -378,6 +389,7 @@ mod stable {
         Signal,
         <V, S>,
         V,
+        true,
         Signal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -386,14 +398,15 @@ mod stable {
         MaybeSignal,
         <V, S>,
         V,
+        true,
         MaybeSignal<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_reactive!(ArcRwSignal, <V>, V, ArcRwSignal<V>: Get<Value = V>);
-    style_reactive!(ArcReadSignal, <V>, V, ArcReadSignal<V>: Get<Value = V>);
-    style_reactive!(ArcMemo, <V>, V, ArcMemo<V>: Get<Value = V>);
-    style_reactive!(ArcSignal, <V>, V, ArcSignal<V>: Get<Value = V>);
+    style_reactive!(ArcRwSignal, <V>, V, false, ArcRwSignal<V>: Get<Value = V>);
+    style_reactive!(ArcReadSignal, <V>, V, false, ArcReadSignal<V>: Get<Value = V>);
+    style_reactive!(ArcMemo, <V>, V, true, ArcMemo<V>: Get<Value = V>);
+    style_reactive!(ArcSignal, <V>, V, true, ArcSignal<V>: Get<Value = V>);
 }
 
 #[cfg(feature = "reactive_stores")]
@@ -415,6 +428,7 @@ mod reactive_stores {
         Subfield,
         <Inner, Prev, V>,
         V,
+        false,
         Subfield<Inner, Prev, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -424,6 +438,7 @@ mod reactive_stores {
         AtKeyed,
         <Inner, Prev, K, V>,
         V,
+        false,
         AtKeyed<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -435,6 +450,7 @@ mod reactive_stores {
         KeyedSubfield,
         <Inner, Prev, K, V>,
         V,
+        false,
         KeyedSubfield<Inner, Prev, K, V>: Get<Value = V>,
         Prev: Send + Sync + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -446,6 +462,7 @@ mod reactive_stores {
         DerefedField,
         <S>,
         <S::Value as Deref>::Target,
+        false,
         S: Clone + StoreField + Send + Sync + 'static,
         <S as StoreField>::Value: Deref + DerefMut
     );
@@ -454,6 +471,7 @@ mod reactive_stores {
         AtIndex,
         <Inner, Prev>,
         <Prev as Index<usize>>::Output,
+        false,
         AtIndex<Inner, Prev>: Get<Value = Prev::Output>,
         Prev: Send + Sync + IndexMut<usize> + 'static,
         Inner: Send + Sync + Clone + 'static,
@@ -462,6 +480,7 @@ mod reactive_stores {
         Store,
         <V, S>,
         V,
+        false,
         Store<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
@@ -470,12 +489,13 @@ mod reactive_stores {
         Field,
         <V, S>,
         V,
+        false,
         Field<V, S>: Get<Value = V>,
         S: Storage<V> + Storage<Option<V>>,
         S: Send + Sync + 'static,
     );
-    style_reactive!(ArcStore, <V>, V, ArcStore<V>: Get<Value = V>);
-    style_reactive!(ArcField, <V>, V, ArcField<V>: Get<Value = V>);
+    style_reactive!(ArcStore, <V>, V, false, ArcStore<V>: Get<Value = V>);
+    style_reactive!(ArcField, <V>, V, false, ArcField<V>: Get<Value = V>);
 }
 /*
 impl<Fut> IntoStyle for Suspend<Fut>


### PR DESCRIPTION
This closes a gap in which resource reads were tracked using `dry_resolve`
1) inside element bodies, and
2) in derived signals used as attributes, but **not** in
3)  `Signal` and `Memo` values used as attributes

This allowed some inconsistencies between client and server state, and also issues like the one described in #4856.