### PR TITLE
fix(router): static optional params, `<Form>` submission fidelity, initial route build race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/leptos/src/form.rs
+++ b/leptos/src/form.rs
@@ -18,11 +18,37 @@ use tachys::{
     reactive_graph::node_ref::NodeRef,
 };
 use thiserror::Error;
-use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
-use web_sys::{
-    Event, FormData, HtmlButtonElement, HtmlFormElement, HtmlInputElement,
-    SubmitEvent,
-};
+use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt, prelude::wasm_bindgen};
+use web_sys::{Event, FormData, HtmlElement, HtmlFormElement, SubmitEvent};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = FormData, js_name = FormData)]
+    type FormDataWithSubmitter;
+
+    #[wasm_bindgen(constructor, catch, js_class = "FormData")]
+    fn new_with_form_and_submitter(
+        form: &HtmlFormElement,
+        submitter: &HtmlElement,
+    ) -> Result<FormDataWithSubmitter, JsValue>;
+}
+
+/// Builds the [`FormData`] for `form` as a native submission would, including
+/// the entry contributed by `submitter` (the button that triggered the
+/// submission). `new FormData(form)` alone leaves that entry out, so servers
+/// that branch on the button's `name`/`value` cannot tell which was activated.
+pub fn form_data_with_submitter(
+    form: &HtmlFormElement,
+    submitter: Option<&HtmlElement>,
+) -> Result<FormData, JsValue> {
+    match submitter {
+        Some(submitter) => {
+            FormDataWithSubmitter::new_with_form_and_submitter(form, submitter)
+                .map(|data| data.unchecked_into())
+        }
+        None => FormData::new_with_form(form),
+    }
+}
 
 /// Automatically turns a server [Action](leptos_server::Action) into an HTML
 /// [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form)
@@ -296,34 +322,10 @@ where
 fn form_data_from_event(
     ev: &SubmitEvent,
 ) -> Result<FormData, FromFormDataError> {
-    let submitter = ev.submitter();
-    let mut submitter_name_value = None;
-    let opt_form = match &submitter {
-        Some(el) => {
-            if let Some(form) = el.dyn_ref::<HtmlFormElement>() {
-                Some(form.clone())
-            } else if let Some(input) = el.dyn_ref::<HtmlInputElement>() {
-                submitter_name_value = Some((input.name(), input.value()));
-                Some(ev.target().unwrap().unchecked_into())
-            } else if let Some(button) = el.dyn_ref::<HtmlButtonElement>() {
-                submitter_name_value = Some((button.name(), button.value()));
-                Some(ev.target().unwrap().unchecked_into())
-            } else {
-                None
-            }
-        }
-        None => ev.target().map(|form| form.unchecked_into()),
-    };
-    match opt_form.as_ref().map(FormData::new_with_form) {
-        None => Err(FromFormDataError::MissingForm(ev.clone().into())),
-        Some(Err(e)) => Err(FromFormDataError::FormData(e)),
-        Some(Ok(form_data)) => {
-            if let Some((name, value)) = submitter_name_value {
-                form_data
-                    .append_with_str(&name, &value)
-                    .map_err(FromFormDataError::FormData)?;
-            }
-            Ok(form_data)
-        }
-    }
+    let form = ev
+        .target()
+        .and_then(|target| target.dyn_into::<HtmlFormElement>().ok())
+        .ok_or_else(|| FromFormDataError::MissingForm(ev.clone().into()))?;
+    form_data_with_submitter(&form, ev.submitter().as_ref())
+        .map_err(FromFormDataError::FormData)
 }

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -63,7 +63,13 @@ default-features = true
 rustc_version = { workspace = true, default-features = true }
 
 [dev-dependencies]
+leptos = { workspace = true, features = ["csr"] }
 wasm-bindgen-test = { workspace = true, default-features = true }
+
+[dev-dependencies.web-sys]
+features = ["Element", "HtmlElement", "Node"]
+workspace = true
+default-features = true
 
 [features]
 tracing = ["dep:tracing"]

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -41,9 +41,12 @@ features = [
   # Form
   "FormData",
   "HtmlButtonElement",
+  "HtmlElement",
   "HtmlFormElement",
   "HtmlInputElement",
+  "Node",
   "SubmitEvent",
+  "SubmitEventInit",
   "Url",
   "UrlSearchParams",
   # Fetching in Hydrate Mode
@@ -58,6 +61,9 @@ default-features = true
 
 [build-dependencies]
 rustc_version = { workspace = true, default-features = true }
+
+[dev-dependencies]
+wasm-bindgen-test = { workspace = true, default-features = true }
 
 [features]
 tracing = ["dep:tracing"]

--- a/router/src/flat_router.rs
+++ b/router/src/flat_router.rs
@@ -162,6 +162,7 @@ where
                         matched,
                     })),
                     None => {
+                        let spawned_owner = owner.clone();
                         let state =
                             Rc::new(RefCell::new(FlatRoutesViewState {
                                 view: ().into_any().build(),
@@ -177,8 +178,12 @@ where
                             let state = Rc::clone(&state);
                             async move {
                                 let view = view.await;
-                                view.into_any()
-                                    .rebuild(&mut state.borrow_mut().view);
+                                let is_current =
+                                    state.borrow().owner == spawned_owner;
+                                if is_current {
+                                    view.into_any()
+                                        .rebuild(&mut state.borrow_mut().view);
+                                }
                             }
                         });
 

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -6,24 +6,12 @@ use crate::{
 };
 use leptos::{ev, html::form, logging::*, prelude::*, task::spawn_local};
 use std::{error::Error, sync::Arc};
-use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt, prelude::wasm_bindgen};
+use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use web_sys::{FormData, RequestRedirect, Response};
 
 type OnFormData = Arc<dyn Fn(&FormData)>;
 type OnResponse = Arc<dyn Fn(&Response)>;
 type OnError = Arc<dyn Fn(&gloo_net::Error)>;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(extends = web_sys::FormData, js_name = FormData)]
-    type FormDataWithSubmitter;
-
-    #[wasm_bindgen(constructor, catch, js_class = "FormData")]
-    fn new_with_form_and_submitter(
-        form: &web_sys::HtmlFormElement,
-        submitter: &web_sys::HtmlElement,
-    ) -> Result<FormDataWithSubmitter, JsValue>;
-}
 
 /// An HTML [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) progressively
 /// enhanced to use client-side routing.
@@ -134,8 +122,11 @@ where
                     return;
                 }
 
-                let submitter = ev.submitter();
-                let form_data = form_data(&form, submitter.as_ref());
+                let form_data = leptos::form::form_data_with_submitter(
+                    &form,
+                    ev.submitter().as_ref(),
+                )
+                .unwrap_throw();
                 if let Some(on_form_data) = on_form_data.clone() {
                     on_form_data(&form_data);
                 }
@@ -370,25 +361,6 @@ fn is_same_origin(action: &str) -> bool {
     .unwrap_or(false)
 }
 
-fn form_data(
-    form: &web_sys::HtmlFormElement,
-    submitter: Option<&web_sys::HtmlElement>,
-) -> FormData {
-    let with_submitter = submitter
-        .filter(|submitter| {
-            submitter.dyn_ref::<web_sys::HtmlButtonElement>().is_some()
-                || submitter.dyn_ref::<web_sys::HtmlInputElement>().is_some()
-        })
-        .and_then(|submitter| {
-            FormDataWithSubmitter::new_with_form_and_submitter(form, submitter)
-                .ok()
-        })
-        .map(|data| data.unchecked_into::<FormData>());
-
-    with_submitter
-        .unwrap_or_else(|| FormData::new_with_form(form).unwrap_throw())
-}
-
 fn extract_form_attributes(
     ev: &web_sys::Event,
 ) -> Option<(web_sys::HtmlFormElement, String, String, String)> {
@@ -505,7 +477,8 @@ fn extract_form_attributes(
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use super::{extract_form_attributes, form_data, is_same_origin};
+    use super::{extract_form_attributes, is_same_origin};
+    use leptos::form::form_data_with_submitter;
     use std::{cell::RefCell, rc::Rc};
     use wasm_bindgen::{JsCast, UnwrapThrowExt, closure::Closure};
     use wasm_bindgen_test::*;
@@ -646,8 +619,11 @@ mod wasm_tests {
         form.append_child(&save).unwrap_throw();
         form.append_child(&delete).unwrap_throw();
 
-        let submitted = form_data(&form, Some(delete.unchecked_ref()));
-        let without_submitter = form_data(&form, None);
+        let submitted =
+            form_data_with_submitter(&form, Some(delete.unchecked_ref()))
+                .unwrap_throw();
+        let without_submitter =
+            form_data_with_submitter(&form, None).unwrap_throw();
         let intents = submitted.get_all("intent");
         let empty_intents = without_submitter.get_all("intent");
         form.remove();

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -6,12 +6,24 @@ use crate::{
 };
 use leptos::{ev, html::form, logging::*, prelude::*, task::spawn_local};
 use std::{error::Error, sync::Arc};
-use wasm_bindgen::{JsCast, UnwrapThrowExt};
+use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt, prelude::wasm_bindgen};
 use web_sys::{FormData, RequestRedirect, Response};
 
 type OnFormData = Arc<dyn Fn(&FormData)>;
 type OnResponse = Arc<dyn Fn(&Response)>;
 type OnError = Arc<dyn Fn(&gloo_net::Error)>;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = web_sys::FormData, js_name = FormData)]
+    type FormDataWithSubmitter;
+
+    #[wasm_bindgen(constructor, catch, js_class = "FormData")]
+    fn new_with_form_and_submitter(
+        form: &web_sys::HtmlFormElement,
+        submitter: &web_sys::HtmlElement,
+    ) -> Result<FormDataWithSubmitter, JsValue>;
+}
 
 /// An HTML [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) progressively
 /// enhanced to use client-side routing.
@@ -118,8 +130,8 @@ where
                     return;
                 };
 
-                let form_data =
-                    web_sys::FormData::new_with_form(&form).unwrap_throw();
+                let submitter = ev.submitter();
+                let form_data = form_data(&form, submitter.as_ref());
                 if let Some(on_form_data) = on_form_data.clone() {
                     on_form_data(&form_data);
                 }
@@ -346,6 +358,25 @@ fn current_window_origin() -> String {
     )
 }
 
+fn form_data(
+    form: &web_sys::HtmlFormElement,
+    submitter: Option<&web_sys::HtmlElement>,
+) -> FormData {
+    let with_submitter = submitter
+        .filter(|submitter| {
+            submitter.dyn_ref::<web_sys::HtmlButtonElement>().is_some()
+                || submitter.dyn_ref::<web_sys::HtmlInputElement>().is_some()
+        })
+        .and_then(|submitter| {
+            FormDataWithSubmitter::new_with_form_and_submitter(form, submitter)
+                .ok()
+        })
+        .map(|data| data.unchecked_into::<FormData>());
+
+    with_submitter
+        .unwrap_or_else(|| FormData::new_with_form(form).unwrap_throw())
+}
+
 fn extract_form_attributes(
     ev: &web_sys::Event,
 ) -> Option<(web_sys::HtmlFormElement, String, String, String)> {
@@ -462,7 +493,7 @@ fn extract_form_attributes(
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use super::extract_form_attributes;
+    use super::{extract_form_attributes, form_data};
     use std::{cell::RefCell, rc::Rc};
     use wasm_bindgen::{JsCast, UnwrapThrowExt, closure::Closure};
     use wasm_bindgen_test::*;
@@ -589,5 +620,28 @@ mod wasm_tests {
             (method.as_str(), action.as_str(), enctype.as_str()),
             ("post", "/InputAction", "text/plain")
         );
+    }
+
+    #[wasm_bindgen_test]
+    fn form_data_includes_only_the_activated_submitter() {
+        let form = append_form();
+        let save = element::<HtmlButtonElement>("button");
+        save.set_attribute("name", "intent").unwrap_throw();
+        save.set_attribute("value", "save").unwrap_throw();
+        let delete = element::<HtmlButtonElement>("button");
+        delete.set_attribute("name", "intent").unwrap_throw();
+        delete.set_attribute("value", "delete").unwrap_throw();
+        form.append_child(&save).unwrap_throw();
+        form.append_child(&delete).unwrap_throw();
+
+        let submitted = form_data(&form, Some(delete.unchecked_ref()));
+        let without_submitter = form_data(&form, None);
+        let intents = submitted.get_all("intent");
+        let empty_intents = without_submitter.get_all("intent");
+        form.remove();
+
+        assert_eq!(intents.length(), 1);
+        assert_eq!(intents.get(0).as_string().as_deref(), Some("delete"));
+        assert_eq!(empty_intents.length(), 0);
     }
 }

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -27,6 +27,7 @@ extern "C" {
 
 /// An HTML [`form`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) progressively
 /// enhanced to use client-side routing.
+/// Cross-origin actions fall back to the browser's native form submission.
 #[component]
 pub fn Form<A>(
     /// [`method`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method)
@@ -129,6 +130,9 @@ where
                 else {
                     return;
                 };
+                if !is_same_origin(&action) {
+                    return;
+                }
 
                 let submitter = ev.submitter();
                 let form_data = form_data(&form, submitter.as_ref());
@@ -358,6 +362,14 @@ fn current_window_origin() -> String {
     )
 }
 
+fn is_same_origin(action: &str) -> bool {
+    <crate::location::BrowserUrl as crate::location::LocationProvider>::parse(
+        action,
+    )
+    .map(|url| url.origin() == current_window_origin())
+    .unwrap_or(false)
+}
+
 fn form_data(
     form: &web_sys::HtmlFormElement,
     submitter: Option<&web_sys::HtmlElement>,
@@ -493,7 +505,7 @@ fn extract_form_attributes(
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use super::{extract_form_attributes, form_data};
+    use super::{extract_form_attributes, form_data, is_same_origin};
     use std::{cell::RefCell, rc::Rc};
     use wasm_bindgen::{JsCast, UnwrapThrowExt, closure::Closure};
     use wasm_bindgen_test::*;
@@ -643,5 +655,19 @@ mod wasm_tests {
         assert_eq!(intents.length(), 1);
         assert_eq!(intents.get(0).as_string().as_deref(), Some("delete"));
         assert_eq!(empty_intents.length(), 0);
+    }
+
+    #[wasm_bindgen_test]
+    fn form_actions_are_classified_by_origin() {
+        let location = leptos::prelude::window().location();
+        let origin = location.origin().unwrap_throw();
+        let hostname = location.hostname().unwrap_throw();
+
+        assert!(is_same_origin(""));
+        assert!(is_same_origin("/x"));
+        assert!(is_same_origin("?q=1"));
+        assert!(is_same_origin(&format!("{origin}/x")));
+        assert!(!is_same_origin("http://example.com/x"));
+        assert!(!is_same_origin(&format!("https://{hostname}:1/x")));
     }
 }

--- a/router/src/form.rs
+++ b/router/src/form.rs
@@ -374,21 +374,28 @@ fn extract_form_attributes(
                     .unchecked_into::<web_sys::HtmlFormElement>();
                 Some((
                     form.clone(),
-                    input.get_attribute("method").unwrap_or_else(|| {
-                        form.get_attribute("method")
-                            .unwrap_or_else(|| "get".to_string())
-                            .to_lowercase()
-                    }),
-                    input.get_attribute("action").unwrap_or_else(|| {
+                    input
+                        .get_attribute("formmethod")
+                        .map(|method| method.to_lowercase())
+                        .unwrap_or_else(|| {
+                            form.get_attribute("method")
+                                .unwrap_or_else(|| "get".to_string())
+                                .to_lowercase()
+                        }),
+                    input.get_attribute("formaction").unwrap_or_else(|| {
                         form.get_attribute("action").unwrap_or_default()
                     }),
-                    input.get_attribute("enctype").unwrap_or_else(|| {
-                        form.get_attribute("enctype")
-                            .unwrap_or_else(|| {
-                                "application/x-www-form-urlencoded".to_string()
-                            })
-                            .to_lowercase()
-                    }),
+                    input
+                        .get_attribute("formenctype")
+                        .map(|enctype| enctype.to_lowercase())
+                        .unwrap_or_else(|| {
+                            form.get_attribute("enctype")
+                                .unwrap_or_else(|| {
+                                    "application/x-www-form-urlencoded"
+                                        .to_string()
+                                })
+                                .to_lowercase()
+                        }),
                 ))
             } else if let Some(button) =
                 el.dyn_ref::<web_sys::HtmlButtonElement>()
@@ -399,21 +406,28 @@ fn extract_form_attributes(
                     .unchecked_into::<web_sys::HtmlFormElement>();
                 Some((
                     form.clone(),
-                    button.get_attribute("method").unwrap_or_else(|| {
-                        form.get_attribute("method")
-                            .unwrap_or_else(|| "get".to_string())
-                            .to_lowercase()
-                    }),
-                    button.get_attribute("action").unwrap_or_else(|| {
+                    button
+                        .get_attribute("formmethod")
+                        .map(|method| method.to_lowercase())
+                        .unwrap_or_else(|| {
+                            form.get_attribute("method")
+                                .unwrap_or_else(|| "get".to_string())
+                                .to_lowercase()
+                        }),
+                    button.get_attribute("formaction").unwrap_or_else(|| {
                         form.get_attribute("action").unwrap_or_default()
                     }),
-                    button.get_attribute("enctype").unwrap_or_else(|| {
-                        form.get_attribute("enctype")
-                            .unwrap_or_else(|| {
-                                "application/x-www-form-urlencoded".to_string()
-                            })
-                            .to_lowercase()
-                    }),
+                    button
+                        .get_attribute("formenctype")
+                        .map(|enctype| enctype.to_lowercase())
+                        .unwrap_or_else(|| {
+                            form.get_attribute("enctype")
+                                .unwrap_or_else(|| {
+                                    "application/x-www-form-urlencoded"
+                                        .to_string()
+                                })
+                                .to_lowercase()
+                        }),
                 ))
             } else {
                 leptos::logging::debug_warn!(
@@ -443,5 +457,137 @@ fn extract_form_attributes(
                 ))
             }
         },
+    }
+}
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_tests {
+    use super::extract_form_attributes;
+    use std::{cell::RefCell, rc::Rc};
+    use wasm_bindgen::{JsCast, UnwrapThrowExt, closure::Closure};
+    use wasm_bindgen_test::*;
+    use web_sys::{
+        Event, HtmlButtonElement, HtmlElement, HtmlFormElement,
+        HtmlInputElement, SubmitEvent, SubmitEventInit,
+    };
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn element<T: JsCast>(tag: &str) -> T {
+        leptos::prelude::document()
+            .create_element(tag)
+            .unwrap_throw()
+            .unchecked_into()
+    }
+
+    fn append_form() -> HtmlFormElement {
+        let form = element::<HtmlFormElement>("form");
+        leptos::prelude::document()
+            .body()
+            .unwrap_throw()
+            .append_child(&form)
+            .unwrap_throw();
+        form
+    }
+
+    fn extracted_attributes(
+        form: &HtmlFormElement,
+        submitter: &HtmlElement,
+    ) -> (HtmlFormElement, String, String, String) {
+        let init = SubmitEventInit::new();
+        init.set_submitter(Some(submitter));
+        let event = SubmitEvent::new_with_event_init_dict("submit", &init)
+            .unwrap_throw();
+        let attributes = Rc::new(RefCell::new(None));
+        let captured = Rc::clone(&attributes);
+        let listener = Closure::<dyn Fn(Event)>::new(move |event| {
+            *captured.borrow_mut() = extract_form_attributes(&event);
+        });
+        form.add_event_listener_with_callback(
+            "submit",
+            listener.as_ref().unchecked_ref(),
+        )
+        .unwrap_throw();
+        form.dispatch_event(&event).unwrap_throw();
+        form.remove_event_listener_with_callback(
+            "submit",
+            listener.as_ref().unchecked_ref(),
+        )
+        .unwrap_throw();
+        attributes.take().unwrap_throw()
+    }
+
+    #[wasm_bindgen_test]
+    fn button_submitter_overrides_form_attributes() {
+        let form = append_form();
+        form.set_attribute("method", "get").unwrap_throw();
+        form.set_attribute("action", "/preview").unwrap_throw();
+        form.set_attribute("enctype", "application/x-www-form-urlencoded")
+            .unwrap_throw();
+        let button = element::<HtmlButtonElement>("button");
+        button.set_attribute("type", "submit").unwrap_throw();
+        button.set_attribute("formmethod", "POST").unwrap_throw();
+        button
+            .set_attribute("formaction", "/DeleteCase")
+            .unwrap_throw();
+        button
+            .set_attribute("formenctype", "TEXT/PLAIN")
+            .unwrap_throw();
+        form.append_child(&button).unwrap_throw();
+
+        let (_, method, action, enctype) =
+            extracted_attributes(&form, button.unchecked_ref());
+        form.remove();
+
+        assert_eq!(
+            (method.as_str(), action.as_str(), enctype.as_str()),
+            ("post", "/DeleteCase", "text/plain")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn submitter_without_overrides_uses_form_attributes() {
+        let form = append_form();
+        form.set_attribute("method", "POST").unwrap_throw();
+        form.set_attribute("action", "/items").unwrap_throw();
+        form.set_attribute("enctype", "TEXT/PLAIN").unwrap_throw();
+        let button = element::<HtmlButtonElement>("button");
+        button.set_attribute("type", "submit").unwrap_throw();
+        form.append_child(&button).unwrap_throw();
+
+        let (_, method, action, enctype) =
+            extracted_attributes(&form, button.unchecked_ref());
+        form.remove();
+
+        assert_eq!(
+            (method.as_str(), action.as_str(), enctype.as_str()),
+            ("post", "/items", "text/plain")
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn input_submitter_overrides_form_attributes() {
+        let form = append_form();
+        form.set_attribute("method", "get").unwrap_throw();
+        form.set_attribute("action", "/preview").unwrap_throw();
+        let input = element::<HtmlInputElement>("input");
+        input.set_attribute("type", "submit").unwrap_throw();
+        input.set_attribute("formmethod", "POST").unwrap_throw();
+        input
+            .set_attribute("formaction", "/InputAction")
+            .unwrap_throw();
+        input
+            .set_attribute("formenctype", "TEXT/PLAIN")
+            .unwrap_throw();
+        form.append_child(&input).unwrap_throw();
+
+        let (_, method, action, enctype) =
+            extracted_attributes(&form, input.unchecked_ref());
+        form.remove();
+
+        assert_eq!(
+            (method.as_str(), action.as_str(), enctype.as_str()),
+            ("post", "/InputAction", "text/plain")
+        );
     }
 }

--- a/router/src/nested_router.rs
+++ b/router/src/nested_router.rs
@@ -127,15 +127,22 @@ where
             }
         };
 
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        let abort_navigation = ArcStoredValue::new(Some(abort_handle));
         Executor::spawn_local({
             let view = Rc::clone(&view);
             let loaders = mem::take(&mut loaders);
+            let abort_navigation = abort_navigation.clone();
             ScopedFuture::new(async move {
-                let triggers = join_all(loaders).await;
-                for trigger in triggers {
-                    trigger.notify();
+                let triggers =
+                    Abortable::new(join_all(loaders), abort_registration).await;
+                if let Ok(triggers) = triggers {
+                    _ = abort_navigation.write_value().take();
+                    for trigger in triggers {
+                        trigger.notify();
+                    }
+                    matched_view.rebuild(&mut *view.borrow_mut());
                 }
-                matched_view.rebuild(&mut *view.borrow_mut());
             })
         });
 
@@ -145,7 +152,7 @@ where
             outlets,
             view,
             outer_owner,
-            abort_navigation: Default::default(),
+            abort_navigation,
         }
     }
 
@@ -247,8 +254,9 @@ where
                     }
                 });
 
-                // if it was on the fallback, show the view instead
-                if matches!(state.view.borrow().state, EitherOf3::B(_)) {
+                // if the top-level outlet is not rendered yet (fallback, or
+                // the initial load was still pending), show the view instead
+                if !matches!(state.view.borrow().state, EitherOf3::C(_)) {
                     EitherOf3::<(), Fal, AnyView>::C(top_level_outlet(
                         &state.outlets,
                         &self.outer_owner,

--- a/router/src/static_routes.rs
+++ b/router/src/static_routes.rs
@@ -259,7 +259,28 @@ impl StaticPath {
                     }
                     paths = new_paths;
                 }
-                OptionalParam(_) => todo!(),
+                OptionalParam(name) => {
+                    let mut new_paths = vec![];
+                    for path in paths {
+                        new_paths.push(path.clone());
+                        if let Some(params) =
+                            params.as_ref().and_then(|params| params.get(name))
+                        {
+                            for val in params.iter() {
+                                new_paths.push(if val.starts_with("/") {
+                                    ResolvedStaticPath {
+                                        path: format!("{}{}", path.path, val),
+                                    }
+                                } else {
+                                    ResolvedStaticPath {
+                                        path: format!("{}/{}", path.path, val),
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    paths = new_paths;
+                }
             }
         }
         paths
@@ -460,6 +481,73 @@ mod tests {
             vec![
                 ResolvedStaticPath::new("/post/first"),
                 ResolvedStaticPath::new("/post/second")
+            ]
+        );
+    }
+
+    #[test]
+    fn static_path_segments_into_path_optional_param_without_params() {
+        let segments = StaticPath::new(vec![
+            PathSegment::Static("/blog".into()),
+            PathSegment::OptionalParam("slug".into()),
+        ]);
+        assert_eq!(
+            segments.into_paths(None),
+            vec![ResolvedStaticPath::new("/blog")]
+        );
+    }
+
+    #[test]
+    fn static_path_segments_into_path_optional_param_with_values() {
+        let mut params = StaticParamsMap::new();
+        params
+            .0
+            .push(("slug".into(), vec!["first".into(), "second".into()]));
+        let segments = StaticPath::new(vec![
+            PathSegment::Static("/blog".into()),
+            PathSegment::OptionalParam("slug".into()),
+        ]);
+        assert_eq!(
+            segments.into_paths(Some(params)),
+            vec![
+                ResolvedStaticPath::new("/blog"),
+                ResolvedStaticPath::new("/blog/first"),
+                ResolvedStaticPath::new("/blog/second")
+            ]
+        );
+    }
+
+    #[test]
+    fn static_path_segments_into_path_optional_param_no_double_slash() {
+        let mut params = StaticParamsMap::new();
+        params.0.push(("slug".into(), vec!["/first".into()]));
+        let segments = StaticPath::new(vec![
+            PathSegment::Static("/blog".into()),
+            PathSegment::OptionalParam("slug".into()),
+        ]);
+        assert_eq!(
+            segments.into_paths(Some(params)),
+            vec![
+                ResolvedStaticPath::new("/blog"),
+                ResolvedStaticPath::new("/blog/first")
+            ]
+        );
+    }
+
+    #[test]
+    fn static_path_segments_into_path_optional_param_before_static() {
+        let mut params = StaticParamsMap::new();
+        params.0.push(("slug".into(), vec!["first".into()]));
+        let segments = StaticPath::new(vec![
+            PathSegment::Static("/blog".into()),
+            PathSegment::OptionalParam("slug".into()),
+            PathSegment::Static("edit".into()),
+        ]);
+        assert_eq!(
+            segments.into_paths(Some(params)),
+            vec![
+                ResolvedStaticPath::new("/blog/edit"),
+                ResolvedStaticPath::new("/blog/first/edit")
             ]
         );
     }

--- a/router/tests/initial_route_build_race.rs
+++ b/router/tests/initial_route_build_race.rs
@@ -1,0 +1,203 @@
+#![cfg(target_arch = "wasm32")]
+
+use futures::channel::oneshot;
+use leptos::{mount::mount_to, prelude::*};
+use leptos_router::{
+    Lazy, LazyRoute, NavigateOptions, StaticSegment,
+    components::{FlatRoutes, Route, Router, Routes},
+    hooks::use_navigate,
+};
+use std::cell::RefCell;
+use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::HtmlElement;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+type Navigate = Box<dyn Fn(&str, NavigateOptions)>;
+
+thread_local! {
+    static CHUNK_WAITERS: RefCell<Vec<oneshot::Sender<()>>> =
+        const { RefCell::new(Vec::new()) };
+    static NAVIGATE: RefCell<Option<Navigate>> = const { RefCell::new(None) };
+}
+
+struct SlowC;
+
+/// Stands in for the wasm chunk of a `#[lazy]` route: both `preload` (used
+/// by `<Routes>`) and `view` (used by `<FlatRoutes>`) wait until the test
+/// releases it.
+async fn await_chunk() {
+    let (sender, receiver) = oneshot::channel();
+    CHUNK_WAITERS.with(|waiters| waiters.borrow_mut().push(sender));
+    _ = receiver.await;
+}
+
+impl LazyRoute for SlowC {
+    fn data() -> Self {
+        Self
+    }
+
+    async fn view(_this: Self) -> AnyView {
+        await_chunk().await;
+        view! { <p id="view-c">"View C"</p> }.into_any()
+    }
+
+    async fn preload() {
+        await_chunk().await;
+    }
+}
+
+#[component]
+fn CaptureNavigate() -> impl IntoView {
+    let navigate = use_navigate();
+    NAVIGATE.with(|slot| *slot.borrow_mut() = Some(Box::new(navigate)));
+}
+
+#[component]
+fn ViewB() -> impl IntoView {
+    view! { <p id="view-b">"View B"</p> }
+}
+
+fn replace_url(path: &str) {
+    web_sys::window()
+        .unwrap_throw()
+        .history()
+        .unwrap_throw()
+        .replace_state_with_url(&JsValue::NULL, "", Some(path))
+        .unwrap_throw();
+}
+
+fn mount_point() -> HtmlElement {
+    let document = web_sys::window().unwrap_throw().document().unwrap_throw();
+    let root = document
+        .create_element("div")
+        .unwrap_throw()
+        .dyn_into::<HtmlElement>()
+        .unwrap_throw();
+    document
+        .body()
+        .unwrap_throw()
+        .append_child(&root)
+        .unwrap_throw();
+    root
+}
+
+fn has(root: &HtmlElement, selector: &str) -> bool {
+    root.query_selector(selector).unwrap_throw().is_some()
+}
+
+fn navigate_to_b() -> Result<(), &'static str> {
+    NAVIGATE.with(|slot| {
+        let slot = slot.borrow();
+        let navigate = slot.as_ref().ok_or("navigate hook was not captured")?;
+        navigate("/b", Default::default());
+        Ok(())
+    })
+}
+
+fn resolve_slow_c() -> Result<(), &'static str> {
+    CHUNK_WAITERS.with(|waiters| {
+        let waiters = std::mem::take(&mut *waiters.borrow_mut());
+        if waiters.is_empty() {
+            return Err("slow route was not started");
+        }
+        for sender in waiters {
+            _ = sender.send(());
+        }
+        Ok(())
+    })
+}
+
+async fn settle() {
+    for _ in 0..4 {
+        leptos::task::tick().await;
+    }
+}
+
+fn check(condition: bool, message: &'static str) -> Result<(), &'static str> {
+    condition.then_some(()).ok_or(message)
+}
+
+fn cleanup(root: &HtmlElement) {
+    root.remove();
+    replace_url("/");
+    NAVIGATE.with(|slot| *slot.borrow_mut() = None);
+    CHUNK_WAITERS.with(|waiters| waiters.borrow_mut().clear());
+}
+
+#[wasm_bindgen_test(async)]
+async fn flat_routes_initial_view_does_not_replace_newer_navigation() {
+    replace_url("/c");
+    let root = mount_point();
+    let mounted = mount_to(root.clone(), || {
+        view! {
+            <Router>
+                <CaptureNavigate/>
+                <FlatRoutes fallback=|| "not found">
+                    <Route path=StaticSegment("c") view={Lazy::<SlowC>::new()}/>
+                    <Route path=StaticSegment("b") view=ViewB/>
+                </FlatRoutes>
+            </Router>
+        }
+    });
+
+    let result = async {
+        settle().await;
+        check(!has(&root, "#view-b"), "view B appeared before navigation")?;
+        check(!has(&root, "#view-c"), "pending view C appeared")?;
+        navigate_to_b()?;
+        settle().await;
+        check(
+            has(&root, "#view-b"),
+            "view B did not appear after navigation",
+        )?;
+        resolve_slow_c()?;
+        settle().await;
+        check(has(&root, "#view-b"), "view B was replaced by stale view C")?;
+        check(!has(&root, "#view-c"), "stale view C appeared")
+    }
+    .await;
+
+    drop(mounted);
+    cleanup(&root);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[wasm_bindgen_test(async)]
+async fn nested_routes_initial_view_does_not_replace_newer_navigation() {
+    replace_url("/c");
+    let root = mount_point();
+    let mounted = mount_to(root.clone(), || {
+        view! {
+            <Router>
+                <CaptureNavigate/>
+                <Routes fallback=|| "not found">
+                    <Route path=StaticSegment("c") view={Lazy::<SlowC>::new()}/>
+                    <Route path=StaticSegment("b") view=ViewB/>
+                </Routes>
+            </Router>
+        }
+    });
+
+    let result = async {
+        settle().await;
+        check(!has(&root, "#view-b"), "view B appeared before navigation")?;
+        check(!has(&root, "#view-c"), "pending view C appeared")?;
+        navigate_to_b()?;
+        settle().await;
+        check(
+            has(&root, "#view-b"),
+            "view B did not appear after navigation",
+        )?;
+        resolve_slow_c()?;
+        settle().await;
+        check(has(&root, "#view-b"), "view B was replaced by stale view C")?;
+        check(!has(&root, "#view-c"), "stale view C appeared")
+    }
+    .await;
+
+    drop(mounted);
+    cleanup(&root);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}


### PR DESCRIPTION
Fixes five bugs in `leptos_router`:

- **Static generation panicked on optional params** — `StaticPath::into_paths` had a `todo!()` for `OptionalParam`; it now expands to the path without the parameter plus one path per configured value.
- **`<Form>` ignored submit-button overrides** — reads `formmethod`/`formaction`/`formenctype` (was `method`/`action`/`enctype`, which are not valid on buttons).
- **`<Form>` dropped the clicked button from the data** — `FormData` is now built with the submitter, so `name=value` of the activated button is sent like a native submit.
- **`<Form>` turned cross-origin POSTs into CORS `fetch`es** — cross-origin actions now fall back to the browser's native submission instead of a request that can succeed server-side but fail client-side.
- **Initial route build could clobber a newer navigation** — on a client-side mount, a slow first (lazy) route could overwrite the route the user had already navigated to (`<FlatRoutes>`) or prevent it from rendering at all (`<Routes>`). The initial build now checks it is still current / is cancelled by the first navigation.