### PR TITLE
Adopt a better Suspense-polling approach

### DIFF
--- a/integrations/axum/tests/streaming_redirect.rs
+++ b/integrations/axum/tests/streaming_redirect.rs
@@ -1,0 +1,108 @@
+//! An integration test for a `<ProtectedRoute/>` whose condition comes from a blocking resource.
+//! This needs to hold the head long enough to redirect under streaming SSR.
+
+#[cfg(test)]
+mod tests {
+    use axum::{Router, body::Body, http::Request};
+    use leptos::{config::LeptosOptions, prelude::*};
+    use leptos_axum::{LeptosRoutes, generate_route_list};
+    use leptos_meta::{MetaTags, provide_meta_context};
+    use leptos_router::{
+        components::{ProtectedRoute, Route, Router as LeptosRouter, Routes},
+        path,
+    };
+    use tower::ServiceExt;
+
+    #[component]
+    fn RedirectApp() -> impl IntoView {
+        provide_meta_context();
+
+        let allowed = Resource::new_blocking(
+            || (),
+            |()| async {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                false
+            },
+        );
+
+        view! {
+            <LeptosRouter>
+                <main>
+                    <Routes fallback=|| view! { <p>"Not found."</p> }>
+                        <ProtectedRoute
+                            path=path!("guarded")
+                            view=|| view! { <h1>"secret"</h1> }
+                            condition=move || allowed.get()
+                            redirect_path=|| "/public"
+                            fallback=|| view! { <p>"Loading"</p> }
+                        />
+                        <Route path=path!("public") view=|| view! { <h1>"public"</h1> } />
+                    </Routes>
+                </main>
+            </LeptosRouter>
+        }
+    }
+
+    fn shell(_options: LeptosOptions) -> impl IntoView {
+        view! {
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="utf-8"/>
+                    <MetaTags/>
+                </head>
+                <body>
+                    <RedirectApp/>
+                </body>
+            </html>
+        }
+    }
+
+    fn app() -> Router {
+        let options = LeptosOptions::builder()
+            .output_name("streaming-redirect")
+            .site_root(std::env::temp_dir().to_string_lossy().to_string())
+            .site_pkg_dir("pkg")
+            .build();
+        let routes = generate_route_list(RedirectApp);
+        Router::new()
+            .leptos_routes(&options, routes, {
+                let options = options.clone();
+                move || shell(options.clone())
+            })
+            .with_state(options)
+    }
+
+    fn navigation(uri: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .header("Accept", "text/html,application/xhtml+xml")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn protected_route_redirects_under_streaming_ssr() {
+        for i in 0..25 {
+            let resp = app().oneshot(navigation("/guarded")).await.unwrap();
+            let status = resp.status();
+            let location = resp
+                .headers()
+                .get("location")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string);
+            assert_eq!(
+                (status.as_u16(), location.as_deref()),
+                (302, Some("/public")),
+                "attempt {i} did not redirect"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unguarded_route_is_untouched() {
+        let resp = app().oneshot(navigation("/public")).await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        assert!(resp.headers().get("location").is_none());
+    }
+}

--- a/integrations/axum/tests/streaming_redirect.rs
+++ b/integrations/axum/tests/streaming_redirect.rs
@@ -1,6 +1,8 @@
 //! An integration test for a `<ProtectedRoute/>` whose condition comes from a blocking resource.
 //! This needs to hold the head long enough to redirect under streaming SSR.
 
+#![cfg(all(feature = "default", not(feature = "wasm")))]
+
 #[cfg(test)]
 mod tests {
     use axum::{Router, body::Body, http::Request};

--- a/leptos/src/suspense_component.rs
+++ b/leptos/src/suspense_component.rs
@@ -3,7 +3,7 @@ use crate::{
     children::{TypedChildren, ViewFnOnce},
     error::ErrorBoundarySuspendedChildren,
 };
-use futures::{FutureExt, channel::oneshot, select};
+use futures::{FutureExt, channel::oneshot, future::poll_fn, select};
 use hydration_context::SerializedDataId;
 use leptos_macro::component;
 use or_poisoned::OrPoisoned;
@@ -15,13 +15,13 @@ use reactive_graph::{
     effect::RenderEffect,
     owner::{ArcStoredValue, Owner, provide_context, use_context},
     signal::ArcRwSignal,
-    traits::{
-        Dispose, Get, Read, ReadUntracked, Track, With, WithUntracked,
-        WriteValue,
-    },
+    traits::{Get, Track, With, WithUntracked, WriteValue},
 };
 use slotmap::{DefaultKey, SlotMap};
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    task::Poll,
+};
 use tachys::{
     either::Either,
     html::attribute::{Attribute, any_attribute::AnyAttribute},
@@ -126,9 +126,7 @@ where
         let fallback = fallback.run();
         let children = children.into_inner()();
         let tasks = ArcRwSignal::new(SlotMap::<DefaultKey, ()>::new());
-        provide_context(SuspenseContext {
-            tasks: tasks.clone(),
-        });
+        provide_context(SuspenseContext::new(tasks.clone()));
         let none_pending = ArcMemo::new({
             let tasks = tasks.clone();
             move |prev: Option<&bool>| {
@@ -340,100 +338,46 @@ where
         // 1. all tasks are finished loading, or
         // 2. we read from a local resource, meaning this Suspense can never resolve on the server
 
-        // first, create listener for tasks
-        let tasks = suspense_context.tasks.clone();
-        let (tasks_tx, mut tasks_rx) =
-            futures::channel::oneshot::channel::<()>();
-
-        let mut tasks_tx = Some(tasks_tx);
-
-        // now, create listener for local resources
+        // first, create listener for local resources
         let (local_tx, mut local_rx) =
             futures::channel::oneshot::channel::<()>();
         provide_context(LocalResourceNotifier::from(local_tx));
 
-        // walk over the tree of children once to make sure that all resource loads are registered
-        self.children.dry_resolve();
         let children = Arc::new(Mutex::new(Some(self.children)));
 
-        // check the set of tasks to see if it is empty, now or later
+        // `tasks_ready` is a `Future` that is ready once every task registered with this
+        // `<Suspense/>` has finished.
         let strict = self.strict;
-        let eff = reactive_graph::effect::Effect::new_isomorphic({
-            let children = Arc::clone(&children);
-            let notify_error_boundary = notify_error_boundary.clone();
-            // tracks whether a task has ever been registered in this Suspense.
-            // if none ever has, no resolving resource could gate a nested
-            // read, so the double-check pass would do no work and we can skip
-            // it (avoiding an extra invocation of the children body).
-            let mut any_task_ever_seen = false;
-            move |double_checking: Option<bool>| {
-                // on the first run, always track the tasks
-                if double_checking.is_none() {
-                    tasks.track();
-                }
-
-                if let Some(curr_tasks) = tasks.try_read_untracked() {
-                    if curr_tasks.is_empty() {
-                        if strict
-                            || double_checking == Some(true)
-                            || !any_task_ever_seen
-                        {
-                            // either we've finished the confirming dry-walk,
-                            // or no task has ever been registered — in both
-                            // cases there is nothing more to discover, so we
-                            // can render both the children and the error
-                            // boundary
-
-                            if let Some(tx) = tasks_tx.take() {
-                                // If the receiver has dropped, it means the ScopedFuture has already
-                                // dropped, so it doesn't matter if we manage to send this.
-                                _ = tx.send(());
-                            }
-                            if let Some(tx) =
-                                notify_error_boundary.write_value().take()
-                            {
-                                _ = tx.send(());
-                            }
-                        } else {
-                            // release the read guard on tasks, as we'll be updating it again
-                            drop(curr_tasks);
-                            // check the children for additional pending tasks
-                            // the will catch additional resource reads nested inside a conditional depending on initial resource reads
-                            if let Some(children) =
-                                children.lock().or_poisoned().as_mut()
-                            {
-                                children.dry_resolve();
-                            }
-
-                            if tasks
-                                .try_read()
-                                .map(|n| n.is_empty())
-                                .unwrap_or(false)
-                            {
-                                // there are no additional pending tasks, and we can simply return
-                                if let Some(tx) = tasks_tx.take() {
-                                    // If the receiver has dropped, it means the ScopedFuture has already
-                                    // dropped, so it doesn't matter if we manage to send this.
-                                    _ = tx.send(());
-                                }
-                                if let Some(tx) =
-                                    notify_error_boundary.write_value().take()
-                                {
-                                    _ = tx.send(());
-                                }
-                            }
-
-                            // tell ourselves that we're just double-checking
-                            return true;
+        let mut tasks_ready = Box::pin(
+            {
+                let suspense_context = suspense_context.clone();
+                let children = Arc::clone(&children);
+                // whether walking the tree again could reveal a resource read
+                // we haven't tracked yet
+                let mut may_reveal_more = true;
+                poll_fn(move |cx| {
+                    loop {
+                        if !suspense_context.poll_empty(cx.waker()) {
+                            return Poll::Pending;
                         }
-                    } else {
-                        any_task_ever_seen = true;
-                        tasks.track();
+
+                        if !may_reveal_more {
+                            return Poll::Ready(());
+                        }
+
+                        if let Some(children) =
+                            children.lock().or_poisoned().as_mut()
+                        {
+                            children.dry_resolve();
+                        }
+
+                        may_reveal_more =
+                            !strict && !suspense_context.poll_empty(cx.waker());
                     }
-                }
-                false
+                })
             }
-        });
+            .fuse(),
+        );
 
         let mut fut = Box::pin(ScopedFuture::new(ErrorHookFuture::new(
             async move {
@@ -461,7 +405,15 @@ where
                         }
                         None
                     }
-                    _ = tasks_rx => {
+                    _ = tasks_ready => {
+                        // every task has finished, so the error boundary can
+                        // render its children too
+                        if let Some(tx) =
+                            notify_error_boundary.write_value().take()
+                        {
+                            let _ = tx.send(());
+                        }
+
                         let children = {
                             let mut children_lock = children.lock().or_poisoned();
                             children_lock.take().expect("children should not be removed until we render here")
@@ -488,9 +440,6 @@ where
                                 None
                             }
                             children = children => {
-                                // clean up the (now useless) effect
-                                eff.dispose();
-
                                 Some(OwnedView::new_with_owner(children, owner))
                             }
                         }

--- a/leptos/src/transition.rs
+++ b/leptos/src/transition.rs
@@ -109,9 +109,7 @@ where
         let fallback = fallback.run();
         let children = children.into_inner()();
         let tasks = ArcRwSignal::new(SlotMap::<DefaultKey, ()>::new());
-        provide_context(SuspenseContext {
-            tasks: tasks.clone(),
-        });
+        provide_context(SuspenseContext::new(tasks.clone()));
         let none_pending = ArcMemo::new({
             let tasks = tasks.clone();
             move |prev: Option<&bool>| {

--- a/leptos/tests/suspense_body_runs.rs
+++ b/leptos/tests/suspense_body_runs.rs
@@ -107,7 +107,7 @@ async fn body_runs_with_conditional_nested_resource() {
     let inner = Resource::new(
         || (),
         |_| async move {
-            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             "inner-data".to_string()
         },
     );
@@ -133,7 +133,7 @@ async fn body_runs_with_conditional_nested_resource() {
 
     let runs = count.load(Ordering::SeqCst);
     println!("nested-resource case: body ran {runs} times");
-    assert_eq!(runs, 3, "expected 3 runs in the nested-resource case");
+    assert_eq!(runs, 4, "expected 4 runs in the nested-resource case");
 }
 
 /// `strict=true` disables the double-check pass, so a Suspense with one

--- a/leptos/tests/suspense_body_runs.rs
+++ b/leptos/tests/suspense_body_runs.rs
@@ -203,3 +203,100 @@ async fn body_runs_with_strict_transition() {
     println!("strict transition case: body ran {runs} times");
     assert_eq!(runs, 2, "expected 2 runs in strict transition mode");
 }
+
+#[tokio::test]
+async fn out_of_order_body_runs_with_conditional_nested_resource() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let outer = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            true
+        },
+    );
+    let inner = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            "inner-data".to_string()
+        },
+    );
+
+    let app = view! {
+        <Suspense>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            outer.get().and_then(|flag| {
+                if flag { inner.get() } else { None }
+            })
+        }}</Suspense>
+    };
+
+    let html = app.to_html_stream_out_of_order().collect::<String>().await;
+    assert!(
+        html.contains("inner-data"),
+        "conditional nested resource must resolve before the out-of-order \
+         fragment renders; got: {html:?}"
+    );
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("out-of-order nested case: body ran {runs} times");
+    assert_eq!(runs, 4, "expected 4 runs in the out-of-order nested case");
+}
+
+#[tokio::test]
+async fn body_runs_with_two_levels_of_nesting() {
+    _ = Executor::init_tokio();
+    let owner = Owner::new();
+    owner.set();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_in = Arc::clone(&count);
+
+    let a = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            true
+        },
+    );
+    let b = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            true
+        },
+    );
+    let c = Resource::new(
+        || (),
+        |_| async move {
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            "deep-data".to_string()
+        },
+    );
+
+    let app = view! {
+        <Suspense>{move || {
+            count_in.fetch_add(1, Ordering::SeqCst);
+            a.get().and_then(|a| if a { b.get() } else { None })
+                   .and_then(|b| if b { c.get() } else { None })
+        }}</Suspense>
+    };
+
+    let html = render(app).await;
+    assert!(
+        html.contains("deep-data"),
+        "a read gated behind two rounds of resources must still be waited \
+         for; got: {html:?}"
+    );
+
+    let runs = count.load(Ordering::SeqCst);
+    println!("two-level nested case: body ran {runs} times");
+    // one walk per level discovered, plus the confirming walk, plus resolve
+    assert_eq!(runs, 5, "expected 5 runs in the two-level nested case");
+}

--- a/leptos_server/src/once_resource.rs
+++ b/leptos_server/src/once_resource.rs
@@ -18,7 +18,8 @@ use futures::{Future, FutureExt};
 use or_poisoned::OrPoisoned;
 use reactive_graph::{
     computed::{
-        AsyncDerivedReadyFuture, ScopedFuture, suspense::SuspenseContext,
+        AsyncDerivedReadyFuture, ScopedFuture,
+        suspense::{SharedTaskHandle, SuspenseContext},
     },
     diagnostics::{SpecialNonReactiveFuture, SpecialNonReactiveZone},
     graph::{AnySource, ToAnySource},
@@ -57,6 +58,7 @@ pub struct ArcOnceResource<T, Ser = JsonSerdeCodec> {
     value: Arc<RwLock<Option<T>>>,
     wakers: Arc<RwLock<Vec<Waker>>>,
     suspenses: Arc<RwLock<Vec<SuspenseContext>>>,
+    pending_suspenses: Arc<RwLock<Vec<SharedTaskHandle>>>,
     loading: Arc<AtomicBool>,
     ser: PhantomData<fn() -> Ser>,
     #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -70,6 +72,7 @@ impl<T, Ser> Clone for ArcOnceResource<T, Ser> {
             value: self.value.clone(),
             wakers: self.wakers.clone(),
             suspenses: self.suspenses.clone(),
+            pending_suspenses: self.pending_suspenses.clone(),
             loading: self.loading.clone(),
             ser: self.ser,
             #[cfg(any(debug_assertions, leptos_debuginfo))]
@@ -111,6 +114,8 @@ where
         let value = Arc::new(RwLock::new(initial));
         let wakers = Arc::new(RwLock::new(Vec::<Waker>::new()));
         let suspenses = Arc::new(RwLock::new(Vec::<SuspenseContext>::new()));
+        let pending_suspenses =
+            Arc::new(RwLock::new(Vec::<SharedTaskHandle>::new()));
         let loading = Arc::new(AtomicBool::new(!is_ready));
         let trigger = ArcTrigger::new();
 
@@ -119,6 +124,7 @@ where
         if !is_ready {
             let value = Arc::clone(&value);
             let wakers = Arc::clone(&wakers);
+            let pending_suspenses = Arc::clone(&pending_suspenses);
             let loading = Arc::clone(&loading);
             let trigger = trigger.clone();
             reactive_graph::spawn(async move {
@@ -133,6 +139,11 @@ where
                     fut.await
                 };
                 *value.write().or_poisoned() = Some(loaded);
+                for handle in
+                    mem::take(&mut *pending_suspenses.write().or_poisoned())
+                {
+                    handle.release();
+                }
                 // `Release` pairs with the `Acquire` load in
                 // `OnceResourceFuture::poll`: a poller that observes
                 // `loading == false` is then guaranteed to see the value write
@@ -152,6 +163,7 @@ where
             loading,
             wakers,
             suspenses,
+            pending_suspenses,
             ser: PhantomData,
             #[cfg(any(debug_assertions, leptos_debuginfo))]
             defined_at: Location::caller(),
@@ -309,9 +321,14 @@ where
             match ready.as_mut().now_or_never() {
                 Some(_) => drop(handle),
                 None => {
+                    let handle = SharedTaskHandle::new(handle);
+                    self.pending_suspenses
+                        .write()
+                        .or_poisoned()
+                        .push(handle.clone());
                     reactive_graph::spawn(async move {
                         ready.await;
-                        drop(handle);
+                        handle.release();
                     });
                 }
             }

--- a/reactive_graph/src/computed/async_derived/arc_async_derived.rs
+++ b/reactive_graph/src/computed/async_derived/arc_async_derived.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::owner::Sandboxed;
 use crate::{
     channel::channel,
-    computed::suspense::SuspenseContext,
+    computed::suspense::{SharedTaskHandle, SuspenseContext},
     diagnostics::SpecialNonReactiveFuture,
     graph::{
         AnySource, AnySubscriber, ReactiveNode, Source, SourceSet, Subscriber,
@@ -371,7 +371,7 @@ macro_rules! spawn_derived {
                                         let version = guard.version;
                                         let suspense_ids = mem::take(&mut guard.suspenses)
                                             .into_iter()
-                                            .map(|sc| sc.task_id())
+                                            .map(|sc| SharedTaskHandle::new(sc.task_id()))
                                             .collect::<Vec<_>>();
                                         guard.pending_suspenses.extend(suspense_ids);
                                         version
@@ -381,7 +381,9 @@ macro_rules! spawn_derived {
 
                                     let latest_version = {
                                         let mut guard = inner.write().or_poisoned();
-                                        drop(mem::take(&mut guard.pending_suspenses));
+                                        for handle in mem::take(&mut guard.pending_suspenses) {
+                                            handle.release();
+                                        }
                                         guard.version
                                     };
 
@@ -646,11 +648,15 @@ impl<T: 'static> ReadUntracked for ArcAsyncDerived<T> {
                     drop(handle);
                 }
                 None => {
-                    // otherwise, spawn a task to wait for it to be ready, then drop the handle,
-                    // which will notify the suspense
+                    let handle = SharedTaskHandle::new(handle);
+                    self.inner
+                        .write()
+                        .or_poisoned()
+                        .pending_suspenses
+                        .push(handle.clone());
                     crate::spawn(async move {
                         ready.await;
-                        drop(handle);
+                        handle.release();
                     });
                 }
             }
@@ -684,7 +690,9 @@ impl<T: 'static> Write for ArcAsyncDerived<T> {
         guard.version += 1;
 
         // tell any suspenses to stop waiting for this
-        drop(mem::take(&mut guard.pending_suspenses));
+        for handle in mem::take(&mut guard.pending_suspenses) {
+            handle.release();
+        }
 
         Some(MappedMut::new(
             WriteGuard::new(self.clone(), self.value.blocking_write()),
@@ -702,7 +710,9 @@ impl<T: 'static> Write for ArcAsyncDerived<T> {
         guard.version += 1;
 
         // tell any suspenses to stop waiting for this
-        drop(mem::take(&mut guard.pending_suspenses));
+        for handle in mem::take(&mut guard.pending_suspenses) {
+            handle.release();
+        }
 
         Some(MappedMut::new(
             self.value.blocking_write(),

--- a/reactive_graph/src/computed/async_derived/inner.rs
+++ b/reactive_graph/src/computed/async_derived/inner.rs
@@ -1,4 +1,4 @@
-use super::suspense::TaskHandle;
+use super::suspense::SharedTaskHandle;
 use crate::{
     channel::Sender,
     computed::suspense::SuspenseContext,
@@ -23,7 +23,7 @@ pub(crate) struct ArcAsyncDerivedInner {
     pub state: AsyncDerivedState,
     pub version: usize,
     pub suspenses: Vec<SuspenseContext>,
-    pub pending_suspenses: Vec<TaskHandle>,
+    pub pending_suspenses: Vec<SharedTaskHandle>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/reactive_graph/src/computed/async_derived/mod.rs
+++ b/reactive_graph/src/computed/async_derived/mod.rs
@@ -94,12 +94,16 @@ impl<Fut: Future> Future for ScopedFuture<Fut> {
 pub mod suspense {
     use crate::{
         signal::ArcRwSignal,
-        traits::{Update, Write},
+        traits::{ReadUntracked, Update, Write},
     };
     use futures::channel::oneshot::Sender;
     use or_poisoned::OrPoisoned;
     use slotmap::{DefaultKey, SlotMap};
-    use std::sync::{Arc, Mutex};
+    use std::{
+        mem,
+        sync::{Arc, Mutex},
+        task::Waker,
+    };
 
     /// Sends a one-time notification that the resource being read from is "local only," i.e.,
     /// that it will only run on the client, not the server.
@@ -126,16 +130,44 @@ pub mod suspense {
     pub struct SuspenseContext {
         /// The set of active tasks.
         pub tasks: ArcRwSignal<SlotMap<DefaultKey, ()>>,
+        empty_wakers: Arc<Mutex<Vec<Waker>>>,
     }
 
     impl SuspenseContext {
+        /// Creates a context that tracks the given set of active tasks.
+        pub fn new(tasks: ArcRwSignal<SlotMap<DefaultKey, ()>>) -> Self {
+            Self {
+                tasks,
+                empty_wakers: Default::default(),
+            }
+        }
+
         /// Generates a unique task ID.
         pub fn task_id(&self) -> TaskHandle {
             let key = self.tasks.write().insert(());
             TaskHandle {
                 tasks: self.tasks.clone(),
+                empty_wakers: Arc::clone(&self.empty_wakers),
                 key,
             }
+        }
+
+        /// Whether the set of active tasks is currently empty.
+        ///
+        /// If not, `waker` will be woken when the last [`TaskHandle`] is dropped.
+        pub fn poll_empty(&self, waker: &Waker) -> bool {
+            let mut wakers = self.empty_wakers.lock().or_poisoned();
+            let empty = self
+                .tasks
+                .try_read_untracked()
+                .map(|tasks| tasks.is_empty())
+                .unwrap_or(false);
+            if empty {
+                wakers.clear();
+            } else if !wakers.iter().any(|w| w.will_wake(waker)) {
+                wakers.push(waker.clone());
+            }
+            empty
         }
     }
 
@@ -143,14 +175,40 @@ pub mod suspense {
     #[derive(Debug)]
     pub struct TaskHandle {
         tasks: ArcRwSignal<SlotMap<DefaultKey, ()>>,
+        empty_wakers: Arc<Mutex<Vec<Waker>>>,
         key: DefaultKey,
     }
 
     impl Drop for TaskHandle {
         fn drop(&mut self) {
+            let mut now_empty = false;
             self.tasks.update(|tasks| {
                 tasks.remove(self.key);
+                now_empty = tasks.is_empty();
             });
+            if now_empty {
+                for waker in
+                    mem::take(&mut *self.empty_wakers.lock().or_poisoned())
+                {
+                    waker.wake();
+                }
+            }
+        }
+    }
+
+    /// A [`TaskHandle`] that can be released from one of multiple places.
+    #[derive(Clone, Debug)]
+    pub struct SharedTaskHandle(Arc<Mutex<Option<TaskHandle>>>);
+
+    impl SharedTaskHandle {
+        /// Wraps a handle so that it can be released from more than one place.
+        pub fn new(handle: TaskHandle) -> Self {
+            Self(Arc::new(Mutex::new(Some(handle))))
+        }
+
+        /// Drops the inner handle, if it has not been dropped already.
+        pub fn release(&self) {
+            drop(self.0.lock().or_poisoned().take());
         }
     }
 }


### PR DESCRIPTION
The current implementation of Suspense uses an effect that tracks a signal of pending tasks. This has ended up being more complex than it needs to be, and also missing a number of edge cases/introducing flakiness due to scheduler timing. This PR introduces a polling-based approach instead that works more like ordinary Rust async.