### PR TITLE
feat(reactive_stores): convert a subfield into MaybeProp

### DIFF
--- a/reactive_stores/src/lib.rs
+++ b/reactive_stores/src/lib.rs
@@ -1427,4 +1427,32 @@ mod tests {
         tick().await;
         assert_eq!(name_count.load(Ordering::Relaxed), 2);
     }
+
+    #[derive(Debug, Clone, Store, Patch, Default)]
+    struct Settings {
+        label: Option<String>,
+        retries: u8,
+    }
+
+    #[tokio::test]
+    async fn subfield_converts_into_maybe_prop() {
+        use reactive_graph::{traits::GetUntracked, wrappers::read::MaybeProp};
+
+        _ = any_spawner::Executor::init_tokio();
+
+        let store = Store::new(Settings::default());
+        let label: MaybeProp<String> = store.label().into();
+        let retries: MaybeProp<u8> = store.retries().into();
+
+        assert_eq!(label.get_untracked(), None);
+        assert_eq!(retries.get_untracked(), Some(0));
+
+        // The conversion derives from the field rather than copying it, so a
+        // later write is visible through the prop.
+        store.label().set(Some("ready".to_string()));
+        store.retries().set(3);
+
+        assert_eq!(label.get_untracked(), Some("ready".to_string()));
+        assert_eq!(retries.get_untracked(), Some(3));
+    }
 }

--- a/reactive_stores/src/subfield.rs
+++ b/reactive_stores/src/subfield.rs
@@ -12,7 +12,7 @@ use reactive_graph::{
         DefinedAt, Get as _, IsDisposed, Notify, ReadUntracked, Track,
         UntrackableGuard, Write,
     },
-    wrappers::read::Signal,
+    wrappers::read::{MaybeProp, Signal},
 };
 use std::{iter, marker::PhantomData, ops::DerefMut, panic::Location};
 
@@ -233,5 +233,27 @@ where
 {
     fn from(subfield: Subfield<Inner, Prev, T>) -> Self {
         Signal::derive(move || subfield.get())
+    }
+}
+
+impl<Inner, Prev, T> From<Subfield<Inner, Prev, Option<T>>> for MaybeProp<T>
+where
+    Inner: StoreField<Value = Prev> + Track + Send + Sync + 'static,
+    Prev: 'static,
+    T: Send + Sync + Clone + 'static,
+{
+    fn from(subfield: Subfield<Inner, Prev, Option<T>>) -> Self {
+        MaybeProp::derive(move || subfield.get())
+    }
+}
+
+impl<Inner, Prev, T> From<Subfield<Inner, Prev, T>> for MaybeProp<T>
+where
+    Inner: StoreField<Value = Prev> + Track + Send + Sync + 'static,
+    Prev: 'static,
+    T: Send + Sync + Clone + 'static,
+{
+    fn from(subfield: Subfield<Inner, Prev, T>) -> Self {
+        MaybeProp::derive(move || Some(subfield.get()))
     }
 }


### PR DESCRIPTION
`MaybeProp<T>` already accepts `ReadSignal`, `RwSignal`, `Memo` and `Signal`, each in both the `Option<T>` and the plain `T` shape. A store subfield had neither, and `Into` does not chain, so a field feeding a `#[prop(into)] MaybeProp<T>` had to spell the hop out at the call site as `Signal::derive(move || store.field().get())`.