### PR TITLE
fix(server_fn): eight panics, leaks and protocol bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4218,6 +4218,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/examples/server_fns_axum/src/middleware.rs
+++ b/examples/server_fns_axum/src/middleware.rs
@@ -18,6 +18,7 @@ impl<S> Layer<S> for LoggingLayer {
     }
 }
 
+#[derive(Clone)]
 pub struct LoggingService<T> {
     inner: T,
 }

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -101,6 +101,18 @@ rustc_version = { workspace = true, default-features = true }
 [dev-dependencies]
 trybuild = { workspace = true, default-features = true }
 
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+tokio = { workspace = true, features = [
+  "macros",
+  "rt-multi-thread",
+  "net",
+  "time",
+  "sync",
+] }
+axum = { workspace = true, default-features = true, features = ["ws"] }
+tokio-tungstenite = { workspace = true }
+serde_json = { workspace = true }
+
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true, default-features = true }
 

--- a/server_fn/Cargo.toml
+++ b/server_fn/Cargo.toml
@@ -112,6 +112,7 @@ tokio = { workspace = true, features = [
 axum = { workspace = true, default-features = true, features = ["ws"] }
 tokio-tungstenite = { workspace = true }
 serde_json = { workspace = true }
+tower = { workspace = true, features = ["limit", "util"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = { workspace = true, default-features = true }

--- a/server_fn/src/codec/stream.rs
+++ b/server_fn/src/codec/stream.rs
@@ -206,6 +206,69 @@ where
     }
 }
 
+fn utf8_error<E: FromServerFnError>(error: std::str::Utf8Error) -> E {
+    E::from_server_fn_error(ServerFnErrorErr::Deserialization(
+        error.to_string(),
+    ))
+}
+
+fn decode_text_stream<E>(
+    stream: impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
+) -> impl Stream<Item = Result<String, E>> + Send
+where
+    E: FromServerFnError,
+{
+    futures::stream::unfold(
+        (Box::pin(stream.fuse()), Vec::new()),
+        |(mut stream, mut buffer)| async move {
+            loop {
+                match stream.next().await {
+                    Some(Ok(bytes)) => {
+                        buffer.extend_from_slice(&bytes);
+                        match std::str::from_utf8(&buffer) {
+                            Ok("") => continue,
+                            Ok(text) => {
+                                let text = text.to_owned();
+                                buffer.clear();
+                                return Some((Ok(text), (stream, buffer)));
+                            }
+                            Err(error) if error.error_len().is_none() => {
+                                let valid_up_to = error.valid_up_to();
+                                if valid_up_to == 0 {
+                                    continue;
+                                }
+                                let text =
+                                    std::str::from_utf8(&buffer[..valid_up_to])
+                                        .map(str::to_owned)
+                                        .map_err(utf8_error::<E>);
+                                buffer = buffer.split_off(valid_up_to);
+                                return Some((text, (stream, buffer)));
+                            }
+                            Err(error) => {
+                                let error = utf8_error(error);
+                                buffer.clear();
+                                return Some((Err(error), (stream, buffer)));
+                            }
+                        }
+                    }
+                    Some(Err(bytes)) => {
+                        return Some((Err(E::de(bytes)), (stream, buffer)));
+                    }
+                    None if buffer.is_empty() => return None,
+                    None => {
+                        let result = match std::str::from_utf8(&buffer) {
+                            Ok(text) => Ok(text.to_owned()),
+                            Err(error) => Err(utf8_error(error)),
+                        };
+                        buffer.clear();
+                        return Some((result, (stream, buffer)));
+                    }
+                }
+            }
+        },
+    )
+}
+
 impl<E, T, Request> IntoReq<StreamingText, Request, E> for T
 where
     Request: ClientReq<E>,
@@ -231,17 +294,7 @@ where
 {
     async fn from_req(req: Request) -> Result<Self, E> {
         let data = req.try_into_stream()?;
-        let s = TextStream::new(data.map(|chunk| match chunk {
-            Ok(bytes) => {
-                let de = String::from_utf8(bytes.to_vec()).map_err(|e| {
-                    E::from_server_fn_error(ServerFnErrorErr::Deserialization(
-                        e.to_string(),
-                    ))
-                })?;
-                Ok(de)
-            }
-            Err(bytes) => Err(E::de(bytes)),
-        }));
+        let s = TextStream::new(decode_text_stream(data));
         Ok(s.into())
     }
 }
@@ -267,16 +320,87 @@ where
 {
     async fn from_res(res: Response) -> Result<Self, E> {
         let stream = res.try_into_stream()?;
-        Ok(TextStream(Box::pin(stream.map(|chunk| match chunk {
-            Ok(bytes) => {
-                let de = String::from_utf8(bytes.into()).map_err(|e| {
-                    E::from_server_fn_error(ServerFnErrorErr::Deserialization(
-                        e.to_string(),
-                    ))
-                })?;
-                Ok(de)
-            }
-            Err(bytes) => Err(E::de(bytes)),
-        }))))
+        Ok(TextStream(Box::pin(decode_text_stream(stream))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{executor::block_on, stream};
+
+    fn decode(
+        chunks: Vec<Result<Bytes, Bytes>>,
+    ) -> Vec<Result<String, ServerFnError>> {
+        block_on(decode_text_stream(stream::iter(chunks)).collect())
+    }
+
+    fn assert_decodes(chunks: Vec<Result<Bytes, Bytes>>, expected: &str) {
+        let decoded = decode(chunks);
+        assert!(decoded.iter().all(Result::is_ok), "{decoded:?}");
+        let text = decoded.into_iter().map(Result::unwrap).collect::<String>();
+        assert_eq!(text, expected);
+    }
+
+    #[test]
+    fn decodes_two_byte_character_split_across_chunks() {
+        assert_decodes(
+            vec![
+                Ok(Bytes::from_static(&[b'a', 0xC3])),
+                Ok(Bytes::from_static(&[0xA9, b'b'])),
+            ],
+            "aéb",
+        );
+    }
+
+    #[test]
+    fn decodes_four_byte_character_split_across_three_chunks() {
+        assert_decodes(
+            vec![
+                Ok(Bytes::from_static(&[b'a', 0xF0])),
+                Ok(Bytes::from_static(&[0x9F, 0x98])),
+                Ok(Bytes::from_static(&[0x80, b'b'])),
+            ],
+            "a😀b",
+        );
+    }
+
+    #[test]
+    fn decodes_complete_utf8_chunk() {
+        assert_decodes(vec![Ok(Bytes::from_static("aéb".as_bytes()))], "aéb");
+    }
+
+    #[test]
+    fn drops_invalid_chunk_and_continues_decoding() {
+        let decoded = decode(vec![
+            Ok(Bytes::from_static(&[b'a', 0xFF, b'b'])),
+            Ok(Bytes::from_static(b"c")),
+        ]);
+
+        assert!(matches!(
+            &decoded[0],
+            Err(ServerFnError::Deserialization(_))
+        ));
+        assert_eq!(&decoded[1], &Ok("c".to_string()));
+    }
+
+    #[test]
+    fn reports_truncated_character_at_end_of_stream() {
+        let decoded = decode(vec![Ok(Bytes::from_static(&[b'a', 0xC3]))]);
+
+        assert_eq!(&decoded[0], &Ok("a".to_string()));
+        assert!(matches!(
+            &decoded[1],
+            Err(ServerFnError::Deserialization(_))
+        ));
+        assert_eq!(decoded.len(), 2);
+    }
+
+    #[test]
+    fn passes_through_stream_errors() {
+        let error = ServerFnError::ServerError("transport error".to_string());
+        let decoded = decode(vec![Err(error.ser().body)]);
+
+        assert_eq!(decoded, vec![Err(error)]);
     }
 }

--- a/server_fn/src/error.rs
+++ b/server_fn/src/error.rs
@@ -599,18 +599,24 @@ pub trait FromServerFnError: std::fmt::Debug + Sized + 'static {
     /// given by [`Self::Encoder`].
     fn ser(&self) -> ServerFnErrorResponseParts {
         let status_code = self.status_code();
-        let body = Self::Encoder::encode(self).unwrap_or_else(|e| {
-            Self::Encoder::encode(&Self::from_server_fn_error(
-                ServerFnErrorErr::Serialization(e.to_string()),
-            ))
-            .expect(
-                "error serializing should success at least with the \
-                 Serialization error",
-            )
-        });
+        let (body, content_type) = match Self::Encoder::encode(self) {
+            Ok(body) => (body, Self::Encoder::CONTENT_TYPE),
+            Err(error) => {
+                let message = error.to_string();
+                match Self::Encoder::encode(&Self::from_server_fn_error(
+                    ServerFnErrorErr::Serialization(message.clone()),
+                )) {
+                    Ok(body) => (body, Self::Encoder::CONTENT_TYPE),
+                    Err(_) => {
+                        // The encoder rejected both error shapes, so bypass it.
+                        (Bytes::from(message), "text/plain")
+                    }
+                }
+            }
+        };
         ServerFnErrorResponseParts::builder()
             .body(body)
-            .content_type(Self::Encoder::CONTENT_TYPE)
+            .content_type(content_type)
             .status_code(status_code)
             .build()
     }
@@ -663,9 +669,65 @@ impl<T, E> ServerFnMustReturnResult for Result<T, E> {
     type Ok = T;
 }
 
-#[test]
-fn assert_from_server_fn_error_impl() {
-    fn assert_impl<T: FromServerFnError>() {}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::JsonEncoding;
 
-    assert_impl::<ServerFnError>();
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum AppError {
+        Internal(String),
+    }
+
+    impl FromServerFnError for AppError {
+        type Encoder = JsonEncoding;
+
+        fn from_server_fn_error(value: ServerFnErrorErr) -> Self {
+            Self::Internal(value.to_string())
+        }
+    }
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    enum EncodableError {
+        Internal(String),
+    }
+
+    impl FromServerFnError for EncodableError {
+        type Encoder = JsonEncoding;
+
+        fn from_server_fn_error(value: ServerFnErrorErr) -> Self {
+            Self::Internal(value.to_string())
+        }
+    }
+
+    #[test]
+    fn assert_from_server_fn_error_impl() {
+        fn assert_impl<T: FromServerFnError>() {}
+
+        assert_impl::<ServerFnError>();
+    }
+
+    #[test]
+    fn ser_does_not_panic_when_fallback_cannot_be_encoded() {
+        let parts = AppError::Internal("x".into()).ser();
+
+        assert_eq!(parts.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(parts.content_type, "text/plain");
+        assert!(!parts.body.is_empty());
+    }
+
+    #[test]
+    fn ser_uses_encoder_for_normally_encodable_error() {
+        let error = EncodableError::Internal("x".into());
+        let parts = error.ser();
+
+        assert_eq!(parts.status_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(parts.content_type, JsonEncoding::CONTENT_TYPE);
+        assert_eq!(
+            serde_json::from_slice::<EncodableError>(&parts.body)
+                .expect("JSON error response should decode"),
+            error
+        );
+    }
 }

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -626,20 +626,29 @@ where
     {
         let (request_bytes, response_stream, closed, response) =
             request.try_into_websocket().await?;
-        let input = request_bytes.map(|request_bytes| {
-            let request_bytes = request_bytes
-                .map(|bytes| deserialize_result::<InputStreamError>(bytes))
-                .unwrap_or_else(Err);
-            match request_bytes {
-                Ok(request_bytes) => InputEncoding::decode(request_bytes)
-                    .map_err(|e| {
-                        InputStreamError::from_server_fn_error(
-                            ServerFnErrorErr::Deserialization(e.to_string()),
-                        )
-                    }),
-                Err(err) => Err(InputStreamError::de(err)),
-            }
-        });
+        let input = request_bytes
+            .take_while(|frame| {
+                std::future::ready(!matches!(
+                    frame,
+                    Ok(bytes) if is_websocket_end_frame(bytes)
+                ))
+            })
+            .map(|request_bytes| {
+                let request_bytes = request_bytes
+                    .map(|bytes| deserialize_result::<InputStreamError>(bytes))
+                    .unwrap_or_else(Err);
+                match request_bytes {
+                    Ok(request_bytes) => InputEncoding::decode(request_bytes)
+                        .map_err(|e| {
+                            InputStreamError::from_server_fn_error(
+                                ServerFnErrorErr::Deserialization(
+                                    e.to_string(),
+                                ),
+                            )
+                        }),
+                    Err(err) => Err(InputStreamError::de(err)),
+                }
+            });
         let boxed = Box::pin(input)
             as Pin<
                 Box<
@@ -693,25 +702,44 @@ where
 
         async move {
             let (stream, sink) = Client::open_websocket(path).await?;
+            let (closed_tx, closed_rx) =
+                futures::channel::oneshot::channel::<()>();
 
             // Forward the input stream to the websocket
             Client::spawn(async move {
-                pin_mut!(input);
-                pin_mut!(sink);
-                while let Some(input) = input.stream.next().await {
-                    let result = encode_websocket_frame::<
-                        InputEncoding,
-                        InputItem,
-                        InputStreamError,
-                    >(input);
-                    if sink.send(result).await.is_err() {
-                        break;
+                let input = input.stream.fuse();
+                let closed = closed_rx.fuse();
+                pin_mut!(input, sink, closed);
+                loop {
+                    futures::select! {
+                        item = input.next() => match item {
+                            Some(item) => {
+                                let frame = encode_websocket_frame::<
+                                    InputEncoding,
+                                    InputItem,
+                                    InputStreamError,
+                                >(item);
+                                if sink.send(frame).await.is_err() {
+                                    break;
+                                }
+                            }
+                            None => {
+                                if sink.send(websocket_end_frame()).await.is_err() {
+                                    break;
+                                }
+                                let _ = (&mut closed).await;
+                                break;
+                            }
+                        },
+                        _ = closed => break,
                     }
                 }
+                let _ = sink.close().await;
             });
 
             // Return the output stream
-            let stream = stream.map(|request_bytes| {
+            let stream = stream.map(move |request_bytes| {
+                let _keep_closed_tx_alive = &closed_tx;
                 let request_bytes = request_bytes
                     .map(|bytes| deserialize_result::<OutputStreamError>(bytes))
                     .unwrap_or_else(Err);
@@ -740,6 +768,20 @@ where
     }
 }
 
+const WS_TAG_OK: u8 = 0;
+const WS_TAG_ERR: u8 = 1;
+const WS_TAG_END: u8 = 2;
+
+// END marks the sender's stream complete while leaving the connection open.
+// A websocket Close frame would end the connection and lose the peer's reply.
+fn websocket_end_frame() -> Bytes {
+    Bytes::from_static(&[WS_TAG_END])
+}
+
+fn is_websocket_end_frame(bytes: &Bytes) -> bool {
+    bytes.len() == 1 && bytes[0] == WS_TAG_END
+}
+
 // Serializes a Result<Bytes, Bytes> into a single Bytes instance.
 // Format: [tag: u8][content: Bytes]
 // - Tag 0: Ok variant
@@ -748,13 +790,13 @@ fn serialize_result(result: Result<Bytes, Bytes>) -> Bytes {
     match result {
         Ok(bytes) => {
             let mut buf = BytesMut::with_capacity(1 + bytes.len());
-            buf.put_u8(0); // Tag for Ok variant
+            buf.put_u8(WS_TAG_OK);
             buf.extend_from_slice(&bytes);
             buf.freeze()
         }
         Err(bytes) => {
             let mut buf = BytesMut::with_capacity(1 + bytes.len());
-            buf.put_u8(1); // Tag for Err variant
+            buf.put_u8(WS_TAG_ERR);
             buf.extend_from_slice(&bytes);
             buf.freeze()
         }
@@ -777,7 +819,7 @@ where
     match item {
         Ok(value) => {
             let mut buf = BytesMut::new();
-            buf.put_u8(0); // Tag for Ok variant
+            buf.put_u8(WS_TAG_OK);
             match Enc::encode_into(&value, &mut buf) {
                 Ok(()) => buf.freeze(),
                 Err(e) => serialize_result(Err(E::from_server_fn_error(
@@ -807,8 +849,8 @@ fn deserialize_result<E: FromServerFnError>(
     let content = bytes.slice(1..);
 
     match tag {
-        0 => Ok(content),
-        1 => Err(content),
+        WS_TAG_OK => Ok(content),
+        WS_TAG_ERR => Err(content),
         _ => Err(E::from_server_fn_error(ServerFnErrorErr::Deserialization(
             "Invalid data tag".into(),
         ))

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -149,7 +149,7 @@ pub use error::ServerFnError;
 #[cfg(feature = "form-redirects")]
 use error::ServerFnUrlError;
 use error::{FromServerFnError, ServerFnErrorErr};
-use futures::{SinkExt, Stream, StreamExt, pin_mut};
+use futures::{FutureExt, SinkExt, Stream, StreamExt, pin_mut};
 use http::Method;
 use middleware::{BoxedService, Layer, Service};
 use redirect::call_redirect_hook;
@@ -624,7 +624,7 @@ where
                 >,
             > + Send,
     {
-        let (request_bytes, response_stream, response) =
+        let (request_bytes, response_stream, closed, response) =
             request.try_into_websocket().await?;
         let input = request_bytes.map(|request_bytes| {
             let request_bytes = request_bytes
@@ -660,11 +660,22 @@ where
         });
 
         Server::spawn(async move {
+            let output = output.fuse();
+            let closed = closed.fuse();
             pin_mut!(response_stream);
             pin_mut!(output);
-            while let Some(output) = output.next().await {
-                if response_stream.send(output).await.is_err() {
-                    break;
+            pin_mut!(closed);
+            loop {
+                futures::select! {
+                    item = output.next() => match item {
+                        Some(item) => {
+                            if response_stream.send(item).await.is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    },
+                    _ = closed => break,
                 }
             }
         })?;

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -1303,7 +1303,7 @@ pub mod actix {
             ActixMethod::TRACE => Method::TRACE,
             ActixMethod::OPTIONS => Method::OPTIONS,
             ActixMethod::CONNECT => Method::CONNECT,
-            _ => unreachable!(),
+            _ => return None,
         };
         REGISTERED_SERVER_FUNCTIONS
             .read()
@@ -1318,6 +1318,25 @@ pub mod actix {
                 }
                 service
             })
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::get_server_fn_service;
+        use actix_web::http::Method;
+
+        #[test]
+        fn extension_method_matches_no_server_fn() {
+            let method = Method::from_bytes(b"PROPFIND").unwrap();
+            assert!(get_server_fn_service("/api/whatever", &method).is_none());
+        }
+
+        #[test]
+        fn standard_method_on_unregistered_path_matches_no_server_fn() {
+            assert!(
+                get_server_fn_service("/api/whatever", &Method::GET).is_none()
+            );
+        }
     }
 }
 

--- a/server_fn/src/lib.rs
+++ b/server_fn/src/lib.rs
@@ -472,13 +472,13 @@ where
             // otherwise, deserialize the body as is
             let output = Output::from_res(res).await?;
             Ok(output)
-        }?;
+        };
 
         // if redirected, call the redirect hook (if that's been set)
         if (300..=399).contains(&status) || has_redirect_header {
             call_redirect_hook(&location);
         }
-        Ok(res)
+        res
     }
 }
 

--- a/server_fn/src/middleware/mod.rs
+++ b/server_fn/src/middleware/mod.rs
@@ -1,5 +1,10 @@
 use crate::error::{ServerFnErrorErr, ServerFnErrorResponseParts};
-use std::{future::Future, pin::Pin};
+use or_poisoned::OrPoisoned;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 
 /// An abstraction over a middleware layer, which can be used to add additional
 /// middleware layer to a [`Service`].
@@ -13,8 +18,17 @@ pub trait Layer<Req, Res>: Send + Sync + 'static {
 pub struct BoxedService<Req, Res> {
     /// A function that converts a [`ServerFnErrorErr`] into [`ServerFnErrorResponseParts`].
     pub err_ser: ServerFnErrorSerializer,
-    /// The inner service.
-    pub service: Box<dyn Service<Req, Res> + Send>,
+    /// The shared inner service, allowing tower middleware to clone it.
+    pub service: Arc<Mutex<Box<dyn Service<Req, Res> + Send>>>,
+}
+
+impl<Req, Res> Clone for BoxedService<Req, Res> {
+    fn clone(&self) -> Self {
+        Self {
+            err_ser: self.err_ser,
+            service: Arc::clone(&self.service),
+        }
+    }
 }
 
 impl<Req, Res> BoxedService<Req, Res> {
@@ -25,7 +39,7 @@ impl<Req, Res> BoxedService<Req, Res> {
     ) -> Self {
         Self {
             err_ser: ser,
-            service: Box::new(service),
+            service: Arc::new(Mutex::new(Box::new(service))),
         }
     }
 
@@ -34,7 +48,7 @@ impl<Req, Res> BoxedService<Req, Res> {
         &mut self,
         req: Req,
     ) -> Pin<Box<dyn Future<Output = Res> + Send>> {
-        self.service.run(req, self.err_ser)
+        self.service.lock().or_poisoned().run(req, self.err_ser)
     }
 }
 
@@ -59,11 +73,15 @@ mod axum {
     use crate::{ServerFnError, error::ServerFnErrorErr, response::Res};
     use axum::body::Body;
     use http::{Request, Response};
+    use or_poisoned::OrPoisoned;
     use std::{future::Future, pin::Pin};
 
     impl<S> super::Service<Request<Body>, Response<Body>> for S
     where
-        S: tower::Service<Request<Body>, Response = Response<Body>>,
+        S: tower::Service<Request<Body>, Response = Response<Body>>
+            + Clone
+            + Send
+            + 'static,
         S::Future: Send + 'static,
         S::Error: std::fmt::Display + Send + 'static,
     {
@@ -73,9 +91,19 @@ mod axum {
             err_ser: ServerFnErrorSerializer,
         ) -> Pin<Box<dyn Future<Output = Response<Body>> + Send>> {
             let path = req.uri().path().to_string();
-            let inner = self.call(req);
+            // Clone-and-replace moves the called instance into the `'static`
+            // future so it can be polled ready first.
+            let clone = self.clone();
+            let mut svc = std::mem::replace(self, clone);
             Box::pin(async move {
-                inner.await.unwrap_or_else(|e| {
+                let res =
+                    match futures::future::poll_fn(|cx| svc.poll_ready(cx))
+                        .await
+                    {
+                        Ok(()) => svc.call(req).await,
+                        Err(e) => Err(e),
+                    };
+                res.unwrap_or_else(|e| {
                     let err = err_ser(ServerFnErrorErr::MiddlewareError(
                         e.to_string(),
                     ));
@@ -106,7 +134,8 @@ mod axum {
         }
 
         fn call(&mut self, req: Request<Body>) -> Self::Future {
-            let inner = self.service.run(req, self.err_ser);
+            let inner =
+                self.service.lock().or_poisoned().run(req, self.err_ser);
             Box::pin(async move { Ok(inner.await) })
         }
     }
@@ -185,5 +214,84 @@ mod actix {
                 }))
             })
         }
+    }
+}
+
+#[cfg(all(test, feature = "axum"))]
+mod tests {
+    use super::{BoxedService, ServerFnErrorSerializer};
+    use crate::error::{ServerFnErrorErr, ServerFnErrorResponseParts};
+    use axum::body::Body;
+    use bytes::Bytes;
+    use http::{Request, Response, StatusCode};
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    struct Inner;
+
+    impl super::Service<Request<Body>, Response<Body>> for Inner {
+        fn run(
+            &mut self,
+            _req: Request<Body>,
+            _err_ser: ServerFnErrorSerializer,
+        ) -> Pin<Box<dyn Future<Output = Response<Body>> + Send>> {
+            Box::pin(async { Response::new(Body::from("ok")) })
+        }
+    }
+
+    fn ser(_: ServerFnErrorErr) -> ServerFnErrorResponseParts {
+        ServerFnErrorResponseParts::builder()
+            .body(Bytes::new())
+            .content_type("text/plain")
+            .status_code(StatusCode::INTERNAL_SERVER_ERROR)
+            .build()
+    }
+
+    #[tokio::test]
+    async fn concurrency_limit_layer_is_polled_ready_before_call() {
+        let layer = tower::limit::ConcurrencyLimitLayer::new(1);
+        let mut svc = <tower::limit::ConcurrencyLimitLayer as super::Layer<
+            Request<Body>,
+            Response<Body>,
+        >>::layer(&layer, BoxedService::new(ser, Inner));
+
+        let response = svc.run(Request::new(Body::empty())).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = svc.run(Request::new(Body::empty())).await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[derive(Clone)]
+    struct NotReady;
+
+    impl tower::Service<Request<Body>> for NotReady {
+        type Response = Response<Body>;
+        type Error = &'static str;
+        type Future =
+            futures::future::Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err("not ready"))
+        }
+
+        fn call(&mut self, _req: Request<Body>) -> Self::Future {
+            futures::future::ready(Ok(Response::new(Body::from("ok"))))
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_error_becomes_middleware_error_response() {
+        let mut svc = BoxedService::new(ser, NotReady);
+
+        let response = svc.run(Request::new(Body::empty())).await;
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/server_fn/src/request/actix.rs
+++ b/server_fn/src/request/actix.rs
@@ -122,6 +122,7 @@ where
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
             impl futures::Sink<Bytes> + Send + 'static,
+            impl Future<Output = ()> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -138,6 +139,7 @@ where
             futures::channel::mpsc::channel(2048);
         let (response_sink_tx, mut response_sink_rx) =
             futures::channel::mpsc::channel::<Bytes>(2048);
+        let (closed_tx, closed_rx) = futures::channel::oneshot::channel::<()>();
 
         actix_web::rt::spawn(async move {
             loop {
@@ -186,11 +188,13 @@ where
                 }
             }
             let _ = session.close(None).await;
+            drop(closed_tx);
         });
 
         Ok((
             response_stream_rx,
             response_sink_tx,
+            closed_rx.map(|_| ()),
             ActixResponse::from(response),
         ))
     }

--- a/server_fn/src/request/axum.rs
+++ b/server_fn/src/request/axum.rs
@@ -83,6 +83,7 @@ where
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
             impl Sink<Bytes> + Send + 'static,
+            impl std::future::Future<Output = ()> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -95,6 +96,7 @@ where
                         std::future::Ready<Result<Bytes, Bytes>>,
                     >,
                     futures::sink::Drain<Bytes>,
+                    std::future::Pending<()>,
                     Self::WebsocketResponse,
                 ),
                 Error,
@@ -123,6 +125,8 @@ where
                 futures::channel::mpsc::channel::<Result<Bytes, Bytes>>(2048);
             let (incoming_tx, mut incoming_rx) =
                 futures::channel::mpsc::channel::<Bytes>(2048);
+            let (closed_tx, closed_rx) =
+                futures::channel::oneshot::channel::<()>();
             let response = upgrade
         .on_failed_upgrade({
             let mut outgoing_tx = outgoing_tx.clone();
@@ -130,7 +134,7 @@ where
                 _ = outgoing_tx.start_send(Err(InputStreamError::from_server_fn_error(ServerFnErrorErr::Response(err.to_string())).ser().body));
             }
         })
-        .on_upgrade(|mut session| async move {
+        .on_upgrade(move |mut session| async move {
             loop {
                 futures::select! {
                     incoming = incoming_rx.next() => {
@@ -173,9 +177,10 @@ where
                 }
             }
             _ = session.send(Message::Close(None)).await;
+            drop(closed_tx);
         });
 
-            Ok((outgoing_rx, incoming_tx, response))
+            Ok((outgoing_rx, incoming_tx, closed_rx.map(|_| ()), response))
         }
     }
 }

--- a/server_fn/src/request/generic.rs
+++ b/server_fn/src/request/generic.rs
@@ -82,6 +82,7 @@ where
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
             impl Sink<Bytes> + Send + 'static,
+            impl std::future::Future<Output = ()> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -90,6 +91,7 @@ where
             (
                 futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
                 futures::sink::Drain<Bytes>,
+                std::future::Pending<()>,
                 Self::WebsocketResponse,
             ),
             _,

--- a/server_fn/src/request/mod.rs
+++ b/server_fn/src/request/mod.rs
@@ -353,6 +353,9 @@ where
     ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, Error>;
 
     /// Attempts to convert the body of the request into a websocket handle.
+    ///
+    /// The third tuple element resolves once the websocket connection has been
+    /// closed by either side and is used to stop forwarding output.
     #[allow(clippy::type_complexity)]
     fn try_into_websocket(
         self,
@@ -361,6 +364,7 @@ where
             (
                 impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
                 impl Sink<Bytes> + Send + 'static,
+                impl Future<Output = ()> + Send + 'static,
                 Self::WebsocketResponse,
             ),
             Error,
@@ -416,6 +420,7 @@ where
         (
             impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static,
             impl Sink<Bytes> + Send + 'static,
+            impl Future<Output = ()> + Send + 'static,
             Self::WebsocketResponse,
         ),
         Error,
@@ -425,6 +430,7 @@ where
             (
                 futures::stream::Once<std::future::Ready<Result<Bytes, Bytes>>>,
                 futures::sink::Drain<Bytes>,
+                std::future::Pending<()>,
                 Self::WebsocketResponse,
             ),
             _,

--- a/server_fn/src/response/browser.rs
+++ b/server_fn/src/response/browser.rs
@@ -61,26 +61,32 @@ impl<E: FromServerFnError> ClientRes<E> for BrowserResponse {
         self,
     ) -> Result<impl Stream<Item = Result<Bytes, Bytes>> + Send + 'static, E>
     {
-        let stream = ReadableStream::from_raw(self.0.body().unwrap())
-            .into_stream()
-            .map(|data| match data {
-                Err(e) => {
-                    web_sys::console::error_1(&e);
-                    Err(E::from_server_fn_error(ServerFnErrorErr::Request(
-                        format!("{e:?}"),
-                    ))
-                    .ser()
-                    .body)
-                }
-                Ok(data) => {
-                    let data = data.unchecked_into::<Uint8Array>();
-                    let mut buf = Vec::new();
-                    let length = data.length();
-                    buf.resize(length as usize, 0);
-                    data.copy_to(&mut buf);
-                    Ok(Bytes::from(buf))
-                }
-            });
+        let body = self.0.body().ok_or_else(|| {
+            E::from_server_fn_error(ServerFnErrorErr::Response(
+                "response has no body".into(),
+            ))
+        })?;
+        let stream =
+            ReadableStream::from_raw(body).into_stream().map(
+                |data| match data {
+                    Err(e) => {
+                        web_sys::console::error_1(&e);
+                        Err(E::from_server_fn_error(ServerFnErrorErr::Request(
+                            format!("{e:?}"),
+                        ))
+                        .ser()
+                        .body)
+                    }
+                    Ok(data) => {
+                        let data = data.unchecked_into::<Uint8Array>();
+                        let mut buf = Vec::new();
+                        let length = data.length();
+                        buf.resize(length as usize, 0);
+                        data.copy_to(&mut buf);
+                        Ok(Bytes::from(buf))
+                    }
+                },
+            );
         Ok(SendWrapper::new(stream))
     }
 
@@ -101,5 +107,55 @@ impl<E: FromServerFnError> ClientRes<E> for BrowserResponse {
 
     fn has_redirect(&self) -> bool {
         self.0.headers().get(REDIRECT_HEADER).is_some()
+    }
+}
+
+#[cfg(all(test, target_family = "wasm"))]
+mod tests {
+    use super::*;
+    use crate::error::ServerFnError;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    fn browser_response(body: &str) -> BrowserResponse {
+        let raw = js_sys::eval(&format!("new Response({body})"))
+            .expect("create fetch Response")
+            .dyn_into::<web_sys::Response>()
+            .expect("cast fetch Response");
+        BrowserResponse(SendWrapper::new(Response::from(raw)))
+    }
+
+    #[wasm_bindgen_test]
+    fn bodyless_response_returns_error() {
+        let response = browser_response("null");
+
+        let result =
+            <BrowserResponse as ClientRes<ServerFnError>>::try_into_stream(
+                response,
+            );
+
+        assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test(async)]
+    async fn response_with_body_returns_stream_bytes() {
+        let response = browser_response("'stream body'");
+        let stream =
+            <BrowserResponse as ClientRes<ServerFnError>>::try_into_stream(
+                response,
+            )
+            .expect("response should have a body");
+
+        let chunks = stream.collect::<Vec<_>>().await;
+        let body = chunks.into_iter().map(Result::unwrap).fold(
+            Vec::new(),
+            |mut body, chunk| {
+                body.extend_from_slice(&chunk);
+                body
+            },
+        );
+
+        assert_eq!(body, b"stream body");
     }
 }

--- a/server_fn/tests/axum_loopback.rs
+++ b/server_fn/tests/axum_loopback.rs
@@ -1,0 +1,157 @@
+#![cfg(all(feature = "axum", feature = "reqwest"))]
+
+//! Shared Axum loopback harness for native client integration tests. The
+//! process-wide server and client URL are initialized once so later HTTP and
+//! websocket regressions can share this file under Cargo test and nextest.
+
+use axum::{
+    Router,
+    http::{HeaderName, StatusCode, header},
+    routing::any,
+};
+use serde::{Deserialize, Serialize};
+use server_fn::{
+    Http, Protocol, ServerFnError,
+    client::{reqwest::ReqwestClient, try_set_server_url},
+    codec::{Json, PostUrl},
+    mock::BrowserMockServer,
+    redirect::{REDIRECT_HEADER, set_redirect_hook},
+};
+use std::{
+    net::SocketAddr,
+    sync::{Mutex, OnceLock},
+    time::Duration,
+};
+use tokio::time::timeout;
+
+static SERVER: OnceLock<SocketAddr> = OnceLock::new();
+static HOOK: OnceLock<()> = OnceLock::new();
+static LOCATIONS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+fn server_addr() -> SocketAddr {
+    *SERVER.get_or_init(|| {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("loopback listener should bind");
+        listener
+            .set_nonblocking(true)
+            .expect("loopback listener should be nonblocking");
+        let addr = listener
+            .local_addr()
+            .expect("loopback listener should have an address");
+
+        std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("loopback runtime should build");
+            runtime.block_on(async move {
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("std listener should convert to Tokio");
+                let app = Router::new()
+                    .route(
+                        "/api/{*rest}",
+                        any(server_fn::axum::handle_server_fn),
+                    )
+                    .route("/needs_login", any(needs_login))
+                    .route("/after", any(after));
+                axum::serve(listener, app)
+                    .await
+                    .expect("loopback server should run");
+            });
+        });
+
+        let server_url = Box::leak(format!("http://{addr}").into_boxed_str());
+        let _ = try_set_server_url(server_url);
+        addr
+    })
+}
+
+async fn needs_login()
+-> (StatusCode, [(HeaderName, &'static str); 2], &'static str) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        [
+            (header::LOCATION, "/login"),
+            (HeaderName::from_static(REDIRECT_HEADER), ""),
+        ],
+        "\"not logged in\"",
+    )
+}
+
+async fn after() -> (StatusCode, [(HeaderName, &'static str); 2], &'static str)
+{
+    (
+        StatusCode::OK,
+        [
+            (header::LOCATION, "/after"),
+            (HeaderName::from_static(REDIRECT_HEADER), ""),
+        ],
+        "\"ok\"",
+    )
+}
+
+fn install_redirect_hook() {
+    HOOK.get_or_init(|| {
+        let result = set_redirect_hook(|location| {
+            LOCATIONS.lock().unwrap().push(location.to_string());
+        });
+        assert!(result.is_ok(), "redirect hook should install once");
+    });
+}
+
+#[derive(Serialize, Deserialize)]
+struct In {
+    a: u32,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn redirect_hook_runs_for_error_and_success_responses() {
+    let _ = server_addr();
+    install_redirect_hook();
+    LOCATIONS.lock().unwrap().clear();
+
+    let error = timeout(
+        Duration::from_secs(5),
+        <Http<PostUrl, Json> as Protocol<
+            In,
+            String,
+            ReqwestClient,
+            BrowserMockServer,
+            ServerFnError,
+        >>::run_client("/needs_login", In { a: 1 }),
+    )
+    .await
+    .expect("error response should arrive before timeout");
+    assert!(error.is_err(), "500 response should decode as an error");
+    assert!(
+        LOCATIONS
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|location| location == "/login"),
+        "redirect hook should record /login for the 500 response"
+    );
+
+    let output = timeout(
+        Duration::from_secs(5),
+        <Http<PostUrl, Json> as Protocol<
+            In,
+            String,
+            ReqwestClient,
+            BrowserMockServer,
+            ServerFnError,
+        >>::run_client("/after", In { a: 1 }),
+    )
+    .await
+    .expect("success response should arrive before timeout")
+    .expect("200 response should decode successfully");
+    assert_eq!(output, "ok");
+    assert!(
+        LOCATIONS
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|location| location == "/after"),
+        "redirect hook should record /after for the 200 response"
+    );
+}

--- a/server_fn/tests/axum_loopback.rs
+++ b/server_fn/tests/axum_loopback.rs
@@ -9,17 +9,23 @@ use axum::{
     http::{HeaderName, StatusCode, header},
     routing::any,
 };
+use futures::{StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use server_fn::{
-    Http, Protocol, ServerFnError,
+    BoxedStream, Http, Protocol, ServerFn, ServerFnError, Websocket,
     client::{reqwest::ReqwestClient, try_set_server_url},
-    codec::{Json, PostUrl},
+    codec::{Json, JsonEncoding, PostUrl},
     mock::BrowserMockServer,
     redirect::{REDIRECT_HEADER, set_redirect_hook},
 };
 use std::{
+    future::Future,
     net::SocketAddr,
-    sync::{Mutex, OnceLock},
+    ops::Deref,
+    sync::{
+        Mutex, OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 use tokio::time::timeout;
@@ -27,9 +33,80 @@ use tokio::time::timeout;
 static SERVER: OnceLock<SocketAddr> = OnceLock::new();
 static HOOK: OnceLock<()> = OnceLock::new();
 static LOCATIONS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Msg {
+    v: u32,
+}
+
+struct LiveGuard;
+
+impl Drop for LiveGuard {
+    fn drop(&mut self) {
+        LIVE.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+async fn idle(
+    input: BoxedStream<Msg, ServerFnError>,
+) -> Result<BoxedStream<Msg, ServerFnError>, ServerFnError> {
+    drop(input);
+    LIVE.fetch_add(1, Ordering::SeqCst);
+    let guard = LiveGuard;
+    Ok(stream::pending::<Result<Msg, ServerFnError>>()
+        .map(move |item| {
+            let _keep = &guard;
+            item
+        })
+        .into())
+}
+
+struct Idle {
+    input: BoxedStream<Msg, ServerFnError>,
+}
+
+impl Deref for Idle {
+    type Target = BoxedStream<Msg, ServerFnError>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.input
+    }
+}
+
+impl From<Idle> for BoxedStream<Msg, ServerFnError> {
+    fn from(value: Idle) -> Self {
+        value.input
+    }
+}
+
+impl From<BoxedStream<Msg, ServerFnError>> for Idle {
+    fn from(input: BoxedStream<Msg, ServerFnError>) -> Self {
+        Self { input }
+    }
+}
+
+impl ServerFn for Idle {
+    const PATH: &'static str = "/api/idle";
+
+    type Client = ReqwestClient;
+    type Server = server_fn::axum::AxumServerFnBackend;
+    type Protocol = Websocket<JsonEncoding, JsonEncoding>;
+    type Output = BoxedStream<Msg, ServerFnError>;
+    type Error = ServerFnError;
+    type InputStreamError = ServerFnError;
+    type OutputStreamError = ServerFnError;
+
+    fn run_body(
+        self,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send {
+        idle(self.input)
+    }
+}
 
 fn server_addr() -> SocketAddr {
     *SERVER.get_or_init(|| {
+        server_fn::axum::register_explicit::<Idle>();
         let listener = std::net::TcpListener::bind("127.0.0.1:0")
             .expect("loopback listener should bind");
         listener
@@ -64,6 +141,33 @@ fn server_addr() -> SocketAddr {
         let _ = try_set_server_url(server_url);
         addr
     })
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn server_forwarder_stops_when_client_disconnects() {
+    let addr = server_addr();
+    let (ws, _) =
+        tokio_tungstenite::connect_async(format!("ws://{addr}{}", Idle::PATH))
+            .await
+            .expect("websocket client should connect");
+
+    timeout(Duration::from_secs(5), async {
+        while LIVE.load(Ordering::SeqCst) != 1 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("idle output stream should become live");
+
+    drop(ws);
+
+    timeout(Duration::from_secs(5), async {
+        while LIVE.load(Ordering::SeqCst) != 0 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("idle output stream should be dropped after disconnect");
 }
 
 async fn needs_login()

--- a/server_fn/tests/axum_loopback.rs
+++ b/server_fn/tests/axum_loopback.rs
@@ -34,6 +34,9 @@ static SERVER: OnceLock<SocketAddr> = OnceLock::new();
 static HOOK: OnceLock<()> = OnceLock::new();
 static LOCATIONS: Mutex<Vec<String>> = Mutex::new(Vec::new());
 static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PULLED: AtomicUsize = AtomicUsize::new(0);
+static WEBSOCKET_TEST: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 struct Msg {
@@ -51,15 +54,28 @@ impl Drop for LiveGuard {
 async fn idle(
     input: BoxedStream<Msg, ServerFnError>,
 ) -> Result<BoxedStream<Msg, ServerFnError>, ServerFnError> {
-    drop(input);
     LIVE.fetch_add(1, Ordering::SeqCst);
     let guard = LiveGuard;
     Ok(stream::pending::<Result<Msg, ServerFnError>>()
         .map(move |item| {
-            let _keep = &guard;
+            let _keep = (&guard, &input);
             item
         })
         .into())
+}
+
+async fn sum(
+    input: BoxedStream<Msg, ServerFnError>,
+) -> Result<BoxedStream<Msg, ServerFnError>, ServerFnError> {
+    Ok(stream::once(async move {
+        let mut total = 0;
+        let mut input = input;
+        while let Some(Ok(message)) = input.next().await {
+            total += message.v;
+        }
+        Ok(Msg { v: total })
+    })
+    .into())
 }
 
 struct Idle {
@@ -104,9 +120,52 @@ impl ServerFn for Idle {
     }
 }
 
+struct Sum {
+    input: BoxedStream<Msg, ServerFnError>,
+}
+
+impl Deref for Sum {
+    type Target = BoxedStream<Msg, ServerFnError>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.input
+    }
+}
+
+impl From<Sum> for BoxedStream<Msg, ServerFnError> {
+    fn from(value: Sum) -> Self {
+        value.input
+    }
+}
+
+impl From<BoxedStream<Msg, ServerFnError>> for Sum {
+    fn from(input: BoxedStream<Msg, ServerFnError>) -> Self {
+        Self { input }
+    }
+}
+
+impl ServerFn for Sum {
+    const PATH: &'static str = "/api/sum";
+
+    type Client = ReqwestClient;
+    type Server = server_fn::axum::AxumServerFnBackend;
+    type Protocol = Websocket<JsonEncoding, JsonEncoding>;
+    type Output = BoxedStream<Msg, ServerFnError>;
+    type Error = ServerFnError;
+    type InputStreamError = ServerFnError;
+    type OutputStreamError = ServerFnError;
+
+    fn run_body(
+        self,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send {
+        sum(self.input)
+    }
+}
+
 fn server_addr() -> SocketAddr {
     *SERVER.get_or_init(|| {
         server_fn::axum::register_explicit::<Idle>();
+        server_fn::axum::register_explicit::<Sum>();
         let listener = std::net::TcpListener::bind("127.0.0.1:0")
             .expect("loopback listener should bind");
         listener
@@ -145,6 +204,8 @@ fn server_addr() -> SocketAddr {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn server_forwarder_stops_when_client_disconnects() {
+    let _guard = WEBSOCKET_TEST.lock().await;
+    let before = LIVE.load(Ordering::SeqCst);
     let addr = server_addr();
     let (ws, _) =
         tokio_tungstenite::connect_async(format!("ws://{addr}{}", Idle::PATH))
@@ -152,7 +213,7 @@ async fn server_forwarder_stops_when_client_disconnects() {
             .expect("websocket client should connect");
 
     timeout(Duration::from_secs(5), async {
-        while LIVE.load(Ordering::SeqCst) != 1 {
+        while LIVE.load(Ordering::SeqCst) != before + 1 {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     })
@@ -162,12 +223,79 @@ async fn server_forwarder_stops_when_client_disconnects() {
     drop(ws);
 
     timeout(Duration::from_secs(5), async {
-        while LIVE.load(Ordering::SeqCst) != 0 {
+        while LIVE.load(Ordering::SeqCst) != before {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
     })
     .await
     .expect("idle output stream should be dropped after disconnect");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn client_signals_end_of_input_so_the_server_can_reply() {
+    let _ = server_addr();
+    let input =
+        stream::iter([Ok(Msg { v: 1 }), Ok(Msg { v: 2 }), Ok(Msg { v: 3 })]);
+    let mut out =
+        <Websocket<JsonEncoding, JsonEncoding> as Protocol<
+            Sum,
+            BoxedStream<Msg, ServerFnError>,
+            ReqwestClient,
+            server_fn::axum::AxumServerFnBackend,
+            ServerFnError,
+        >>::run_client(Sum::PATH, Sum::from(BoxedStream::from(input)))
+        .await
+        .expect("websocket client should connect");
+
+    let result = timeout(Duration::from_secs(5), out.next())
+        .await
+        .expect("sum response should arrive before timeout");
+    assert_eq!(result, Some(Ok(Msg { v: 6 })));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_the_output_stream_closes_the_socket_and_stops_the_pump() {
+    let _guard = WEBSOCKET_TEST.lock().await;
+    let _ = server_addr();
+    let before = LIVE.load(Ordering::SeqCst);
+    PULLED.store(0, Ordering::SeqCst);
+    let input = stream::repeat(Ok(Msg { v: 0 })).inspect(|_| {
+        PULLED.fetch_add(1, Ordering::SeqCst);
+    });
+    let out =
+        <Websocket<JsonEncoding, JsonEncoding> as Protocol<
+            Idle,
+            BoxedStream<Msg, ServerFnError>,
+            ReqwestClient,
+            server_fn::axum::AxumServerFnBackend,
+            ServerFnError,
+        >>::run_client(Idle::PATH, Idle::from(BoxedStream::from(input)))
+        .await
+        .expect("websocket client should connect");
+
+    timeout(Duration::from_secs(5), async {
+        while LIVE.load(Ordering::SeqCst) != before + 1 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("idle output stream should become live");
+
+    drop(out);
+
+    timeout(Duration::from_secs(5), async {
+        while LIVE.load(Ordering::SeqCst) != before {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("idle output stream should be dropped after client closes");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let first = PULLED.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let second = PULLED.load(Ordering::SeqCst);
+    assert_eq!(first, second, "input pump should stop polling");
 }
 
 async fn needs_login()


### PR DESCRIPTION
This fixes eight issues in `server_fn`, one commit each, with regression tests.

**Panics on plausible input**
- actix `get_server_fn_service` panicked via `unreachable!()` on any non-standard HTTP method (`PROPFIND /api/foo` dropped the connection, or aborted the process under `panic = "abort"`). It now returns `None`, so the handler answers 400.
- `FromServerFnError::ser` panicked when neither the app error nor its `Serialization` fallback could be encoded (e.g. an internally-tagged newtype enum with `JsonEncoding`). It now degrades to a `text/plain` error body.
- The browser client's `try_into_stream` unwrapped `Response::body()`, aborting the wasm module on a body-less response (204/304/HEAD/opaque). It now returns an error.
- The tower blanket `Service` impl called `call()` without `poll_ready`, so `#[middleware(ConcurrencyLimitLayer::new(1))]` panicked on the first request. Readiness is now awaited (clone-and-replace); `BoxedService` is `Clone` so tower middleware can wrap it.

**Wrong behaviour**
- `StreamingText` decoded each transport chunk with `String::from_utf8`, so a multi-byte character split across chunks produced two `Deserialization` errors. Decoding now carries the incomplete tail over to the next chunk.
- `Http::run_client` returned early on 4xx/5xx before calling the redirect hook, so `redirect("/login"); Err(..)` never navigated. The hook now runs regardless of status.

**Websocket lifecycle**
- The server's output-forwarding task only noticed a disconnected client on a failed send, leaking a task and stream per disconnected client whenever the output was idle. `Req::try_into_websocket` now also returns a future that resolves on close, and the forwarder selects on it.
- The client never told the server its input had ended (a server function that drains input before replying hung forever), and dropping the output stream neither stopped the input pump nor closed the socket. An end-of-input frame is now sent (tag `2` in the existing framing — a Close frame would cut off the reply), and dropping the output stream cancels the pump and closes the socket.

**API notes:** `Req::try_into_websocket` returns a fourth tuple element; `BoxedService.service` is now `Arc<Mutex<Box<dyn Service + Send>>>` and `BoxedService: Clone`; the tower blanket impl requires `Clone` (tower convention — non-`Clone` services such as `RateLimit` no longer satisfy it).

**What changes for users (`BoxedService: Clone`)**

- **Non-breaking for the normal case.** `#[middleware(...)]` with any layer whose service is `Clone` (`ConcurrencyLimitLayer`, `TimeoutLayer`, `LoadShedLayer`, `BufferLayer`, `ServiceBuilder` stacks, most hand-written middleware) keeps compiling — and now actually works instead of panicking.
- **Breaking for non-`Clone` tower services.** A `#[middleware]` whose service is not `Clone` (`tower::limit::RateLimitLayer` is the notable one) is rejected at compile time with an unsatisfied `Clone` bound. Before, it compiled but couldn't limit anything: a fresh `RateLimit` is created per request and its `call` panics once the per-instance quota is exhausted. Rate limiting belongs at the router level anyway.
- **Custom `server_fn::middleware::Service` impls** (not tower-based) are unaffected — the trait itself didn't change.
- **Code that read `BoxedService.service` directly** (the field is `pub`, but nothing in-tree outside `server_fn` touches it) now sees `Arc<Mutex<..>>`; `BoxedService::new` and `run` are unchanged.
- The actix blanket impls are untouched; actix services are often neither `Clone` nor `Send`, and no failure was demonstrated there.
