### PR TITLE
fix(router): three route-matching panics / silent match failures

### DIFF
--- a/router/src/matching/horizontal/param_segments.rs
+++ b/router/src/matching/horizontal/param_segments.rs
@@ -42,29 +42,27 @@ impl PossibleRouteMatch for ParamSegment {
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let bytes = path.as_bytes();
         let has_leading_slash = bytes.first() == Some(&b'/');
-        // the first char of the path is always consumed before scanning, but
-        // only counts toward the match when it is the leading `/`
-        let (param_offset, scan_start) = if has_leading_slash {
-            (1, 1)
-        } else {
-            (0, path.chars().next().map(char::len_utf8).unwrap_or(0))
-        };
+        if !has_leading_slash && !path.is_empty() {
+            return None;
+        }
+        let offset = usize::from(has_leading_slash);
         // the param ends at the next `/`; `/` is ASCII, so scanning bytes is
         // equivalent to scanning chars without the UTF-8 decoding
-        let param_len = bytes[scan_start..]
+        let param_len = bytes[offset..]
             .iter()
             .position(|&byte| byte == b'/')
-            .unwrap_or(bytes.len() - scan_start);
-        let matched_len = param_offset + param_len;
+            .unwrap_or(bytes.len() - offset);
+        let matched_len = offset + param_len;
 
         if matched_len == 0 || (matched_len == 1 && has_leading_slash) {
             return None;
         }
 
+        debug_assert!(path.is_char_boundary(matched_len));
         let (matched, remaining) = path.split_at(matched_len);
         let param_value = vec![(
             Cow::Borrowed(self.0),
-            path[param_offset..param_len + param_offset].to_string(),
+            path[offset..param_len + offset].to_string(),
         )];
         Some(PartialPathMatch::new(remaining, param_value, matched))
     }
@@ -127,22 +125,20 @@ impl PossibleRouteMatch for WildcardSegment {
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let bytes = path.as_bytes();
         let has_leading_slash = bytes.first() == Some(&b'/');
-        // the first char of the path is always consumed before scanning, but
-        // only counts toward the match when it is the leading `/`
-        let (param_offset, scan_start) = if has_leading_slash {
-            (1, 1)
-        } else {
-            (0, path.chars().next().map(char::len_utf8).unwrap_or(0))
-        };
+        if !has_leading_slash && !path.is_empty() {
+            return None;
+        }
+        let offset = usize::from(has_leading_slash);
         // the wildcard consumes the entire remaining path, so no scan is
         // needed at all
-        let param_len = bytes.len() - scan_start;
-        let matched_len = param_offset + param_len;
+        let param_len = bytes.len() - offset;
+        let matched_len = offset + param_len;
 
+        debug_assert!(path.is_char_boundary(matched_len));
         let (matched, remaining) = path.split_at(matched_len);
         let param_value = iter::once((
             Cow::Borrowed(self.0),
-            path[param_offset..param_len + param_offset].to_string(),
+            path[offset..param_len + offset].to_string(),
         ));
         Some(PartialPathMatch::new(
             remaining,
@@ -167,32 +163,30 @@ impl PossibleRouteMatch for OptionalParamSegment {
     fn test<'a>(&self, path: &'a str) -> Option<PartialPathMatch<'a>> {
         let bytes = path.as_bytes();
         let has_leading_slash = bytes.first() == Some(&b'/');
-        // the first char of the path is always consumed before scanning, but
-        // only counts toward the match when it is the leading `/`
-        let (param_offset, scan_start) = if has_leading_slash {
-            (1, 1)
-        } else {
-            (0, path.chars().next().map(char::len_utf8).unwrap_or(0))
-        };
+        if !has_leading_slash && !path.is_empty() {
+            return Some(PartialPathMatch::new(path, Vec::new(), ""));
+        }
+        let offset = usize::from(has_leading_slash);
         // the param ends at the next `/`; `/` is ASCII, so scanning bytes is
         // equivalent to scanning chars without the UTF-8 decoding
-        let param_len = bytes[scan_start..]
+        let param_len = bytes[offset..]
             .iter()
             .position(|&byte| byte == b'/')
-            .unwrap_or(bytes.len() - scan_start);
-        let matched_len = param_offset + param_len;
+            .unwrap_or(bytes.len() - offset);
+        let matched_len = offset + param_len;
 
         let matched_len = if matched_len == 1 && has_leading_slash {
             0
         } else {
             matched_len
         };
+        debug_assert!(path.is_char_boundary(matched_len));
         let (matched, remaining) = path.split_at(matched_len);
         let param_value = (matched_len > 0)
             .then(|| {
                 (
                     Cow::Borrowed(self.0),
-                    path[param_offset..param_len + param_offset].to_string(),
+                    path[offset..param_len + offset].to_string(),
                 )
             })
             .into_iter()
@@ -277,6 +271,56 @@ mod tests {
         assert_eq!(matched.remaining(), "");
         let params = matched.params();
         assert_eq!(params[0], ("a".into(), "héllo".into()));
+    }
+
+    #[test]
+    fn non_slash_multi_byte_param_does_not_match() {
+        let def = ParamSegment("a");
+        for path in ["éx", "日本語"] {
+            assert!(def.test(path).is_none());
+        }
+    }
+
+    #[test]
+    fn non_slash_multi_byte_wildcard_does_not_match() {
+        let def = WildcardSegment("rest");
+        for path in ["éx", "日本語"] {
+            assert!(def.test(path).is_none());
+        }
+    }
+
+    #[test]
+    fn non_slash_multi_byte_optional_param_matches_nothing() {
+        let def = OptionalParamSegment("a");
+        for path in ["éx", "日本語"] {
+            let matched = def.test(path).expect("couldn't match route");
+            assert_eq!(matched.matched(), "");
+            assert_eq!(matched.remaining(), path);
+            assert!(matched.params().is_empty());
+        }
+    }
+
+    #[test]
+    fn non_slash_ascii_param_segments_do_not_match() {
+        assert!(ParamSegment("a").test("abc").is_none());
+        assert!(WildcardSegment("rest").test("abc").is_none());
+    }
+
+    #[test]
+    fn leading_slash_multi_byte_segments_match_fully() {
+        let path = "/é";
+        for matched in [
+            ParamSegment("a").test(path).expect("couldn't match route"),
+            WildcardSegment("rest")
+                .test(path)
+                .expect("couldn't match route"),
+            OptionalParamSegment("a")
+                .test(path)
+                .expect("couldn't match route"),
+        ] {
+            assert_eq!(matched.matched(), path);
+            assert_eq!(matched.remaining(), "");
+        }
     }
 
     #[test]

--- a/router/src/matching/mod.rs
+++ b/router/src/matching/mod.rs
@@ -60,12 +60,17 @@ where
         let path = match &self.base {
             None => path,
             Some(base) => {
-                let (base, path) = if base.starts_with('/') {
-                    (base.trim_start_matches('/'), path.trim_start_matches('/'))
+                let base = base.trim_matches('/');
+                if base.is_empty() {
+                    path
                 } else {
-                    (base.as_ref(), path)
-                };
-                path.strip_prefix(base)?
+                    let rest =
+                        path.trim_start_matches('/').strip_prefix(base)?;
+                    if !(rest.is_empty() || rest.starts_with('/')) {
+                        return None;
+                    }
+                    rest
+                }
             }
         };
 
@@ -359,6 +364,47 @@ mod tests {
         let matched = routes.match_route("/portfolio/contact/foobar").unwrap();
         let params = matched.to_params();
         assert_eq!(params, vec![("any".into(), "foobar".into())]);
+    }
+
+    #[test]
+    pub fn base_with_root_or_trailing_slash_matches() {
+        for (base, path) in [
+            ("/", "/about"),
+            ("/app/", "/app/about"),
+            ("/app", "/app/about"),
+            ("app", "/app/about"),
+            ("", "/about"),
+        ] {
+            let routes = RouteDefs::new_with_base(
+                NestedRoute::new(StaticSegment("about"), || ()),
+                base,
+            );
+            assert!(routes.match_route(path).is_some(), "base {base:?}");
+        }
+
+        let routes = RouteDefs::new_with_base(
+            NestedRoute::new(StaticSegment(""), || ()),
+            "/app",
+        );
+        assert!(routes.match_route("/app").is_some());
+
+        let routes = RouteDefs::new_with_base(
+            NestedRoute::new(ParamSegment("id"), || ()),
+            "/",
+        );
+        let matched = routes.match_route("/123").unwrap();
+        assert_eq!(matched.to_params(), vec![("id".into(), "123".into())]);
+    }
+
+    #[test]
+    pub fn base_must_match_whole_segment() {
+        let routes = RouteDefs::new_with_base(
+            NestedRoute::new(StaticSegment("about"), || ()),
+            "/app",
+        );
+
+        assert!(routes.match_route("/apple/about").is_none());
+        assert!(routes.match_route("/about").is_none());
     }
 
     #[test]

--- a/router/src/matching/nested/mod.rs
+++ b/router/src/matching/nested/mod.rs
@@ -260,7 +260,7 @@ where
                             let rematch = path.trim_end_matches(&format!(
                                 "{matched}{remaining}"
                             ));
-                            let new_partial = segments.test(rematch).unwrap();
+                            let new_partial = segments.test(rematch)?;
                             params = new_partial.params;
                         }
 
@@ -362,5 +362,38 @@ where
                 ))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NestedRoute;
+    use crate::{MatchParams, OptionalParamSegment, RouteDefs, StaticSegment};
+
+    #[test]
+    fn optional_fallback_rematch_failure_returns_none() {
+        let routes = RouteDefs::new(
+            NestedRoute::new(
+                (OptionalParamSegment("x"), StaticSegment("bar")),
+                || (),
+            )
+            .child(NestedRoute::new(StaticSegment("bar"), || ())),
+        );
+
+        assert!(routes.match_route("/bar").is_none());
+
+        let matched = routes
+            .match_route("/foo/bar/bar")
+            .expect("route should match with optional parameter");
+        assert_eq!(matched.to_params(), vec![("x".into(), "foo".into())]);
+
+        let optional_routes = RouteDefs::new(
+            NestedRoute::new(OptionalParamSegment("foo"), || ())
+                .child(NestedRoute::new(StaticSegment("bar"), || ())),
+        );
+        let matched = optional_routes
+            .match_route("/bar")
+            .expect("route should match without optional parameter");
+        assert!(matched.to_params().is_empty());
     }
 }


### PR DESCRIPTION
Fixes three bugs in `leptos_router`'s matching code, one commit each with a regression test.

- **Base stripping** (`RouteDefs::match_route`): `base="/"`, `"/app/"`, or `"app"` stripped the leading `/` the segment matchers rely on, so every route under such a base silently failed to match. The base is now trimmed of slashes and stripped only as a whole path segment; the remainder keeps its leading `/`.
- **UTF-8 boundary panic** (`ParamSegment`, `WildcardSegment`, `OptionalParamSegment`): a path without a leading `/` was scanned from after its first character but split from byte 0, so a multi-byte first character (`"éx"`, `"日本語"`) panicked in `split_at` and ASCII input lost its last character. Such paths now follow `StaticSegment`'s rule (no match; zero-length match for the optional segment), and a `debug_assert!` pins the char-boundary invariant.
- **Optional-segment fallback** (`NestedRoute::match_nested`): the re-parse after a child fallback called `.unwrap()`; `/:x?/bar` with child `bar` panicked on `/bar`. Now returns `None`.